### PR TITLE
GEODE-3870: clean up region entry classes

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractLRURegionMap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractLRURegionMap.java
@@ -182,7 +182,7 @@ public abstract class AbstractLRURegionMap extends AbstractRegionMap {
         // no need to worry about the value changing form with entry LRU.
         return false;
       }
-      Object curVal = le._getValue(); // OFFHEAP: _getValue ok
+      Object curVal = le.getValue(); // OFFHEAP: _getValue ok
       if (curVal != cd) {
         if (cd instanceof StoredObject) {
           if (!cd.equals(curVal)) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegion.java
@@ -98,8 +98,8 @@ import org.apache.geode.pdx.internal.PeerTypeRegistration;
  * Takes care of RegionAttributes, AttributesMutator, and some no-brainer method implementations.
  */
 @SuppressWarnings("deprecation")
-public abstract class AbstractRegion implements Region, RegionAttributes, AttributesMutator,
-    CacheStatistics, DataSerializableFixedID, RegionEntryContext, Extensible<Region<?, ?>> {
+public abstract class AbstractRegion implements InternalRegion, AttributesMutator, CacheStatistics,
+    DataSerializableFixedID, Extensible<Region<?, ?>> {
 
   private static final Logger logger = LogService.getLogger();
 
@@ -427,8 +427,6 @@ public abstract class AbstractRegion implements Region, RegionAttributes, Attrib
   }
 
   abstract Map basicGetAll(Collection keys, Object callback);
-
-  public abstract RegionEntry basicGetEntry(Object key);
 
   protected StringBuilder getStringBuilder() {
     StringBuilder buf = new StringBuilder();
@@ -808,6 +806,7 @@ public abstract class AbstractRegion implements Region, RegionAttributes, Attrib
   /**
    * Get IndexManger for region
    */
+  @Override
   public IndexManager getIndexManager() {
     return this.indexManager;
   }
@@ -845,6 +844,7 @@ public abstract class AbstractRegion implements Region, RegionAttributes, Attrib
   // block
   // in case the value of the entry is "REMOVED" token. This prevents dead lock
   // caused by the Bug # 33336
+  @Override
   public boolean isIndexCreationThread() {
     Boolean value = isIndexCreator.get();
     return value != null ? value : false;
@@ -1473,6 +1473,7 @@ public abstract class AbstractRegion implements Region, RegionAttributes, Attrib
    *
    * @since GemFire 5.0
    */
+  @Override
   public boolean isProxy() {
     return getDataPolicy().isEmpty();
   }
@@ -1515,6 +1516,7 @@ public abstract class AbstractRegion implements Region, RegionAttributes, Attrib
   /**
    * Returns true if this region could expire an entry
    */
+  @Override
   public boolean isEntryExpiryPossible() {
     return this.entryExpiryPossible;
   }
@@ -1760,6 +1762,7 @@ public abstract class AbstractRegion implements Region, RegionAttributes, Attrib
     return this.cache;
   }
 
+  @Override
   public DM getDistributionManager() {
     return getSystem().getDistributionManager();
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegionMap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegionMap.java
@@ -150,6 +150,7 @@ public abstract class AbstractRegionMap implements RegionMap {
     }
   }
 
+  @Override
   public void changeOwner(LocalRegion r) {
     if (r == _getOwnerObject()) {
       return;
@@ -162,6 +163,7 @@ public abstract class AbstractRegionMap implements RegionMap {
     this.entryFactory = f;
   }
 
+  @Override
   public RegionEntryFactory getEntryFactory() {
     return this.entryFactory;
   }
@@ -170,6 +172,7 @@ public abstract class AbstractRegionMap implements RegionMap {
     this.attr = a;
   }
 
+  @Override
   public Attributes getAttributes() {
     return this.attr;
   }
@@ -186,6 +189,7 @@ public abstract class AbstractRegionMap implements RegionMap {
     return this.owner;
   }
 
+  @Override
   public void setOwner(Object r) {
     this.owner = r;
   }
@@ -198,6 +202,7 @@ public abstract class AbstractRegionMap implements RegionMap {
     this.map = m;
   }
 
+  @Override
   public int size() {
     return _getMap().size();
   }
@@ -208,14 +213,17 @@ public abstract class AbstractRegionMap implements RegionMap {
     return _getMap().size();
   }
 
+  @Override
   public boolean isEmpty() {
     return _getMap().isEmpty();
   }
 
+  @Override
   public Set keySet() {
     return _getMap().keySet();
   }
 
+  @Override
   @SuppressWarnings({"unchecked", "rawtypes"})
   public Collection<RegionEntry> regionEntries() {
     return (Collection) _getMap().values();
@@ -227,6 +235,7 @@ public abstract class AbstractRegionMap implements RegionMap {
     return (Collection) _getMap().values();
   }
 
+  @Override
   public boolean containsKey(Object key) {
     RegionEntry re = getEntry(key);
     if (re == null) {
@@ -238,6 +247,7 @@ public abstract class AbstractRegionMap implements RegionMap {
     return true;
   }
 
+  @Override
   public RegionEntry getEntry(Object key) {
     RegionEntry re = (RegionEntry) _getMap().get(key);
     return re;
@@ -254,12 +264,13 @@ public abstract class AbstractRegionMap implements RegionMap {
   }
 
 
+  @Override
   public RegionEntry putEntryIfAbsent(Object key, RegionEntry re) {
     RegionEntry oldRe = (RegionEntry) _getMap().putIfAbsent(key, re);
     if (oldRe == null && (re instanceof OffHeapRegionEntry) && _isOwnerALocalRegion()
         && _getOwner().isThisRegionBeingClosedOrDestroyed()) {
       // prevent orphan during concurrent destroy (#48068)
-      Object v = re._getValue();
+      Object v = re.getValue();
       if (v != Token.REMOVED_PHASE1 && v != Token.REMOVED_PHASE2 && v instanceof StoredObject
           && ((StoredObject) v).hasRefCount()) {
         if (_getMap().remove(key, re)) {
@@ -277,6 +288,7 @@ public abstract class AbstractRegionMap implements RegionMap {
   }
 
 
+  @Override
   public void removeEntry(Object key, RegionEntry re, boolean updateStat) {
     if (re.isTombstone() && _getMap().get(key) == re) {
       logger.fatal(
@@ -292,8 +304,9 @@ public abstract class AbstractRegionMap implements RegionMap {
     }
   }
 
+  @Override
   public void removeEntry(Object key, RegionEntry re, boolean updateStat, EntryEventImpl event,
-      final LocalRegion owner) {
+      final InternalRegion owner) {
     boolean success = false;
     if (re.isTombstone() && _getMap().get(key) == re) {
       logger.fatal(
@@ -333,11 +346,8 @@ public abstract class AbstractRegionMap implements RegionMap {
     _getMap().clear();
   }
 
+  @Override
   public void close() {
-    /*
-     * for (SuspectEntryList l: this.suspectEntries.values()) { for (EntryEventImpl e: l) {
-     * e.release(); } }
-     */
     clear(null);
   }
 
@@ -345,6 +355,7 @@ public abstract class AbstractRegionMap implements RegionMap {
    * Clear the region and, if an RVV is given, return a collection of the version sources in all
    * remaining tags
    */
+  @Override
   public Set<VersionSource> clear(RegionVersionVector rvv) {
     Set<VersionSource> result = new HashSet<VersionSource>();
 
@@ -408,7 +419,7 @@ public abstract class AbstractRegionMap implements RegionMap {
               // note: it.remove() did not reliably remove the entry so we use remove(K,V) here
               if (_getMap().remove(re.getKey(), re)) {
                 if (OffHeapRegionEntryHelper.doesClearNeedToCheckForOffHeap()) {
-                  GatewaySenderEventImpl.release(re._getValue()); // OFFHEAP _getValue ok
+                  GatewaySenderEventImpl.release(re.getValue()); // OFFHEAP _getValue ok
                 }
                 // If this is an overflow only region, we need to free the entry on
                 // disk at this point.
@@ -445,6 +456,7 @@ public abstract class AbstractRegionMap implements RegionMap {
     return result;
   }
 
+  @Override
   public void lruUpdateCallback() {
     // By default do nothing; LRU maps needs to override this method
   }
@@ -453,19 +465,23 @@ public abstract class AbstractRegionMap implements RegionMap {
     // By default do nothing; LRU maps needs to override this method
   }
 
+  @Override
   public void lruUpdateCallback(int i) {
     // By default do nothing; LRU maps needs to override this method
   }
 
+  @Override
   public boolean disableLruUpdateCallback() {
     // By default do nothing; LRU maps needs to override this method
     return false;
   }
 
+  @Override
   public void enableLruUpdateCallback() {
     // By default do nothing; LRU maps needs to override this method
   }
 
+  @Override
   public void resetThreadLocals() {
     // By default do nothing; LRU maps needs to override this method
   }
@@ -505,10 +521,12 @@ public abstract class AbstractRegionMap implements RegionMap {
     return false;
   }
 
+  @Override
   public void lruCloseStats() {
     // do nothing by default
   }
 
+  @Override
   public void lruEntryFaultIn(LRUEntry entry) {
     // do nothing by default
   }
@@ -516,7 +534,7 @@ public abstract class AbstractRegionMap implements RegionMap {
   /**
    * Process an incoming version tag for concurrent operation detection. This must be done before
    * modifying the region entry.
-   * 
+   *
    * @param re the entry that is to be modified
    * @param event the modification to the entry
    * @throws InvalidDeltaException if the event contains a delta that cannot be applied
@@ -549,6 +567,7 @@ public abstract class AbstractRegionMap implements RegionMap {
         owner.getMyId(), sender, checkConflicts);
   }
 
+  @Override
   public void copyRecoveredEntries(RegionMap rm) {
     // We need to sort the tombstones before scheduling them,
     // so that they will be in the correct order.
@@ -566,7 +585,7 @@ public abstract class AbstractRegionMap implements RegionMap {
         @Retained
         @Released
         Object value = oldRe
-            ._getValueRetain((RegionEntryContext) ((AbstractRegionMap) rm)._getOwnerObject(), true);
+            .getValueRetain((RegionEntryContext) ((AbstractRegionMap) rm)._getOwnerObject(), true);
 
         try {
           if (value == Token.NOT_AVAILABLE) {
@@ -645,6 +664,7 @@ public abstract class AbstractRegionMap implements RegionMap {
     _getMap().put(newRe.getKey(), newRe);
   }
 
+  @Override
   @Retained // Region entry may contain an off-heap value
   public RegionEntry initRecoveredEntry(Object key, DiskEntry.RecoveredEntry value) {
     boolean needsCallback = false;
@@ -702,6 +722,7 @@ public abstract class AbstractRegionMap implements RegionMap {
     return newRe;
   }
 
+  @Override
   public RegionEntry updateRecoveredEntry(Object key, DiskEntry.RecoveredEntry value) {
     boolean needsCallback = false;
     RegionEntry re = getEntry(key);
@@ -761,6 +782,7 @@ public abstract class AbstractRegionMap implements RegionMap {
     return re;
   }
 
+  @Override
   public boolean initialImagePut(final Object key, final long lastModified, Object newValue,
       final boolean wasRecovered, boolean deferLRUCallback, VersionTag entryVersion,
       InternalDistributedMember sender, boolean isSynchronizing) {
@@ -1036,6 +1058,7 @@ public abstract class AbstractRegionMap implements RegionMap {
     return true;
   }
 
+  @Override
   public boolean destroy(EntryEventImpl event, boolean inTokenMode, boolean duringRI,
       boolean cacheWrite, boolean isEviction, Object expectedOldValue, boolean removeRecoveredEntry)
       throws CacheWriterException, EntryNotFoundException, TimeoutException {
@@ -1583,6 +1606,7 @@ public abstract class AbstractRegionMap implements RegionMap {
     return tag;
   }
 
+  @Override
   public void txApplyDestroy(Object key, TransactionId txId, TXRmtEvent txEvent,
       boolean inTokenMode, boolean inRI, Operation op, EventID eventId, Object aCallbackArgument,
       List<EntryEventImpl> pendingCallbacks, FilterRoutingInfo filterRoutingInfo,
@@ -1886,6 +1910,7 @@ public abstract class AbstractRegionMap implements RegionMap {
     }
   }
 
+  @Override
   public boolean invalidate(EntryEventImpl event, boolean invokeCallbacks, boolean forceNewEntry,
       boolean forceCallbacks) throws EntryNotFoundException {
     final boolean isDebugEnabled = logger.isDebugEnabled();
@@ -2313,7 +2338,7 @@ public abstract class AbstractRegionMap implements RegionMap {
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see
    * org.apache.geode.internal.cache.RegionMap#updateEntryVersion(org.apache.geode.internal.cache.
    * EntryEventImpl)
@@ -2372,6 +2397,7 @@ public abstract class AbstractRegionMap implements RegionMap {
     }
   }
 
+  @Override
   public void txApplyInvalidate(Object key, Object newValue, boolean didDestroy, TransactionId txId,
       TXRmtEvent txEvent, boolean localOp, EventID eventId, Object aCallbackArgument,
       List<EntryEventImpl> pendingCallbacks, FilterRoutingInfo filterRoutingInfo,
@@ -2629,6 +2655,7 @@ public abstract class AbstractRegionMap implements RegionMap {
    * This code needs to be evaluated. It was added quickly to help PR persistence not to consume as
    * much memory.
    */
+  @Override
   public void evictValue(Object key) {
     final LocalRegion owner = _getOwner();
     RegionEntry re = getEntry(key);
@@ -2679,6 +2706,7 @@ public abstract class AbstractRegionMap implements RegionMap {
   /*
    * returns null if the operation fails
    */
+  @Override
   public RegionEntry basicPut(EntryEventImpl event, final long lastModified, final boolean ifNew,
       final boolean ifOld, Object expectedOldValue, // only non-null if ifOld
       boolean requireOldValue, final boolean overwriteDestroyed)
@@ -2951,9 +2979,9 @@ public abstract class AbstractRegionMap implements RegionMap {
 
         @Retained
         @Released
-        Object oldValueInVM = re._getValueRetain(event.getLocalRegion(), true); // OFFHEAP: re
-                                                                                // synced so can use
-                                                                                // its ref.
+        Object oldValueInVM = re.getValueRetain(event.getLocalRegion(), true); // OFFHEAP: re
+                                                                               // synced so can use
+                                                                               // its ref.
 
         ReferenceCountHelper.unskipRefCountTracking();
         try {
@@ -2966,8 +2994,8 @@ public abstract class AbstractRegionMap implements RegionMap {
       // if the old value is in memory then if it is a GatewaySenderEventImpl then
       // we want to set the old value.
       @Unretained
-      Object ov = re._getValue(); // OFFHEAP _getValue is ok since re is synced and we only use it
-                                  // if its a GatewaySenderEventImpl.
+      Object ov = re.getValue(); // OFFHEAP _getValue is ok since re is synced and we only use it
+                                 // if its a GatewaySenderEventImpl.
       // Since GatewaySenderEventImpl is never stored in an off-heap region nor a compressed region
       // we don't need to worry about ov being compressed.
       if (ov instanceof GatewaySenderEventImpl) {
@@ -3106,6 +3134,7 @@ public abstract class AbstractRegionMap implements RegionMap {
     return retVal;
   }
 
+  @Override
   public void txApplyPut(Operation p_putOp, Object key, Object nv, boolean didDestroy,
       TransactionId txId, TXRmtEvent txEvent, EventID eventId, Object aCallbackArgument,
       List<EntryEventImpl> pendingCallbacks, FilterRoutingInfo filterRoutingInfo,
@@ -3494,7 +3523,7 @@ public abstract class AbstractRegionMap implements RegionMap {
   /**
    * Removing the existing indexed value requires the current value in the cache, that is the one
    * prior to applying the operation.
-   * 
+   *
    * @param entry the RegionEntry that contains the value prior to applying the op
    */
   private void txRemoveOldIndexEntry(Operation op, RegionEntry entry) {
@@ -3640,6 +3669,7 @@ public abstract class AbstractRegionMap implements RegionMap {
     }
   }
 
+  @Override
   public void writeSyncIfPresent(Object key, Runnable runner) {
     RegionEntry re = getEntry(key);
     if (re != null) {
@@ -3664,6 +3694,7 @@ public abstract class AbstractRegionMap implements RegionMap {
     }
   }
 
+  @Override
   public void removeIfDestroyed(Object key) {
     LocalRegion owner = _getOwner();
     // boolean makeTombstones = owner.concurrencyChecksEnabled;
@@ -3755,13 +3786,14 @@ public abstract class AbstractRegionMap implements RegionMap {
 
   /**
    * for testing race conditions between threads trying to apply ops to the same entry
-   * 
+   *
    * @param entry the entry to attempt to add to the system
    */
   protected RegionEntry putEntryIfAbsentForTest(RegionEntry entry) {
     return (RegionEntry) putEntryIfAbsent(entry.getKey(), entry);
   }
 
+  @Override
   public boolean isTombstoneNotNeeded(RegionEntry re, int destroyedVersion) {
     // no need for synchronization - stale values are okay here
     // TODO this looks like a problem for regionEntry pooling
@@ -3794,6 +3826,7 @@ public abstract class AbstractRegionMap implements RegionMap {
   }
 
   /** removes a tombstone that has expired locally */
+  @Override
   public boolean removeTombstone(RegionEntry re, VersionHolder version, boolean isEviction,
       boolean isScheduledTombstone) {
     boolean result = false;
@@ -3908,6 +3941,7 @@ public abstract class AbstractRegionMap implements RegionMap {
 
   private ARMLockTestHook armLockTestHook;
 
+  @Override
   public ARMLockTestHook getARMLockTestHook() {
     return armLockTestHook;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/BucketRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/BucketRegion.java
@@ -1478,7 +1478,6 @@ public class BucketRegion extends DistributedRegion implements Bucket {
    * Horribly plagiarized from the similar method in LocalRegion
    * 
    * @param clientEvent holder for the entry's version information
-   * @param returnTombstones TODO
    * @return serialized (byte) form
    * @throws IOException if the result is not serializable
    * @see LocalRegion#get(Object, Object, boolean, EntryEventImpl)
@@ -2120,7 +2119,7 @@ public class BucketRegion extends DistributedRegion implements Bucket {
 
   @Override
   public int calculateRegionEntryValueSize(RegionEntry regionEntry) {
-    return calcMemSize(regionEntry._getValue()); // OFFHEAP _getValue ok
+    return calcMemSize(regionEntry.getValue()); // OFFHEAP _getValue ok
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DiskRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DiskRegion.java
@@ -346,7 +346,7 @@ public class DiskRegion extends AbstractDiskRegion {
    *         completed successfully, resulting in the put operation to abort.
    * @throws IllegalArgumentException If <code>id</code> is less than zero
    */
-  public void put(DiskEntry entry, LocalRegion region, ValueWrapper value, boolean async)
+  public void put(DiskEntry entry, InternalRegion region, ValueWrapper value, boolean async)
       throws RegionClearedException {
     getDiskStore().put(region, entry, value, async);
   }
@@ -418,7 +418,7 @@ public class DiskRegion extends AbstractDiskRegion {
     getDiskStore().remove(region, entry, false, false);
   }
 
-  public void remove(LocalRegion region, DiskEntry entry, boolean async, boolean isClear)
+  public void remove(InternalRegion region, DiskEntry entry, boolean async, boolean isClear)
       throws RegionClearedException {
     getDiskStore().remove(region, entry, async, isClear);
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/EntryEventImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/EntryEventImpl.java
@@ -1501,10 +1501,10 @@ public class EntryEventImpl
           Object ov;
           if (ReferenceCountHelper.trackReferenceCounts()) {
             ReferenceCountHelper.setReferenceCountOwner(new OldValueOwner());
-            ov = reentry._getValueRetain(owner, true);
+            ov = reentry.getValueRetain(owner, true);
             ReferenceCountHelper.setReferenceCountOwner(null);
           } else {
-            ov = reentry._getValueRetain(owner, true);
+            ov = reentry.getValueRetain(owner, true);
           }
           if (ov == null)
             ov = Token.NOT_AVAILABLE;
@@ -1803,7 +1803,7 @@ public class EntryEventImpl
       if (re == null)
         return false;
       ReferenceCountHelper.skipRefCountTracking();
-      Object v = re._getValueRetain(this.region, true);
+      Object v = re.getValueRetain(this.region, true);
       ReferenceCountHelper.unskipRefCountTracking();
       try {
         return setOldValue(v);
@@ -2292,7 +2292,7 @@ public class EntryEventImpl
    * 
    * @param notifyGateways pass the event on to WAN queues
    */
-  public void invokeCallbacks(LocalRegion rgn, boolean skipListeners, boolean notifyGateways) {
+  public void invokeCallbacks(InternalRegion rgn, boolean skipListeners, boolean notifyGateways) {
     if (!callbacksInvoked()) {
       callbacksInvoked(true);
       if (this.op.isUpdate()) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/HasDiskRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/HasDiskRegion.java
@@ -14,7 +14,7 @@
  */
 package org.apache.geode.internal.cache;
 
-public interface HasCachePerfStats {
+public interface HasDiskRegion {
 
-  CachePerfStats getCachePerfStats();
+  DiskRegion getDiskRegion();
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalRegion.java
@@ -14,8 +14,18 @@
  */
 package org.apache.geode.internal.cache;
 
+import org.apache.geode.CancelCriterion;
+import org.apache.geode.cache.CacheWriterException;
+import org.apache.geode.cache.EntryNotFoundException;
 import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionAttributes;
+import org.apache.geode.cache.TimeoutException;
+import org.apache.geode.cache.client.internal.ServerRegionProxy;
+import org.apache.geode.cache.query.internal.index.IndexManager;
 import org.apache.geode.distributed.internal.DM;
+import org.apache.geode.internal.cache.versions.RegionVersionVector;
+import org.apache.geode.internal.cache.versions.VersionSource;
+import org.apache.geode.internal.cache.versions.VersionTag;
 
 /**
  * Interface to be used instead of type-casting to LocalRegion.
@@ -30,10 +40,10 @@ import org.apache.geode.distributed.internal.DM;
  * <li>DataSerializableFixedID
  * <li>RegionEntryContext
  * <li>Extensible
- * </pre>
  * </ul>
  */
-public interface InternalRegion<K, V> extends Region<K, V>, HasCachePerfStats {
+public interface InternalRegion<K, V>
+    extends Region<K, V>, HasCachePerfStats, RegionEntryContext, RegionAttributes, HasDiskRegion {
 
   CachePerfStats getCachePerfStats();
 
@@ -41,4 +51,67 @@ public interface InternalRegion<K, V> extends Region<K, V>, HasCachePerfStats {
 
   RegionEntry getRegionEntry(K key);
 
+  RegionVersionVector getVersionVector();
+
+  long cacheTimeMillis();
+
+  Object getValueInVM(Object key) throws EntryNotFoundException;
+
+  Object getValueOnDisk(Object key) throws EntryNotFoundException;
+
+  void dispatchListenerEvent(EnumListenerEvent op, InternalCacheEvent event);
+
+  boolean isUsedForPartitionedRegionAdmin();
+
+  ImageState getImageState();
+
+  VersionSource getVersionMember();
+
+  long updateStatsForPut(RegionEntry entry, long lastModified, boolean lruRecentUse);
+
+  FilterProfile getFilterProfile();
+
+  ServerRegionProxy getServerProxy();
+
+  void unscheduleTombstone(RegionEntry entry);
+
+  void scheduleTombstone(RegionEntry entry, VersionTag destroyedVersion);
+
+  boolean isEntryExpiryPossible();
+
+  void addExpiryTaskIfAbsent(RegionEntry entry);
+
+  DM getDistributionManager();
+
+  void generateAndSetVersionTag(InternalCacheEvent event, RegionEntry entry);
+
+  boolean cacheWriteBeforeDestroy(EntryEventImpl event, Object expectedOldValue)
+      throws CacheWriterException, EntryNotFoundException, TimeoutException;
+
+  void recordEvent(InternalCacheEvent event);
+
+  boolean isProxy();
+
+  IndexManager getIndexManager();
+
+  boolean isConcurrencyChecksEnabled();
+
+  boolean isThisRegionBeingClosedOrDestroyed();
+
+  CancelCriterion getCancelCriterion();
+
+  boolean isIndexCreationThread();
+
+  int updateSizeOnEvict(Object key, int oldSize);
+
+  RegionEntry basicGetEntry(Object key);
+
+  void invokePutCallbacks(final EnumListenerEvent eventType, final EntryEventImpl event,
+      final boolean callDispatchListenerEvent, boolean notifyGateways);
+
+  void invokeDestroyCallbacks(final EnumListenerEvent eventType, final EntryEventImpl event,
+      final boolean callDispatchListenerEvent, boolean notifyGateways);
+
+  void invokeInvalidateCallbacks(final EnumListenerEvent eventType, final EntryEventImpl event,
+      final boolean callDispatchListenerEvent);
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
@@ -536,6 +536,7 @@ public class LocalRegion extends AbstractRegion implements InternalRegion, Loade
     return initializingRegion.get();
   }
 
+  @Override
   public CancelCriterion getCancelCriterion() {
     return this.stopper;
   }
@@ -690,6 +691,7 @@ public class LocalRegion extends AbstractRegion implements InternalRegion, Loade
   }
 
   /** returns the regions version-vector */
+  @Override
   public RegionVersionVector getVersionVector() {
     return this.versionVector;
   }
@@ -779,6 +781,7 @@ public class LocalRegion extends AbstractRegion implements InternalRegion, Loade
 
   private final InternalDataView sharedDataView;
 
+  @Override
   public ServerRegionProxy getServerProxy() {
     return this.serverRegionProxy;
   }
@@ -838,6 +841,7 @@ public class LocalRegion extends AbstractRegion implements InternalRegion, Loade
     return this.cache.getInternalDistributedSystem().getDistributedMember();
   }
 
+  @Override
   public VersionSource getVersionMember() {
     if (this.dataPolicy.withPersistence()) {
       return getDiskStore().getDiskStoreID();
@@ -1797,6 +1801,7 @@ public class LocalRegion extends AbstractRegion implements InternalRegion, Loade
    * {@link #isDestroyed()} this method will not return true if the cache is closing but has not yet
    * started closing this region.
    */
+  @Override
   public boolean isThisRegionBeingClosedOrDestroyed() {
     return this.isDestroyed;
   }
@@ -2900,6 +2905,7 @@ public class LocalRegion extends AbstractRegion implements InternalRegion, Loade
    * @return true if cacheWrite was performed
    * @see DistributedRegion#cacheWriteBeforeDestroy(EntryEventImpl, Object)
    */
+  @Override
   public boolean cacheWriteBeforeDestroy(EntryEventImpl event, Object expectedOldValue)
       throws CacheWriterException, EntryNotFoundException, TimeoutException {
     boolean result = false;
@@ -3204,6 +3210,7 @@ public class LocalRegion extends AbstractRegion implements InternalRegion, Loade
     return this.tombstoneCount.get();
   }
 
+  @Override
   public void scheduleTombstone(RegionEntry entry, VersionTag destroyedVersion) {
     scheduleTombstone(entry, destroyedVersion, false);
   }
@@ -3237,6 +3244,7 @@ public class LocalRegion extends AbstractRegion implements InternalRegion, Loade
     scheduleTombstone(entry, version, true);
   }
 
+  @Override
   public void unscheduleTombstone(RegionEntry entry) {
     unscheduleTombstone(entry, true);
   }
@@ -3380,6 +3388,7 @@ public class LocalRegion extends AbstractRegion implements InternalRegion, Loade
    *
    * @since GemFire 3.2
    */
+  @Override
   public Object getValueInVM(Object key) throws EntryNotFoundException {
     return basicGetValueInVM(key, true);
   }
@@ -3450,6 +3459,7 @@ public class LocalRegion extends AbstractRegion implements InternalRegion, Loade
    *
    * @since GemFire 3.2
    */
+  @Override
   public Object getValueOnDisk(Object key) throws EntryNotFoundException {
     // Ok for this to ignore tx state
     RegionEntry re = this.entries.getEntry(key);
@@ -4960,6 +4970,7 @@ public class LocalRegion extends AbstractRegion implements InternalRegion, Loade
   /**
    * invoke callbacks for an invalidation
    */
+  @Override
   public void invokeInvalidateCallbacks(final EnumListenerEvent eventType,
       final EntryEventImpl event, final boolean callDispatchListenerEvent) {
     // Notify bridge clients (if this is a CacheServer)
@@ -5877,6 +5888,7 @@ public class LocalRegion extends AbstractRegion implements InternalRegion, Loade
     }
   }
 
+  @Override
   public void invokePutCallbacks(final EnumListenerEvent eventType, final EntryEventImpl event,
       final boolean callDispatchListenerEvent, boolean notifyGateways) {
 
@@ -5930,6 +5942,7 @@ public class LocalRegion extends AbstractRegion implements InternalRegion, Loade
   /**
    * generate version tag if it does not exist and set it into the event.
    */
+  @Override
   public void generateAndSetVersionTag(InternalCacheEvent event, RegionEntry entry) {
     if (entry != null && event.getOperation().isEntry()) {
       EntryEventImpl entryEvent = (EntryEventImpl) event;
@@ -5947,8 +5960,14 @@ public class LocalRegion extends AbstractRegion implements InternalRegion, Loade
   /**
    * record the event's sequenceId in Region's event state to prevent replay.
    */
+  @Override
   public void recordEvent(InternalCacheEvent event) {
     getEventTracker().recordEvent(event);
+  }
+
+  @Override
+  public boolean isConcurrencyChecksEnabled() {
+    return this.concurrencyChecksEnabled;
   }
 
   /**
@@ -6717,6 +6736,7 @@ public class LocalRegion extends AbstractRegion implements InternalRegion, Loade
     }
   }
 
+  @Override
   public void invokeDestroyCallbacks(final EnumListenerEvent eventType, final EntryEventImpl event,
       final boolean callDispatchListenerEvent, boolean notifyGateways) {
 
@@ -6885,7 +6905,8 @@ public class LocalRegion extends AbstractRegion implements InternalRegion, Loade
     return expTime != 0 && expTime <= cacheTimeMillis();
   }
 
-  void dispatchListenerEvent(EnumListenerEvent op, InternalCacheEvent event) {
+  @Override
+  public void dispatchListenerEvent(EnumListenerEvent op, InternalCacheEvent event) {
     // Return if the inhibit all notifications flag is set
     boolean isEntryEvent = event instanceof EntryEventImpl;
     if (isEntryEvent) {
@@ -7065,6 +7086,7 @@ public class LocalRegion extends AbstractRegion implements InternalRegion, Loade
    *
    * @return the actual lastModifiedTime used.
    */
+  @Override
   public long updateStatsForPut(RegionEntry entry, long lastModified, boolean lruRecentUse) {
     long lastAccessed = cacheTimeMillis();
     if (lruRecentUse) {
@@ -7775,8 +7797,9 @@ public class LocalRegion extends AbstractRegion implements InternalRegion, Loade
     }
   }
 
-  public void addExpiryTaskIfAbsent(RegionEntry re) {
-    addExpiryTask(re, true);
+  @Override
+  public void addExpiryTaskIfAbsent(RegionEntry entry) {
+    addExpiryTask(entry, true);
   }
 
   void addExpiryTask(RegionEntry re) {
@@ -8143,6 +8166,7 @@ public class LocalRegion extends AbstractRegion implements InternalRegion, Loade
   /**
    * get the ImageState for this region
    */
+  @Override
   public ImageState getImageState() {
     return this.imageState;
   }
@@ -8513,6 +8537,7 @@ public class LocalRegion extends AbstractRegion implements InternalRegion, Loade
           return this.currentIterator != null && this.currentIterator.hasNext();
         }
 
+        @Override
         public Object next() {
           return next(false);
         }
@@ -8758,6 +8783,7 @@ public class LocalRegion extends AbstractRegion implements InternalRegion, Loade
   /**
    * For internal use only.
    */
+  @Override
   public RegionMap getRegionMap() {
     // OK to ignore tx state
     return this.entries;
@@ -10222,9 +10248,7 @@ public class LocalRegion extends AbstractRegion implements InternalRegion, Loade
     // nothing needs to be done here since LocalRegion does not have an advisor.
   }
 
-  /**
-   * @return Returns the isUsedForPartitionedRegionAdmin.
-   */
+  @Override
   public boolean isUsedForPartitionedRegionAdmin() {
     return this.isUsedForPartitionedRegionAdmin;
   }
@@ -10488,6 +10512,7 @@ public class LocalRegion extends AbstractRegion implements InternalRegion, Loade
   /**
    * Returns the CQ/interest profile for this region
    */
+  @Override
   public FilterProfile getFilterProfile() {
     return this.filterProfile;
   }
@@ -10697,6 +10722,7 @@ public class LocalRegion extends AbstractRegion implements InternalRegion, Loade
   }
 
   // TODO: return value is never used
+  @Override
   public int updateSizeOnEvict(Object key, int oldSize) {
     // Only needed by BucketRegion
     return 0;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/NonLocalRegionEntry.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/NonLocalRegionEntry.java
@@ -37,7 +37,7 @@ import org.apache.geode.internal.cache.DistributedRegion;
 import org.apache.geode.internal.cache.EntryEventImpl;
 import org.apache.geode.internal.cache.EntrySnapshot;
 import org.apache.geode.internal.cache.InitialImageOperation.Entry;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionClearedException;
 import org.apache.geode.internal.cache.RegionEntry;
 import org.apache.geode.internal.cache.RegionEntryContext;
@@ -60,10 +60,10 @@ public class NonLocalRegionEntry implements RegionEntry, VersionStamp {
    * Create one of these in the local case so that we have a snapshot of the state and can allow the
    * bucket to move out from under us.
    */
-  public NonLocalRegionEntry(RegionEntry re, LocalRegion br, boolean allowTombstones) {
+  public NonLocalRegionEntry(RegionEntry re, InternalRegion br, boolean allowTombstones) {
     this.key = re.getKey();
-    if (allowTombstones && re.isTombstone()) { // client get() operations need to see tombstone
-                                               // values
+    if (allowTombstones && re.isTombstone()) {
+      // client get() operations need to see tombstone values
       this.value = Token.TOMBSTONE;
     } else {
       this.value = re.getValue(br); // OFFHEAP: copy into heap cd
@@ -82,22 +82,18 @@ public class NonLocalRegionEntry implements RegionEntry, VersionStamp {
    * Create one of these in the local case so that we have a snapshot of the state and can allow the
    * bucket to move out from under us.
    */
-  public NonLocalRegionEntry(LocalRegion br, Object key, Object value) {
+  public NonLocalRegionEntry(InternalRegion br, Object key, Object value) {
     this.key = key;
     this.value = value;
     Assert.assertTrue(this.value != Token.NOT_AVAILABLE,
         "getEntry did not fault value in from disk");
-    // this.lastModified = re.getLastModified();
-    // this.isRemoved = re.isRemoved();
   }
-
-
 
   /**
    * Create one of these in the local case so that we have a snapshot of the state and can allow the
    * bucket to move out from under us.
    */
-  public NonLocalRegionEntry(Region.Entry re, LocalRegion br) {
+  public NonLocalRegionEntry(Region.Entry re, InternalRegion br) {
     this.key = re.getKey();
     this.value = re.getValue();
     if (this.value instanceof CachedDeserializable) {
@@ -124,27 +120,33 @@ public class NonLocalRegionEntry implements RegionEntry, VersionStamp {
         + this.versionTag;
   }
 
-  public void makeTombstone(LocalRegion r, VersionTag isOperationRemote) {
+  @Override
+  public void makeTombstone(InternalRegion region, VersionTag version) {
     throw new UnsupportedOperationException();
   }
 
+  @Override
   public boolean dispatchListenerEvents(EntryEventImpl event) {
     throw new UnsupportedOperationException();
   }
 
+  @Override
   public VersionStamp getVersionStamp() {
     return this;
   }
 
+  @Override
   public boolean hasValidVersion() {
     return this.versionTag != null && this.versionTag.hasValidVersion();
   }
 
+  @Override
   public void setVersionTimeStamp(long time) {
     throw new UnsupportedOperationException();
   }
 
-  public void processVersionTag(EntryEvent ev) {
+  @Override
+  public void processVersionTag(EntryEvent event) {
     throw new UnsupportedOperationException();
   }
 
@@ -168,51 +170,63 @@ public class NonLocalRegionEntry implements RegionEntry, VersionStamp {
     this.versionTag = (VersionTag) DataSerializer.readObject(in);
   }
 
+  @Override
   public long getLastModified() {
     return this.lastModified;
   }
 
+  @Override
   public long getLastAccessed() throws StatisticsDisabledException {
     return -1;
   }
 
+  @Override
   public long getHitCount() throws StatisticsDisabledException {
     return -1;
   }
 
+  @Override
   public long getMissCount() throws StatisticsDisabledException {
     return -1;
   }
 
+  @Override
   public boolean isRemoved() {
     return this.isRemoved;
   }
 
+  @Override
   public boolean isRemovedPhase2() {
     return this.isRemoved;
   }
 
+  @Override
   public boolean isTombstone() {
     return false;
   }
 
-  public boolean fillInValue(LocalRegion r, Entry entry, ByteArrayDataInput in, DM mgr,
-      final Version version) {
+  @Override
+  public boolean fillInValue(InternalRegion region, Entry entry, ByteArrayDataInput in,
+      DM distributionManager, final Version version) {
     throw new UnsupportedOperationException(
         LocalizedStrings.PartitionedRegion_NOT_APPROPRIATE_FOR_PARTITIONEDREGIONNONLOCALREGIONENTRY
             .toLocalizedString());
   }
 
-  public boolean isOverflowedToDisk(LocalRegion r, DistributedRegion.DiskPosition dp) {
+  @Override
+  public boolean isOverflowedToDisk(InternalRegion region,
+      DistributedRegion.DiskPosition diskPosition) {
     throw new UnsupportedOperationException(
         LocalizedStrings.PartitionedRegion_NOT_APPROPRIATE_FOR_PARTITIONEDREGIONNONLOCALREGIONENTRY
             .toLocalizedString());
   }
 
+  @Override
   public Object getKey() {
     return this.key;
   }
 
+  @Override
   public Object getValue(RegionEntryContext context) {
     return this.value;
   }
@@ -228,45 +242,53 @@ public class NonLocalRegionEntry implements RegionEntry, VersionStamp {
   }
 
   // now for the fun part
+  @Override
   public void updateStatsForPut(long lastModifiedTime, long lastAccessedTime) {
     throw new UnsupportedOperationException(
         LocalizedStrings.PartitionedRegion_NOT_APPROPRIATE_FOR_PARTITIONEDREGIONNONLOCALREGIONENTRY
             .toLocalizedString());
   }
 
+  @Override
   public void setRecentlyUsed() {
     throw new UnsupportedOperationException(
         LocalizedStrings.PartitionedRegion_NOT_APPROPRIATE_FOR_PARTITIONEDREGIONNONLOCALREGIONENTRY
             .toLocalizedString());
   }
 
+  @Override
   public void updateStatsForGet(boolean hit, long time) throws StatisticsDisabledException {
     // this method has been made a noop to fix bug 37436
   }
 
-  public void txDidDestroy(long currTime) {
+  @Override
+  public void txDidDestroy(long currentTime) {
     throw new UnsupportedOperationException(
         LocalizedStrings.PartitionedRegion_NOT_APPROPRIATE_FOR_PARTITIONEDREGIONNONLOCALREGIONENTRY
             .toLocalizedString());
   }
 
+  @Override
   public void resetCounts() throws StatisticsDisabledException {
     throw new UnsupportedOperationException(
         LocalizedStrings.PartitionedRegion_NOT_APPROPRIATE_FOR_PARTITIONEDREGIONNONLOCALREGIONENTRY
             .toLocalizedString());
   }
 
-  public void removePhase1(LocalRegion r, boolean isClear) {
+  @Override
+  public void removePhase1(InternalRegion region, boolean clear) {
     throw new UnsupportedOperationException(
         LocalizedStrings.PartitionedRegion_NOT_APPROPRIATE_FOR_PARTITIONEDREGIONNONLOCALREGIONENTRY
             .toLocalizedString());
   }
 
+  @Override
   public void removePhase2() {
     throw new UnsupportedOperationException(
         "Not appropriate for PartitionedRegion.NonLocalRegionEntry");
   }
 
+  @Override
   public void setValue(RegionEntryContext context, Object value) {
     throw new UnsupportedOperationException(
         LocalizedStrings.PartitionedRegion_NOT_APPROPRIATE_FOR_PARTITIONEDREGIONNONLOCALREGIONENTRY
@@ -274,7 +296,7 @@ public class NonLocalRegionEntry implements RegionEntry, VersionStamp {
   }
 
   @Override
-  public Object _getValue() {
+  public Object getValue() {
     throw new UnsupportedOperationException(
         LocalizedStrings.PartitionedRegion_NOT_APPROPRIATE_FOR_PARTITIONEDREGIONNONLOCALREGIONENTRY
             .toLocalizedString());
@@ -288,7 +310,7 @@ public class NonLocalRegionEntry implements RegionEntry, VersionStamp {
   }
 
   @Override
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(RegionEntryContext context, boolean decompress) {
     throw new UnsupportedOperationException(
         LocalizedStrings.PartitionedRegion_NOT_APPROPRIATE_FOR_PARTITIONEDREGIONNONLOCALREGIONENTRY
             .toLocalizedString());
@@ -301,31 +323,36 @@ public class NonLocalRegionEntry implements RegionEntry, VersionStamp {
             .toLocalizedString());
   }
 
+  @Override
   public Object getValueInVM(RegionEntryContext context) {
     return this.value;
   }
 
-  public Object getValueOnDisk(LocalRegion r) throws EntryNotFoundException {
+  @Override
+  public Object getValueOnDisk(InternalRegion region) throws EntryNotFoundException {
     throw new UnsupportedOperationException(
         LocalizedStrings.PartitionedRegion_NOT_APPROPRIATE_FOR_PARTITIONEDREGIONNONLOCALREGIONENTRY
             .toLocalizedString());
   }
 
-  public boolean initialImagePut(LocalRegion region, long lastModified1, Object newValue,
-      boolean wasRecovered, boolean versionTagAccepted) {
+  @Override
+  public boolean initialImagePut(InternalRegion region, long lastModified, Object newValue,
+      boolean wasRecovered, boolean acceptedVersionTag) {
     throw new UnsupportedOperationException(
         LocalizedStrings.PartitionedRegion_NOT_APPROPRIATE_FOR_PARTITIONEDREGIONNONLOCALREGIONENTRY
             .toLocalizedString());
   }
 
-  public boolean initialImageInit(LocalRegion region, long lastModified1, Object newValue,
-      boolean create, boolean wasRecovered, boolean versionTagAccepted) {
+  @Override
+  public boolean initialImageInit(InternalRegion region, long lastModified, Object newValue,
+      boolean create, boolean wasRecovered, boolean acceptedVersionTag) {
     throw new UnsupportedOperationException(
         LocalizedStrings.PartitionedRegion_NOT_APPROPRIATE_FOR_PARTITIONEDREGIONNONLOCALREGIONENTRY
             .toLocalizedString());
   }
 
-  public boolean destroy(LocalRegion region, EntryEventImpl event, boolean inTokenMode,
+  @Override
+  public boolean destroy(InternalRegion region, EntryEventImpl event, boolean inTokenMode,
       boolean cacheWrite, Object expectedOldValue, boolean forceDestroy,
       boolean removeRecoveredEntry)
       throws CacheWriterException, EntryNotFoundException, TimeoutException {
@@ -334,48 +361,47 @@ public class NonLocalRegionEntry implements RegionEntry, VersionStamp {
             .toLocalizedString());
   }
 
+  @Override
   public boolean getValueWasResultOfSearch() {
     throw new UnsupportedOperationException(
         LocalizedStrings.PartitionedRegion_NOT_APPROPRIATE_FOR_PARTITIONEDREGIONNONLOCALREGIONENTRY
             .toLocalizedString());
   }
 
-  public void setValueResultOfSearch(boolean v) {
+  @Override
+  public void setValueResultOfSearch(boolean value) {
     throw new UnsupportedOperationException(
         LocalizedStrings.PartitionedRegion_NOT_APPROPRIATE_FOR_PARTITIONEDREGIONNONLOCALREGIONENTRY
             .toLocalizedString());
   }
 
-  /*
-   * (non-Javadoc)
-   * 
-   * @see
-   * org.apache.geode.internal.cache.RegionEntry#getValueOnDiskOrBuffer(org.apache.geode.internal.
-   * cache.LocalRegion)
-   */
-  public Object getValueOnDiskOrBuffer(LocalRegion r) throws EntryNotFoundException {
+  @Override
+  public Object getValueOnDiskOrBuffer(InternalRegion region) throws EntryNotFoundException {
     throw new UnsupportedOperationException(
         LocalizedStrings.PartitionedRegion_NOT_APPROPRIATE_FOR_PARTITIONEDREGIONNONLOCALREGIONENTRY
             .toLocalizedString());
   }
 
-  public Object getSerializedValueOnDisk(LocalRegion localRegion) {
+  @Override
+  public Object getSerializedValueOnDisk(InternalRegion region) {
     throw new UnsupportedOperationException(
         LocalizedStrings.PartitionedRegion_NOT_APPROPRIATE_FOR_PARTITIONEDREGIONNONLOCALREGIONENTRY
             .toLocalizedString());
   }
 
 
+  @Override
   public boolean hasStats() {
     return false;
   }
 
-  public Object getValueInVMOrDiskWithoutFaultIn(LocalRegion owner) {
+  @Override
+  public Object getValueInVMOrDiskWithoutFaultIn(InternalRegion region) {
     return this.value;
   }
 
   @Override
-  public Object getValueOffHeapOrDiskWithoutFaultIn(LocalRegion owner) {
+  public Object getValueOffHeapOrDiskWithoutFaultIn(InternalRegion region) {
     return this.value;
   }
 
@@ -383,41 +409,18 @@ public class NonLocalRegionEntry implements RegionEntry, VersionStamp {
     this.key = key2;
   }
 
-  // VersionStamp methods ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-  /*
-   * (non-Javadoc)
-   * 
-   * @see
-   * org.apache.geode.internal.cache.RegionEntry#generateVersionTag(org.apache.geode.distributed.
-   * DistributedMember, boolean)
-   */
-  public VersionTag generateVersionTag(VersionSource member, boolean withDelta, LocalRegion region,
-      EntryEventImpl event) {
+  @Override
+  public VersionTag generateVersionTag(VersionSource member, boolean withDelta,
+      InternalRegion region, EntryEventImpl event) {
     throw new UnsupportedOperationException(); // no text needed - not a customer visible method
   }
 
-
-  /*
-   * (non-Javadoc)
-   * 
-   * @see
-   * org.apache.geode.internal.cache.RegionEntry#concurrencyCheck(org.apache.geode.internal.cache.
-   * LocalRegion, org.apache.geode.internal.cache.versions.VersionTag,
-   * org.apache.geode.distributed.internal.membership.InternalDistributedMember,
-   * org.apache.geode.distributed.internal.membership.InternalDistributedMember)
-   */
-  public void processVersionTag(LocalRegion r, VersionTag tag, InternalDistributedMember thisVM,
+  public void processVersionTag(InternalRegion r, VersionTag tag, InternalDistributedMember thisVM,
       InternalDistributedMember sender) {
     throw new UnsupportedOperationException();
   }
 
-
-  /*
-   * (non-Javadoc)
-   * 
-   * @see org.apache.geode.internal.cache.versions.VersionStamp#getEntryVersion()
-   */
+  @Override
   public int getEntryVersion() {
     if (this.versionTag != null) {
       return this.versionTag.getEntryVersion();
@@ -425,6 +428,7 @@ public class NonLocalRegionEntry implements RegionEntry, VersionStamp {
     return 0;
   }
 
+  @Override
   public long getRegionVersion() {
     if (this.versionTag != null) {
       return this.versionTag.getRegionVersion();
@@ -432,11 +436,7 @@ public class NonLocalRegionEntry implements RegionEntry, VersionStamp {
     return 0;
   }
 
-  /*
-   * (non-Javadoc)
-   * 
-   * @see org.apache.geode.internal.cache.versions.VersionStamp#getMemberID()
-   */
+  @Override
   public VersionSource getMemberID() {
     if (this.versionTag != null) {
       return this.versionTag.getMemberID();
@@ -444,6 +444,7 @@ public class NonLocalRegionEntry implements RegionEntry, VersionStamp {
     return null;
   }
 
+  @Override
   public int getDistributedSystemId() {
     if (this.versionTag != null) {
       return this.versionTag.getDistributedSystemId();
@@ -451,81 +452,45 @@ public class NonLocalRegionEntry implements RegionEntry, VersionStamp {
     return -1;
   }
 
-
-  /*
-   * (non-Javadoc)
-   * 
-   * @see org.apache.geode.internal.cache.versions.VersionStamp#setEntryVersion(int)
-   */
+  @Override
   public void setVersions(VersionTag tag) {
     throw new UnsupportedOperationException();
   }
 
-
-  /*
-   * (non-Javadoc)
-   * 
-   * @see
-   * org.apache.geode.internal.cache.versions.VersionStamp#setMemberID(org.apache.geode.distributed.
-   * DistributedMember)
-   */
+  @Override
   public void setMemberID(VersionSource memberID) {
     throw new UnsupportedOperationException();
   }
 
-
-  /*
-   * (non-Javadoc)
-   * 
-   * @see
-   * org.apache.geode.internal.cache.versions.VersionStamp#setPreviousMemberID(org.apache.geode.
-   * distributed.DistributedMember)
-   */
   public void setPreviousMemberID(DistributedMember previousMemberID) {
     throw new UnsupportedOperationException();
   }
 
-
-  /*
-   * (non-Javadoc)
-   * 
-   * @see org.apache.geode.internal.cache.versions.VersionStamp#asVersionTag()
-   */
+  @Override
   public VersionTag asVersionTag() {
     return this.versionTag;
   }
 
-
-  /*
-   * (non-Javadoc)
-   * 
-   * @see org.apache.geode.internal.cache.versions.VersionStamp#processVersionTag(org.apache.geode.
-   * internal.cache.LocalRegion, org.apache.geode.internal.cache.versions.VersionTag, boolean,
-   * org.apache.geode.distributed.internal.membership.InternalDistributedMember,
-   * org.apache.geode.distributed.internal.membership.InternalDistributedMember)
-   */
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
+  @Override
+  public void processVersionTag(InternalRegion region, VersionTag tag, boolean isTombstoneFromGII,
+      boolean hasDelta, VersionSource versionSource, InternalDistributedMember sender,
+      boolean checkConflicts) {
     throw new UnsupportedOperationException();
   }
 
-  /*
-   * (non-Javadoc)
-   * 
-   * @see org.apache.geode.internal.cache.versions.VersionStamp#getVersionTimeStamp()
-   */
   @Override
   public long getVersionTimeStamp() {
     return this.versionTag != null ? this.versionTag.getVersionTimeStamp() : 0;
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.versionTag != null ? this.versionTag.getRegionVersionHighBytes() : 0;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.versionTag != null ? this.versionTag.getRegionVersionLowBytes() : 0;
   }
@@ -631,24 +596,33 @@ public class NonLocalRegionEntry implements RegionEntry, VersionStamp {
   }
 
   @Override
-  public void setInUseByTransaction(boolean v) {}
+  public void setInUseByTransaction(boolean inUseByTransaction) {
+    // nothing
+  }
 
   @Override
-  public void incRefCount() {}
+  public void incRefCount() {
+    // nothing
+  }
 
   @Override
-  public void decRefCount(NewLRUClockHand lruList, LocalRegion lr) {}
+  public void decRefCount(NewLRUClockHand lruList, InternalRegion region) {
+    // nothing
+  }
 
   @Override
-  public void resetRefCount(NewLRUClockHand lruList) {}
+  public void resetRefCount(NewLRUClockHand lruList) {
+    // nothing
+  }
 
   @Override
-  public Object prepareValueForCache(RegionEntryContext r, Object val, boolean isEntryUpdate) {
+  public Object prepareValueForCache(RegionEntryContext context, Object value,
+      boolean isEntryUpdate) {
     throw new IllegalStateException("Should never be called");
   }
 
   @Override
-  public Object prepareValueForCache(RegionEntryContext r, Object val, EntryEventImpl event,
+  public Object prepareValueForCache(RegionEntryContext context, Object value, EntryEventImpl event,
       boolean isEntryUpdate) {
     throw new IllegalStateException("Should never be called");
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/Oplog.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/Oplog.java
@@ -1270,7 +1270,8 @@ public class Oplog implements CompactableOplog, Flushable {
    *        present. @param faultingIn @param bitOnly boolean indicating whether to extract just the
    *        UserBit or UserBit with value @return BytesAndBits object wrapping the value & user bit
    */
-  public BytesAndBits getBytesAndBits(DiskRegionView dr, DiskId id, boolean faultingIn,
+  @Override
+  public BytesAndBits getBytesAndBits(DiskRegionView dr, DiskId id, boolean faultIn,
       boolean bitOnly) {
     Oplog retryOplog = null;
     long offset = 0;
@@ -1286,7 +1287,7 @@ public class Oplog implements CompactableOplog, Flushable {
       }
     }
     if (retryOplog != null) {
-      return retryOplog.getBytesAndBits(dr, id, faultingIn, bitOnly);
+      return retryOplog.getBytesAndBits(dr, id, faultIn, bitOnly);
     }
     BytesAndBits bb = null;
     long start = this.stats.startRead();
@@ -1335,6 +1336,7 @@ public class Oplog implements CompactableOplog, Flushable {
    * 
    * @param id A DiskId object for which the value on disk will be fetched
    */
+  @Override
   public BytesAndBits getNoBuffer(DiskRegion dr, DiskId id) {
     if (logger.isDebugEnabled()) {
       logger.debug("Oplog::getNoBuffer:Before invoking Oplog.basicGet for DiskID ={}", id);
@@ -3505,7 +3507,7 @@ public class Oplog implements CompactableOplog, Flushable {
    * @param entry The DiskEntry object for this key/value pair.
    * @param value byte array representing the value
    */
-  public void create(LocalRegion region, DiskEntry entry, ValueWrapper value, boolean async) {
+  public void create(InternalRegion region, DiskEntry entry, ValueWrapper value, boolean async) {
 
     if (this != getOplogSet().getChild()) {
       getOplogSet().getChild().create(region, entry, value, async);
@@ -3820,6 +3822,7 @@ public class Oplog implements CompactableOplog, Flushable {
       // RAF
       // as needed.
       getParent().executeDelayedExpensiveWrite(new Runnable() {
+        @Override
         public void run() {
           // need to truncate crf and drf if their actual size is less than
           // their pregrow size
@@ -3871,6 +3874,7 @@ public class Oplog implements CompactableOplog, Flushable {
    */
   protected void createKrfAsync() {
     getParent().executeDiskStoreTask(new Runnable() {
+      @Override
       public void run() {
         createKrf(false);
       }
@@ -4118,7 +4122,6 @@ public class Oplog implements CompactableOplog, Flushable {
 
       allClosed = true;
     } catch (IOException e) {
-      // TODO Auto-generated catch block
       if (getParent().getDiskAccessException() == null) {
         throw new DiskAccessException("Fail to close krf file " + this.krf.f, e, getParent());
       } else {
@@ -4210,14 +4213,13 @@ public class Oplog implements CompactableOplog, Flushable {
               CacheObserverHolder.getInstance().afterKrfCreated();
             }
           } catch (FileNotFoundException ex) {
-            // TODO handle exception; we couldn't open the krf file
+            // we couldn't open the krf file
             throw new IllegalStateException("could not create krf " + this.krf.f, ex);
           } catch (IOException ex) {
-            // TODO handle io exceptions; we failed to write to the file
+            // we failed to write to the file
             throw new IllegalStateException("failed writing krf " + this.krf.f, ex);
           } finally {
-            // if IOException happened in writeOneKeyEntryForKRF(), delete krf
-            // here
+            // if IOException happened in writeOneKeyEntryForKRF(), delete krf here
             if (!krfCreateSuccess) {
               closeAndDeleteKrf();
             }
@@ -4252,6 +4254,7 @@ public class Oplog implements CompactableOplog, Flushable {
     }
     // idx is now the length of sortedLiveEntries
     Arrays.sort(sortedLiveEntries, 0, idx, new Comparator<KRFEntry>() {
+      @Override
       public int compare(KRFEntry o1, KRFEntry o2) {
         long val1 = o1.getOffsetInOplogForSorting();
         long val2 = o2.getOffsetInOplogForSorting();
@@ -4283,7 +4286,7 @@ public class Oplog implements CompactableOplog, Flushable {
     ReferenceCountHelper.skipRefCountTracking();
     @Retained
     @Released
-    Object value = entry._getValueRetain(dr, true);
+    Object value = entry.getValueRetain(dr, true);
     ReferenceCountHelper.unskipRefCountTracking();
     boolean foundData = false;
     if (value == null) {
@@ -4427,7 +4430,7 @@ public class Oplog implements CompactableOplog, Flushable {
    * 
    * @param value byte array representing the value
    */
-  public void modify(LocalRegion region, DiskEntry entry, ValueWrapper value, boolean async) {
+  public void modify(InternalRegion region, DiskEntry entry, ValueWrapper value, boolean async) {
     if (getOplogSet().getChild() != this) {
       getOplogSet().getChild().modify(region, entry, value, async);
     } else {
@@ -4506,7 +4509,7 @@ public class Oplog implements CompactableOplog, Flushable {
     }
   }
 
-  public void saveConflictVersionTag(LocalRegion region, VersionTag tag, boolean async) {
+  public void saveConflictVersionTag(InternalRegion region, VersionTag tag, boolean async) {
     if (getOplogSet().getChild() != this) {
       getOplogSet().getChild().saveConflictVersionTag(region, tag, async);
     } else {
@@ -4910,7 +4913,7 @@ public class Oplog implements CompactableOplog, Flushable {
    * 
    * @param entry DiskEntry object on which remove operation is called
    */
-  public void remove(LocalRegion region, DiskEntry entry, boolean async, boolean isClear) {
+  public void remove(InternalRegion region, DiskEntry entry, boolean async, boolean isClear) {
     DiskRegion dr = region.getDiskRegion();
     if (getOplogSet().getChild() != this) {
       getOplogSet().getChild().remove(region, entry, async, isClear);
@@ -5168,13 +5171,13 @@ public class Oplog implements CompactableOplog, Flushable {
   }
 
   @Override
-  public void flush(ByteBuffer b1, ByteBuffer b2) throws IOException {
-    if (b1 == this.drf.writeBuf) {
-      flush(this.drf, b1, b2);
+  public void flush(ByteBuffer bb, ByteBuffer chunkbb) throws IOException {
+    if (bb == this.drf.writeBuf) {
+      flush(this.drf, bb, chunkbb);
       flush(this.crf, false);
     } else {
       flush(this.drf, false);
-      flush(this.crf, b1, b2);
+      flush(this.crf, bb, chunkbb);
     }
   }
 
@@ -5729,6 +5732,7 @@ public class Oplog implements CompactableOplog, Flushable {
         return;
       }
       getParent().executeDelayedExpensiveWrite(new Runnable() {
+        @Override
         public void run() {
           if (!krf.delete()) {
             if (krf.exists()) {
@@ -5795,6 +5799,7 @@ public class Oplog implements CompactableOplog, Flushable {
       // bounded
       // queue
       getParent().executeDelayedExpensiveWrite(new Runnable() {
+        @Override
         public void run() {
           if (!olf.f.delete() && olf.f.exists()) {
             logger.warn(LocalizedMessage.create(LocalizedStrings.Oplog_DELETE_FAIL_0_1_2,
@@ -5972,6 +5977,7 @@ public class Oplog implements CompactableOplog, Flushable {
         } else {
           // schedule another thread to do it
           getParent().executeDiskStoreTask(new Runnable() {
+            @Override
             public void run() {
               handleEmptyAndOldest(false);
             }
@@ -5984,6 +5990,7 @@ public class Oplog implements CompactableOplog, Flushable {
         } else {
           // schedule another thread to do it
           getParent().executeDiskStoreTask(new Runnable() {
+            @Override
             public void run() {
               handleEmpty(false);
             }
@@ -6036,6 +6043,7 @@ public class Oplog implements CompactableOplog, Flushable {
     }
   }
 
+  @Override
   public void prepareForCompact() {
     this.compacting = true;
   }
@@ -6054,6 +6062,7 @@ public class Oplog implements CompactableOplog, Flushable {
    * Copy any live entries last stored in this oplog to the current oplog. No need to copy deletes
    * in the drf. Backup only needs them until all the older crfs are empty.
    */
+  @Override
   public int compact(OplogCompactor compactor) {
     if (!needsCompaction()) {
       return 0; // @todo check new logic that deals with not compacting oplogs
@@ -6884,18 +6893,22 @@ public class Oplog implements CompactableOplog, Flushable {
     private DiskEntry next = this;
     private DiskEntry prev = this;
 
+    @Override
     public synchronized DiskEntry getPrev() {
       return this.prev;
     }
 
+    @Override
     public synchronized void setPrev(DiskEntry v) {
       this.prev = v;
     }
 
+    @Override
     public synchronized DiskEntry getNext() {
       return this.next;
     }
 
+    @Override
     public synchronized void setNext(DiskEntry v) {
       this.next = v;
     }
@@ -7000,7 +7013,7 @@ public class Oplog implements CompactableOplog, Flushable {
     }
 
     @Override
-    public Object _getValue() {
+    public Object getValue() {
       throw new IllegalStateException();
     }
 
@@ -7015,12 +7028,13 @@ public class Oplog implements CompactableOplog, Flushable {
     }
 
     @Override
-    public Object prepareValueForCache(RegionEntryContext r, Object val, boolean isEntryUpdate) {
+    public Object prepareValueForCache(RegionEntryContext context, Object value,
+        boolean isEntryUpdate) {
       throw new IllegalStateException("Should never be called");
     }
 
     @Override
-    public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+    public Object getValueRetain(RegionEntryContext context, boolean decompress) {
       throw new IllegalStateException();
     }
 
@@ -7033,10 +7047,12 @@ public class Oplog implements CompactableOplog, Flushable {
       throw new IllegalStateException();
     }
 
+    @Override
     public DiskId getDiskId() {
       throw new IllegalStateException();
     }
 
+    @Override
     public long getLastModified() {
       throw new IllegalStateException();
     }
@@ -7045,14 +7061,17 @@ public class Oplog implements CompactableOplog, Flushable {
       throw new IllegalStateException();
     }
 
+    @Override
     public boolean isValueNull() {
       throw new IllegalStateException();
     }
 
+    @Override
     public boolean isRemovedFromDisk() {
       throw new IllegalStateException();
     }
 
+    @Override
     public int updateAsyncEntrySize(EnableLRU capacityController) {
       throw new IllegalStateException();
     }
@@ -7094,115 +7113,104 @@ public class Oplog implements CompactableOplog, Flushable {
 
     @Override
     public boolean hasStats() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public long getLastAccessed() throws InternalStatisticsDisabledException {
-      // TODO Auto-generated method stub
       return 0;
     }
 
     @Override
     public long getHitCount() throws InternalStatisticsDisabledException {
-      // TODO Auto-generated method stub
       return 0;
     }
 
     @Override
     public long getMissCount() throws InternalStatisticsDisabledException {
-      // TODO Auto-generated method stub
       return 0;
     }
 
     @Override
     public void updateStatsForPut(long lastModifiedTime, long lastAccessedTime) {
-      // TODO Auto-generated method stub
+      // nothing
     }
 
     @Override
     public VersionTag generateVersionTag(VersionSource member, boolean withDelta,
-        LocalRegion region, EntryEventImpl event) {
-      // TODO Auto-generated method stub
+        InternalRegion region, EntryEventImpl event) {
       return null;
     }
 
     @Override
     public boolean dispatchListenerEvents(EntryEventImpl event) throws InterruptedException {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public void setRecentlyUsed() {
-      // TODO Auto-generated method stub
+      // nothing
     }
 
     @Override
     public void updateStatsForGet(boolean hit, long time) {
-      // TODO Auto-generated method stub
+      // nothing
     }
 
     @Override
-    public void txDidDestroy(long currTime) {
-      // TODO Auto-generated method stub
+    public void txDidDestroy(long currentTime) {
+      // nothing
     }
 
     @Override
     public void resetCounts() throws InternalStatisticsDisabledException {
-      // TODO Auto-generated method stub
+      // nothing
     }
 
     @Override
-    public void makeTombstone(LocalRegion r, VersionTag version) throws RegionClearedException {
-      // TODO Auto-generated method stub
+    public void makeTombstone(InternalRegion region, VersionTag version)
+        throws RegionClearedException {
+      // nothing
     }
 
     @Override
-    public void removePhase1(LocalRegion r, boolean clear) throws RegionClearedException {
-      // TODO Auto-generated method stub
+    public void removePhase1(InternalRegion region, boolean clear) throws RegionClearedException {
+      // nothing
     }
 
     @Override
     public void removePhase2() {
-      // TODO Auto-generated method stub
+      // nothing
     }
 
     @Override
     public boolean isRemoved() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public boolean isRemovedPhase2() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public boolean isTombstone() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
-    public boolean fillInValue(LocalRegion r, InitialImageOperation.Entry entry,
-        ByteArrayDataInput in, DM mgr, final Version version) {
-      // TODO Auto-generated method stub
+    public boolean fillInValue(InternalRegion region, InitialImageOperation.Entry entry,
+        ByteArrayDataInput in, DM distributionManager, final Version version) {
       return false;
     }
 
     @Override
-    public boolean isOverflowedToDisk(LocalRegion r, DiskPosition dp) {
-      // TODO Auto-generated method stub
+    public boolean isOverflowedToDisk(InternalRegion region, DiskPosition diskPosition) {
       return false;
     }
 
     @Override
     public Object getValue(RegionEntryContext context) {
-      // TODO Auto-generated method stub
       return null;
     }
 
@@ -7213,153 +7221,134 @@ public class Oplog implements CompactableOplog, Flushable {
 
     @Override
     public void setValue(RegionEntryContext context, Object value) throws RegionClearedException {
-      // TODO Auto-generated method stub
+      // nothing
     }
 
     @Override
     public void setValueWithTombstoneCheck(Object value, EntryEvent event)
         throws RegionClearedException {
-      // TODO Auto-generated method stub
+      // nothing
     }
 
     @Override
     public Object getTransformedValue() {
-      // TODO Auto-generated method stub
       return null;
     }
 
     @Override
     public Object getValueInVM(RegionEntryContext context) {
-      // TODO Auto-generated method stub
       return null;
     }
 
     @Override
-    public Object getValueOnDisk(LocalRegion r) throws EntryNotFoundException {
-      // TODO Auto-generated method stub
+    public Object getValueOnDisk(InternalRegion region) throws EntryNotFoundException {
       return null;
     }
 
     @Override
-    public Object getValueOnDiskOrBuffer(LocalRegion r) throws EntryNotFoundException {
-      // TODO Auto-generated method stub
+    public Object getValueOnDiskOrBuffer(InternalRegion region) throws EntryNotFoundException {
       return null;
     }
 
     @Override
-    public boolean initialImagePut(LocalRegion region, long lastModified, Object newValue,
+    public boolean initialImagePut(InternalRegion region, long lastModified, Object newValue,
         boolean wasRecovered, boolean acceptedVersionTag) throws RegionClearedException {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
-    public boolean initialImageInit(LocalRegion region, long lastModified, Object newValue,
+    public boolean initialImageInit(InternalRegion region, long lastModified, Object newValue,
         boolean create, boolean wasRecovered, boolean acceptedVersionTag)
         throws RegionClearedException {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
-    public boolean destroy(LocalRegion region, EntryEventImpl event, boolean inTokenMode,
+    public boolean destroy(InternalRegion region, EntryEventImpl event, boolean inTokenMode,
         boolean cacheWrite, Object expectedOldValue, boolean forceDestroy,
         boolean removeRecoveredEntry) throws CacheWriterException, EntryNotFoundException,
         TimeoutException, RegionClearedException {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public boolean getValueWasResultOfSearch() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
-    public void setValueResultOfSearch(boolean v) {
-      // TODO Auto-generated method stub
+    public void setValueResultOfSearch(boolean value) {
+      // nothing
     }
 
     @Override
-    public Object getSerializedValueOnDisk(LocalRegion localRegion) {
-      // TODO Auto-generated method stub
+    public Object getSerializedValueOnDisk(InternalRegion region) {
       return null;
     }
 
     @Override
-    public Object getValueInVMOrDiskWithoutFaultIn(LocalRegion owner) {
-      // TODO Auto-generated method stub
+    public Object getValueInVMOrDiskWithoutFaultIn(InternalRegion region) {
       return null;
     }
 
     @Override
-    public Object getValueOffHeapOrDiskWithoutFaultIn(LocalRegion owner) {
-      // TODO Auto-generated method stub
+    public Object getValueOffHeapOrDiskWithoutFaultIn(InternalRegion region) {
       return null;
     }
 
     @Override
     public boolean isUpdateInProgress() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public void setUpdateInProgress(boolean underUpdate) {
-      // TODO Auto-generated method stub
+      // nothing
     }
 
     @Override
     public boolean isInvalid() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public boolean isDestroyed() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public boolean isDestroyedOrRemoved() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public boolean isDestroyedOrRemovedButNotTombstone() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public boolean isInvalidOrRemoved() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public void setValueToNull() {
-      // TODO Auto-generated method stub
+      // nothing
     }
 
     @Override
     public void returnToPool() {
-      // TODO Auto-generated method stub
+      // nothing
     }
 
     @Override
     public boolean isCacheListenerInvocationInProgress() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public void setCacheListenerInvocationInProgress(boolean isListenerInvoked) {
-      // TODO Auto-generated method stub
-
+      // nothing
     }
 
     @Override
@@ -7372,20 +7361,28 @@ public class Oplog implements CompactableOplog, Flushable {
     }
 
     @Override
-    public void setInUseByTransaction(boolean v) {}
+    public void setInUseByTransaction(boolean inUseByTransaction) {
+      // nothing
+    }
 
     @Override
-    public void incRefCount() {}
+    public void incRefCount() {
+      // nothing
+    }
 
     @Override
-    public void decRefCount(NewLRUClockHand lruList, LocalRegion lr) {}
+    public void decRefCount(NewLRUClockHand lruList, InternalRegion region) {
+      // nothing
+    }
 
     @Override
-    public void resetRefCount(NewLRUClockHand lruList) {}
+    public void resetRefCount(NewLRUClockHand lruList) {
+      // nothing
+    }
 
     @Override
-    public Object prepareValueForCache(RegionEntryContext r, Object val, EntryEventImpl event,
-        boolean isEntryUpdate) {
+    public Object prepareValueForCache(RegionEntryContext context, Object value,
+        EntryEventImpl event, boolean isEntryUpdate) {
       throw new IllegalStateException("Should never be called");
     }
 
@@ -7439,20 +7436,26 @@ public class Oplog implements CompactableOplog, Flushable {
       this.dr = dr;
     }
 
+    @Override
     public abstract void addLive(DiskEntry de);
 
+    @Override
     public abstract DiskEntry getNextLiveEntry();
 
+    @Override
     public abstract long clear(RegionVersionVector rvv);
 
+    @Override
     public DiskRegionView getDiskRegion() {
       return this.dr;
     }
 
+    @Override
     public void setDiskRegion(DiskRegionView dr) {
       this.dr = dr;
     }
 
+    @Override
     synchronized public boolean testAndSetUnrecovered() {
       boolean result = !this.unrecovered;
       if (result) {
@@ -7462,10 +7465,12 @@ public class Oplog implements CompactableOplog, Flushable {
       return result;
     }
 
+    @Override
     synchronized public boolean getUnrecovered() {
       return this.unrecovered;
     }
 
+    @Override
     synchronized public boolean testAndSetRecovered(DiskRegionView dr) {
       boolean result = this.unrecovered;
       if (result) {
@@ -7511,11 +7516,13 @@ public class Oplog implements CompactableOplog, Flushable {
       return this.liveCount.getAndSet(0);
     }
 
+    @Override
     public int addLiveEntriesToList(KRFEntry[] liveEntries, int idx) {
       // nothing needed since no linked list
       return idx;
     }
 
+    @Override
     public void afterKrfCreated() {
       // do nothing
     }
@@ -7558,10 +7565,10 @@ public class Oplog implements CompactableOplog, Flushable {
     }
 
     @Override
-    public void update(DiskEntry de) {
-      if (pendingKrfTags != null && de.getVersionStamp() != null) {
+    public void update(DiskEntry entry) {
+      if (pendingKrfTags != null && entry.getVersionStamp() != null) {
         // Remember the version tag of the entry as it was written to the crf.
-        pendingKrfTags.put(de, new CompactVersionHolder(de.getVersionStamp()));
+        pendingKrfTags.put(entry, new CompactVersionHolder(entry.getVersionStamp()));
       }
     }
 
@@ -7619,6 +7626,7 @@ public class Oplog implements CompactableOplog, Flushable {
       return result;
     }
 
+    @Override
     public int addLiveEntriesToList(KRFEntry[] liveEntries, int idx) {
       synchronized (liveEntries) {
         return this.liveEntries.addLiveEntriesToList(liveEntries, idx, getDiskRegion(),
@@ -7626,6 +7634,7 @@ public class Oplog implements CompactableOplog, Flushable {
       }
     }
 
+    @Override
     public void afterKrfCreated() {
       synchronized (liveEntries) {
         this.pendingKrfTags = null;
@@ -7831,13 +7840,14 @@ public class Oplog implements CompactableOplog, Flushable {
     }
 
     @Override
-    public boolean equals(Object other) {
-      if (!(other instanceof RawByteKey)) {
+    public boolean equals(Object obj) {
+      if (!(obj instanceof RawByteKey)) {
         return false;
       }
-      return Arrays.equals(this.bytes, ((RawByteKey) other).bytes);
+      return Arrays.equals(this.bytes, ((RawByteKey) obj).bytes);
     }
 
+    @Override
     public void sendTo(DataOutput out) throws IOException {
       out.write(this.bytes);
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/OplogSet.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/OplogSet.java
@@ -20,11 +20,11 @@ import org.apache.geode.internal.cache.entries.DiskEntry.Helper.ValueWrapper;
 public interface OplogSet {
 
 
-  public void create(LocalRegion region, DiskEntry entry, ValueWrapper value, boolean async);
+  public void create(InternalRegion region, DiskEntry entry, ValueWrapper value, boolean async);
 
-  public void modify(LocalRegion region, DiskEntry entry, ValueWrapper value, boolean async);
+  public void modify(InternalRegion region, DiskEntry entry, ValueWrapper value, boolean async);
 
   public CompactableOplog getChild(long oplogId);
 
-  public void remove(LocalRegion region, DiskEntry entry, boolean async, boolean isClear);
+  public void remove(InternalRegion region, DiskEntry entry, boolean async, boolean isClear);
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
@@ -7699,7 +7699,7 @@ public class PartitionedRegion extends LocalRegion
   }
 
   @Override
-  void dispatchListenerEvent(EnumListenerEvent op, InternalCacheEvent event) {
+  public void dispatchListenerEvent(EnumListenerEvent op, InternalCacheEvent event) {
     // don't dispatch the event if the interest policy forbids it
     if (hasListener()) {
       if (event.getOperation().isEntry()) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PersistentOplogSet.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PersistentOplogSet.java
@@ -179,12 +179,12 @@ public class PersistentOplogSet implements OplogSet {
   }
 
   @Override
-  public void create(LocalRegion region, DiskEntry entry, ValueWrapper value, boolean async) {
+  public void create(InternalRegion region, DiskEntry entry, ValueWrapper value, boolean async) {
     getChild().create(region, entry, value, async);
   }
 
   @Override
-  public void modify(LocalRegion region, DiskEntry entry, ValueWrapper value, boolean async) {
+  public void modify(InternalRegion region, DiskEntry entry, ValueWrapper value, boolean async) {
     getChild().modify(region, entry, value, async);
   }
 
@@ -194,7 +194,7 @@ public class PersistentOplogSet implements OplogSet {
   }
 
   @Override
-  public void remove(LocalRegion region, DiskEntry entry, boolean async, boolean isClear) {
+  public void remove(InternalRegion region, DiskEntry entry, boolean async, boolean isClear) {
     getChild().remove(region, entry, async, isClear);
   }
 
@@ -1035,9 +1035,6 @@ public class PersistentOplogSet implements OplogSet {
 
   /**
    * Add compactable oplogs to the list, up to the maximum size.
-   * 
-   * @param l
-   * @param max
    */
   public void getCompactableOplogs(List<CompactableOplog> l, int max) {
     synchronized (this.oplogIdToOplog) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/ProxyRegionMap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/ProxyRegionMap.java
@@ -69,34 +69,42 @@ class ProxyRegionMap implements RegionMap {
 
   private final Attributes attr;
 
+  @Override
   public RegionEntryFactory getEntryFactory() {
     throw new UnsupportedOperationException();
   }
 
+  @Override
   public Attributes getAttributes() {
     return this.attr;
   }
 
+  @Override
   public void setOwner(Object r) {
     throw new UnsupportedOperationException();
   }
 
+  @Override
   public void changeOwner(LocalRegion r) {
     throw new UnsupportedOperationException();
   }
 
+  @Override
   public int size() {
     return 0;
   }
 
+  @Override
   public boolean isEmpty() {
     return true;
   }
 
+  @Override
   public Set keySet() {
     return Collections.EMPTY_SET;
   }
 
+  @Override
   public Collection<RegionEntry> regionEntries() {
     return Collections.emptySet();
   }
@@ -106,18 +114,22 @@ class ProxyRegionMap implements RegionMap {
     return Collections.emptySet();
   }
 
+  @Override
   public boolean containsKey(Object key) {
     return false;
   }
 
+  @Override
   public RegionEntry getEntry(Object key) {
     return null;
   }
 
+  @Override
   public RegionEntry putEntryIfAbsent(Object key, RegionEntry re) {
     return null;
   }
 
+  @Override
   @SuppressWarnings({"rawtypes", "unchecked"})
   public Set<VersionSource> clear(RegionVersionVector rvv) {
     // nothing needs to be done
@@ -133,10 +145,12 @@ class ProxyRegionMap implements RegionMap {
     // nothing needs to be done
   }
 
+  @Override
   public RegionEntry initRecoveredEntry(Object key, DiskEntry.RecoveredEntry value) {
     throw new UnsupportedOperationException();
   }
 
+  @Override
   public RegionEntry updateRecoveredEntry(Object key, DiskEntry.RecoveredEntry value) {
     throw new UnsupportedOperationException();
   }
@@ -145,12 +159,14 @@ class ProxyRegionMap implements RegionMap {
    * Used to modify an existing RegionEntry or create a new one when processing the values obtained
    * during a getInitialImage.
    */
+  @Override
   public boolean initialImagePut(Object key, long lastModified, Object newValue,
-      boolean wasRecovered, boolean deferLRUCallback, VersionTag version,
+      boolean wasRecovered, boolean deferLRUCallback, VersionTag entryVersion,
       InternalDistributedMember sender, boolean forceValue) {
     throw new UnsupportedOperationException();
   }
 
+  @Override
   public boolean destroy(EntryEventImpl event, boolean inTokenMode, boolean duringRI,
       boolean cacheWrite, boolean isEviction, Object expectedOldValue, boolean removeRecoveredEntry)
       throws CacheWriterException, EntryNotFoundException, TimeoutException {
@@ -167,8 +183,9 @@ class ProxyRegionMap implements RegionMap {
     return true;
   }
 
+  @Override
   public boolean invalidate(EntryEventImpl event, boolean invokeCallbacks, boolean forceNewEntry,
-      boolean forceCallback) throws EntryNotFoundException {
+      boolean forceCallbacks) throws EntryNotFoundException {
 
     if (event.getOperation().isLocal()) {
       if (this.owner.isInitialized()) {
@@ -187,6 +204,7 @@ class ProxyRegionMap implements RegionMap {
     // noop
   }
 
+  @Override
   public void evictValue(Object key) {
     // noop
   }
@@ -196,6 +214,7 @@ class ProxyRegionMap implements RegionMap {
    */
   private static final RegionEntry markerEntry = new ProxyRegionEntry();
 
+  @Override
   public RegionEntry basicPut(EntryEventImpl event, long lastModified, boolean ifNew, boolean ifOld,
       Object expectedOldValue, boolean requireOldValue, boolean overwriteDestroyed)
       throws CacheWriterException, TimeoutException {
@@ -233,31 +252,34 @@ class ProxyRegionMap implements RegionMap {
     return markerEntry;
   }
 
+  @Override
   public void writeSyncIfPresent(Object key, Runnable runner) {
     // nothing needed
   }
 
+  @Override
   public void removeIfDestroyed(Object key) {
     // nothing needed
   }
 
-  public void txApplyDestroy(Object key, TransactionId txId, TXRmtEvent txEvent,
+  @Override
+  public void txApplyDestroy(Object key, TransactionId rmtOrigin, TXRmtEvent event,
       boolean inTokenMode, boolean inRI, Operation op, EventID eventId, Object aCallbackArgument,
       List<EntryEventImpl> pendingCallbacks, FilterRoutingInfo filterRoutingInfo,
-      ClientProxyMembershipID bridgeContext, boolean isOriginRemote, TXEntryState txEntryState,
+      ClientProxyMembershipID bridgeContext, boolean isOperationRemote, TXEntryState txEntryState,
       VersionTag versionTag, long tailKey) {
     this.owner.txApplyDestroyPart2(markerEntry, key, inTokenMode,
         false /* Clear conflict occurred */);
     if (!inTokenMode) {
-      if (txEvent != null) {
-        txEvent.addDestroy(this.owner, markerEntry, key, aCallbackArgument);
+      if (event != null) {
+        event.addDestroy(this.owner, markerEntry, key, aCallbackArgument);
       }
       if (AbstractRegionMap.shouldCreateCBEvent(this.owner, !inTokenMode)) {
         // fix for bug 39526
         @Released
-        EntryEventImpl e = AbstractRegionMap.createCBEvent(this.owner, op, key, null, txId, txEvent,
-            eventId, aCallbackArgument, filterRoutingInfo, bridgeContext, txEntryState, versionTag,
-            tailKey);
+        EntryEventImpl e = AbstractRegionMap.createCBEvent(this.owner, op, key, null, rmtOrigin,
+            event, eventId, aCallbackArgument, filterRoutingInfo, bridgeContext, txEntryState,
+            versionTag, tailKey);
         boolean cbEventInPending = false;
         try {
           AbstractRegionMap.switchEventOwnerAndOriginRemote(e, txEntryState == null);
@@ -276,23 +298,24 @@ class ProxyRegionMap implements RegionMap {
     }
   }
 
-  public void txApplyInvalidate(Object key, Object newValue, boolean didDestroy, TransactionId txId,
-      TXRmtEvent txEvent, boolean localOp, EventID eventId, Object aCallbackArgument,
-      List<EntryEventImpl> pendingCallbacks, FilterRoutingInfo filterRoutingInfo,
-      ClientProxyMembershipID bridgeContext, TXEntryState txEntryState, VersionTag versionTag,
-      long tailKey) {
+  @Override
+  public void txApplyInvalidate(Object key, Object newValue, boolean didDestroy,
+      TransactionId rmtOrigin, TXRmtEvent event, boolean localOp, EventID eventId,
+      Object aCallbackArgument, List<EntryEventImpl> pendingCallbacks,
+      FilterRoutingInfo filterRoutingInfo, ClientProxyMembershipID bridgeContext,
+      TXEntryState txEntryState, VersionTag versionTag, long tailKey) {
     this.owner.txApplyInvalidatePart2(markerEntry, key, didDestroy, true);
     if (this.owner.isInitialized()) {
-      if (txEvent != null) {
-        txEvent.addInvalidate(this.owner, markerEntry, key, newValue, aCallbackArgument);
+      if (event != null) {
+        event.addInvalidate(this.owner, markerEntry, key, newValue, aCallbackArgument);
       }
       if (AbstractRegionMap.shouldCreateCBEvent(this.owner, this.owner.isInitialized())) {
         // fix for bug 39526
         boolean cbEventInPending = false;
         @Released
         EntryEventImpl e = AbstractRegionMap.createCBEvent(this.owner,
-            localOp ? Operation.LOCAL_INVALIDATE : Operation.INVALIDATE, key, newValue, txId,
-            txEvent, eventId, aCallbackArgument, filterRoutingInfo, bridgeContext, txEntryState,
+            localOp ? Operation.LOCAL_INVALIDATE : Operation.INVALIDATE, key, newValue, rmtOrigin,
+            event, eventId, aCallbackArgument, filterRoutingInfo, bridgeContext, txEntryState,
             versionTag, tailKey);
         try {
           AbstractRegionMap.switchEventOwnerAndOriginRemote(e, txEntryState == null);
@@ -311,26 +334,26 @@ class ProxyRegionMap implements RegionMap {
     }
   }
 
-  public void txApplyPut(Operation p_putOp, Object key, Object newValue, boolean didDestroy,
-      TransactionId txId, TXRmtEvent txEvent, EventID eventId, Object aCallbackArgument,
+  @Override
+  public void txApplyPut(Operation putOp, Object key, Object newValue, boolean didDestroy,
+      TransactionId rmtOrigin, TXRmtEvent event, EventID eventId, Object aCallbackArgument,
       List<EntryEventImpl> pendingCallbacks, FilterRoutingInfo filterRoutingInfo,
       ClientProxyMembershipID bridgeContext, TXEntryState txEntryState, VersionTag versionTag,
       long tailKey) {
-    Operation putOp = p_putOp.getCorrespondingCreateOp();
+    Operation putOperation = putOp.getCorrespondingCreateOp();
     long lastMod = owner.cacheTimeMillis();
-    this.owner.txApplyPutPart2(markerEntry, key, lastMod, true, didDestroy,
-        false /* Clear conflict occurred */);
+    this.owner.txApplyPutPart2(markerEntry, key, lastMod, true, didDestroy, false);
     if (this.owner.isInitialized()) {
-      if (txEvent != null) {
-        txEvent.addPut(putOp, this.owner, markerEntry, key, newValue, aCallbackArgument);
+      if (event != null) {
+        event.addPut(putOperation, this.owner, markerEntry, key, newValue, aCallbackArgument);
       }
       if (AbstractRegionMap.shouldCreateCBEvent(this.owner, this.owner.isInitialized())) {
         // fix for bug 39526
         boolean cbEventInPending = false;
         @Released
-        EntryEventImpl e = AbstractRegionMap.createCBEvent(this.owner, putOp, key, newValue, txId,
-            txEvent, eventId, aCallbackArgument, filterRoutingInfo, bridgeContext, txEntryState,
-            versionTag, tailKey);
+        EntryEventImpl e = AbstractRegionMap.createCBEvent(this.owner, putOperation, key, newValue,
+            rmtOrigin, event, eventId, aCallbackArgument, filterRoutingInfo, bridgeContext,
+            txEntryState, versionTag, tailKey);
         try {
           AbstractRegionMap.switchEventOwnerAndOriginRemote(e, txEntryState == null);
           if (pendingCallbacks == null) {
@@ -349,15 +372,18 @@ class ProxyRegionMap implements RegionMap {
   }
 
   // LRUMapCallbacks methods
+  @Override
   public void lruUpdateCallback() {
     // nothing needed
   }
 
+  @Override
   public boolean disableLruUpdateCallback() {
     // nothing needed
     return false;
   }
 
+  @Override
   public void enableLruUpdateCallback() {
     // nothing needed
   }
@@ -372,20 +398,24 @@ class ProxyRegionMap implements RegionMap {
     return false;
   }
 
+  @Override
   public void lruCloseStats() {
     // nothing needed
   }
 
+  @Override
   public void resetThreadLocals() {
     // nothing needed
   }
 
-  public void removeEntry(Object key, RegionEntry entry, boolean updateStats) {
+  @Override
+  public void removeEntry(Object key, RegionEntry value, boolean updateStats) {
     // nothing to do
   }
 
+  @Override
   public void removeEntry(Object key, RegionEntry re, boolean updateStat, EntryEventImpl event,
-      LocalRegion owner) {
+      InternalRegion owner) {
     // nothing to do
   }
 
@@ -395,40 +425,47 @@ class ProxyRegionMap implements RegionMap {
    */
   public static class ProxyRegionEntry implements RegionEntry {
 
+    @Override
     public long getLastModified() {
       throw new UnsupportedOperationException(
           LocalizedStrings.ProxyRegionMap_NO_ENTRY_SUPPORT_ON_REGIONS_WITH_DATAPOLICY_0
               .toLocalizedString(DataPolicy.EMPTY));
     }
 
+    @Override
     public long getLastAccessed() throws InternalStatisticsDisabledException {
       throw new UnsupportedOperationException(
           LocalizedStrings.ProxyRegionMap_NO_ENTRY_SUPPORT_ON_REGIONS_WITH_DATAPOLICY_0
               .toLocalizedString(DataPolicy.EMPTY));
     }
 
+    @Override
     public long getHitCount() throws InternalStatisticsDisabledException {
       throw new UnsupportedOperationException(
           LocalizedStrings.ProxyRegionMap_NO_ENTRY_SUPPORT_ON_REGIONS_WITH_DATAPOLICY_0
               .toLocalizedString(DataPolicy.EMPTY));
     }
 
+    @Override
     public long getMissCount() throws InternalStatisticsDisabledException {
       throw new UnsupportedOperationException(
           LocalizedStrings.ProxyRegionMap_NO_ENTRY_SUPPORT_ON_REGIONS_WITH_DATAPOLICY_0
               .toLocalizedString(DataPolicy.EMPTY));
     }
 
+    @Override
     public VersionStamp getVersionStamp() {
       return null;
     }
 
+    @Override
     public boolean isTombstone() {
       return false;
     }
 
+    @Override
     public VersionTag generateVersionTag(VersionSource member, boolean withDelta,
-        LocalRegion region, EntryEventImpl event) {
+        InternalRegion region, EntryEventImpl event) {
       return null; // proxies don't do versioning
     }
 
@@ -436,77 +473,92 @@ class ProxyRegionMap implements RegionMap {
       return;
     }
 
-    public void makeTombstone(LocalRegion r, VersionTag isOperationRemote) {
+    @Override
+    public void makeTombstone(InternalRegion region, VersionTag version) {
       return;
     }
 
+    @Override
     public void updateStatsForPut(long lastModifiedTime, long lastAccessedTime) {
       // do nothing; called by LocalRegion.updateStatsForPut
     }
 
+    @Override
     public void setRecentlyUsed() {
       // do nothing; called by LocalRegion.updateStatsForPut
     }
 
+    @Override
     public void updateStatsForGet(boolean hit, long time) {
       // do nothing; no entry stats
     }
 
-    public void txDidDestroy(long currTime) {
+    @Override
+    public void txDidDestroy(long currentTime) {
       throw new UnsupportedOperationException(
           LocalizedStrings.ProxyRegionMap_NO_ENTRY_SUPPORT_ON_REGIONS_WITH_DATAPOLICY_0
               .toLocalizedString(DataPolicy.EMPTY));
     }
 
+    @Override
     public void resetCounts() throws InternalStatisticsDisabledException {
       throw new UnsupportedOperationException(
           LocalizedStrings.ProxyRegionMap_NO_ENTRY_SUPPORT_ON_REGIONS_WITH_DATAPOLICY_0
               .toLocalizedString(DataPolicy.EMPTY));
     }
 
-    public void removePhase1(LocalRegion r, boolean isClear) {
+    @Override
+    public void removePhase1(InternalRegion region, boolean clear) {
       throw new UnsupportedOperationException(
           LocalizedStrings.ProxyRegionMap_NO_ENTRY_SUPPORT_ON_REGIONS_WITH_DATAPOLICY_0
               .toLocalizedString(DataPolicy.EMPTY));
     }
 
+    @Override
     public void removePhase2() {
       throw new UnsupportedOperationException(
           LocalizedStrings.ProxyRegionMap_NO_ENTRY_SUPPORT_ON_REGIONS_WITH_DATAPOLICY_0
               .toLocalizedString(DataPolicy.EMPTY));
     }
 
+    @Override
     public boolean isRemoved() {
       throw new UnsupportedOperationException(
           LocalizedStrings.ProxyRegionMap_NO_ENTRY_SUPPORT_ON_REGIONS_WITH_DATAPOLICY_0
               .toLocalizedString(DataPolicy.EMPTY));
     }
 
+    @Override
     public boolean isRemovedPhase2() {
       throw new UnsupportedOperationException(
           LocalizedStrings.ProxyRegionMap_NO_ENTRY_SUPPORT_ON_REGIONS_WITH_DATAPOLICY_0
               .toLocalizedString(DataPolicy.EMPTY));
     }
 
-    public boolean fillInValue(LocalRegion r, Entry entry, ByteArrayDataInput in, DM mgr,
-        final Version version) {
+    @Override
+    public boolean fillInValue(InternalRegion region, Entry entry, ByteArrayDataInput in,
+        DM distributionManager, final Version version) {
       throw new UnsupportedOperationException(
           LocalizedStrings.ProxyRegionMap_NO_ENTRY_SUPPORT_ON_REGIONS_WITH_DATAPOLICY_0
               .toLocalizedString(DataPolicy.EMPTY));
     }
 
-    public boolean isOverflowedToDisk(LocalRegion r, DistributedRegion.DiskPosition dp) {
+    @Override
+    public boolean isOverflowedToDisk(InternalRegion region,
+        DistributedRegion.DiskPosition diskPosition) {
       throw new UnsupportedOperationException(
           LocalizedStrings.ProxyRegionMap_NO_ENTRY_SUPPORT_ON_REGIONS_WITH_DATAPOLICY_0
               .toLocalizedString(DataPolicy.EMPTY));
     }
 
+    @Override
     public Object getKey() {
       throw new UnsupportedOperationException(
           LocalizedStrings.ProxyRegionMap_NO_ENTRY_SUPPORT_ON_REGIONS_WITH_DATAPOLICY_0
               .toLocalizedString(DataPolicy.EMPTY));
     }
 
+    @Override
     public Object getValue(RegionEntryContext context) {
       throw new UnsupportedOperationException(
           LocalizedStrings.ProxyRegionMap_NO_ENTRY_SUPPORT_ON_REGIONS_WITH_DATAPOLICY_0
@@ -520,6 +572,7 @@ class ProxyRegionMap implements RegionMap {
               .toLocalizedString(DataPolicy.EMPTY));
     }
 
+    @Override
     public void setValue(RegionEntryContext context, Object value) {
       throw new UnsupportedOperationException(
           LocalizedStrings.ProxyRegionMap_NO_ENTRY_SUPPORT_ON_REGIONS_WITH_DATAPOLICY_0
@@ -527,18 +580,13 @@ class ProxyRegionMap implements RegionMap {
     }
 
     @Override
-    public Object prepareValueForCache(RegionEntryContext r, Object val, boolean isEntryUpdate) {
+    public Object prepareValueForCache(RegionEntryContext context, Object value,
+        boolean isEntryUpdate) {
       throw new IllegalStateException("Should never be called");
     }
 
-    // @Override
-    // public void _setValue(Object value) {
-    // throw new
-    // UnsupportedOperationException(LocalizedStrings.ProxyRegionMap_NO_ENTRY_SUPPORT_ON_REGIONS_WITH_DATAPOLICY_0.toLocalizedString(DataPolicy.EMPTY));
-    // }
-
     @Override
-    public Object _getValue() {
+    public Object getValue() {
       throw new UnsupportedOperationException(
           LocalizedStrings.ProxyRegionMap_NO_ENTRY_SUPPORT_ON_REGIONS_WITH_DATAPOLICY_0
               .toLocalizedString(DataPolicy.EMPTY));
@@ -552,7 +600,7 @@ class ProxyRegionMap implements RegionMap {
     }
 
     @Override
-    public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+    public Object getValueRetain(RegionEntryContext context, boolean decompress) {
       throw new UnsupportedOperationException(
           LocalizedStrings.ProxyRegionMap_NO_ENTRY_SUPPORT_ON_REGIONS_WITH_DATAPOLICY_0
               .toLocalizedString(DataPolicy.EMPTY));
@@ -570,39 +618,45 @@ class ProxyRegionMap implements RegionMap {
       return null; // called by TXRmtEvent.createEvent
     }
 
-    public Object getValueOnDisk(LocalRegion r) throws EntryNotFoundException {
+    @Override
+    public Object getValueOnDisk(InternalRegion region) throws EntryNotFoundException {
       throw new UnsupportedOperationException(
           LocalizedStrings.ProxyRegionMap_NO_ENTRY_SUPPORT_ON_REGIONS_WITH_DATAPOLICY_0
               .toLocalizedString(DataPolicy.EMPTY));
     }
 
-    public Object getValueOnDiskOrBuffer(LocalRegion r) throws EntryNotFoundException {
+    @Override
+    public Object getValueOnDiskOrBuffer(InternalRegion region) throws EntryNotFoundException {
       throw new UnsupportedOperationException(
           LocalizedStrings.ProxyRegionMap_NO_ENTRY_SUPPORT_ON_REGIONS_WITH_DATAPOLICY_0
               .toLocalizedString(DataPolicy.EMPTY));
     }
 
-    public Object getSerializedValueOnDisk(LocalRegion localRegion) {
+    @Override
+    public Object getSerializedValueOnDisk(InternalRegion region) {
       throw new UnsupportedOperationException(
           LocalizedStrings.ProxyRegionMap_NO_ENTRY_SUPPORT_ON_REGIONS_WITH_DATAPOLICY_0
               .toLocalizedString(DataPolicy.EMPTY));
     }
 
-    public boolean initialImagePut(LocalRegion region, long lastModified, Object newValue,
-        boolean wasRecovered, boolean versionTagAccepted) {
+    @Override
+    public boolean initialImagePut(InternalRegion region, long lastModified, Object newValue,
+        boolean wasRecovered, boolean acceptedVersionTag) {
       throw new UnsupportedOperationException(
           LocalizedStrings.ProxyRegionMap_NO_ENTRY_SUPPORT_ON_REGIONS_WITH_DATAPOLICY_0
               .toLocalizedString(DataPolicy.EMPTY));
     }
 
-    public boolean initialImageInit(LocalRegion region, long lastModified, Object newValue,
-        boolean create, boolean wasRecovered, boolean versionTagAccepted) {
+    @Override
+    public boolean initialImageInit(InternalRegion region, long lastModified, Object newValue,
+        boolean create, boolean wasRecovered, boolean acceptedVersionTag) {
       throw new UnsupportedOperationException(
           LocalizedStrings.ProxyRegionMap_NO_ENTRY_SUPPORT_ON_REGIONS_WITH_DATAPOLICY_0
               .toLocalizedString(DataPolicy.EMPTY));
     }
 
-    public boolean destroy(LocalRegion region, EntryEventImpl event, boolean inTokenMode,
+    @Override
+    public boolean destroy(InternalRegion region, EntryEventImpl event, boolean inTokenMode,
         boolean cacheWrite, Object expectedOldValue, boolean forceDestroy,
         boolean removeRecoveredEntry)
         throws CacheWriterException, EntryNotFoundException, TimeoutException {
@@ -611,54 +665,44 @@ class ProxyRegionMap implements RegionMap {
               .toLocalizedString(DataPolicy.EMPTY));
     }
 
+    @Override
     public boolean getValueWasResultOfSearch() {
       throw new UnsupportedOperationException(
           LocalizedStrings.ProxyRegionMap_NO_ENTRY_SUPPORT_ON_REGIONS_WITH_DATAPOLICY_0
               .toLocalizedString(DataPolicy.EMPTY));
     }
 
-    public void setValueResultOfSearch(boolean v) {
-      throw new UnsupportedOperationException(
-          LocalizedStrings.ProxyRegionMap_NO_ENTRY_SUPPORT_ON_REGIONS_WITH_DATAPOLICY_0
-              .toLocalizedString(DataPolicy.EMPTY));
-    }
-
-    public boolean dispatchListenerEvents(EntryEventImpl event) throws InterruptedException {
-      // note that we don't synchronize on the RE before dispatching
-      // events
-      event.invokeCallbacks(event.getRegion(), event.inhibitCacheListenerNotification(), false);
-      return true;
-    }
-
-    public boolean hasStats() {
-      return false;
-    }
-
-    public Object getValueInVMOrDiskWithoutFaultIn(LocalRegion owner) {
+    @Override
+    public void setValueResultOfSearch(boolean value) {
       throw new UnsupportedOperationException(
           LocalizedStrings.ProxyRegionMap_NO_ENTRY_SUPPORT_ON_REGIONS_WITH_DATAPOLICY_0
               .toLocalizedString(DataPolicy.EMPTY));
     }
 
     @Override
-    public Object getValueOffHeapOrDiskWithoutFaultIn(LocalRegion owner) {
+    public boolean dispatchListenerEvents(EntryEventImpl event) throws InterruptedException {
+      // note that we don't synchronize on the RE before dispatching events
+      event.invokeCallbacks(event.getRegion(), event.inhibitCacheListenerNotification(), false);
+      return true;
+    }
+
+    @Override
+    public boolean hasStats() {
+      return false;
+    }
+
+    @Override
+    public Object getValueInVMOrDiskWithoutFaultIn(InternalRegion region) {
       throw new UnsupportedOperationException(
           LocalizedStrings.ProxyRegionMap_NO_ENTRY_SUPPORT_ON_REGIONS_WITH_DATAPOLICY_0
               .toLocalizedString(DataPolicy.EMPTY));
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see
-     * org.apache.geode.internal.cache.RegionEntry#concurrencyCheck(org.apache.geode.internal.cache.
-     * LocalRegion, org.apache.geode.internal.cache.versions.VersionTag,
-     * org.apache.geode.distributed.internal.membership.InternalDistributedMember,
-     * org.apache.geode.distributed.internal.membership.InternalDistributedMember)
-     */
-    public void processVersionTag(LocalRegion r, VersionTag tag, InternalDistributedMember thisVM,
-        InternalDistributedMember sender) {
-      return;
+    @Override
+    public Object getValueOffHeapOrDiskWithoutFaultIn(InternalRegion region) {
+      throw new UnsupportedOperationException(
+          LocalizedStrings.ProxyRegionMap_NO_ENTRY_SUPPORT_ON_REGIONS_WITH_DATAPOLICY_0
+              .toLocalizedString(DataPolicy.EMPTY));
     }
 
     @Override
@@ -726,8 +770,7 @@ class ProxyRegionMap implements RegionMap {
 
     @Override
     public void returnToPool() {
-      // TODO Auto-generated method stub
-
+      // nothing
     }
 
     @Override
@@ -740,14 +783,12 @@ class ProxyRegionMap implements RegionMap {
 
     @Override
     public boolean isCacheListenerInvocationInProgress() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public void setCacheListenerInvocationInProgress(boolean isListenerInvoked) {
-      // TODO Auto-generated method stub
-
+      // nothing
     }
 
     @Override
@@ -764,46 +805,58 @@ class ProxyRegionMap implements RegionMap {
     }
 
     @Override
-    public void setInUseByTransaction(boolean v) {}
+    public void setInUseByTransaction(boolean inUseByTransaction) {
+      // nothing
+    }
 
     @Override
     public void incRefCount() {}
 
     @Override
-    public void decRefCount(NewLRUClockHand lruList, LocalRegion lr) {}
+    public void decRefCount(NewLRUClockHand lruList, InternalRegion region) {
+      // nothing
+    }
 
     @Override
-    public void resetRefCount(NewLRUClockHand lruList) {}
+    public void resetRefCount(NewLRUClockHand lruList) {
+      // nothing
+    }
 
     @Override
-    public Object prepareValueForCache(RegionEntryContext r, Object val, EntryEventImpl event,
-        boolean isEntryUpdate) {
+    public Object prepareValueForCache(RegionEntryContext context, Object value,
+        EntryEventImpl event, boolean isEntryUpdate) {
       throw new IllegalStateException("Should never be called");
     }
   }
 
+  @Override
   public void lruUpdateCallback(int n) {
     // do nothing
   }
 
+  @Override
   public void lruEntryFaultIn(LRUEntry entry) {
     // do nothing.
 
   }
 
+  @Override
   public void copyRecoveredEntries(RegionMap rm) {
     throw new IllegalStateException("copyRecoveredEntries should never be called on proxy");
   }
 
+  @Override
   public boolean removeTombstone(RegionEntry re, VersionHolder destroyedVersion, boolean isEviction,
       boolean isScheduledTombstone) {
     throw new IllegalStateException("removeTombstone should never be called on a proxy");
   }
 
+  @Override
   public boolean isTombstoneNotNeeded(RegionEntry re, int destroyedVersion) {
     throw new IllegalStateException("removeTombstone should never be called on a proxy");
   }
 
+  @Override
   public void setEntryFactory(RegionEntryFactory f) {
     throw new IllegalStateException("Should not be called on a ProxyRegionMap");
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/RegionMap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/RegionMap.java
@@ -12,7 +12,6 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package org.apache.geode.internal.cache;
 
 import java.util.Collection;
@@ -40,8 +39,6 @@ import org.apache.geode.internal.cache.versions.VersionTag;
  * that the value of every entry in this map will implement {@link RegionEntry}.
  *
  * @since GemFire 3.5.1
- *
- *
  */
 public interface RegionMap extends LRUMapCallbacks {
 
@@ -49,7 +46,7 @@ public interface RegionMap extends LRUMapCallbacks {
    * Parameter object used to facilitate construction of an EntriesMap. Modification of fields after
    * the map is constructed has no effect.
    */
-  static class Attributes {
+  class Attributes {
     /**
      * The initial capacity. The implementation performs internal sizing to accommodate this many
      * elements.
@@ -67,99 +64,80 @@ public interface RegionMap extends LRUMapCallbacks {
 
     /** whether "api" statistics are enabled */
     boolean statisticsEnabled = false;
-
-    /** whether LRU stats are required */
-    // boolean lru = false;
   }
 
-  public RegionEntryFactory getEntryFactory();
+  RegionEntryFactory getEntryFactory();
 
   /**
    * This method should be called before region is initialized to ensure there is no mix of region
    * entries
    */
-  public void setEntryFactory(RegionEntryFactory f);
+  void setEntryFactory(RegionEntryFactory f);
 
   /**
    * Gets the attributes that this map was created with.
    */
-  public Attributes getAttributes();
+  Attributes getAttributes();
 
   /**
    * Tells this map what region owns it.
    */
-  public void setOwner(Object r);
+  void setOwner(Object r);
 
-  public void changeOwner(LocalRegion r);
+  void changeOwner(LocalRegion r);
 
-  public int size();
+  int size();
 
-  public boolean isEmpty();
+  boolean isEmpty();
 
   /**
    * @return number of entries cached in the backing CHM
    */
-  public int sizeInVM();
+  int sizeInVM();
 
-  public Set keySet();
+  Set keySet();
 
   /**
    * Returns a collection of RegionEntry instances.
    */
-  public Collection<RegionEntry> regionEntries();
+  Collection<RegionEntry> regionEntries();
 
   /**
    * Returns a collection of RegionEntry instances from memory only.
    */
-  public Collection<RegionEntry> regionEntriesInVM();
+  Collection<RegionEntry> regionEntriesInVM();
 
-  public boolean containsKey(Object key);
+  boolean containsKey(Object key);
 
   /**
    * fetches the entry from the backing ConcurrentHashMap
    * 
-   * @param key
    * @return the RegionEntry from memory or disk
    */
-  public RegionEntry getEntry(Object key);
+  RegionEntry getEntry(Object key);
 
-  public RegionEntry putEntryIfAbsent(Object key, RegionEntry re);
+  RegionEntry putEntryIfAbsent(Object key, RegionEntry re);
 
   /**
    * fetches the entry from the backing ConcurrentHashMap.
    * 
-   * @param key
    * @return the RegionEntry from memory
    */
-  public RegionEntry getEntryInVM(Object key);
+  RegionEntry getEntryInVM(Object key);
 
   /**
    * fetches the entry from the backing ConcurrentHashMap only if the entry is considered to be in
    * operational data i.e. does not have isMarkedForEviction() bit set.
    * 
-   * @param key
    * @return the RegionEntry in operational data
    */
-  public RegionEntry getOperationalEntryInVM(Object key);
-
-  // /**
-  // * Removes any entry associated with <code>key</code>.
-  // * Do nothing if the map has no entry for key.
-  // */
-  // public void remove(Object key);
-
-  // /**
-  // * Removes the entry associated with <code>key</code>
-  // * if it is <code>entry</code>.
-  // * Otherwise do nothing.
-  // */
-  // public void remove(Object key, RegionEntry entry);
+  RegionEntry getOperationalEntryInVM(Object key);
 
   /**
    * Clear the region and, if the parameter rvv is not null, return a collection of the IDs of
    * version sources that are still in the map when the operation completes.
    */
-  public Set<VersionSource> clear(RegionVersionVector rvv);
+  Set<VersionSource> clear(RegionVersionVector rvv);
 
   /**
    * Used by disk regions when recovering data from backup. Currently this "put" is done at a very
@@ -167,7 +145,7 @@ public interface RegionMap extends LRUMapCallbacks {
    * 
    * @return the created RegionEntry or null if entry already existed
    */
-  public RegionEntry initRecoveredEntry(Object key, DiskEntry.RecoveredEntry value);
+  RegionEntry initRecoveredEntry(Object key, DiskEntry.RecoveredEntry value);
 
   /**
    * Used by disk regions when recovering data from backup and initRecoveredEntry has already been
@@ -176,7 +154,7 @@ public interface RegionMap extends LRUMapCallbacks {
    * 
    * @return the updated RegionEntry
    */
-  public RegionEntry updateRecoveredEntry(Object key, DiskEntry.RecoveredEntry value);
+  RegionEntry updateRecoveredEntry(Object key, DiskEntry.RecoveredEntry value);
 
   /**
    * Used to modify an existing RegionEntry or create a new one when processing the values obtained
@@ -187,9 +165,9 @@ public interface RegionMap extends LRUMapCallbacks {
    * @param sender the sender of the initial image, if IIO. Not needed on clients
    * @param forceValue TODO
    */
-  public boolean initialImagePut(Object key, long lastModified, Object newValue,
-      boolean wasRecovered, boolean deferLRUCallback, VersionTag entryVersion,
-      InternalDistributedMember sender, boolean forceValue);
+  boolean initialImagePut(Object key, long lastModified, Object newValue, boolean wasRecovered,
+      boolean deferLRUCallback, VersionTag entryVersion, InternalDistributedMember sender,
+      boolean forceValue);
 
   /**
    * Destroy an entry the map.
@@ -208,8 +186,8 @@ public interface RegionMap extends LRUMapCallbacks {
    * @see CacheCallback
    * @see AbstractLRURegionMap
    */
-  public boolean destroy(EntryEventImpl event, boolean inTokenMode, boolean duringRI,
-      boolean cacheWrite, boolean isEviction, Object expectedOldValue, boolean removeRecoveredEntry)
+  boolean destroy(EntryEventImpl event, boolean inTokenMode, boolean duringRI, boolean cacheWrite,
+      boolean isEviction, Object expectedOldValue, boolean removeRecoveredEntry)
       throws CacheWriterException, EntryNotFoundException, TimeoutException;
 
   /**
@@ -220,10 +198,10 @@ public interface RegionMap extends LRUMapCallbacks {
    *        mode in that it doesn't leave an Invalid token in the cache.
    * @return true if invalidate was done
    */
-  public boolean invalidate(EntryEventImpl event, boolean invokeCallbacks, boolean forceNewEntry,
+  boolean invalidate(EntryEventImpl event, boolean invokeCallbacks, boolean forceNewEntry,
       boolean forceCallbacks) throws EntryNotFoundException;
 
-  public void evictValue(Object key);
+  void evictValue(Object key);
 
   /**
    * @param event the event object for this operation, with the exception that the oldValue
@@ -243,7 +221,7 @@ public interface RegionMap extends LRUMapCallbacks {
    *        because there is a DESTROYED token present then the entry flag blockedDestroyed is set.
    * @return null if put was not done; otherwise reference to put entry
    */
-  public RegionEntry basicPut(EntryEventImpl event, long lastModified, boolean ifNew, boolean ifOld,
+  RegionEntry basicPut(EntryEventImpl event, long lastModified, boolean ifNew, boolean ifOld,
       Object expectedOldValue, boolean requireOldValue, boolean overwriteDestroyed)
       throws CacheWriterException, TimeoutException;
 
@@ -251,13 +229,13 @@ public interface RegionMap extends LRUMapCallbacks {
    * Write synchronizes the given entry and invokes the runable while holding the lock. Does nothing
    * if the entry does not exist.
    */
-  public void writeSyncIfPresent(Object key, Runnable runner);
+  void writeSyncIfPresent(Object key, Runnable runner);
 
   /**
    * Remove the entry with the given key if it has been marked as destroyed This is currently used
    * in the cleanup phase of getInitialImage.
    */
-  public void removeIfDestroyed(Object key);
+  void removeIfDestroyed(Object key);
 
   /**
    * @param key the key of the entry to destroy
@@ -269,7 +247,6 @@ public interface RegionMap extends LRUMapCallbacks {
    * @param op the destroy operation to apply
    * @param eventId filled in if operation performed
    * @param aCallbackArgument callback argument passed by user
-   * @param filterRoutingInfo
    * @param isOperationRemote whether the operation is remote or originated here
    * @param txEntryState when not null, txEntryState.versionTag is set (used on near-side to pass
    *        versionTag to TXCommitMessage)
@@ -278,8 +255,8 @@ public interface RegionMap extends LRUMapCallbacks {
    * @param tailKey when not -1, it is the tailKey generated on near-side to be associated with
    *        entry on far-side for WAN
    */
-  public void txApplyDestroy(Object key, TransactionId rmtOrigin, TXRmtEvent event,
-      boolean inTokenMode, boolean inRI, Operation op, EventID eventId, Object aCallbackArgument,
+  void txApplyDestroy(Object key, TransactionId rmtOrigin, TXRmtEvent event, boolean inTokenMode,
+      boolean inRI, Operation op, EventID eventId, Object aCallbackArgument,
       List<EntryEventImpl> pendingCallbacks, FilterRoutingInfo filterRoutingInfo,
       ClientProxyMembershipID bridgeContext, boolean isOperationRemote, TXEntryState txEntryState,
       VersionTag versionTag, long tailKey);
@@ -292,7 +269,6 @@ public interface RegionMap extends LRUMapCallbacks {
    * @param event filled in if operation performed
    * @param localOp true for localInvalidates, false otherwise
    * @param aCallbackArgument callback argument passed by user
-   * @param filterRoutingInfo
    * @param txEntryState when not null, txEntryState.versionTag is set (used on near-side to pass
    *        versionTag to TXCommitMessage)
    * @param versionTag when not null, it is the tag generated on near-side to be associated with the
@@ -300,11 +276,11 @@ public interface RegionMap extends LRUMapCallbacks {
    * @param tailKey when not -1, it is the tailKey generated on near-side to be associated with
    *        entry on far-side for WAN
    */
-  public void txApplyInvalidate(Object key, Object newValue, boolean didDestroy,
-      TransactionId rmtOrigin, TXRmtEvent event, boolean localOp, EventID eventId,
-      Object aCallbackArgument, List<EntryEventImpl> pendingCallbacks,
-      FilterRoutingInfo filterRoutingInfo, ClientProxyMembershipID bridgeContext,
-      TXEntryState txEntryState, VersionTag versionTag, long tailKey);
+  void txApplyInvalidate(Object key, Object newValue, boolean didDestroy, TransactionId rmtOrigin,
+      TXRmtEvent event, boolean localOp, EventID eventId, Object aCallbackArgument,
+      List<EntryEventImpl> pendingCallbacks, FilterRoutingInfo filterRoutingInfo,
+      ClientProxyMembershipID bridgeContext, TXEntryState txEntryState, VersionTag versionTag,
+      long tailKey);
 
   /**
    * @param putOp describes the operation that did the put
@@ -314,7 +290,6 @@ public interface RegionMap extends LRUMapCallbacks {
    * @param rmtOrigin true if transaction being applied had a remote origin
    * @param event filled in if operation performed
    * @param aCallbackArgument callback argument passed by user
-   * @param filterRoutingInfo
    * @param txEntryState when not null, txEntryState.versionTag is set (used on near-side to pass
    *        versionTag to TXCommitMessage)
    * @param versionTag when not null, it is the tag generated on near-side to be associated with the
@@ -322,7 +297,7 @@ public interface RegionMap extends LRUMapCallbacks {
    * @param tailKey when not -1, it is the tailKey generated on near-side to be associated with
    *        entry on far-side for WAN
    */
-  public void txApplyPut(Operation putOp, Object key, Object newValue, boolean didDestroy,
+  void txApplyPut(Operation putOp, Object key, Object newValue, boolean didDestroy,
       TransactionId rmtOrigin, TXRmtEvent event, EventID eventId, Object aCallbackArgument,
       List<EntryEventImpl> pendingCallbacks, FilterRoutingInfo filterRoutingInfo,
       ClientProxyMembershipID bridgeContext, TXEntryState txEntryState, VersionTag versionTag,
@@ -331,16 +306,16 @@ public interface RegionMap extends LRUMapCallbacks {
   /**
    * removes the given key if the enclosing RegionEntry is still in this map
    */
-  public void removeEntry(Object key, RegionEntry value, boolean updateStats);
+  void removeEntry(Object key, RegionEntry value, boolean updateStats);
 
   /**
    * Removes the given key if the enclosing RegionEntry is still in this map for the given
    * EntryEvent
    */
-  public void removeEntry(Object key, RegionEntry re, boolean updateStat, EntryEventImpl event,
-      LocalRegion owner);
+  void removeEntry(Object key, RegionEntry re, boolean updateStat, EntryEventImpl event,
+      InternalRegion owner);
 
-  public void copyRecoveredEntries(RegionMap rm);
+  void copyRecoveredEntries(RegionMap rm);
 
   /**
    * Removes an entry that was previously destroyed and made into a tombstone.
@@ -351,7 +326,7 @@ public interface RegionMap extends LRUMapCallbacks {
    * @param isScheduledTombstone TODO
    * @return true if the tombstone entry was removed from the entry map
    */
-  public boolean removeTombstone(RegionEntry re, VersionHolder destroyedVersion, boolean isEviction,
+  boolean removeTombstone(RegionEntry re, VersionHolder destroyedVersion, boolean isEviction,
       boolean isScheduledTombstone);
 
   /**
@@ -361,22 +336,21 @@ public interface RegionMap extends LRUMapCallbacks {
    * @param destroyedVersion the version that was destroyed
    * @return true of the tombstone is no longer needed (entry was resurrected or evicted)
    */
-  public boolean isTombstoneNotNeeded(RegionEntry re, int destroyedVersion);
+  boolean isTombstoneNotNeeded(RegionEntry re, int destroyedVersion);
 
-  public void updateEntryVersion(EntryEventImpl event);
+  void updateEntryVersion(EntryEventImpl event);
 
   /**
    * Decrements the transaction reference count. Some features, like eviction and expiration, will
    * not modify an entry while it is referenced by a transaction.
    */
-  public void decTxRefCount(RegionEntry e);
+  void decTxRefCount(RegionEntry e);
 
-  public void close();
+  void close();
 
   default void lockRegionForAtomicTX(LocalRegion r) {}
 
   default void unlockRegionForAtomicTX(LocalRegion r) {}
 
-  public ARMLockTestHook getARMLockTestHook();
-
+  ARMLockTestHook getARMLockTestHook();
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/ValidatingDiskRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/ValidatingDiskRegion.java
@@ -69,14 +69,17 @@ public class ValidatingDiskRegion extends DiskRegion implements DiskRecoveryStor
   private final ConcurrentMap<Object, DiskEntry> map = new ConcurrentHashMap<Object, DiskEntry>();
 
   ///////////// DiskRecoveryStore methods ////////////////
+  @Override
   public DiskRegionView getDiskRegionView() {
     return this;
   }
 
+  @Override
   public DiskEntry getDiskEntry(Object key) {
     return this.map.get(key);
   }
 
+  @Override
   public DiskEntry initializeRecoveredEntry(Object key, DiskEntry.RecoveredEntry re) {
     ValidatingDiskEntry de = new ValidatingDiskEntry(key, re);
     if (this.map.putIfAbsent(key, de) != null) {
@@ -86,30 +89,36 @@ public class ValidatingDiskRegion extends DiskRegion implements DiskRecoveryStor
     return de;
   }
 
+  @Override
   public DiskEntry updateRecoveredEntry(Object key, DiskEntry.RecoveredEntry re) {
     ValidatingDiskEntry de = new ValidatingDiskEntry(key, re);
     this.map.put(key, de);
     return de;
   }
 
+  @Override
   public void destroyRecoveredEntry(Object key) {
     this.map.remove(key);
   }
 
+  @Override
   public void foreachRegionEntry(LocalRegion.RegionEntryCallback callback) {
     throw new IllegalStateException(
         "foreachRegionEntry should not be called when validating disk store");
   }
 
+  @Override
   public boolean lruLimitExceeded() {
     return false;
   }
 
+  @Override
   public void copyRecoveredEntries(RegionMap rm) {
     throw new IllegalStateException(
         "copyRecoveredEntries should not be called on ValidatingDiskRegion");
   }
 
+  @Override
   public void updateSizeOnFaultIn(Object key, int newSize, int bytesOnDisk) {
     throw new IllegalStateException(
         "updateSizeOnFaultIn should not be called on ValidatingDiskRegion");
@@ -125,15 +134,18 @@ public class ValidatingDiskRegion extends DiskRegion implements DiskRecoveryStor
     return 0;
   }
 
+  @Override
   public RegionMap getRegionMap() {
     throw new IllegalStateException("getRegionMap should not be called on ValidatingDiskRegion");
   }
 
+  @Override
   public void handleDiskAccessException(DiskAccessException dae) {
     throw new IllegalStateException(
         "handleDiskAccessException should not be called on ValidatingDiskRegion");
   }
 
+  @Override
   public void initializeStats(long numEntriesInVM, long numOverflowOnDisk,
       long numOverflowBytesOnDisk) {
     throw new IllegalStateException("initializeStats should not be called on ValidatingDiskRegion");
@@ -157,11 +169,13 @@ public class ValidatingDiskRegion extends DiskRegion implements DiskRecoveryStor
       this.diskId.setValueLength(re.getValueLength());
     }
 
+    @Override
     public Object getKey() {
       return this.key;
     }
 
-    public Object _getValue() {
+    @Override
+    public Object getValue() {
       return null;
     }
 
@@ -170,10 +184,12 @@ public class ValidatingDiskRegion extends DiskRegion implements DiskRecoveryStor
       return null;
     }
 
-    public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+    @Override
+    public Object getValueRetain(RegionEntryContext context, boolean decompress) {
       return null;
     }
 
+    @Override
     public boolean isValueNull() {
       throw new IllegalStateException("should never be called");
     }
@@ -193,7 +209,8 @@ public class ValidatingDiskRegion extends DiskRegion implements DiskRecoveryStor
     }
 
     @Override
-    public Object prepareValueForCache(RegionEntryContext r, Object val, boolean isEntryUpdate) {
+    public Object prepareValueForCache(RegionEntryContext context, Object value,
+        boolean isEntryUpdate) {
       throw new IllegalStateException("Should never be called");
     }
 
@@ -201,30 +218,37 @@ public class ValidatingDiskRegion extends DiskRegion implements DiskRecoveryStor
       throw new IllegalStateException("should never be called");
     }
 
+    @Override
     public DiskId getDiskId() {
       return this.diskId;
     }
 
+    @Override
     public long getLastModified() {
       throw new IllegalStateException("should never be called");
     }
 
+    @Override
     public int updateAsyncEntrySize(EnableLRU capacityController) {
       throw new IllegalStateException("should never be called");
     }
 
+    @Override
     public DiskEntry getPrev() {
       throw new IllegalStateException("should never be called");
     }
 
+    @Override
     public DiskEntry getNext() {
       throw new IllegalStateException("should never be called");
     }
 
+    @Override
     public void setPrev(DiskEntry v) {
       throw new IllegalStateException("should never be called");
     }
 
+    @Override
     public void setNext(DiskEntry v) {
       throw new IllegalStateException("should never be called");
     }
@@ -236,7 +260,6 @@ public class ValidatingDiskRegion extends DiskRegion implements DiskRecoveryStor
      */
     @Override
     public VersionStamp getVersionStamp() {
-      // TODO Auto-generated method stub
       return null;
     }
 
@@ -247,115 +270,104 @@ public class ValidatingDiskRegion extends DiskRegion implements DiskRecoveryStor
 
     @Override
     public boolean hasStats() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public long getLastAccessed() throws InternalStatisticsDisabledException {
-      // TODO Auto-generated method stub
       return 0;
     }
 
     @Override
     public long getHitCount() throws InternalStatisticsDisabledException {
-      // TODO Auto-generated method stub
       return 0;
     }
 
     @Override
     public long getMissCount() throws InternalStatisticsDisabledException {
-      // TODO Auto-generated method stub
       return 0;
     }
 
     @Override
     public void updateStatsForPut(long lastModifiedTime, long lastAccessedTime) {
-      // TODO Auto-generated method stub
+      // nothing
     }
 
     @Override
     public VersionTag generateVersionTag(VersionSource member, boolean withDelta,
-        LocalRegion region, EntryEventImpl event) {
-      // TODO Auto-generated method stub
+        InternalRegion region, EntryEventImpl event) {
       return null;
     }
 
     @Override
     public boolean dispatchListenerEvents(EntryEventImpl event) throws InterruptedException {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public void setRecentlyUsed() {
-      // TODO Auto-generated method stub
+      // nothing
     }
 
     @Override
     public void updateStatsForGet(boolean hit, long time) {
-      // TODO Auto-generated method stub
+      // nothing
     }
 
     @Override
-    public void txDidDestroy(long currTime) {
-      // TODO Auto-generated method stub
+    public void txDidDestroy(long currentTime) {
+      // Tnothing
     }
 
     @Override
     public void resetCounts() throws InternalStatisticsDisabledException {
-      // TODO Auto-generated method stub
+      // nothing
     }
 
     @Override
-    public void makeTombstone(LocalRegion r, VersionTag version) throws RegionClearedException {
-      // TODO Auto-generated method stub
+    public void makeTombstone(InternalRegion region, VersionTag version)
+        throws RegionClearedException {
+      // nothing
     }
 
     @Override
-    public void removePhase1(LocalRegion r, boolean clear) throws RegionClearedException {
-      // TODO Auto-generated method stub
+    public void removePhase1(InternalRegion region, boolean clear) throws RegionClearedException {
+      // nothing
     }
 
     @Override
     public void removePhase2() {
-      // TODO Auto-generated method stub
+      // nothing
     }
 
     @Override
     public boolean isRemoved() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public boolean isRemovedPhase2() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public boolean isTombstone() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
-    public boolean fillInValue(LocalRegion r, Entry entry, ByteArrayDataInput in, DM mgr,
-        final Version version) {
-      // TODO Auto-generated method stub
+    public boolean fillInValue(InternalRegion region, Entry entry, ByteArrayDataInput in,
+        DM distributionManager, final Version version) {
       return false;
     }
 
     @Override
-    public boolean isOverflowedToDisk(LocalRegion r, DiskPosition dp) {
-      // TODO Auto-generated method stub
+    public boolean isOverflowedToDisk(InternalRegion region, DiskPosition diskPosition) {
       return false;
     }
 
     @Override
     public Object getValue(RegionEntryContext context) {
-      // TODO Auto-generated method stub
       return null;
     }
 
@@ -366,153 +378,134 @@ public class ValidatingDiskRegion extends DiskRegion implements DiskRecoveryStor
 
     @Override
     public void setValue(RegionEntryContext context, Object value) throws RegionClearedException {
-      // TODO Auto-generated method stub
+      // nothing
     }
 
     @Override
     public void setValueWithTombstoneCheck(Object value, EntryEvent event)
         throws RegionClearedException {
-      // TODO Auto-generated method stub
+      // nothing
     }
 
     @Override
     public Object getTransformedValue() {
-      // TODO Auto-generated method stub
       return null;
     }
 
     @Override
     public Object getValueInVM(RegionEntryContext context) {
-      // TODO Auto-generated method stub
       return null;
     }
 
     @Override
-    public Object getValueOnDisk(LocalRegion r) throws EntryNotFoundException {
-      // TODO Auto-generated method stub
+    public Object getValueOnDisk(InternalRegion region) throws EntryNotFoundException {
       return null;
     }
 
     @Override
-    public Object getValueOnDiskOrBuffer(LocalRegion r) throws EntryNotFoundException {
-      // TODO Auto-generated method stub
+    public Object getValueOnDiskOrBuffer(InternalRegion region) throws EntryNotFoundException {
       return null;
     }
 
     @Override
-    public boolean initialImagePut(LocalRegion region, long lastModified, Object newValue,
+    public boolean initialImagePut(InternalRegion region, long lastModified, Object newValue,
         boolean wasRecovered, boolean acceptedVersionTag) throws RegionClearedException {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
-    public boolean initialImageInit(LocalRegion region, long lastModified, Object newValue,
+    public boolean initialImageInit(InternalRegion region, long lastModified, Object newValue,
         boolean create, boolean wasRecovered, boolean acceptedVersionTag)
         throws RegionClearedException {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
-    public boolean destroy(LocalRegion region, EntryEventImpl event, boolean inTokenMode,
+    public boolean destroy(InternalRegion region, EntryEventImpl event, boolean inTokenMode,
         boolean cacheWrite, Object expectedOldValue, boolean forceDestroy,
         boolean removeRecoveredEntry) throws CacheWriterException, EntryNotFoundException,
         TimeoutException, RegionClearedException {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public boolean getValueWasResultOfSearch() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
-    public void setValueResultOfSearch(boolean v) {
-      // TODO Auto-generated method stub
+    public void setValueResultOfSearch(boolean value) {
+      // nothing
     }
 
     @Override
-    public Object getSerializedValueOnDisk(LocalRegion localRegion) {
-      // TODO Auto-generated method stub
+    public Object getSerializedValueOnDisk(InternalRegion region) {
       return null;
     }
 
     @Override
-    public Object getValueInVMOrDiskWithoutFaultIn(LocalRegion owner) {
-      // TODO Auto-generated method stub
+    public Object getValueInVMOrDiskWithoutFaultIn(InternalRegion region) {
       return null;
     }
 
     @Override
-    public Object getValueOffHeapOrDiskWithoutFaultIn(LocalRegion owner) {
-      // TODO Auto-generated method stub
+    public Object getValueOffHeapOrDiskWithoutFaultIn(InternalRegion region) {
       return null;
     }
 
     @Override
     public boolean isUpdateInProgress() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public void setUpdateInProgress(boolean underUpdate) {
-      // TODO Auto-generated method stub
+      // nothing
     }
 
     @Override
     public boolean isInvalid() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public boolean isDestroyed() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public boolean isDestroyedOrRemoved() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public boolean isDestroyedOrRemovedButNotTombstone() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public boolean isInvalidOrRemoved() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public void setValueToNull() {
-      // TODO Auto-generated method stub
+      // nothing
     }
 
     @Override
     public void returnToPool() {
-      // TODO Auto-generated method stub
+      // nothing
     }
 
     @Override
     public boolean isCacheListenerInvocationInProgress() {
-      // TODO Auto-generated method stub
       return false;
     }
 
     @Override
     public void setCacheListenerInvocationInProgress(boolean isListenerInvoked) {
-      // TODO Auto-generated method stub
-
+      // nothing
     }
 
     @Override
@@ -525,20 +518,28 @@ public class ValidatingDiskRegion extends DiskRegion implements DiskRecoveryStor
     }
 
     @Override
-    public void setInUseByTransaction(boolean v) {}
+    public void setInUseByTransaction(boolean inUseByTransaction) {
+      // nothing
+    }
 
     @Override
-    public void incRefCount() {}
+    public void incRefCount() {
+      // nothing
+    }
 
     @Override
-    public void decRefCount(NewLRUClockHand lruList, LocalRegion lr) {}
+    public void decRefCount(NewLRUClockHand lruList, InternalRegion region) {
+      // nothing
+    }
 
     @Override
-    public void resetRefCount(NewLRUClockHand lruList) {}
+    public void resetRefCount(NewLRUClockHand lruList) {
+      // nothing
+    }
 
     @Override
-    public Object prepareValueForCache(RegionEntryContext r, Object val, EntryEventImpl event,
-        boolean isEntryUpdate) {
+    public Object prepareValueForCache(RegionEntryContext context, Object value,
+        EntryEventImpl event, boolean isEntryUpdate) {
       throw new IllegalStateException("Should never be called");
     }
   }
@@ -547,6 +548,7 @@ public class ValidatingDiskRegion extends DiskRegion implements DiskRecoveryStor
   //////////////// DiskExceptionHandler methods ////////////////////
 
   public static class DummyDiskExceptionHandler implements DiskExceptionHandler {
+    @Override
     public void handleDiskAccessException(DiskAccessException dae) {
       // nothing needed
     }
@@ -564,8 +566,8 @@ public class ValidatingDiskRegion extends DiskRegion implements DiskRecoveryStor
     }
 
     @Override
-    public RuntimeException generateCancelledException(Throwable e) {
-      return new RuntimeException(e);
+    public RuntimeException generateCancelledException(Throwable throwable) {
+      return new RuntimeException(throwable);
     }
 
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/AbstractDiskRegionEntry.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/AbstractDiskRegionEntry.java
@@ -60,7 +60,7 @@ public abstract class AbstractDiskRegionEntry extends AbstractRegionEntry implem
   public void handleValueOverflow(RegionEntryContext context) {
     if (context instanceof BucketRegionQueue
         || context instanceof SerialGatewaySenderQueue.SerialGatewaySenderQueueMetaRegion) {
-      GatewaySenderEventImpl.release(this._getValue()); // OFFHEAP _getValue ok
+      GatewaySenderEventImpl.release(this.getValue()); // OFFHEAP _getValue ok
     }
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/AbstractRegionEntry.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/AbstractRegionEntry.java
@@ -54,7 +54,7 @@ import org.apache.geode.internal.InternalStatisticsDisabledException;
 import org.apache.geode.internal.Version;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.InternalCacheEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionClearedException;
 import org.apache.geode.internal.cache.RegionEntry;
 import org.apache.geode.internal.cache.RegionEntryContext;
@@ -65,6 +65,7 @@ import org.apache.geode.internal.cache.Token;
 import org.apache.geode.internal.cache.TombstoneService;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.persistence.DiskStoreID;
 import org.apache.geode.internal.cache.versions.ConcurrentCacheModificationException;
 import org.apache.geode.internal.cache.versions.RegionVersionVector;
@@ -148,7 +149,7 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
   @Override
   @SuppressWarnings("IMSE_DONT_CATCH_IMSE")
   public boolean dispatchListenerEvents(final EntryEventImpl event) throws InterruptedException {
-    final LocalRegion rgn = event.getRegion();
+    final InternalRegion rgn = event.getRegion();
 
     if (event.callbacksInvoked()) {
       return true;
@@ -177,7 +178,8 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
         // by the RegionMap. It is unclear why this code is needed. ARM destroy
         // does this also and we are now doing it as phase3 of the ARM destroy.
         removePhase2();
-        rgn.getRegionMap().removeEntry(event.getKey(), this, true, event, rgn);
+        ((DiskRecoveryStore) rgn).getRegionMap().removeEntry(event.getKey(), this, true, event,
+            rgn);
       }
     }
   }
@@ -220,8 +222,8 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
   }
 
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModifiedAndAccessedTimes(currTime, currTime);
+  public void txDidDestroy(long currentTime) {
+    setLastModifiedAndAccessedTimes(currentTime, currentTime);
   }
 
   @Override
@@ -249,7 +251,7 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
   }
 
   @Override
-  public void removePhase1(LocalRegion r, boolean clear) throws RegionClearedException {
+  public void removePhase1(InternalRegion region, boolean clear) throws RegionClearedException {
     _removePhase1();
   }
 
@@ -259,37 +261,38 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
   }
 
   @Override
-  public void makeTombstone(LocalRegion r, VersionTag version) throws RegionClearedException {
-    assert r.getVersionVector() != null;
+  public void makeTombstone(InternalRegion region, VersionTag version)
+      throws RegionClearedException {
+    assert region.getVersionVector() != null;
     assert version != null;
-    if (r.getServerProxy() == null && r.getVersionVector().isTombstoneTooOld(version.getMemberID(),
-        version.getRegionVersion())) {
+    if (region.getServerProxy() == null && region.getVersionVector()
+        .isTombstoneTooOld(version.getMemberID(), version.getRegionVersion())) {
       // distributed gc with higher vector version preempts this operation
       if (!isTombstone()) {
-        basicMakeTombstone(r);
-        r.incTombstoneCount(1);
+        basicMakeTombstone(region);
+        region.getCachePerfStats().incTombstoneCount(1);
       }
-      r.getRegionMap().removeTombstone(this, version, false, true);
+      ((DiskRecoveryStore) region).getRegionMap().removeTombstone(this, version, false, true);
     } else {
       if (isTombstone()) {
         // unschedule the old tombstone
-        r.unscheduleTombstone(this);
+        region.unscheduleTombstone(this);
       }
       setRecentlyUsed();
       boolean newEntry = getValueAsToken() == Token.REMOVED_PHASE1;
-      basicMakeTombstone(r);
-      r.scheduleTombstone(this, version);
+      basicMakeTombstone(region);
+      region.scheduleTombstone(this, version);
       if (newEntry) {
         // bug #46631 - entry count is decremented by scheduleTombstone but this is a new entry
-        r.getCachePerfStats().incEntryCount(1);
+        region.getCachePerfStats().incEntryCount(1);
       }
     }
   }
 
-  private void basicMakeTombstone(LocalRegion r) throws RegionClearedException {
+  private void basicMakeTombstone(InternalRegion region) throws RegionClearedException {
     boolean setValueCompleted = false;
     try {
-      setValue(r, Token.TOMBSTONE);
+      setValue(region, Token.TOMBSTONE);
       setValueCompleted = true;
     } finally {
       if (!setValueCompleted && isTombstone()) {
@@ -302,7 +305,7 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
   public void setValueWithTombstoneCheck(@Unretained Object v, EntryEvent e)
       throws RegionClearedException {
     if (v == Token.TOMBSTONE) {
-      makeTombstone((LocalRegion) e.getRegion(), ((InternalCacheEvent) e).getVersionTag());
+      makeTombstone((InternalRegion) e.getRegion(), ((InternalCacheEvent) e).getVersionTag());
     } else {
       setValue((RegionEntryContext) e.getRegion(), v, (EntryEventImpl) e);
     }
@@ -344,7 +347,7 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
   }
 
   @Override
-  public boolean fillInValue(LocalRegion region,
+  public boolean fillInValue(InternalRegion region,
       @Retained(ABSTRACT_REGION_ENTRY_FILL_IN_VALUE) Entry entry, ByteArrayDataInput in, DM mgr,
       final Version version) {
 
@@ -435,7 +438,8 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
   }
 
   @Override
-  public boolean isOverflowedToDisk(LocalRegion r, DistributedRegion.DiskPosition dp) {
+  public boolean isOverflowedToDisk(InternalRegion region,
+      DistributedRegion.DiskPosition diskPosition) {
     return false;
   }
 
@@ -443,7 +447,7 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
   public Object getValue(RegionEntryContext context) {
     ReferenceCountHelper.createReferenceCountOwner();
     @Retained
-    Object result = _getValueRetain(context, true);
+    Object result = getValueRetain(context, true);
 
     // If the thread is an Index Creation Thread & the value obtained is
     // Token.REMOVED , we can skip synchronization block. This is required to prevent
@@ -468,7 +472,7 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
   @Retained
   public Object getValueRetain(RegionEntryContext context) {
     @Retained
-    Object result = _getValueRetain(context, true);
+    Object result = getValueRetain(context, true);
     if (Token.isRemoved(result)) {
       return null;
     } else {
@@ -510,8 +514,8 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
   }
 
   private boolean isThisRegionBeingClosedOrDestroyed(RegionEntryContext context) {
-    return context instanceof LocalRegion
-        && ((LocalRegion) context).isThisRegionBeingClosedOrDestroyed();
+    return context instanceof InternalRegion
+        && ((InternalRegion) context).isThisRegionBeingClosedOrDestroyed();
   }
 
   private boolean isOffHeapReference(Object ref) {
@@ -608,7 +612,7 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
   public Object getValueInVM(RegionEntryContext context) {
     ReferenceCountHelper.createReferenceCountOwner();
     @Released
-    Object v = _getValueRetain(context, true);
+    Object v = getValueRetain(context, true);
 
     if (v == null) {
       // should only be possible if disk entry
@@ -620,27 +624,27 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
   }
 
   @Override
-  public Object getValueInVMOrDiskWithoutFaultIn(LocalRegion owner) {
-    return getValueInVM(owner);
+  public Object getValueInVMOrDiskWithoutFaultIn(InternalRegion region) {
+    return getValueInVM(region);
   }
 
   @Override
   @Retained
-  public Object getValueOffHeapOrDiskWithoutFaultIn(LocalRegion owner) {
+  public Object getValueOffHeapOrDiskWithoutFaultIn(InternalRegion region) {
     @Retained
-    Object result = _getValueRetain(owner, true);
+    Object result = getValueRetain(region, true);
     return result;
   }
 
   @Override
-  public Object getValueOnDisk(LocalRegion r) throws EntryNotFoundException {
+  public Object getValueOnDisk(InternalRegion region) throws EntryNotFoundException {
     throw new IllegalStateException(
         LocalizedStrings.AbstractRegionEntry_CANNOT_GET_VALUE_ON_DISK_FOR_A_REGION_THAT_DOES_NOT_ACCESS_THE_DISK
             .toLocalizedString());
   }
 
   @Override
-  public Object getSerializedValueOnDisk(final LocalRegion localRegion)
+  public Object getSerializedValueOnDisk(final InternalRegion region)
       throws EntryNotFoundException {
     throw new IllegalStateException(
         LocalizedStrings.AbstractRegionEntry_CANNOT_GET_VALUE_ON_DISK_FOR_A_REGION_THAT_DOES_NOT_ACCESS_THE_DISK
@@ -648,7 +652,7 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
   }
 
   @Override
-  public Object getValueOnDiskOrBuffer(LocalRegion r) throws EntryNotFoundException {
+  public Object getValueOnDiskOrBuffer(InternalRegion region) throws EntryNotFoundException {
     throw new IllegalStateException(
         LocalizedStrings.AbstractRegionEntry_CANNOT_GET_VALUE_ON_DISK_FOR_A_REGION_THAT_DOES_NOT_ACCESS_THE_DISK
             .toLocalizedString());
@@ -656,15 +660,16 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
   }
 
   @Override
-  public boolean initialImagePut(final LocalRegion region, final long lastModified, Object newValue,
-      boolean wasRecovered, boolean acceptedVersionTag) throws RegionClearedException {
+  public boolean initialImagePut(final InternalRegion region, final long lastModified,
+      Object newValue, boolean wasRecovered, boolean acceptedVersionTag)
+      throws RegionClearedException {
     // note that the caller has already write synced this RegionEntry
     return initialImageInit(region, lastModified, newValue, this.isTombstone(), wasRecovered,
         acceptedVersionTag);
   }
 
   @Override
-  public boolean initialImageInit(final LocalRegion region, final long lastModified,
+  public boolean initialImageInit(final InternalRegion region, final long lastModified,
       final Object newValue, final boolean create, final boolean wasRecovered,
       final boolean acceptedVersionTag) throws RegionClearedException {
 
@@ -772,7 +777,7 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
    */
   @Override
   @Released
-  public boolean destroy(LocalRegion region, EntryEventImpl event, boolean inTokenMode,
+  public boolean destroy(InternalRegion region, EntryEventImpl event, boolean inTokenMode,
       boolean cacheWrite, @Unretained Object expectedOldValue, boolean forceDestroy,
       boolean removeRecoveredEntry) throws CacheWriterException, EntryNotFoundException,
       TimeoutException, RegionClearedException {
@@ -794,7 +799,7 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
     ReferenceCountHelper.skipRefCountTracking();
     @Retained
     @Released
-    Object curValue = _getValueRetain(region, true);
+    Object curValue = getValueRetain(region, true);
     ReferenceCountHelper.unskipRefCountTracking();
     boolean proceed;
     try {
@@ -927,13 +932,13 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
   }
 
   public static boolean checkExpectedOldValue(@Unretained Object expectedOldValue,
-      @Unretained Object actualValue, LocalRegion lr) {
+      @Unretained Object actualValue, InternalRegion region) {
 
     if (Token.isInvalid(expectedOldValue)) {
       return actualValue == null || Token.isInvalid(actualValue);
     } else {
       boolean isCompressedOffHeap =
-          lr.getAttributes().getOffHeap() && lr.getAttributes().getCompressor() != null;
+          region.getAttributes().getOffHeap() && region.getAttributes().getCompressor() != null;
       return checkEquals(expectedOldValue, actualValue, isCompressedOffHeap);
     }
   }
@@ -1404,7 +1409,7 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
 
   @Override
   @Unretained
-  public Object _getValue() {
+  public Object getValue() {
     return getValueField();
   }
 
@@ -1457,7 +1462,7 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
   }
 
   @Override
-  public synchronized void decRefCount(NewLRUClockHand lruList, LocalRegion lr) {
+  public synchronized void decRefCount(NewLRUClockHand lruList, InternalRegion region) {
     if (TXManagerImpl.decRefCount(this)) {
       if (isInUseByTransaction()) {
         setInUseByTransaction(false);
@@ -1465,8 +1470,8 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
           // No more transactions, place in lru list
           lruList.appendEntry((LRUClockNode) this);
         }
-        if (lr != null && lr.isEntryExpiryPossible()) {
-          lr.addExpiryTaskIfAbsent(this);
+        if (region != null && region.isEntryExpiryPossible()) {
+          region.addExpiryTaskIfAbsent(this);
         }
       }
     }
@@ -1514,7 +1519,7 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
   @Override
   @Retained
   public Object getTransformedValue() {
-    return _getValueRetain(null, false);
+    return getValueRetain(null, false);
   }
 
   @Override
@@ -1567,7 +1572,7 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
   protected StringBuilder appendFieldsToString(final StringBuilder sb) {
     // OFFHEAP _getValue ok: the current toString on ObjectChunk is safe to use without incing
     // refcount.
-    sb.append("key=").append(getKey()).append("; rawValue=").append(_getValue());
+    sb.append("key=").append(getKey()).append("; rawValue=").append(getValue());
     VersionStamp stamp = getVersionStamp();
     if (stamp != null) {
       sb.append("; version=").append(stamp.asVersionTag()).append(";member=")
@@ -1581,8 +1586,8 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
    * versioning. It also sets the entry's version stamp to the tag's values.
    */
   @Override
-  public VersionTag generateVersionTag(VersionSource member, boolean withDelta, LocalRegion region,
-      EntryEventImpl event) {
+  public VersionTag generateVersionTag(VersionSource member, boolean withDelta,
+      InternalRegion region, EntryEventImpl event) {
     VersionStamp stamp = this.getVersionStamp();
     if (stamp != null && region.getServerProxy() == null) {
       // clients do not generate versions
@@ -1710,7 +1715,7 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
       final InternalDistributedMember originator =
           (InternalDistributedMember) event.getDistributedMember();
       final VersionSource dmId = event.getRegion().getVersionMember();
-      LocalRegion r = event.getLocalRegion();
+      InternalRegion r = event.getLocalRegion();
       boolean eventHasDelta = event.getDeltaBytes() != null && event.getRawNewValue() == null;
 
       VersionStamp stamp = getVersionStamp();
@@ -1791,7 +1796,7 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
     }
   }
 
-  protected void basicProcessVersionTag(LocalRegion region, VersionTag tag,
+  protected void basicProcessVersionTag(InternalRegion region, VersionTag tag,
       boolean isTombstoneFromGII, boolean deltaCheck, VersionSource dmId,
       InternalDistributedMember sender, boolean checkForConflict) {
 
@@ -1849,7 +1854,7 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
     }
   }
 
-  private void applyVersionTag(LocalRegion region, VersionStamp stamp, VersionTag tag,
+  private void applyVersionTag(InternalRegion region, VersionStamp stamp, VersionTag tag,
       InternalDistributedMember sender) {
     VersionSource mbr = tag.getMemberID();
     if (mbr == null) {
@@ -1869,7 +1874,7 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
   }
 
   /** perform conflict checking for a stamp/tag */
-  private boolean checkForConflict(LocalRegion region, VersionStamp stamp, VersionTag tag,
+  private boolean checkForConflict(InternalRegion region, VersionStamp stamp, VersionTag tag,
       boolean isTombstoneFromGII, boolean deltaCheck, VersionSource dmId,
       InternalDistributedMember sender, StringBuilder verbose) {
 
@@ -1977,12 +1982,12 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
     return apply;
   }
 
-  private boolean isExpiredTombstone(LocalRegion region, long timestamp, boolean isTombstone) {
+  private boolean isExpiredTombstone(InternalRegion region, long timestamp, boolean isTombstone) {
     return isTombstone
         && timestamp + TombstoneService.REPLICATE_TOMBSTONE_TIMEOUT <= region.cacheTimeMillis();
   }
 
-  private boolean overwritingOldTombstone(LocalRegion region, VersionStamp stamp, VersionTag tag,
+  private boolean overwritingOldTombstone(InternalRegion region, VersionStamp stamp, VersionTag tag,
       StringBuilder verbose) {
     // Tombstone GC does not use locking to stop operations when old tombstones
     // are being removed. Because of this we might get an operation that was applied
@@ -2002,7 +2007,7 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
     }
   }
 
-  protected void persistConflictingTag(LocalRegion region, VersionTag tag) {
+  protected void persistConflictingTag(InternalRegion region, VersionTag tag) {
     // only persist region needs to persist conflict tag
   }
 
@@ -2011,7 +2016,7 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
    * stamp's member id and ensure that the version is only incremented by 1. Otherwise the delta is
    * being applied to a value that does not match the source of the delta.
    */
-  private void checkForDeltaConflict(LocalRegion region, long stampVersion, long tagVersion,
+  private void checkForDeltaConflict(InternalRegion region, long stampVersion, long tagVersion,
       VersionStamp stamp, VersionTag tag, VersionSource dmId, InternalDistributedMember sender,
       StringBuilder verbose) {
 
@@ -2045,7 +2050,7 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
   }
 
   private boolean processGatewayTag(EntryEvent cacheEvent) {
-    // Gateway tags are installed in the server-side LocalRegion cache
+    // Gateway tags are installed in the server-side InternalRegion cache
     // modification methods. They do not have version numbers or distributed
     // member IDs. Instead they only have timestamps and distributed system IDs.
 
@@ -2212,11 +2217,11 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
    */
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(RegionEntryContext context, boolean decompress) {
     if (decompress) {
-      return decompress(context, _getValue());
+      return decompress(context, getValue());
     } else {
-      return _getValue();
+      return getValue();
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/LeafRegionEntry.cpp
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/LeafRegionEntry.cpp
@@ -38,24 +38,24 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 #if defined(VERSIONED)
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 #endif
 import org.apache.geode.internal.cache.RegionEntryContext;
 #if defined(DISK) || defined(LRU)
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 #endif
 #ifdef DISK
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 #endif
 #ifdef STATS
 import org.apache.geode.internal.InternalStatisticsDisabledException;
 #endif
 #ifdef LRU
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 #endif
@@ -74,32 +74,141 @@ import org.apache.geode.internal.offheap.annotations.Unretained;
 #endif
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK
+ * lru: LRU
+ * stats: STATS
+ * versioned: VERSIONED
+ * offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT
+ * key int: KEY_INT
+ * key long: KEY_LONG
+ * key uuid: KEY_UUID
+ * key string1: KEY_STRING1
+ * key string2: KEY_STRING2
+ */
 
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class LEAF_CLASS extends PARENT_CLASS {
-  public LEAF_CLASS  (RegionEntryContext context, KEY_TYPE key, 
+
+  // --------------------------------------- common fields ----------------------------------------
+
+  private static final AtomicLongFieldUpdater<LEAF_CLASS> LAST_MODIFIED_UPDATER
+    = AtomicLongFieldUpdater.newUpdater(LEAF_CLASS.class, "lastModified");
+
+  protected int hash;
+
+  private HashEntry<Object, Object> nextEntry;
+
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+
+#ifdef OFFHEAP
+#else
+  private volatile Object value;
+#endif
+#ifdef OFFHEAP
+  // --------------------------------------- offheap fields ---------------------------------------
+
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained @Released private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<LEAF_CLASS> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(LEAF_CLASS.class, "offHeapAddress");
+#endif
+#ifdef DISK
+
+  // ---------------------------------------- disk fields -----------------------------------------
+
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+#endif
+#ifdef STATS
+
+  // --------------------------------------- stats fields -----------------------------------------
+
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+
+  private static final AtomicIntegerFieldUpdater<LEAF_CLASS> HIT_COUNT_UPDATER
+    = AtomicIntegerFieldUpdater.newUpdater(LEAF_CLASS.class, "hitCount");
+
+  private static final AtomicIntegerFieldUpdater<LEAF_CLASS> MISS_COUNT_UPDATER
+    = AtomicIntegerFieldUpdater.newUpdater(LEAF_CLASS.class, "missCount");
+#endif
+#ifdef VERSIONED
+
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+#endif
+
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
+#ifdef KEY_OBJECT
+  private final Object key;
+#elif defined(KEY_INT)
+  private final int key;
+#elif defined(KEY_LONG)
+  private final long key;
+#elif defined(KEY_LONG)
+  private final long key;
+#elif defined(KEY_UUID)
+  private final long keyMostSigBits;
+  private final long keyLeastSigBits;
+#elif defined(KEY_STRING1)
+  private final long bits1;
+#elif defined(KEY_STRING2)
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
+  private final long bits1;
+
+  /**
+   * bits2 encodes character data
+   */
+  private final long bits2;
+#endif
+
+  public LEAF_CLASS (final RegionEntryContext context, final KEY_TYPE key,
 #ifdef OFFHEAP
       @Retained
 #endif
-      Object value
+      final Object value
 #if defined(KEY_STRING1) || defined(KEY_STRING2)
-      , boolean byteEncode
+      , final boolean byteEncode
 #endif
       ) {
     super(context, 
@@ -124,80 +233,60 @@ public class LEAF_CLASS extends PARENT_CLASS {
     this.keyLeastSigBits = key.getLeastSignificantBits();
 #elif defined(KEY_STRING1)
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
-      for (int i=key.length()-1; i >= 0; i--) {
-        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to keep findbugs happy.
-        tmpBits1 |= (byte)key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+      for (int i = key.length() - 1; i >= 0; i--) {
+        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
+        // keep findbugs happy.
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1<<6;
+      tempBits1 |= 1<<6;
     } else {
-      for (int i=key.length()-1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+      for (int i = key.length() - 1; i >= 0; i--) {
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
 #elif defined(KEY_STRING2)
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
-      for (int i=key.length()-1; i >= 0; i--) {
-        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to keep findbugs happy.
+      for (int i = key.length() - 1; i >= 0; i--) {
+        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
+        // keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte)key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte)key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte)key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte)key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1<<6;
+      tempBits1 |= 1<<6;
     } else {
-      for (int i=key.length()-1; i >= 0; i--) {
+      for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
 #endif
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<LEAF_CLASS> lastModifiedUpdater
-    = AtomicLongFieldUpdater.newUpdater(LEAF_CLASS.class, "lastModified");
+
 #ifdef OFFHEAP
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained @Released private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called while the re is synced.
-   * But if I sync in that code it causes a lock ordering deadlock with the disk regions because they also get a rw lock in clear.
-   * Some hardware platforms do not support CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync
-   * on the re and we will once again be deadlocked.
-   * I don't know if we support any of the hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks
-   * on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<LEAF_CLASS> ohAddrUpdater = AtomicLongFieldUpdater.newUpdater(LEAF_CLASS.class, "ohAddress");
-  
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -209,31 +298,33 @@ public class LEAF_CLASS extends PARENT_CLASS {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+
   @Override
 #ifdef OFFHEAP
   @Unretained
-  protected void setValueField(@Unretained Object v) {
+  protected void setValueField(@Unretained final Object value) {
 #else
-  protected void setValueField(Object v) {
+  protected void setValueField(final Object value) {
 #endif
-    OffHeapRegionEntryHelper.setValue(this, v);
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
+
   @Override
 #ifdef OFFHEAP
   @Retained
 #endif
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
   
   @Override
@@ -246,154 +337,169 @@ public class LEAF_CLASS extends PARENT_CLASS {
   
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
-#else    
-  private volatile Object value;
+#else
   @Override
   protected Object getValueField() {
     return this.value;
   }
+
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 #endif
+
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
-  protected void setEntryHash(int v) {
-    this.hash = v;
+
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 #ifdef DISK
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  
-  // disk code
+
 #ifdef LRU
-  protected void initialize(RegionEntryContext drs, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion)drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof InternalRegion) {
+      isBackup = ((InternalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
-      throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
+      throw new IllegalArgumentException("expected a InternalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
+
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
-    int newSize = capacityController.entrySize( getKeyForSizing(), null);
+    int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
     int delta = newSize - oldSize;
     return delta;
   }
 #else
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
+
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 #endif
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore)context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    //get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;//= new DiskId();
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
+
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry)old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
+  }
+
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
   }
 #endif
   
 #ifdef LRU
+  // --------------------------------------- eviction code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  
-  // lru code
+
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
 #ifdef DISK
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
 #else
     // nothing needed for LRUs with no disk
 #endif
   }
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue());  // OFHEAP: _getValue ok w/o incing refcount because we are synced and only getting the size
+
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
   
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   
-  public synchronized int updateEntrySize(EnableLRU capacityController,
-                                                Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
-    int newSize = capacityController.entrySize( getKeyForSizing(), value);
+    int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
     int delta = newSize - oldSize;
     return delta;
   }
+
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
+
   @Override
   public void setRecentlyUsed() {
     setBits(RECENTLY_USED);
   }
+
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
+
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
+
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
+
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
@@ -401,24 +507,35 @@ public class LEAF_CLASS extends PARENT_CLASS {
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
-  public void setNextLRUNode( LRUClockNode next ) {
-    this.nextLRU = next;
+
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
+
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
-  public void setPrevLRUNode( LRUClockNode prev ) {
-    this.prevLRU = prev;
+
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
+
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
+
+  @Override
   public int getEntrySize() {
     return this.size;
   }
-  protected void setEntrySize(int size) {
+
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -437,71 +554,70 @@ public class LEAF_CLASS extends PARENT_CLASS {
 #endif
 
 #ifdef STATS
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  
-  // stats code
+
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
     }
   }
+
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) { 
       setLastAccessed(lastAccessed);
     }
   }
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  
-  private static final AtomicIntegerFieldUpdater<LEAF_CLASS> hitCountUpdater 
-    = AtomicIntegerFieldUpdater.newUpdater(LEAF_CLASS.class, "hitCount");
-  private static final AtomicIntegerFieldUpdater<LEAF_CLASS> missCountUpdater 
-    = AtomicIntegerFieldUpdater.newUpdater(LEAF_CLASS.class, "missCount");
-  
+
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
     return this.lastAccessed;
   }
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
+
   @Override
   public long getHitCount() throws InternalStatisticsDisabledException {
     return this.hitCount & 0xFFFFFFFFL;
   }
+
   @Override
   public long getMissCount() throws InternalStatisticsDisabledException {
     return this.missCount & 0xFFFFFFFFL;
   }
+
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
+
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
+
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this,0);
-    missCountUpdater.set(this,0);
+    HIT_COUNT_UPDATER.set(this,0);
+    MISS_COUNT_UPDATER.set(this,0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
+
   @Override
   public boolean hasStats() {
     return true;
@@ -509,63 +625,66 @@ public class LEAF_CLASS extends PARENT_CLASS {
 #endif
   
 #ifdef VERSIONED
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
 
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
   
+  @Override
   public long getRegionVersion() {
     return (((long)regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);  
   }
-  
-  
+
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
   
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
+
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
-    this.entryVersionLowBytes = (short)(eVersion & 0xffff);
-    this.entryVersionHighByte = (byte)((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
+    this.entryVersionLowBytes = (short) (eVersion & 0xffff);
+    this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+
+    if (!versionTag.isGatewayTag() && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte)(tag.getDistributedSystemId() & 0xff);
+
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID; 
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -575,8 +694,9 @@ public class LEAF_CLASS extends PARENT_CLASS {
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -584,79 +704,79 @@ public class LEAF_CLASS extends PARENT_CLASS {
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag,
-      boolean isTombstoneFromGII, boolean hasDelta,
-      VersionSource thisVM, InternalDistributedMember sender, boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender, checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
   
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 #endif
   
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  
-  // key code
+
 #ifdef KEY_OBJECT
-  private final Object key;
   @Override
   public Object getKey() {
     return this.key;
   }
 
 #elif defined(KEY_INT)
-  private final int key;
   @Override
   public Object getKey() {
     return this.key;
   }
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }
   
 #elif defined(KEY_LONG)
-  private final long key;
   @Override
   public Object getKey() {
     return this.key;
   }
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }
   
 #elif defined(KEY_UUID)
-  private final long keyMostSigBits;
-  private final long keyLeastSigBits;
   @Override
   public Object getKey() {
     return new UUID(this.keyMostSigBits, this.keyLeastSigBits);
   }
+
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }
@@ -664,60 +784,66 @@ public class LEAF_CLASS extends PARENT_CLASS {
   }
   
 #elif defined(KEY_STRING1)
-  private final long bits1;
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
+
   private int getEncoding() {
     // 0 means encoded as char
     // 1 means encoded as bytes that are all <= 0x7f;
     return (int) (this.bits1 >> 6) & 0x03;
   }
+
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+
     if (getEncoding() == 1) {
-      for (int i=0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-      chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i=0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+      chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i=0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i=0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
+
     return new String(chars);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String)k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+
         if (getEncoding() == 1) {
-          for (int i=0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i=0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
@@ -725,44 +851,42 @@ public class LEAF_CLASS extends PARENT_CLASS {
   }
   
 #elif defined(KEY_STRING2)
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
-  private final long bits1;
-  // bits2 encodes character data
-  private final long bits2;
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
+
   private int getEncoding() {
     // 0 means encoded as char
     // 1 means encoded as bytes that are all <= 0x7f;
     return (int) (this.bits1 >> 6) & 0x03;
   }
+
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
+
     if (getEncoding() == 1) {
-      for (int i=0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
+
     } else {
-      for (int i=0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -772,47 +896,51 @@ public class LEAF_CLASS extends PARENT_CLASS {
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String)k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String)key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
+
         if (getEncoding() == 1) {
-          for (int i=0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
+
         } else {
-          for (int i=0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         }
+
         return true;
       }
     }
     return false;
   }
 #endif
+
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskLRURegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskLRURegionEntryHeapIntKey.java
@@ -19,36 +19,59 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskLRURegionEntryHeapIntKey extends VMStatsDiskLRURegionEntryHeap {
-  public VMStatsDiskLRURegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryHeapIntKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapIntKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapIntKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapIntKey.class, "hitCount");
+  private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapIntKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapIntKey.class, "missCount");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final int key;
+
+  public VMStatsDiskLRURegionEntryHeapIntKey(final RegionEntryContext context, final int key,
+      final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -56,77 +79,65 @@ public class VMStatsDiskLRURegionEntryHeapIntKey extends VMStatsDiskLRURegionEnt
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryHeapIntKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapIntKey.class, "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof InternalRegion) {
+      isBackup = ((InternalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
-      throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
+      throw new IllegalArgumentException("expected a InternalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -135,48 +146,43 @@ public class VMStatsDiskLRURegionEntryHeapIntKey extends VMStatsDiskLRURegionEnt
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -184,6 +190,7 @@ public class VMStatsDiskLRURegionEntryHeapIntKey extends VMStatsDiskLRURegionEnt
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -193,48 +200,57 @@ public class VMStatsDiskLRURegionEntryHeapIntKey extends VMStatsDiskLRURegionEnt
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -245,12 +261,12 @@ public class VMStatsDiskLRURegionEntryHeapIntKey extends VMStatsDiskLRURegionEnt
     return null;
   }
 
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -258,20 +274,12 @@ public class VMStatsDiskLRURegionEntryHeapIntKey extends VMStatsDiskLRURegionEnt
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapIntKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapIntKey.class, "hitCount");
-  private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapIntKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapIntKey.class, "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -279,7 +287,7 @@ public class VMStatsDiskLRURegionEntryHeapIntKey extends VMStatsDiskLRURegionEnt
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -294,24 +302,24 @@ public class VMStatsDiskLRURegionEntryHeapIntKey extends VMStatsDiskLRURegionEnt
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -321,19 +329,17 @@ public class VMStatsDiskLRURegionEntryHeapIntKey extends VMStatsDiskLRURegionEnt
     return true;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final int key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskLRURegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskLRURegionEntryHeapLongKey.java
@@ -19,36 +19,59 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskLRURegionEntryHeapLongKey extends VMStatsDiskLRURegionEntryHeap {
-  public VMStatsDiskLRURegionEntryHeapLongKey(RegionEntryContext context, long key, Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryHeapLongKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapLongKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapLongKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapLongKey.class, "hitCount");
+  private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapLongKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapLongKey.class, "missCount");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long key;
+
+  public VMStatsDiskLRURegionEntryHeapLongKey(final RegionEntryContext context, final long key,
+      final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -56,77 +79,65 @@ public class VMStatsDiskLRURegionEntryHeapLongKey extends VMStatsDiskLRURegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryHeapLongKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapLongKey.class, "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof InternalRegion) {
+      isBackup = ((InternalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
-      throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
+      throw new IllegalArgumentException("expected a InternalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -135,48 +146,43 @@ public class VMStatsDiskLRURegionEntryHeapLongKey extends VMStatsDiskLRURegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -184,6 +190,7 @@ public class VMStatsDiskLRURegionEntryHeapLongKey extends VMStatsDiskLRURegionEn
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -193,48 +200,57 @@ public class VMStatsDiskLRURegionEntryHeapLongKey extends VMStatsDiskLRURegionEn
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -245,12 +261,12 @@ public class VMStatsDiskLRURegionEntryHeapLongKey extends VMStatsDiskLRURegionEn
     return null;
   }
 
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -258,20 +274,12 @@ public class VMStatsDiskLRURegionEntryHeapLongKey extends VMStatsDiskLRURegionEn
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapLongKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapLongKey.class, "hitCount");
-  private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapLongKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapLongKey.class, "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -279,7 +287,7 @@ public class VMStatsDiskLRURegionEntryHeapLongKey extends VMStatsDiskLRURegionEn
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -294,24 +302,24 @@ public class VMStatsDiskLRURegionEntryHeapLongKey extends VMStatsDiskLRURegionEn
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -321,19 +329,17 @@ public class VMStatsDiskLRURegionEntryHeapLongKey extends VMStatsDiskLRURegionEn
     return true;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskLRURegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskLRURegionEntryHeapObjectKey.java
@@ -19,37 +19,62 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskLRURegionEntryHeapObjectKey extends VMStatsDiskLRURegionEntryHeap {
-  public VMStatsDiskLRURegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-      Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryHeapObjectKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapObjectKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapObjectKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapObjectKey.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapObjectKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapObjectKey.class,
+          "missCount");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final Object key;
+
+  public VMStatsDiskLRURegionEntryHeapObjectKey(final RegionEntryContext context, final Object key,
+      final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -57,78 +82,65 @@ public class VMStatsDiskLRURegionEntryHeapObjectKey extends VMStatsDiskLRURegion
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryHeapObjectKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapObjectKey.class,
-          "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof InternalRegion) {
+      isBackup = ((InternalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
-      throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
+      throw new IllegalArgumentException("expected a InternalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -137,48 +149,43 @@ public class VMStatsDiskLRURegionEntryHeapObjectKey extends VMStatsDiskLRURegion
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -186,6 +193,7 @@ public class VMStatsDiskLRURegionEntryHeapObjectKey extends VMStatsDiskLRURegion
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -195,48 +203,57 @@ public class VMStatsDiskLRURegionEntryHeapObjectKey extends VMStatsDiskLRURegion
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -247,12 +264,12 @@ public class VMStatsDiskLRURegionEntryHeapObjectKey extends VMStatsDiskLRURegion
     return getKey();
   }
 
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -260,22 +277,12 @@ public class VMStatsDiskLRURegionEntryHeapObjectKey extends VMStatsDiskLRURegion
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapObjectKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapObjectKey.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapObjectKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapObjectKey.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -283,7 +290,7 @@ public class VMStatsDiskLRURegionEntryHeapObjectKey extends VMStatsDiskLRURegion
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -298,24 +305,24 @@ public class VMStatsDiskLRURegionEntryHeapObjectKey extends VMStatsDiskLRURegion
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -325,10 +332,8 @@ public class VMStatsDiskLRURegionEntryHeapObjectKey extends VMStatsDiskLRURegion
     return true;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final Object key;
-
   @Override
   public Object getKey() {
     return this.key;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskLRURegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskLRURegionEntryHeapStringKey1.java
@@ -19,133 +19,145 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegionEntryHeap {
-  public VMStatsDiskLRURegionEntryHeapStringKey1(RegionEntryContext context, String key,
-      Object value, boolean byteEncode) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryHeapStringKey1> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapStringKey1.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapStringKey1> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapStringKey1.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapStringKey1> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapStringKey1.class,
+          "missCount");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long bits1;
+
+  public VMStatsDiskLRURegionEntryHeapStringKey1(final RegionEntryContext context, final String key,
+      final Object value, final boolean byteEncode) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryHeapStringKey1> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapStringKey1.class,
-          "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof InternalRegion) {
+      isBackup = ((InternalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
-      throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
+      throw new IllegalArgumentException("expected a InternalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -154,48 +166,43 @@ public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -203,6 +210,7 @@ public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegio
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -212,48 +220,57 @@ public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegio
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -264,12 +281,12 @@ public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegio
     return null;
   }
 
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -277,22 +294,12 @@ public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegio
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapStringKey1> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapStringKey1.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapStringKey1> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapStringKey1.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -300,7 +307,7 @@ public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegio
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -315,24 +322,24 @@ public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegio
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -342,10 +349,8 @@ public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegio
     return true;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long bits1;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -358,18 +363,18 @@ public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegio
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
     return new String(chars);
@@ -377,25 +382,25 @@ public class VMStatsDiskLRURegionEntryHeapStringKey1 extends VMStatsDiskLRURegio
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskLRURegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskLRURegionEntryHeapStringKey2.java
@@ -19,145 +19,166 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegionEntryHeap {
-  public VMStatsDiskLRURegionEntryHeapStringKey2(RegionEntryContext context, String key,
-      Object value, boolean byteEncode) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryHeapStringKey2> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapStringKey2.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapStringKey2> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapStringKey2.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapStringKey2> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapStringKey2.class,
+          "missCount");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
+  private final long bits1;
+  /**
+   * bits2 encodes character data
+   */
+  private final long bits2;
+
+  public VMStatsDiskLRURegionEntryHeapStringKey2(final RegionEntryContext context, final String key,
+      final Object value, final boolean byteEncode) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryHeapStringKey2> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapStringKey2.class,
-          "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof InternalRegion) {
+      isBackup = ((InternalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
-      throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
+      throw new IllegalArgumentException("expected a InternalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -166,48 +187,43 @@ public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -215,6 +231,7 @@ public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegio
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -224,48 +241,57 @@ public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegio
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -276,12 +302,12 @@ public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegio
     return null;
   }
 
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -289,22 +315,12 @@ public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegio
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapStringKey2> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapStringKey2.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapStringKey2> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapStringKey2.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -312,7 +328,7 @@ public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegio
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -327,24 +343,24 @@ public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegio
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -354,15 +370,8 @@ public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegio
     return true;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
-  private final long bits1;
-  // bits2 encodes character data
-  private final long bits2;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -375,28 +384,28 @@ public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegio
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -405,38 +414,38 @@ public class VMStatsDiskLRURegionEntryHeapStringKey2 extends VMStatsDiskLRURegio
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskLRURegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskLRURegionEntryHeapUUIDKey.java
@@ -20,36 +20,60 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskLRURegionEntryHeapUUIDKey extends VMStatsDiskLRURegionEntryHeap {
-  public VMStatsDiskLRURegionEntryHeapUUIDKey(RegionEntryContext context, UUID key, Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryHeapUUIDKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapUUIDKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapUUIDKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapUUIDKey.class, "hitCount");
+  private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapUUIDKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapUUIDKey.class, "missCount");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long keyMostSigBits;
+  private final long keyLeastSigBits;
+
+  public VMStatsDiskLRURegionEntryHeapUUIDKey(final RegionEntryContext context, final UUID key,
+      final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -58,77 +82,65 @@ public class VMStatsDiskLRURegionEntryHeapUUIDKey extends VMStatsDiskLRURegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryHeapUUIDKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapUUIDKey.class, "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof InternalRegion) {
+      isBackup = ((InternalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
-      throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
+      throw new IllegalArgumentException("expected a InternalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -137,48 +149,43 @@ public class VMStatsDiskLRURegionEntryHeapUUIDKey extends VMStatsDiskLRURegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -186,6 +193,7 @@ public class VMStatsDiskLRURegionEntryHeapUUIDKey extends VMStatsDiskLRURegionEn
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -195,48 +203,57 @@ public class VMStatsDiskLRURegionEntryHeapUUIDKey extends VMStatsDiskLRURegionEn
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -247,12 +264,12 @@ public class VMStatsDiskLRURegionEntryHeapUUIDKey extends VMStatsDiskLRURegionEn
     return null;
   }
 
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -260,20 +277,12 @@ public class VMStatsDiskLRURegionEntryHeapUUIDKey extends VMStatsDiskLRURegionEn
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapUUIDKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapUUIDKey.class, "hitCount");
-  private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryHeapUUIDKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryHeapUUIDKey.class, "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -281,7 +290,7 @@ public class VMStatsDiskLRURegionEntryHeapUUIDKey extends VMStatsDiskLRURegionEn
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -296,24 +305,24 @@ public class VMStatsDiskLRURegionEntryHeapUUIDKey extends VMStatsDiskLRURegionEn
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -323,20 +332,17 @@ public class VMStatsDiskLRURegionEntryHeapUUIDKey extends VMStatsDiskLRURegionEn
     return true;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long keyMostSigBits;
-  private final long keyLeastSigBits;
-
   @Override
   public Object getKey() {
     return new UUID(this.keyMostSigBits, this.keyLeastSigBits);
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskLRURegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskLRURegionEntryOffHeapIntKey.java
@@ -19,13 +19,13 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.cache.Token;
@@ -35,26 +35,71 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegionEntryOffHeap {
-  public VMStatsDiskLRURegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapIntKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapIntKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapIntKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapIntKey.class,
+          "offHeapAddress");
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryOffHeapIntKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapIntKey.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryOffHeapIntKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapIntKey.class,
+          "missCount");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final int key;
+
+  public VMStatsDiskLRURegionEntryOffHeapIntKey(final RegionEntryContext context, final int key,
+      @Retained final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -62,32 +107,6 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapIntKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapIntKey.class,
-          "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapIntKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapIntKey.class, "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -101,24 +120,24 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -129,61 +148,58 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof InternalRegion) {
+      isBackup = ((InternalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
-      throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
+      throw new IllegalArgumentException("expected a InternalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -192,48 +208,43 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -241,6 +252,7 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -250,48 +262,57 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -302,12 +323,12 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
     return null;
   }
 
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -315,22 +336,12 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryOffHeapIntKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapIntKey.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryOffHeapIntKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapIntKey.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -338,7 +349,7 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -353,24 +364,24 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -380,19 +391,17 @@ public class VMStatsDiskLRURegionEntryOffHeapIntKey extends VMStatsDiskLRURegion
     return true;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final int key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskLRURegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskLRURegionEntryOffHeapLongKey.java
@@ -19,13 +19,13 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.cache.Token;
@@ -35,26 +35,71 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegionEntryOffHeap {
-  public VMStatsDiskLRURegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapLongKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapLongKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapLongKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapLongKey.class,
+          "offHeapAddress");
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryOffHeapLongKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapLongKey.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryOffHeapLongKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapLongKey.class,
+          "missCount");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long key;
+
+  public VMStatsDiskLRURegionEntryOffHeapLongKey(final RegionEntryContext context, final long key,
+      @Retained final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -62,32 +107,6 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapLongKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapLongKey.class,
-          "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapLongKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapLongKey.class, "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -101,24 +120,24 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -129,61 +148,58 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof InternalRegion) {
+      isBackup = ((InternalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
-      throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
+      throw new IllegalArgumentException("expected a InternalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -192,48 +208,43 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -241,6 +252,7 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -250,48 +262,57 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -302,12 +323,12 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
     return null;
   }
 
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -315,22 +336,12 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryOffHeapLongKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapLongKey.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryOffHeapLongKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapLongKey.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -338,7 +349,7 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -353,24 +364,24 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -380,19 +391,17 @@ public class VMStatsDiskLRURegionEntryOffHeapLongKey extends VMStatsDiskLRURegio
     return true;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskLRURegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskLRURegionEntryOffHeapObjectKey.java
@@ -19,13 +19,13 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.cache.Token;
@@ -35,26 +35,71 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRURegionEntryOffHeap {
-  public VMStatsDiskLRURegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapObjectKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapObjectKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapObjectKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapObjectKey.class,
+          "offHeapAddress");
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryOffHeapObjectKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapObjectKey.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryOffHeapObjectKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapObjectKey.class,
+          "missCount");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final Object key;
+
+  public VMStatsDiskLRURegionEntryOffHeapObjectKey(final RegionEntryContext context,
+      final Object key, @Retained final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -62,33 +107,6 @@ public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRUReg
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapObjectKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapObjectKey.class,
-          "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapObjectKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapObjectKey.class,
-          "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -102,24 +120,24 @@ public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRUReg
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -130,61 +148,58 @@ public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRUReg
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof InternalRegion) {
+      isBackup = ((InternalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
-      throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
+      throw new IllegalArgumentException("expected a InternalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -193,48 +208,43 @@ public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRUReg
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -242,6 +252,7 @@ public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRUReg
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -251,48 +262,57 @@ public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRUReg
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -303,12 +323,12 @@ public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRUReg
     return getKey();
   }
 
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -316,22 +336,12 @@ public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRUReg
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryOffHeapObjectKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapObjectKey.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryOffHeapObjectKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapObjectKey.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -339,7 +349,7 @@ public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRUReg
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -354,24 +364,24 @@ public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRUReg
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -381,10 +391,8 @@ public class VMStatsDiskLRURegionEntryOffHeapObjectKey extends VMStatsDiskLRUReg
     return true;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final Object key;
-
   @Override
   public Object getKey() {
     return this.key;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskLRURegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskLRURegionEntryOffHeapStringKey1.java
@@ -19,13 +19,13 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.cache.Token;
@@ -35,77 +35,95 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURegionEntryOffHeap {
-  public VMStatsDiskLRURegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
-    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-    initialize(context, value);
-    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    if (byteEncode) {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
-        // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
-      }
-      tmpBits1 |= 1 << 6;
-    } else {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
-      }
-    }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapStringKey1> lastModifiedUpdater =
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapStringKey1> LAST_MODIFIED_UPDATER =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapStringKey1.class,
           "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
    * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
    * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
    */
-  private final static AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapStringKey1> ohAddrUpdater =
+  private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapStringKey1> OFF_HEAP_ADDRESS_UPDATER =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapStringKey1.class,
-          "ohAddress");
+          "offHeapAddress");
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryOffHeapStringKey1> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapStringKey1.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryOffHeapStringKey1> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapStringKey1.class,
+          "missCount");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long bits1;
 
+  public VMStatsDiskLRURegionEntryOffHeapStringKey1(final RegionEntryContext context,
+      final String key, @Retained final Object value, final boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
+    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+    initialize(context, value);
+    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
+    long tempBits1 = 0L;
+    if (byteEncode) {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
+        // keep findbugs happy.
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
+      }
+      tempBits1 |= 1 << 6;
+    } else {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
+      }
+    }
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+  }
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -119,24 +137,24 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -147,61 +165,58 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof InternalRegion) {
+      isBackup = ((InternalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
-      throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
+      throw new IllegalArgumentException("expected a InternalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -210,48 +225,43 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -259,6 +269,7 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -268,48 +279,57 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -320,12 +340,12 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
     return null;
   }
 
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -333,22 +353,12 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryOffHeapStringKey1> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapStringKey1.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryOffHeapStringKey1> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapStringKey1.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -356,7 +366,7 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -371,24 +381,24 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -398,10 +408,8 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
     return true;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long bits1;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -414,18 +422,18 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
     return new String(chars);
@@ -433,25 +441,25 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey1 extends VMStatsDiskLRURe
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskLRURegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskLRURegionEntryOffHeapStringKey2.java
@@ -19,13 +19,13 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.cache.Token;
@@ -35,89 +35,116 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURegionEntryOffHeap {
-  public VMStatsDiskLRURegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
-    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-    initialize(context, value);
-    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
-    if (byteEncode) {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
-        // keep findbugs happy.
-        if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
-        } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
-        }
-      }
-      tmpBits1 |= 1 << 6;
-    } else {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
-        } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
-        }
-      }
-    }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapStringKey2> lastModifiedUpdater =
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapStringKey2> LAST_MODIFIED_UPDATER =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapStringKey2.class,
           "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
    * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
    * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
    */
-  private final static AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapStringKey2> ohAddrUpdater =
+  private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapStringKey2> OFF_HEAP_ADDRESS_UPDATER =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapStringKey2.class,
-          "ohAddress");
+          "offHeapAddress");
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryOffHeapStringKey2> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapStringKey2.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryOffHeapStringKey2> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapStringKey2.class,
+          "missCount");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
+  private final long bits1;
+  /**
+   * bits2 encodes character data
+   */
+  private final long bits2;
 
+  public VMStatsDiskLRURegionEntryOffHeapStringKey2(final RegionEntryContext context,
+      final String key, @Retained final Object value, final boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
+    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+    initialize(context, value);
+    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
+    if (byteEncode) {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
+        // keep findbugs happy.
+        if (i < 7) {
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
+        } else {
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
+        }
+      }
+      tempBits1 |= 1 << 6;
+    } else {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        if (i < 3) {
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
+        } else {
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
+        }
+      }
+    }
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
+  }
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -131,24 +158,24 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -159,61 +186,58 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof InternalRegion) {
+      isBackup = ((InternalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
-      throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
+      throw new IllegalArgumentException("expected a InternalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -222,48 +246,43 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -271,6 +290,7 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -280,48 +300,57 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -332,12 +361,12 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
     return null;
   }
 
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -345,22 +374,12 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryOffHeapStringKey2> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapStringKey2.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryOffHeapStringKey2> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapStringKey2.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -368,7 +387,7 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -383,24 +402,24 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -410,15 +429,8 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
     return true;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
-  private final long bits1;
-  // bits2 encodes character data
-  private final long bits2;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -431,28 +443,28 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -461,38 +473,38 @@ public class VMStatsDiskLRURegionEntryOffHeapStringKey2 extends VMStatsDiskLRURe
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskLRURegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskLRURegionEntryOffHeapUUIDKey.java
@@ -20,13 +20,13 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.cache.Token;
@@ -36,26 +36,72 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegionEntryOffHeap {
-  public VMStatsDiskLRURegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapUUIDKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapUUIDKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapUUIDKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapUUIDKey.class,
+          "offHeapAddress");
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryOffHeapUUIDKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapUUIDKey.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryOffHeapUUIDKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapUUIDKey.class,
+          "missCount");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long keyMostSigBits;
+  private final long keyLeastSigBits;
+
+  public VMStatsDiskLRURegionEntryOffHeapUUIDKey(final RegionEntryContext context, final UUID key,
+      @Retained final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -64,32 +110,6 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapUUIDKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapUUIDKey.class,
-          "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VMStatsDiskLRURegionEntryOffHeapUUIDKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapUUIDKey.class, "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -103,24 +123,24 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -131,61 +151,58 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof InternalRegion) {
+      isBackup = ((InternalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
-      throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
+      throw new IllegalArgumentException("expected a InternalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -194,48 +211,43 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -243,6 +255,7 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -252,48 +265,57 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -304,12 +326,12 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
     return null;
   }
 
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -317,22 +339,12 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryOffHeapUUIDKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapUUIDKey.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VMStatsDiskLRURegionEntryOffHeapUUIDKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskLRURegionEntryOffHeapUUIDKey.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -340,7 +352,7 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -355,24 +367,24 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -382,20 +394,17 @@ public class VMStatsDiskLRURegionEntryOffHeapUUIDKey extends VMStatsDiskLRURegio
     return true;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long keyMostSigBits;
-  private final long keyLeastSigBits;
-
   @Override
   public Object getKey() {
     return new UUID(this.keyMostSigBits, this.keyLeastSigBits);
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskRegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskRegionEntryHeapIntKey.java
@@ -19,33 +19,56 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskRegionEntryHeapIntKey extends VMStatsDiskRegionEntryHeap {
-  public VMStatsDiskRegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryHeapIntKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapIntKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapIntKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapIntKey.class, "hitCount");
+  private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapIntKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapIntKey.class, "missCount");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final int key;
+
+  public VMStatsDiskRegionEntryHeapIntKey(final RegionEntryContext context, final int key,
+      final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -53,101 +76,83 @@ public class VMStatsDiskRegionEntryHeapIntKey extends VMStatsDiskRegionEntryHeap
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryHeapIntKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapIntKey.class, "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -155,20 +160,12 @@ public class VMStatsDiskRegionEntryHeapIntKey extends VMStatsDiskRegionEntryHeap
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapIntKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapIntKey.class, "hitCount");
-  private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapIntKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapIntKey.class, "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -176,7 +173,7 @@ public class VMStatsDiskRegionEntryHeapIntKey extends VMStatsDiskRegionEntryHeap
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -191,24 +188,24 @@ public class VMStatsDiskRegionEntryHeapIntKey extends VMStatsDiskRegionEntryHeap
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -218,19 +215,17 @@ public class VMStatsDiskRegionEntryHeapIntKey extends VMStatsDiskRegionEntryHeap
     return true;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final int key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskRegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskRegionEntryHeapLongKey.java
@@ -19,33 +19,56 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskRegionEntryHeapLongKey extends VMStatsDiskRegionEntryHeap {
-  public VMStatsDiskRegionEntryHeapLongKey(RegionEntryContext context, long key, Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryHeapLongKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapLongKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapLongKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapLongKey.class, "hitCount");
+  private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapLongKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapLongKey.class, "missCount");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long key;
+
+  public VMStatsDiskRegionEntryHeapLongKey(final RegionEntryContext context, final long key,
+      final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -53,101 +76,83 @@ public class VMStatsDiskRegionEntryHeapLongKey extends VMStatsDiskRegionEntryHea
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryHeapLongKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapLongKey.class, "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -155,20 +160,12 @@ public class VMStatsDiskRegionEntryHeapLongKey extends VMStatsDiskRegionEntryHea
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapLongKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapLongKey.class, "hitCount");
-  private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapLongKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapLongKey.class, "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -176,7 +173,7 @@ public class VMStatsDiskRegionEntryHeapLongKey extends VMStatsDiskRegionEntryHea
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -191,24 +188,24 @@ public class VMStatsDiskRegionEntryHeapLongKey extends VMStatsDiskRegionEntryHea
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -218,19 +215,17 @@ public class VMStatsDiskRegionEntryHeapLongKey extends VMStatsDiskRegionEntryHea
     return true;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskRegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskRegionEntryHeapObjectKey.java
@@ -19,33 +19,56 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskRegionEntryHeapObjectKey extends VMStatsDiskRegionEntryHeap {
-  public VMStatsDiskRegionEntryHeapObjectKey(RegionEntryContext context, Object key, Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryHeapObjectKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapObjectKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapObjectKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapObjectKey.class, "hitCount");
+  private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapObjectKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapObjectKey.class, "missCount");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final Object key;
+
+  public VMStatsDiskRegionEntryHeapObjectKey(final RegionEntryContext context, final Object key,
+      final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -53,101 +76,83 @@ public class VMStatsDiskRegionEntryHeapObjectKey extends VMStatsDiskRegionEntryH
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryHeapObjectKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapObjectKey.class, "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -155,20 +160,12 @@ public class VMStatsDiskRegionEntryHeapObjectKey extends VMStatsDiskRegionEntryH
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapObjectKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapObjectKey.class, "hitCount");
-  private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapObjectKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapObjectKey.class, "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -176,7 +173,7 @@ public class VMStatsDiskRegionEntryHeapObjectKey extends VMStatsDiskRegionEntryH
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -191,24 +188,24 @@ public class VMStatsDiskRegionEntryHeapObjectKey extends VMStatsDiskRegionEntryH
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -218,10 +215,8 @@ public class VMStatsDiskRegionEntryHeapObjectKey extends VMStatsDiskRegionEntryH
     return true;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final Object key;
-
   @Override
   public Object getKey() {
     return this.key;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskRegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskRegionEntryHeapStringKey1.java
@@ -19,153 +19,157 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskRegionEntryHeapStringKey1 extends VMStatsDiskRegionEntryHeap {
-  public VMStatsDiskRegionEntryHeapStringKey1(RegionEntryContext context, String key, Object value,
-      boolean byteEncode) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryHeapStringKey1> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapStringKey1.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapStringKey1> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapStringKey1.class, "hitCount");
+  private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapStringKey1> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapStringKey1.class, "missCount");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long bits1;
+
+  public VMStatsDiskRegionEntryHeapStringKey1(final RegionEntryContext context, final String key,
+      final Object value, final boolean byteEncode) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryHeapStringKey1> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapStringKey1.class, "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -173,20 +177,12 @@ public class VMStatsDiskRegionEntryHeapStringKey1 extends VMStatsDiskRegionEntry
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapStringKey1> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapStringKey1.class, "hitCount");
-  private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapStringKey1> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapStringKey1.class, "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -194,7 +190,7 @@ public class VMStatsDiskRegionEntryHeapStringKey1 extends VMStatsDiskRegionEntry
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -209,24 +205,24 @@ public class VMStatsDiskRegionEntryHeapStringKey1 extends VMStatsDiskRegionEntry
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -236,10 +232,8 @@ public class VMStatsDiskRegionEntryHeapStringKey1 extends VMStatsDiskRegionEntry
     return true;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long bits1;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -252,18 +246,18 @@ public class VMStatsDiskRegionEntryHeapStringKey1 extends VMStatsDiskRegionEntry
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
     return new String(chars);
@@ -271,25 +265,25 @@ public class VMStatsDiskRegionEntryHeapStringKey1 extends VMStatsDiskRegionEntry
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskRegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskRegionEntryHeapStringKey2.java
@@ -19,165 +19,178 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskRegionEntryHeapStringKey2 extends VMStatsDiskRegionEntryHeap {
-  public VMStatsDiskRegionEntryHeapStringKey2(RegionEntryContext context, String key, Object value,
-      boolean byteEncode) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryHeapStringKey2> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapStringKey2.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapStringKey2> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapStringKey2.class, "hitCount");
+  private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapStringKey2> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapStringKey2.class, "missCount");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
+  private final long bits1;
+  /**
+   * bits2 encodes character data
+   */
+  private final long bits2;
+
+  public VMStatsDiskRegionEntryHeapStringKey2(final RegionEntryContext context, final String key,
+      final Object value, final boolean byteEncode) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryHeapStringKey2> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapStringKey2.class, "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -185,20 +198,12 @@ public class VMStatsDiskRegionEntryHeapStringKey2 extends VMStatsDiskRegionEntry
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapStringKey2> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapStringKey2.class, "hitCount");
-  private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapStringKey2> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapStringKey2.class, "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -206,7 +211,7 @@ public class VMStatsDiskRegionEntryHeapStringKey2 extends VMStatsDiskRegionEntry
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -221,24 +226,24 @@ public class VMStatsDiskRegionEntryHeapStringKey2 extends VMStatsDiskRegionEntry
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -248,15 +253,8 @@ public class VMStatsDiskRegionEntryHeapStringKey2 extends VMStatsDiskRegionEntry
     return true;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
-  private final long bits1;
-  // bits2 encodes character data
-  private final long bits2;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -269,28 +267,28 @@ public class VMStatsDiskRegionEntryHeapStringKey2 extends VMStatsDiskRegionEntry
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -299,38 +297,38 @@ public class VMStatsDiskRegionEntryHeapStringKey2 extends VMStatsDiskRegionEntry
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskRegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskRegionEntryHeapUUIDKey.java
@@ -20,33 +20,57 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskRegionEntryHeapUUIDKey extends VMStatsDiskRegionEntryHeap {
-  public VMStatsDiskRegionEntryHeapUUIDKey(RegionEntryContext context, UUID key, Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryHeapUUIDKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapUUIDKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapUUIDKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapUUIDKey.class, "hitCount");
+  private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapUUIDKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapUUIDKey.class, "missCount");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long keyMostSigBits;
+  private final long keyLeastSigBits;
+
+  public VMStatsDiskRegionEntryHeapUUIDKey(final RegionEntryContext context, final UUID key,
+      final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -55,101 +79,83 @@ public class VMStatsDiskRegionEntryHeapUUIDKey extends VMStatsDiskRegionEntryHea
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryHeapUUIDKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapUUIDKey.class, "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -157,20 +163,12 @@ public class VMStatsDiskRegionEntryHeapUUIDKey extends VMStatsDiskRegionEntryHea
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapUUIDKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapUUIDKey.class, "hitCount");
-  private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryHeapUUIDKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryHeapUUIDKey.class, "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -178,7 +176,7 @@ public class VMStatsDiskRegionEntryHeapUUIDKey extends VMStatsDiskRegionEntryHea
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -193,24 +191,24 @@ public class VMStatsDiskRegionEntryHeapUUIDKey extends VMStatsDiskRegionEntryHea
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -220,20 +218,17 @@ public class VMStatsDiskRegionEntryHeapUUIDKey extends VMStatsDiskRegionEntryHea
     return true;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long keyMostSigBits;
-  private final long keyLeastSigBits;
-
   @Override
   public Object getKey() {
     return new UUID(this.keyMostSigBits, this.keyLeastSigBits);
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskRegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskRegionEntryOffHeapIntKey.java
@@ -19,11 +19,11 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
 import org.apache.geode.internal.cache.Token;
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
@@ -32,26 +32,68 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskRegionEntryOffHeapIntKey extends VMStatsDiskRegionEntryOffHeap {
-  public VMStatsDiskRegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapIntKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapIntKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapIntKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapIntKey.class,
+          "offHeapAddress");
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapIntKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapIntKey.class, "hitCount");
+  private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapIntKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapIntKey.class, "missCount");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final int key;
+
+  public VMStatsDiskRegionEntryOffHeapIntKey(final RegionEntryContext context, final int key,
+      @Retained final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -59,31 +101,6 @@ public class VMStatsDiskRegionEntryOffHeapIntKey extends VMStatsDiskRegionEntryO
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapIntKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapIntKey.class, "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapIntKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapIntKey.class, "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -97,24 +114,24 @@ public class VMStatsDiskRegionEntryOffHeapIntKey extends VMStatsDiskRegionEntryO
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -125,85 +142,76 @@ public class VMStatsDiskRegionEntryOffHeapIntKey extends VMStatsDiskRegionEntryO
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -211,20 +219,12 @@ public class VMStatsDiskRegionEntryOffHeapIntKey extends VMStatsDiskRegionEntryO
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapIntKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapIntKey.class, "hitCount");
-  private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapIntKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapIntKey.class, "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -232,7 +232,7 @@ public class VMStatsDiskRegionEntryOffHeapIntKey extends VMStatsDiskRegionEntryO
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -247,24 +247,24 @@ public class VMStatsDiskRegionEntryOffHeapIntKey extends VMStatsDiskRegionEntryO
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -274,19 +274,17 @@ public class VMStatsDiskRegionEntryOffHeapIntKey extends VMStatsDiskRegionEntryO
     return true;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final int key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskRegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskRegionEntryOffHeapLongKey.java
@@ -19,11 +19,11 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
 import org.apache.geode.internal.cache.Token;
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
@@ -32,26 +32,68 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskRegionEntryOffHeapLongKey extends VMStatsDiskRegionEntryOffHeap {
-  public VMStatsDiskRegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapLongKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapLongKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapLongKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapLongKey.class,
+          "offHeapAddress");
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapLongKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapLongKey.class, "hitCount");
+  private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapLongKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapLongKey.class, "missCount");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long key;
+
+  public VMStatsDiskRegionEntryOffHeapLongKey(final RegionEntryContext context, final long key,
+      @Retained final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -59,31 +101,6 @@ public class VMStatsDiskRegionEntryOffHeapLongKey extends VMStatsDiskRegionEntry
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapLongKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapLongKey.class, "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapLongKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapLongKey.class, "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -97,24 +114,24 @@ public class VMStatsDiskRegionEntryOffHeapLongKey extends VMStatsDiskRegionEntry
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -125,85 +142,76 @@ public class VMStatsDiskRegionEntryOffHeapLongKey extends VMStatsDiskRegionEntry
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -211,20 +219,12 @@ public class VMStatsDiskRegionEntryOffHeapLongKey extends VMStatsDiskRegionEntry
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapLongKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapLongKey.class, "hitCount");
-  private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapLongKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapLongKey.class, "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -232,7 +232,7 @@ public class VMStatsDiskRegionEntryOffHeapLongKey extends VMStatsDiskRegionEntry
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -247,24 +247,24 @@ public class VMStatsDiskRegionEntryOffHeapLongKey extends VMStatsDiskRegionEntry
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -274,19 +274,17 @@ public class VMStatsDiskRegionEntryOffHeapLongKey extends VMStatsDiskRegionEntry
     return true;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskRegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskRegionEntryOffHeapObjectKey.java
@@ -19,11 +19,11 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
 import org.apache.geode.internal.cache.Token;
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
@@ -32,26 +32,71 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskRegionEntryOffHeapObjectKey extends VMStatsDiskRegionEntryOffHeap {
-  public VMStatsDiskRegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapObjectKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapObjectKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapObjectKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapObjectKey.class,
+          "offHeapAddress");
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapObjectKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapObjectKey.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapObjectKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapObjectKey.class,
+          "missCount");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final Object key;
+
+  public VMStatsDiskRegionEntryOffHeapObjectKey(final RegionEntryContext context, final Object key,
+      @Retained final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -59,32 +104,6 @@ public class VMStatsDiskRegionEntryOffHeapObjectKey extends VMStatsDiskRegionEnt
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapObjectKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapObjectKey.class,
-          "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapObjectKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapObjectKey.class, "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -98,24 +117,24 @@ public class VMStatsDiskRegionEntryOffHeapObjectKey extends VMStatsDiskRegionEnt
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -126,85 +145,76 @@ public class VMStatsDiskRegionEntryOffHeapObjectKey extends VMStatsDiskRegionEnt
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -212,22 +222,12 @@ public class VMStatsDiskRegionEntryOffHeapObjectKey extends VMStatsDiskRegionEnt
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapObjectKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapObjectKey.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapObjectKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapObjectKey.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -235,7 +235,7 @@ public class VMStatsDiskRegionEntryOffHeapObjectKey extends VMStatsDiskRegionEnt
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -250,24 +250,24 @@ public class VMStatsDiskRegionEntryOffHeapObjectKey extends VMStatsDiskRegionEnt
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -277,10 +277,8 @@ public class VMStatsDiskRegionEntryOffHeapObjectKey extends VMStatsDiskRegionEnt
     return true;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final Object key;
-
   @Override
   public Object getKey() {
     return this.key;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskRegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskRegionEntryOffHeapStringKey1.java
@@ -19,11 +19,11 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
 import org.apache.geode.internal.cache.Token;
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
@@ -32,76 +32,95 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskRegionEntryOffHeapStringKey1 extends VMStatsDiskRegionEntryOffHeap {
-  public VMStatsDiskRegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
-    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-    initialize(context, value);
-    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    if (byteEncode) {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
-        // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
-      }
-      tmpBits1 |= 1 << 6;
-    } else {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
-      }
-    }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapStringKey1> lastModifiedUpdater =
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapStringKey1> LAST_MODIFIED_UPDATER =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapStringKey1.class,
           "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
    * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
    * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
    */
-  private final static AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapStringKey1> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapStringKey1.class, "ohAddress");
+  private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapStringKey1> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapStringKey1.class,
+          "offHeapAddress");
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapStringKey1> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapStringKey1.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapStringKey1> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapStringKey1.class,
+          "missCount");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long bits1;
 
+  public VMStatsDiskRegionEntryOffHeapStringKey1(final RegionEntryContext context, final String key,
+      @Retained final Object value, final boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
+    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+    initialize(context, value);
+    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
+    long tempBits1 = 0L;
+    if (byteEncode) {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
+        // keep findbugs happy.
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
+      }
+      tempBits1 |= 1 << 6;
+    } else {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
+      }
+    }
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+  }
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -115,24 +134,24 @@ public class VMStatsDiskRegionEntryOffHeapStringKey1 extends VMStatsDiskRegionEn
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -143,85 +162,76 @@ public class VMStatsDiskRegionEntryOffHeapStringKey1 extends VMStatsDiskRegionEn
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -229,22 +239,12 @@ public class VMStatsDiskRegionEntryOffHeapStringKey1 extends VMStatsDiskRegionEn
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapStringKey1> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapStringKey1.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapStringKey1> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapStringKey1.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -252,7 +252,7 @@ public class VMStatsDiskRegionEntryOffHeapStringKey1 extends VMStatsDiskRegionEn
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -267,24 +267,24 @@ public class VMStatsDiskRegionEntryOffHeapStringKey1 extends VMStatsDiskRegionEn
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -294,10 +294,8 @@ public class VMStatsDiskRegionEntryOffHeapStringKey1 extends VMStatsDiskRegionEn
     return true;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long bits1;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -310,18 +308,18 @@ public class VMStatsDiskRegionEntryOffHeapStringKey1 extends VMStatsDiskRegionEn
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
     return new String(chars);
@@ -329,25 +327,25 @@ public class VMStatsDiskRegionEntryOffHeapStringKey1 extends VMStatsDiskRegionEn
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskRegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskRegionEntryOffHeapStringKey2.java
@@ -19,11 +19,11 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
 import org.apache.geode.internal.cache.Token;
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
@@ -32,88 +32,116 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskRegionEntryOffHeapStringKey2 extends VMStatsDiskRegionEntryOffHeap {
-  public VMStatsDiskRegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
-    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-    initialize(context, value);
-    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
-    if (byteEncode) {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
-        // keep findbugs happy.
-        if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
-        } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
-        }
-      }
-      tmpBits1 |= 1 << 6;
-    } else {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
-        } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
-        }
-      }
-    }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapStringKey2> lastModifiedUpdater =
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapStringKey2> LAST_MODIFIED_UPDATER =
       AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapStringKey2.class,
           "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
    * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
    * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
    */
-  private final static AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapStringKey2> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapStringKey2.class, "ohAddress");
+  private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapStringKey2> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapStringKey2.class,
+          "offHeapAddress");
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapStringKey2> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapStringKey2.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapStringKey2> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapStringKey2.class,
+          "missCount");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
+  private final long bits1;
+  /**
+   * bits2 encodes character data
+   */
+  private final long bits2;
 
+  public VMStatsDiskRegionEntryOffHeapStringKey2(final RegionEntryContext context, final String key,
+      @Retained final Object value, final boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
+    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+    initialize(context, value);
+    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
+    if (byteEncode) {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
+        // keep findbugs happy.
+        if (i < 7) {
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
+        } else {
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
+        }
+      }
+      tempBits1 |= 1 << 6;
+    } else {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        if (i < 3) {
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
+        } else {
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
+        }
+      }
+    }
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
+  }
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -127,24 +155,24 @@ public class VMStatsDiskRegionEntryOffHeapStringKey2 extends VMStatsDiskRegionEn
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -155,85 +183,76 @@ public class VMStatsDiskRegionEntryOffHeapStringKey2 extends VMStatsDiskRegionEn
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -241,22 +260,12 @@ public class VMStatsDiskRegionEntryOffHeapStringKey2 extends VMStatsDiskRegionEn
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapStringKey2> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapStringKey2.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapStringKey2> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapStringKey2.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -264,7 +273,7 @@ public class VMStatsDiskRegionEntryOffHeapStringKey2 extends VMStatsDiskRegionEn
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -279,24 +288,24 @@ public class VMStatsDiskRegionEntryOffHeapStringKey2 extends VMStatsDiskRegionEn
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -306,15 +315,8 @@ public class VMStatsDiskRegionEntryOffHeapStringKey2 extends VMStatsDiskRegionEn
     return true;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
-  private final long bits1;
-  // bits2 encodes character data
-  private final long bits2;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -327,28 +329,28 @@ public class VMStatsDiskRegionEntryOffHeapStringKey2 extends VMStatsDiskRegionEn
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -357,38 +359,38 @@ public class VMStatsDiskRegionEntryOffHeapStringKey2 extends VMStatsDiskRegionEn
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskRegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskRegionEntryOffHeapUUIDKey.java
@@ -20,11 +20,11 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
 import org.apache.geode.internal.cache.Token;
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
@@ -33,26 +33,69 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsDiskRegionEntryOffHeapUUIDKey extends VMStatsDiskRegionEntryOffHeap {
-  public VMStatsDiskRegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapUUIDKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapUUIDKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapUUIDKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapUUIDKey.class,
+          "offHeapAddress");
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapUUIDKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapUUIDKey.class, "hitCount");
+  private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapUUIDKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapUUIDKey.class, "missCount");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long keyMostSigBits;
+  private final long keyLeastSigBits;
+
+  public VMStatsDiskRegionEntryOffHeapUUIDKey(final RegionEntryContext context, final UUID key,
+      @Retained final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -61,31 +104,6 @@ public class VMStatsDiskRegionEntryOffHeapUUIDKey extends VMStatsDiskRegionEntry
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapUUIDKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapUUIDKey.class, "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VMStatsDiskRegionEntryOffHeapUUIDKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapUUIDKey.class, "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -99,24 +117,24 @@ public class VMStatsDiskRegionEntryOffHeapUUIDKey extends VMStatsDiskRegionEntry
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -127,85 +145,76 @@ public class VMStatsDiskRegionEntryOffHeapUUIDKey extends VMStatsDiskRegionEntry
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -213,20 +222,12 @@ public class VMStatsDiskRegionEntryOffHeapUUIDKey extends VMStatsDiskRegionEntry
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapUUIDKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapUUIDKey.class, "hitCount");
-  private static final AtomicIntegerFieldUpdater<VMStatsDiskRegionEntryOffHeapUUIDKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsDiskRegionEntryOffHeapUUIDKey.class, "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -234,7 +235,7 @@ public class VMStatsDiskRegionEntryOffHeapUUIDKey extends VMStatsDiskRegionEntry
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -249,24 +250,24 @@ public class VMStatsDiskRegionEntryOffHeapUUIDKey extends VMStatsDiskRegionEntry
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -276,20 +277,17 @@ public class VMStatsDiskRegionEntryOffHeapUUIDKey extends VMStatsDiskRegionEntry
     return true;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long keyMostSigBits;
-  private final long keyLeastSigBits;
-
   @Override
   public Object getKey() {
     return new UUID(this.keyMostSigBits, this.keyLeastSigBits);
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsLRURegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsLRURegionEntryHeapIntKey.java
@@ -19,104 +19,112 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsLRURegionEntryHeapIntKey extends VMStatsLRURegionEntryHeap {
-  public VMStatsLRURegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryHeapIntKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapIntKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapIntKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapIntKey.class, "hitCount");
+  private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapIntKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapIntKey.class, "missCount");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final int key;
+
+  public VMStatsLRURegionEntryHeapIntKey(final RegionEntryContext context, final int key,
+      final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.key = key;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryHeapIntKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapIntKey.class, "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
     // nothing needed for LRUs with no disk
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -124,6 +132,7 @@ public class VMStatsLRURegionEntryHeapIntKey extends VMStatsLRURegionEntryHeap {
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -133,48 +142,57 @@ public class VMStatsLRURegionEntryHeapIntKey extends VMStatsLRURegionEntryHeap {
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -185,12 +203,12 @@ public class VMStatsLRURegionEntryHeapIntKey extends VMStatsLRURegionEntryHeap {
     return null;
   }
 
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -198,20 +216,12 @@ public class VMStatsLRURegionEntryHeapIntKey extends VMStatsLRURegionEntryHeap {
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapIntKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapIntKey.class, "hitCount");
-  private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapIntKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapIntKey.class, "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -219,7 +229,7 @@ public class VMStatsLRURegionEntryHeapIntKey extends VMStatsLRURegionEntryHeap {
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -234,24 +244,24 @@ public class VMStatsLRURegionEntryHeapIntKey extends VMStatsLRURegionEntryHeap {
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -261,19 +271,17 @@ public class VMStatsLRURegionEntryHeapIntKey extends VMStatsLRURegionEntryHeap {
     return true;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final int key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsLRURegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsLRURegionEntryHeapLongKey.java
@@ -19,104 +19,112 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsLRURegionEntryHeapLongKey extends VMStatsLRURegionEntryHeap {
-  public VMStatsLRURegionEntryHeapLongKey(RegionEntryContext context, long key, Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryHeapLongKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapLongKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapLongKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapLongKey.class, "hitCount");
+  private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapLongKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapLongKey.class, "missCount");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long key;
+
+  public VMStatsLRURegionEntryHeapLongKey(final RegionEntryContext context, final long key,
+      final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.key = key;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryHeapLongKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapLongKey.class, "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
     // nothing needed for LRUs with no disk
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -124,6 +132,7 @@ public class VMStatsLRURegionEntryHeapLongKey extends VMStatsLRURegionEntryHeap 
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -133,48 +142,57 @@ public class VMStatsLRURegionEntryHeapLongKey extends VMStatsLRURegionEntryHeap 
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -185,12 +203,12 @@ public class VMStatsLRURegionEntryHeapLongKey extends VMStatsLRURegionEntryHeap 
     return null;
   }
 
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -198,20 +216,12 @@ public class VMStatsLRURegionEntryHeapLongKey extends VMStatsLRURegionEntryHeap 
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapLongKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapLongKey.class, "hitCount");
-  private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapLongKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapLongKey.class, "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -219,7 +229,7 @@ public class VMStatsLRURegionEntryHeapLongKey extends VMStatsLRURegionEntryHeap 
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -234,24 +244,24 @@ public class VMStatsLRURegionEntryHeapLongKey extends VMStatsLRURegionEntryHeap 
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -261,19 +271,17 @@ public class VMStatsLRURegionEntryHeapLongKey extends VMStatsLRURegionEntryHeap 
     return true;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsLRURegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsLRURegionEntryHeapObjectKey.java
@@ -19,104 +19,112 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsLRURegionEntryHeapObjectKey extends VMStatsLRURegionEntryHeap {
-  public VMStatsLRURegionEntryHeapObjectKey(RegionEntryContext context, Object key, Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryHeapObjectKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapObjectKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapObjectKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapObjectKey.class, "hitCount");
+  private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapObjectKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapObjectKey.class, "missCount");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final Object key;
+
+  public VMStatsLRURegionEntryHeapObjectKey(final RegionEntryContext context, final Object key,
+      final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.key = key;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryHeapObjectKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapObjectKey.class, "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
     // nothing needed for LRUs with no disk
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -124,6 +132,7 @@ public class VMStatsLRURegionEntryHeapObjectKey extends VMStatsLRURegionEntryHea
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -133,48 +142,57 @@ public class VMStatsLRURegionEntryHeapObjectKey extends VMStatsLRURegionEntryHea
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -185,12 +203,12 @@ public class VMStatsLRURegionEntryHeapObjectKey extends VMStatsLRURegionEntryHea
     return getKey();
   }
 
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -198,20 +216,12 @@ public class VMStatsLRURegionEntryHeapObjectKey extends VMStatsLRURegionEntryHea
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapObjectKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapObjectKey.class, "hitCount");
-  private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapObjectKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapObjectKey.class, "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -219,7 +229,7 @@ public class VMStatsLRURegionEntryHeapObjectKey extends VMStatsLRURegionEntryHea
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -234,24 +244,24 @@ public class VMStatsLRURegionEntryHeapObjectKey extends VMStatsLRURegionEntryHea
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -261,10 +271,8 @@ public class VMStatsLRURegionEntryHeapObjectKey extends VMStatsLRURegionEntryHea
     return true;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final Object key;
-
   @Override
   public Object getKey() {
     return this.key;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsLRURegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsLRURegionEntryHeapStringKey1.java
@@ -19,122 +19,129 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsLRURegionEntryHeapStringKey1 extends VMStatsLRURegionEntryHeap {
-  public VMStatsLRURegionEntryHeapStringKey1(RegionEntryContext context, String key, Object value,
-      boolean byteEncode) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryHeapStringKey1> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapStringKey1.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapStringKey1> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapStringKey1.class, "hitCount");
+  private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapStringKey1> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapStringKey1.class, "missCount");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long bits1;
+
+  public VMStatsLRURegionEntryHeapStringKey1(final RegionEntryContext context, final String key,
+      final Object value, final boolean byteEncode) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryHeapStringKey1> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapStringKey1.class, "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
     // nothing needed for LRUs with no disk
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -142,6 +149,7 @@ public class VMStatsLRURegionEntryHeapStringKey1 extends VMStatsLRURegionEntryHe
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -151,48 +159,57 @@ public class VMStatsLRURegionEntryHeapStringKey1 extends VMStatsLRURegionEntryHe
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -203,12 +220,12 @@ public class VMStatsLRURegionEntryHeapStringKey1 extends VMStatsLRURegionEntryHe
     return null;
   }
 
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -216,20 +233,12 @@ public class VMStatsLRURegionEntryHeapStringKey1 extends VMStatsLRURegionEntryHe
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapStringKey1> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapStringKey1.class, "hitCount");
-  private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapStringKey1> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapStringKey1.class, "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -237,7 +246,7 @@ public class VMStatsLRURegionEntryHeapStringKey1 extends VMStatsLRURegionEntryHe
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -252,24 +261,24 @@ public class VMStatsLRURegionEntryHeapStringKey1 extends VMStatsLRURegionEntryHe
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -279,10 +288,8 @@ public class VMStatsLRURegionEntryHeapStringKey1 extends VMStatsLRURegionEntryHe
     return true;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long bits1;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -295,18 +302,18 @@ public class VMStatsLRURegionEntryHeapStringKey1 extends VMStatsLRURegionEntryHe
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
     return new String(chars);
@@ -314,25 +321,25 @@ public class VMStatsLRURegionEntryHeapStringKey1 extends VMStatsLRURegionEntryHe
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsLRURegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsLRURegionEntryHeapStringKey2.java
@@ -19,134 +19,150 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsLRURegionEntryHeapStringKey2 extends VMStatsLRURegionEntryHeap {
-  public VMStatsLRURegionEntryHeapStringKey2(RegionEntryContext context, String key, Object value,
-      boolean byteEncode) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryHeapStringKey2> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapStringKey2.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapStringKey2> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapStringKey2.class, "hitCount");
+  private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapStringKey2> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapStringKey2.class, "missCount");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
+  private final long bits1;
+  /**
+   * bits2 encodes character data
+   */
+  private final long bits2;
+
+  public VMStatsLRURegionEntryHeapStringKey2(final RegionEntryContext context, final String key,
+      final Object value, final boolean byteEncode) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryHeapStringKey2> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapStringKey2.class, "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
     // nothing needed for LRUs with no disk
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -154,6 +170,7 @@ public class VMStatsLRURegionEntryHeapStringKey2 extends VMStatsLRURegionEntryHe
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -163,48 +180,57 @@ public class VMStatsLRURegionEntryHeapStringKey2 extends VMStatsLRURegionEntryHe
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -215,12 +241,12 @@ public class VMStatsLRURegionEntryHeapStringKey2 extends VMStatsLRURegionEntryHe
     return null;
   }
 
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -228,20 +254,12 @@ public class VMStatsLRURegionEntryHeapStringKey2 extends VMStatsLRURegionEntryHe
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapStringKey2> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapStringKey2.class, "hitCount");
-  private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapStringKey2> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapStringKey2.class, "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -249,7 +267,7 @@ public class VMStatsLRURegionEntryHeapStringKey2 extends VMStatsLRURegionEntryHe
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -264,24 +282,24 @@ public class VMStatsLRURegionEntryHeapStringKey2 extends VMStatsLRURegionEntryHe
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -291,15 +309,8 @@ public class VMStatsLRURegionEntryHeapStringKey2 extends VMStatsLRURegionEntryHe
     return true;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
-  private final long bits1;
-  // bits2 encodes character data
-  private final long bits2;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -312,28 +323,28 @@ public class VMStatsLRURegionEntryHeapStringKey2 extends VMStatsLRURegionEntryHe
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -342,38 +353,38 @@ public class VMStatsLRURegionEntryHeapStringKey2 extends VMStatsLRURegionEntryHe
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsLRURegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsLRURegionEntryHeapUUIDKey.java
@@ -20,31 +20,51 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsLRURegionEntryHeapUUIDKey extends VMStatsLRURegionEntryHeap {
-  public VMStatsLRURegionEntryHeapUUIDKey(RegionEntryContext context, UUID key, Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryHeapUUIDKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapUUIDKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapUUIDKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapUUIDKey.class, "hitCount");
+  private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapUUIDKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapUUIDKey.class, "missCount");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long keyMostSigBits;
+  private final long keyLeastSigBits;
+
+  public VMStatsLRURegionEntryHeapUUIDKey(final RegionEntryContext context, final UUID key,
+      final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.keyMostSigBits = key.getMostSignificantBits();
@@ -52,73 +72,62 @@ public class VMStatsLRURegionEntryHeapUUIDKey extends VMStatsLRURegionEntryHeap 
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryHeapUUIDKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapUUIDKey.class, "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
     // nothing needed for LRUs with no disk
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -126,6 +135,7 @@ public class VMStatsLRURegionEntryHeapUUIDKey extends VMStatsLRURegionEntryHeap 
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -135,48 +145,57 @@ public class VMStatsLRURegionEntryHeapUUIDKey extends VMStatsLRURegionEntryHeap 
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -187,12 +206,12 @@ public class VMStatsLRURegionEntryHeapUUIDKey extends VMStatsLRURegionEntryHeap 
     return null;
   }
 
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -200,20 +219,12 @@ public class VMStatsLRURegionEntryHeapUUIDKey extends VMStatsLRURegionEntryHeap 
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapUUIDKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapUUIDKey.class, "hitCount");
-  private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryHeapUUIDKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryHeapUUIDKey.class, "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -221,7 +232,7 @@ public class VMStatsLRURegionEntryHeapUUIDKey extends VMStatsLRURegionEntryHeap 
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -236,24 +247,24 @@ public class VMStatsLRURegionEntryHeapUUIDKey extends VMStatsLRURegionEntryHeap 
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -263,20 +274,17 @@ public class VMStatsLRURegionEntryHeapUUIDKey extends VMStatsLRURegionEntryHeap 
     return true;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long keyMostSigBits;
-  private final long keyLeastSigBits;
-
   @Override
   public Object getKey() {
     return new UUID(this.keyMostSigBits, this.keyLeastSigBits);
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsLRURegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsLRURegionEntryOffHeapIntKey.java
@@ -19,8 +19,9 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.cache.Token;
@@ -30,57 +31,68 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsLRURegionEntryOffHeapIntKey extends VMStatsLRURegionEntryOffHeap {
-  public VMStatsLRURegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapIntKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapIntKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapIntKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapIntKey.class, "offHeapAddress");
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapIntKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapIntKey.class, "hitCount");
+  private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapIntKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapIntKey.class, "missCount");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final int key;
+
+  public VMStatsLRURegionEntryOffHeapIntKey(final RegionEntryContext context, final int key,
+      @Retained final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.key = key;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapIntKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapIntKey.class, "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapIntKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapIntKey.class, "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -94,24 +106,24 @@ public class VMStatsLRURegionEntryOffHeapIntKey extends VMStatsLRURegionEntryOff
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -122,57 +134,55 @@ public class VMStatsLRURegionEntryOffHeapIntKey extends VMStatsLRURegionEntryOff
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
     // nothing needed for LRUs with no disk
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -180,6 +190,7 @@ public class VMStatsLRURegionEntryOffHeapIntKey extends VMStatsLRURegionEntryOff
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -189,48 +200,57 @@ public class VMStatsLRURegionEntryOffHeapIntKey extends VMStatsLRURegionEntryOff
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -241,12 +261,12 @@ public class VMStatsLRURegionEntryOffHeapIntKey extends VMStatsLRURegionEntryOff
     return null;
   }
 
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -254,20 +274,12 @@ public class VMStatsLRURegionEntryOffHeapIntKey extends VMStatsLRURegionEntryOff
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapIntKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapIntKey.class, "hitCount");
-  private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapIntKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapIntKey.class, "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -275,7 +287,7 @@ public class VMStatsLRURegionEntryOffHeapIntKey extends VMStatsLRURegionEntryOff
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -290,24 +302,24 @@ public class VMStatsLRURegionEntryOffHeapIntKey extends VMStatsLRURegionEntryOff
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -317,19 +329,17 @@ public class VMStatsLRURegionEntryOffHeapIntKey extends VMStatsLRURegionEntryOff
     return true;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final int key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsLRURegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsLRURegionEntryOffHeapLongKey.java
@@ -19,8 +19,9 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.cache.Token;
@@ -30,57 +31,69 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsLRURegionEntryOffHeapLongKey extends VMStatsLRURegionEntryOffHeap {
-  public VMStatsLRURegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapLongKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapLongKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapLongKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapLongKey.class,
+          "offHeapAddress");
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapLongKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapLongKey.class, "hitCount");
+  private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapLongKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapLongKey.class, "missCount");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long key;
+
+  public VMStatsLRURegionEntryOffHeapLongKey(final RegionEntryContext context, final long key,
+      @Retained final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.key = key;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapLongKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapLongKey.class, "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapLongKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapLongKey.class, "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -94,24 +107,24 @@ public class VMStatsLRURegionEntryOffHeapLongKey extends VMStatsLRURegionEntryOf
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -122,57 +135,55 @@ public class VMStatsLRURegionEntryOffHeapLongKey extends VMStatsLRURegionEntryOf
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
     // nothing needed for LRUs with no disk
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -180,6 +191,7 @@ public class VMStatsLRURegionEntryOffHeapLongKey extends VMStatsLRURegionEntryOf
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -189,48 +201,57 @@ public class VMStatsLRURegionEntryOffHeapLongKey extends VMStatsLRURegionEntryOf
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -241,12 +262,12 @@ public class VMStatsLRURegionEntryOffHeapLongKey extends VMStatsLRURegionEntryOf
     return null;
   }
 
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -254,20 +275,12 @@ public class VMStatsLRURegionEntryOffHeapLongKey extends VMStatsLRURegionEntryOf
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapLongKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapLongKey.class, "hitCount");
-  private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapLongKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapLongKey.class, "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -275,7 +288,7 @@ public class VMStatsLRURegionEntryOffHeapLongKey extends VMStatsLRURegionEntryOf
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -290,24 +303,24 @@ public class VMStatsLRURegionEntryOffHeapLongKey extends VMStatsLRURegionEntryOf
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -317,19 +330,17 @@ public class VMStatsLRURegionEntryOffHeapLongKey extends VMStatsLRURegionEntryOf
     return true;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsLRURegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsLRURegionEntryOffHeapObjectKey.java
@@ -19,8 +19,9 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.cache.Token;
@@ -30,58 +31,71 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsLRURegionEntryOffHeapObjectKey extends VMStatsLRURegionEntryOffHeap {
-  public VMStatsLRURegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapObjectKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapObjectKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapObjectKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapObjectKey.class,
+          "offHeapAddress");
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapObjectKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapObjectKey.class, "hitCount");
+  private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapObjectKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapObjectKey.class,
+          "missCount");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final Object key;
+
+  public VMStatsLRURegionEntryOffHeapObjectKey(final RegionEntryContext context, final Object key,
+      @Retained final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.key = key;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapObjectKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapObjectKey.class,
-          "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapObjectKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapObjectKey.class, "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -95,24 +109,24 @@ public class VMStatsLRURegionEntryOffHeapObjectKey extends VMStatsLRURegionEntry
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -123,57 +137,55 @@ public class VMStatsLRURegionEntryOffHeapObjectKey extends VMStatsLRURegionEntry
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
     // nothing needed for LRUs with no disk
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -181,6 +193,7 @@ public class VMStatsLRURegionEntryOffHeapObjectKey extends VMStatsLRURegionEntry
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -190,48 +203,57 @@ public class VMStatsLRURegionEntryOffHeapObjectKey extends VMStatsLRURegionEntry
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -242,12 +264,12 @@ public class VMStatsLRURegionEntryOffHeapObjectKey extends VMStatsLRURegionEntry
     return getKey();
   }
 
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -255,21 +277,12 @@ public class VMStatsLRURegionEntryOffHeapObjectKey extends VMStatsLRURegionEntry
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapObjectKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapObjectKey.class, "hitCount");
-  private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapObjectKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapObjectKey.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -277,7 +290,7 @@ public class VMStatsLRURegionEntryOffHeapObjectKey extends VMStatsLRURegionEntry
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -292,24 +305,24 @@ public class VMStatsLRURegionEntryOffHeapObjectKey extends VMStatsLRURegionEntry
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -319,10 +332,8 @@ public class VMStatsLRURegionEntryOffHeapObjectKey extends VMStatsLRURegionEntry
     return true;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final Object key;
-
   @Override
   public Object getKey() {
     return this.key;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsLRURegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsLRURegionEntryOffHeapStringKey1.java
@@ -19,8 +19,9 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.cache.Token;
@@ -30,75 +31,89 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntryOffHeap {
-  public VMStatsLRURegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, value);
-    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    if (byteEncode) {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
-        // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
-      }
-      tmpBits1 |= 1 << 6;
-    } else {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
-      }
-    }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapStringKey1> lastModifiedUpdater =
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapStringKey1> LAST_MODIFIED_UPDATER =
       AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapStringKey1.class,
           "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
    * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
    * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
    */
-  private final static AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapStringKey1> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapStringKey1.class, "ohAddress");
+  private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapStringKey1> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapStringKey1.class,
+          "offHeapAddress");
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapStringKey1> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapStringKey1.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapStringKey1> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapStringKey1.class,
+          "missCount");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long bits1;
 
+  public VMStatsLRURegionEntryOffHeapStringKey1(final RegionEntryContext context, final String key,
+      @Retained final Object value, final boolean byteEncode) {
+    super(context, value);
+    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
+    long tempBits1 = 0L;
+    if (byteEncode) {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
+        // keep findbugs happy.
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
+      }
+      tempBits1 |= 1 << 6;
+    } else {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
+      }
+    }
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+  }
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -112,24 +127,24 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -140,57 +155,55 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
     // nothing needed for LRUs with no disk
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -198,6 +211,7 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -207,48 +221,57 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -259,12 +282,12 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
     return null;
   }
 
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -272,22 +295,12 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapStringKey1> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapStringKey1.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapStringKey1> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapStringKey1.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -295,7 +308,7 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -310,24 +323,24 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -337,10 +350,8 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
     return true;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long bits1;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -353,18 +364,18 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
     return new String(chars);
@@ -372,25 +383,25 @@ public class VMStatsLRURegionEntryOffHeapStringKey1 extends VMStatsLRURegionEntr
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsLRURegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsLRURegionEntryOffHeapStringKey2.java
@@ -19,8 +19,9 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.cache.Token;
@@ -30,87 +31,110 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntryOffHeap {
-  public VMStatsLRURegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, value);
-    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
-    if (byteEncode) {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
-        // keep findbugs happy.
-        if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
-        } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
-        }
-      }
-      tmpBits1 |= 1 << 6;
-    } else {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
-        } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
-        }
-      }
-    }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapStringKey2> lastModifiedUpdater =
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapStringKey2> LAST_MODIFIED_UPDATER =
       AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapStringKey2.class,
           "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
    * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
    * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
    */
-  private final static AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapStringKey2> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapStringKey2.class, "ohAddress");
+  private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapStringKey2> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapStringKey2.class,
+          "offHeapAddress");
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapStringKey2> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapStringKey2.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapStringKey2> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapStringKey2.class,
+          "missCount");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
+  private final long bits1;
+  /**
+   * bits2 encodes character data
+   */
+  private final long bits2;
 
+  public VMStatsLRURegionEntryOffHeapStringKey2(final RegionEntryContext context, final String key,
+      @Retained final Object value, final boolean byteEncode) {
+    super(context, value);
+    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
+    if (byteEncode) {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
+        // keep findbugs happy.
+        if (i < 7) {
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
+        } else {
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
+        }
+      }
+      tempBits1 |= 1 << 6;
+    } else {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        if (i < 3) {
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
+        } else {
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
+        }
+      }
+    }
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
+  }
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -124,24 +148,24 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -152,57 +176,55 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
     // nothing needed for LRUs with no disk
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -210,6 +232,7 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -219,48 +242,57 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -271,12 +303,12 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
     return null;
   }
 
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -284,22 +316,12 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapStringKey2> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapStringKey2.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapStringKey2> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapStringKey2.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -307,7 +329,7 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -322,24 +344,24 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -349,15 +371,8 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
     return true;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
-  private final long bits1;
-  // bits2 encodes character data
-  private final long bits2;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -370,28 +385,28 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -400,38 +415,38 @@ public class VMStatsLRURegionEntryOffHeapStringKey2 extends VMStatsLRURegionEntr
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsLRURegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsLRURegionEntryOffHeapUUIDKey.java
@@ -20,8 +20,9 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.cache.Token;
@@ -31,26 +32,64 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsLRURegionEntryOffHeapUUIDKey extends VMStatsLRURegionEntryOffHeap {
-  public VMStatsLRURegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapUUIDKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapUUIDKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapUUIDKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapUUIDKey.class,
+          "offHeapAddress");
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapUUIDKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapUUIDKey.class, "hitCount");
+  private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapUUIDKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapUUIDKey.class, "missCount");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long keyMostSigBits;
+  private final long keyLeastSigBits;
+
+  public VMStatsLRURegionEntryOffHeapUUIDKey(final RegionEntryContext context, final UUID key,
+      @Retained final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.keyMostSigBits = key.getMostSignificantBits();
@@ -58,31 +97,6 @@ public class VMStatsLRURegionEntryOffHeapUUIDKey extends VMStatsLRURegionEntryOf
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapUUIDKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapUUIDKey.class, "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VMStatsLRURegionEntryOffHeapUUIDKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapUUIDKey.class, "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -96,24 +110,24 @@ public class VMStatsLRURegionEntryOffHeapUUIDKey extends VMStatsLRURegionEntryOf
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -124,57 +138,55 @@ public class VMStatsLRURegionEntryOffHeapUUIDKey extends VMStatsLRURegionEntryOf
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
     // nothing needed for LRUs with no disk
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -182,6 +194,7 @@ public class VMStatsLRURegionEntryOffHeapUUIDKey extends VMStatsLRURegionEntryOf
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -191,48 +204,57 @@ public class VMStatsLRURegionEntryOffHeapUUIDKey extends VMStatsLRURegionEntryOf
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -243,12 +265,12 @@ public class VMStatsLRURegionEntryOffHeapUUIDKey extends VMStatsLRURegionEntryOf
     return null;
   }
 
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -256,20 +278,12 @@ public class VMStatsLRURegionEntryOffHeapUUIDKey extends VMStatsLRURegionEntryOf
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapUUIDKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapUUIDKey.class, "hitCount");
-  private static final AtomicIntegerFieldUpdater<VMStatsLRURegionEntryOffHeapUUIDKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsLRURegionEntryOffHeapUUIDKey.class, "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -277,7 +291,7 @@ public class VMStatsLRURegionEntryOffHeapUUIDKey extends VMStatsLRURegionEntryOf
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -292,24 +306,24 @@ public class VMStatsLRURegionEntryOffHeapUUIDKey extends VMStatsLRURegionEntryOf
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -319,20 +333,17 @@ public class VMStatsLRURegionEntryOffHeapUUIDKey extends VMStatsLRURegionEntryOf
     return true;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long keyMostSigBits;
-  private final long keyLeastSigBits;
-
   @Override
   public Object getKey() {
     return new UUID(this.keyMostSigBits, this.keyLeastSigBits);
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsRegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsRegionEntryHeapIntKey.java
@@ -21,89 +21,95 @@ import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsRegionEntryHeapIntKey extends VMStatsRegionEntryHeap {
-  public VMStatsRegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMStatsRegionEntryHeapIntKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryHeapIntKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapIntKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryHeapIntKey.class, "hitCount");
+  private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapIntKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryHeapIntKey.class, "missCount");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final int key;
+
+  public VMStatsRegionEntryHeapIntKey(final RegionEntryContext context, final int key,
+      final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.key = key;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMStatsRegionEntryHeapIntKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryHeapIntKey.class, "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // ---------------------------------------- stats code ------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -111,20 +117,12 @@ public class VMStatsRegionEntryHeapIntKey extends VMStatsRegionEntryHeap {
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapIntKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryHeapIntKey.class, "hitCount");
-  private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapIntKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryHeapIntKey.class, "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -132,7 +130,7 @@ public class VMStatsRegionEntryHeapIntKey extends VMStatsRegionEntryHeap {
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -147,24 +145,24 @@ public class VMStatsRegionEntryHeapIntKey extends VMStatsRegionEntryHeap {
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -174,19 +172,17 @@ public class VMStatsRegionEntryHeapIntKey extends VMStatsRegionEntryHeap {
     return true;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final int key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsRegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsRegionEntryHeapLongKey.java
@@ -21,89 +21,95 @@ import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsRegionEntryHeapLongKey extends VMStatsRegionEntryHeap {
-  public VMStatsRegionEntryHeapLongKey(RegionEntryContext context, long key, Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMStatsRegionEntryHeapLongKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryHeapLongKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapLongKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryHeapLongKey.class, "hitCount");
+  private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapLongKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryHeapLongKey.class, "missCount");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long key;
+
+  public VMStatsRegionEntryHeapLongKey(final RegionEntryContext context, final long key,
+      final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.key = key;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMStatsRegionEntryHeapLongKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryHeapLongKey.class, "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // ---------------------------------------- stats code ------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -111,20 +117,12 @@ public class VMStatsRegionEntryHeapLongKey extends VMStatsRegionEntryHeap {
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapLongKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryHeapLongKey.class, "hitCount");
-  private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapLongKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryHeapLongKey.class, "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -132,7 +130,7 @@ public class VMStatsRegionEntryHeapLongKey extends VMStatsRegionEntryHeap {
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -147,24 +145,24 @@ public class VMStatsRegionEntryHeapLongKey extends VMStatsRegionEntryHeap {
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -174,19 +172,17 @@ public class VMStatsRegionEntryHeapLongKey extends VMStatsRegionEntryHeap {
     return true;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsRegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsRegionEntryHeapObjectKey.java
@@ -21,89 +21,95 @@ import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsRegionEntryHeapObjectKey extends VMStatsRegionEntryHeap {
-  public VMStatsRegionEntryHeapObjectKey(RegionEntryContext context, Object key, Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMStatsRegionEntryHeapObjectKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryHeapObjectKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapObjectKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryHeapObjectKey.class, "hitCount");
+  private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapObjectKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryHeapObjectKey.class, "missCount");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final Object key;
+
+  public VMStatsRegionEntryHeapObjectKey(final RegionEntryContext context, final Object key,
+      final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.key = key;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMStatsRegionEntryHeapObjectKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryHeapObjectKey.class, "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // ---------------------------------------- stats code ------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -111,20 +117,12 @@ public class VMStatsRegionEntryHeapObjectKey extends VMStatsRegionEntryHeap {
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapObjectKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryHeapObjectKey.class, "hitCount");
-  private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapObjectKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryHeapObjectKey.class, "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -132,7 +130,7 @@ public class VMStatsRegionEntryHeapObjectKey extends VMStatsRegionEntryHeap {
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -147,24 +145,24 @@ public class VMStatsRegionEntryHeapObjectKey extends VMStatsRegionEntryHeap {
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -174,10 +172,8 @@ public class VMStatsRegionEntryHeapObjectKey extends VMStatsRegionEntryHeap {
     return true;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final Object key;
-
   @Override
   public Object getKey() {
     return this.key;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsRegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsRegionEntryHeapStringKey1.java
@@ -21,107 +21,112 @@ import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsRegionEntryHeapStringKey1 extends VMStatsRegionEntryHeap {
-  public VMStatsRegionEntryHeapStringKey1(RegionEntryContext context, String key, Object value,
-      boolean byteEncode) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMStatsRegionEntryHeapStringKey1> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryHeapStringKey1.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapStringKey1> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryHeapStringKey1.class, "hitCount");
+  private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapStringKey1> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryHeapStringKey1.class, "missCount");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long bits1;
+
+  public VMStatsRegionEntryHeapStringKey1(final RegionEntryContext context, final String key,
+      final Object value, final boolean byteEncode) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMStatsRegionEntryHeapStringKey1> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryHeapStringKey1.class, "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // ---------------------------------------- stats code ------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -129,20 +134,12 @@ public class VMStatsRegionEntryHeapStringKey1 extends VMStatsRegionEntryHeap {
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapStringKey1> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryHeapStringKey1.class, "hitCount");
-  private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapStringKey1> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryHeapStringKey1.class, "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -150,7 +147,7 @@ public class VMStatsRegionEntryHeapStringKey1 extends VMStatsRegionEntryHeap {
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -165,24 +162,24 @@ public class VMStatsRegionEntryHeapStringKey1 extends VMStatsRegionEntryHeap {
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -192,10 +189,8 @@ public class VMStatsRegionEntryHeapStringKey1 extends VMStatsRegionEntryHeap {
     return true;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long bits1;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -208,18 +203,18 @@ public class VMStatsRegionEntryHeapStringKey1 extends VMStatsRegionEntryHeap {
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
     return new String(chars);
@@ -227,25 +222,25 @@ public class VMStatsRegionEntryHeapStringKey1 extends VMStatsRegionEntryHeap {
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsRegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsRegionEntryHeapStringKey2.java
@@ -21,119 +21,133 @@ import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsRegionEntryHeapStringKey2 extends VMStatsRegionEntryHeap {
-  public VMStatsRegionEntryHeapStringKey2(RegionEntryContext context, String key, Object value,
-      boolean byteEncode) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMStatsRegionEntryHeapStringKey2> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryHeapStringKey2.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapStringKey2> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryHeapStringKey2.class, "hitCount");
+  private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapStringKey2> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryHeapStringKey2.class, "missCount");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
+  private final long bits1;
+  /**
+   * bits2 encodes character data
+   */
+  private final long bits2;
+
+  public VMStatsRegionEntryHeapStringKey2(final RegionEntryContext context, final String key,
+      final Object value, final boolean byteEncode) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMStatsRegionEntryHeapStringKey2> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryHeapStringKey2.class, "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // ---------------------------------------- stats code ------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -141,20 +155,12 @@ public class VMStatsRegionEntryHeapStringKey2 extends VMStatsRegionEntryHeap {
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapStringKey2> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryHeapStringKey2.class, "hitCount");
-  private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapStringKey2> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryHeapStringKey2.class, "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -162,7 +168,7 @@ public class VMStatsRegionEntryHeapStringKey2 extends VMStatsRegionEntryHeap {
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -177,24 +183,24 @@ public class VMStatsRegionEntryHeapStringKey2 extends VMStatsRegionEntryHeap {
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -204,15 +210,8 @@ public class VMStatsRegionEntryHeapStringKey2 extends VMStatsRegionEntryHeap {
     return true;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
-  private final long bits1;
-  // bits2 encodes character data
-  private final long bits2;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -225,28 +224,28 @@ public class VMStatsRegionEntryHeapStringKey2 extends VMStatsRegionEntryHeap {
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -255,38 +254,38 @@ public class VMStatsRegionEntryHeapStringKey2 extends VMStatsRegionEntryHeap {
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsRegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsRegionEntryHeapUUIDKey.java
@@ -22,25 +22,44 @@ import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsRegionEntryHeapUUIDKey extends VMStatsRegionEntryHeap {
-  public VMStatsRegionEntryHeapUUIDKey(RegionEntryContext context, UUID key, Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMStatsRegionEntryHeapUUIDKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryHeapUUIDKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapUUIDKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryHeapUUIDKey.class, "hitCount");
+  private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapUUIDKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryHeapUUIDKey.class, "missCount");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long keyMostSigBits;
+  private final long keyLeastSigBits;
+
+  public VMStatsRegionEntryHeapUUIDKey(final RegionEntryContext context, final UUID key,
+      final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.keyMostSigBits = key.getMostSignificantBits();
@@ -48,64 +67,52 @@ public class VMStatsRegionEntryHeapUUIDKey extends VMStatsRegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMStatsRegionEntryHeapUUIDKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryHeapUUIDKey.class, "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // ---------------------------------------- stats code ------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -113,20 +120,12 @@ public class VMStatsRegionEntryHeapUUIDKey extends VMStatsRegionEntryHeap {
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapUUIDKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryHeapUUIDKey.class, "hitCount");
-  private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryHeapUUIDKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryHeapUUIDKey.class, "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -134,7 +133,7 @@ public class VMStatsRegionEntryHeapUUIDKey extends VMStatsRegionEntryHeap {
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -149,24 +148,24 @@ public class VMStatsRegionEntryHeapUUIDKey extends VMStatsRegionEntryHeap {
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -176,20 +175,17 @@ public class VMStatsRegionEntryHeapUUIDKey extends VMStatsRegionEntryHeap {
     return true;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long keyMostSigBits;
-  private final long keyLeastSigBits;
-
   @Override
   public Object getKey() {
     return new UUID(this.keyMostSigBits, this.keyLeastSigBits);
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsRegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsRegionEntryOffHeapIntKey.java
@@ -26,57 +26,68 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsRegionEntryOffHeapIntKey extends VMStatsRegionEntryOffHeap {
-  public VMStatsRegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapIntKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapIntKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapIntKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapIntKey.class, "offHeapAddress");
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapIntKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapIntKey.class, "hitCount");
+  private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapIntKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapIntKey.class, "missCount");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final int key;
+
+  public VMStatsRegionEntryOffHeapIntKey(final RegionEntryContext context, final int key,
+      @Retained final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.key = key;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapIntKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapIntKey.class, "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapIntKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapIntKey.class, "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -90,24 +101,24 @@ public class VMStatsRegionEntryOffHeapIntKey extends VMStatsRegionEntryOffHeap {
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -118,48 +129,45 @@ public class VMStatsRegionEntryOffHeapIntKey extends VMStatsRegionEntryOffHeap {
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // ---------------------------------------- stats code ------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -167,20 +175,12 @@ public class VMStatsRegionEntryOffHeapIntKey extends VMStatsRegionEntryOffHeap {
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapIntKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapIntKey.class, "hitCount");
-  private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapIntKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapIntKey.class, "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -188,7 +188,7 @@ public class VMStatsRegionEntryOffHeapIntKey extends VMStatsRegionEntryOffHeap {
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -203,24 +203,24 @@ public class VMStatsRegionEntryOffHeapIntKey extends VMStatsRegionEntryOffHeap {
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -230,19 +230,17 @@ public class VMStatsRegionEntryOffHeapIntKey extends VMStatsRegionEntryOffHeap {
     return true;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final int key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsRegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsRegionEntryOffHeapLongKey.java
@@ -26,57 +26,68 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsRegionEntryOffHeapLongKey extends VMStatsRegionEntryOffHeap {
-  public VMStatsRegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapLongKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapLongKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapLongKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapLongKey.class, "offHeapAddress");
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapLongKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapLongKey.class, "hitCount");
+  private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapLongKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapLongKey.class, "missCount");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long key;
+
+  public VMStatsRegionEntryOffHeapLongKey(final RegionEntryContext context, final long key,
+      @Retained final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.key = key;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapLongKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapLongKey.class, "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapLongKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapLongKey.class, "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -90,24 +101,24 @@ public class VMStatsRegionEntryOffHeapLongKey extends VMStatsRegionEntryOffHeap 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -118,48 +129,45 @@ public class VMStatsRegionEntryOffHeapLongKey extends VMStatsRegionEntryOffHeap 
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // ---------------------------------------- stats code ------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -167,20 +175,12 @@ public class VMStatsRegionEntryOffHeapLongKey extends VMStatsRegionEntryOffHeap 
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapLongKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapLongKey.class, "hitCount");
-  private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapLongKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapLongKey.class, "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -188,7 +188,7 @@ public class VMStatsRegionEntryOffHeapLongKey extends VMStatsRegionEntryOffHeap 
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -203,24 +203,24 @@ public class VMStatsRegionEntryOffHeapLongKey extends VMStatsRegionEntryOffHeap 
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -230,19 +230,17 @@ public class VMStatsRegionEntryOffHeapLongKey extends VMStatsRegionEntryOffHeap 
     return true;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsRegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsRegionEntryOffHeapObjectKey.java
@@ -26,57 +26,68 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsRegionEntryOffHeapObjectKey extends VMStatsRegionEntryOffHeap {
-  public VMStatsRegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapObjectKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapObjectKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapObjectKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapObjectKey.class, "offHeapAddress");
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapObjectKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapObjectKey.class, "hitCount");
+  private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapObjectKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapObjectKey.class, "missCount");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final Object key;
+
+  public VMStatsRegionEntryOffHeapObjectKey(final RegionEntryContext context, final Object key,
+      @Retained final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.key = key;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapObjectKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapObjectKey.class, "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapObjectKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapObjectKey.class, "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -90,24 +101,24 @@ public class VMStatsRegionEntryOffHeapObjectKey extends VMStatsRegionEntryOffHea
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -118,48 +129,45 @@ public class VMStatsRegionEntryOffHeapObjectKey extends VMStatsRegionEntryOffHea
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // ---------------------------------------- stats code ------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -167,20 +175,12 @@ public class VMStatsRegionEntryOffHeapObjectKey extends VMStatsRegionEntryOffHea
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapObjectKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapObjectKey.class, "hitCount");
-  private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapObjectKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapObjectKey.class, "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -188,7 +188,7 @@ public class VMStatsRegionEntryOffHeapObjectKey extends VMStatsRegionEntryOffHea
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -203,24 +203,24 @@ public class VMStatsRegionEntryOffHeapObjectKey extends VMStatsRegionEntryOffHea
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -230,10 +230,8 @@ public class VMStatsRegionEntryOffHeapObjectKey extends VMStatsRegionEntryOffHea
     return true;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final Object key;
-
   @Override
   public Object getKey() {
     return this.key;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsRegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsRegionEntryOffHeapStringKey1.java
@@ -26,74 +26,86 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsRegionEntryOffHeapStringKey1 extends VMStatsRegionEntryOffHeap {
-  public VMStatsRegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, value);
-    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    if (byteEncode) {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
-        // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
-      }
-      tmpBits1 |= 1 << 6;
-    } else {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
-      }
-    }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapStringKey1> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapStringKey1.class, "lastModified");
   protected int hash;
-  private HashEntry<Object, Object> next;
+  private HashEntry<Object, Object> nextEntry;
   @SuppressWarnings("unused")
   private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapStringKey1> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapStringKey1.class, "lastModified");
+  // --------------------------------------- offheap fields ---------------------------------------
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
    * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
    * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
    */
-  private final static AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapStringKey1> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapStringKey1.class, "ohAddress");
+  private static final AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapStringKey1> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapStringKey1.class,
+          "offHeapAddress");
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapStringKey1> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapStringKey1.class, "hitCount");
+  private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapStringKey1> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapStringKey1.class, "missCount");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long bits1;
 
+  public VMStatsRegionEntryOffHeapStringKey1(final RegionEntryContext context, final String key,
+      @Retained final Object value, final boolean byteEncode) {
+    super(context, value);
+    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
+    long tempBits1 = 0L;
+    if (byteEncode) {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
+        // keep findbugs happy.
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
+      }
+      tempBits1 |= 1 << 6;
+    } else {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
+      }
+    }
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+  }
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -107,24 +119,24 @@ public class VMStatsRegionEntryOffHeapStringKey1 extends VMStatsRegionEntryOffHe
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -135,48 +147,45 @@ public class VMStatsRegionEntryOffHeapStringKey1 extends VMStatsRegionEntryOffHe
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // ---------------------------------------- stats code ------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -184,20 +193,12 @@ public class VMStatsRegionEntryOffHeapStringKey1 extends VMStatsRegionEntryOffHe
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapStringKey1> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapStringKey1.class, "hitCount");
-  private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapStringKey1> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapStringKey1.class, "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -205,7 +206,7 @@ public class VMStatsRegionEntryOffHeapStringKey1 extends VMStatsRegionEntryOffHe
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -220,24 +221,24 @@ public class VMStatsRegionEntryOffHeapStringKey1 extends VMStatsRegionEntryOffHe
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -247,10 +248,8 @@ public class VMStatsRegionEntryOffHeapStringKey1 extends VMStatsRegionEntryOffHe
     return true;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long bits1;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -263,18 +262,18 @@ public class VMStatsRegionEntryOffHeapStringKey1 extends VMStatsRegionEntryOffHe
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
     return new String(chars);
@@ -282,25 +281,25 @@ public class VMStatsRegionEntryOffHeapStringKey1 extends VMStatsRegionEntryOffHe
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsRegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsRegionEntryOffHeapStringKey2.java
@@ -26,86 +26,107 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsRegionEntryOffHeapStringKey2 extends VMStatsRegionEntryOffHeap {
-  public VMStatsRegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, value);
-    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
-    if (byteEncode) {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
-        // keep findbugs happy.
-        if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
-        } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
-        }
-      }
-      tmpBits1 |= 1 << 6;
-    } else {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
-        } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
-        }
-      }
-    }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapStringKey2> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapStringKey2.class, "lastModified");
   protected int hash;
-  private HashEntry<Object, Object> next;
+  private HashEntry<Object, Object> nextEntry;
   @SuppressWarnings("unused")
   private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapStringKey2> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapStringKey2.class, "lastModified");
+  // --------------------------------------- offheap fields ---------------------------------------
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
    * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
    * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
    */
-  private final static AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapStringKey2> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapStringKey2.class, "ohAddress");
+  private static final AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapStringKey2> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapStringKey2.class,
+          "offHeapAddress");
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapStringKey2> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapStringKey2.class, "hitCount");
+  private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapStringKey2> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapStringKey2.class, "missCount");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
+  private final long bits1;
+  /**
+   * bits2 encodes character data
+   */
+  private final long bits2;
 
+  public VMStatsRegionEntryOffHeapStringKey2(final RegionEntryContext context, final String key,
+      @Retained final Object value, final boolean byteEncode) {
+    super(context, value);
+    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
+    if (byteEncode) {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
+        // keep findbugs happy.
+        if (i < 7) {
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
+        } else {
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
+        }
+      }
+      tempBits1 |= 1 << 6;
+    } else {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        if (i < 3) {
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
+        } else {
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
+        }
+      }
+    }
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
+  }
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -119,24 +140,24 @@ public class VMStatsRegionEntryOffHeapStringKey2 extends VMStatsRegionEntryOffHe
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -147,48 +168,45 @@ public class VMStatsRegionEntryOffHeapStringKey2 extends VMStatsRegionEntryOffHe
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // ---------------------------------------- stats code ------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -196,20 +214,12 @@ public class VMStatsRegionEntryOffHeapStringKey2 extends VMStatsRegionEntryOffHe
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapStringKey2> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapStringKey2.class, "hitCount");
-  private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapStringKey2> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapStringKey2.class, "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -217,7 +227,7 @@ public class VMStatsRegionEntryOffHeapStringKey2 extends VMStatsRegionEntryOffHe
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -232,24 +242,24 @@ public class VMStatsRegionEntryOffHeapStringKey2 extends VMStatsRegionEntryOffHe
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -259,15 +269,8 @@ public class VMStatsRegionEntryOffHeapStringKey2 extends VMStatsRegionEntryOffHe
     return true;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
-  private final long bits1;
-  // bits2 encodes character data
-  private final long bits2;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -280,28 +283,28 @@ public class VMStatsRegionEntryOffHeapStringKey2 extends VMStatsRegionEntryOffHe
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -310,38 +313,38 @@ public class VMStatsRegionEntryOffHeapStringKey2 extends VMStatsRegionEntryOffHe
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsRegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsRegionEntryOffHeapUUIDKey.java
@@ -27,26 +27,63 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMStatsRegionEntryOffHeapUUIDKey extends VMStatsRegionEntryOffHeap {
-  public VMStatsRegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapUUIDKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapUUIDKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapUUIDKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapUUIDKey.class, "offHeapAddress");
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapUUIDKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapUUIDKey.class, "hitCount");
+  private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapUUIDKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapUUIDKey.class, "missCount");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long keyMostSigBits;
+  private final long keyLeastSigBits;
+
+  public VMStatsRegionEntryOffHeapUUIDKey(final RegionEntryContext context, final UUID key,
+      @Retained final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.keyMostSigBits = key.getMostSignificantBits();
@@ -54,31 +91,6 @@ public class VMStatsRegionEntryOffHeapUUIDKey extends VMStatsRegionEntryOffHeap 
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapUUIDKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapUUIDKey.class, "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VMStatsRegionEntryOffHeapUUIDKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapUUIDKey.class, "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -92,24 +104,24 @@ public class VMStatsRegionEntryOffHeapUUIDKey extends VMStatsRegionEntryOffHeap 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -120,48 +132,45 @@ public class VMStatsRegionEntryOffHeapUUIDKey extends VMStatsRegionEntryOffHeap 
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // ---------------------------------------- stats code ------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -169,20 +178,12 @@ public class VMStatsRegionEntryOffHeapUUIDKey extends VMStatsRegionEntryOffHeap 
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapUUIDKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapUUIDKey.class, "hitCount");
-  private static final AtomicIntegerFieldUpdater<VMStatsRegionEntryOffHeapUUIDKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VMStatsRegionEntryOffHeapUUIDKey.class, "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -190,7 +191,7 @@ public class VMStatsRegionEntryOffHeapUUIDKey extends VMStatsRegionEntryOffHeap 
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -205,24 +206,24 @@ public class VMStatsRegionEntryOffHeapUUIDKey extends VMStatsRegionEntryOffHeap 
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -232,20 +233,17 @@ public class VMStatsRegionEntryOffHeapUUIDKey extends VMStatsRegionEntryOffHeap 
     return true;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long keyMostSigBits;
-  private final long keyLeastSigBits;
-
   @Override
   public Object getKey() {
     return new UUID(this.keyMostSigBits, this.keyLeastSigBits);
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskLRURegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskLRURegionEntryHeapIntKey.java
@@ -19,35 +19,50 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskLRURegionEntryHeapIntKey extends VMThinDiskLRURegionEntryHeap {
-  public VMThinDiskLRURegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryHeapIntKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryHeapIntKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final int key;
+
+  public VMThinDiskLRURegionEntryHeapIntKey(final RegionEntryContext context, final int key,
+      final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -55,77 +70,65 @@ public class VMThinDiskLRURegionEntryHeapIntKey extends VMThinDiskLRURegionEntry
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryHeapIntKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryHeapIntKey.class, "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof InternalRegion) {
+      isBackup = ((InternalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
-      throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
+      throw new IllegalArgumentException("expected a InternalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -134,48 +137,43 @@ public class VMThinDiskLRURegionEntryHeapIntKey extends VMThinDiskLRURegionEntry
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -183,6 +181,7 @@ public class VMThinDiskLRURegionEntryHeapIntKey extends VMThinDiskLRURegionEntry
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -192,48 +191,57 @@ public class VMThinDiskLRURegionEntryHeapIntKey extends VMThinDiskLRURegionEntry
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -244,19 +252,17 @@ public class VMThinDiskLRURegionEntryHeapIntKey extends VMThinDiskLRURegionEntry
     return null;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final int key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskLRURegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskLRURegionEntryHeapLongKey.java
@@ -19,35 +19,50 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskLRURegionEntryHeapLongKey extends VMThinDiskLRURegionEntryHeap {
-  public VMThinDiskLRURegionEntryHeapLongKey(RegionEntryContext context, long key, Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryHeapLongKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryHeapLongKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long key;
+
+  public VMThinDiskLRURegionEntryHeapLongKey(final RegionEntryContext context, final long key,
+      final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -55,77 +70,65 @@ public class VMThinDiskLRURegionEntryHeapLongKey extends VMThinDiskLRURegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryHeapLongKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryHeapLongKey.class, "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof InternalRegion) {
+      isBackup = ((InternalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
-      throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
+      throw new IllegalArgumentException("expected a InternalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -134,48 +137,43 @@ public class VMThinDiskLRURegionEntryHeapLongKey extends VMThinDiskLRURegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -183,6 +181,7 @@ public class VMThinDiskLRURegionEntryHeapLongKey extends VMThinDiskLRURegionEntr
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -192,48 +191,57 @@ public class VMThinDiskLRURegionEntryHeapLongKey extends VMThinDiskLRURegionEntr
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -244,19 +252,17 @@ public class VMThinDiskLRURegionEntryHeapLongKey extends VMThinDiskLRURegionEntr
     return null;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskLRURegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskLRURegionEntryHeapObjectKey.java
@@ -19,36 +19,51 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskLRURegionEntryHeapObjectKey extends VMThinDiskLRURegionEntryHeap {
-  public VMThinDiskLRURegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-      Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryHeapObjectKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryHeapObjectKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final Object key;
+
+  public VMThinDiskLRURegionEntryHeapObjectKey(final RegionEntryContext context, final Object key,
+      final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -56,78 +71,65 @@ public class VMThinDiskLRURegionEntryHeapObjectKey extends VMThinDiskLRURegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryHeapObjectKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryHeapObjectKey.class,
-          "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof InternalRegion) {
+      isBackup = ((InternalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
-      throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
+      throw new IllegalArgumentException("expected a InternalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -136,48 +138,43 @@ public class VMThinDiskLRURegionEntryHeapObjectKey extends VMThinDiskLRURegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -185,6 +182,7 @@ public class VMThinDiskLRURegionEntryHeapObjectKey extends VMThinDiskLRURegionEn
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -194,48 +192,57 @@ public class VMThinDiskLRURegionEntryHeapObjectKey extends VMThinDiskLRURegionEn
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -246,10 +253,8 @@ public class VMThinDiskLRURegionEntryHeapObjectKey extends VMThinDiskLRURegionEn
     return getKey();
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final Object key;
-
   @Override
   public Object getKey() {
     return this.key;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskLRURegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskLRURegionEntryHeapStringKey1.java
@@ -19,132 +19,134 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskLRURegionEntryHeapStringKey1 extends VMThinDiskLRURegionEntryHeap {
-  public VMThinDiskLRURegionEntryHeapStringKey1(RegionEntryContext context, String key,
-      Object value, boolean byteEncode) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryHeapStringKey1> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryHeapStringKey1.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long bits1;
+
+  public VMThinDiskLRURegionEntryHeapStringKey1(final RegionEntryContext context, final String key,
+      final Object value, final boolean byteEncode) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryHeapStringKey1> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryHeapStringKey1.class,
-          "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof InternalRegion) {
+      isBackup = ((InternalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
-      throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
+      throw new IllegalArgumentException("expected a InternalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -153,48 +155,43 @@ public class VMThinDiskLRURegionEntryHeapStringKey1 extends VMThinDiskLRURegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -202,6 +199,7 @@ public class VMThinDiskLRURegionEntryHeapStringKey1 extends VMThinDiskLRURegionE
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -211,48 +209,57 @@ public class VMThinDiskLRURegionEntryHeapStringKey1 extends VMThinDiskLRURegionE
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -263,10 +270,8 @@ public class VMThinDiskLRURegionEntryHeapStringKey1 extends VMThinDiskLRURegionE
     return null;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long bits1;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -279,18 +284,18 @@ public class VMThinDiskLRURegionEntryHeapStringKey1 extends VMThinDiskLRURegionE
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
     return new String(chars);
@@ -298,25 +303,25 @@ public class VMThinDiskLRURegionEntryHeapStringKey1 extends VMThinDiskLRURegionE
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskLRURegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskLRURegionEntryHeapStringKey2.java
@@ -19,144 +19,155 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskLRURegionEntryHeapStringKey2 extends VMThinDiskLRURegionEntryHeap {
-  public VMThinDiskLRURegionEntryHeapStringKey2(RegionEntryContext context, String key,
-      Object value, boolean byteEncode) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryHeapStringKey2> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryHeapStringKey2.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
+  private final long bits1;
+  /**
+   * bits2 encodes character data
+   */
+  private final long bits2;
+
+  public VMThinDiskLRURegionEntryHeapStringKey2(final RegionEntryContext context, final String key,
+      final Object value, final boolean byteEncode) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryHeapStringKey2> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryHeapStringKey2.class,
-          "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof InternalRegion) {
+      isBackup = ((InternalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
-      throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
+      throw new IllegalArgumentException("expected a InternalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -165,48 +176,43 @@ public class VMThinDiskLRURegionEntryHeapStringKey2 extends VMThinDiskLRURegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -214,6 +220,7 @@ public class VMThinDiskLRURegionEntryHeapStringKey2 extends VMThinDiskLRURegionE
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -223,48 +230,57 @@ public class VMThinDiskLRURegionEntryHeapStringKey2 extends VMThinDiskLRURegionE
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -275,15 +291,8 @@ public class VMThinDiskLRURegionEntryHeapStringKey2 extends VMThinDiskLRURegionE
     return null;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
-  private final long bits1;
-  // bits2 encodes character data
-  private final long bits2;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -296,28 +305,28 @@ public class VMThinDiskLRURegionEntryHeapStringKey2 extends VMThinDiskLRURegionE
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -326,38 +335,38 @@ public class VMThinDiskLRURegionEntryHeapStringKey2 extends VMThinDiskLRURegionE
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskLRURegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskLRURegionEntryHeapUUIDKey.java
@@ -20,35 +20,51 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskLRURegionEntryHeapUUIDKey extends VMThinDiskLRURegionEntryHeap {
-  public VMThinDiskLRURegionEntryHeapUUIDKey(RegionEntryContext context, UUID key, Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryHeapUUIDKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryHeapUUIDKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long keyMostSigBits;
+  private final long keyLeastSigBits;
+
+  public VMThinDiskLRURegionEntryHeapUUIDKey(final RegionEntryContext context, final UUID key,
+      final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -57,77 +73,65 @@ public class VMThinDiskLRURegionEntryHeapUUIDKey extends VMThinDiskLRURegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryHeapUUIDKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryHeapUUIDKey.class, "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof InternalRegion) {
+      isBackup = ((InternalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
-      throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
+      throw new IllegalArgumentException("expected a InternalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -136,48 +140,43 @@ public class VMThinDiskLRURegionEntryHeapUUIDKey extends VMThinDiskLRURegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -185,6 +184,7 @@ public class VMThinDiskLRURegionEntryHeapUUIDKey extends VMThinDiskLRURegionEntr
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -194,48 +194,57 @@ public class VMThinDiskLRURegionEntryHeapUUIDKey extends VMThinDiskLRURegionEntr
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -246,20 +255,17 @@ public class VMThinDiskLRURegionEntryHeapUUIDKey extends VMThinDiskLRURegionEntr
     return null;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long keyMostSigBits;
-  private final long keyLeastSigBits;
-
   @Override
   public Object getKey() {
     return new UUID(this.keyMostSigBits, this.keyLeastSigBits);
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskLRURegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskLRURegionEntryOffHeapIntKey.java
@@ -19,12 +19,12 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.cache.Token;
@@ -34,26 +34,61 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskLRURegionEntryOffHeapIntKey extends VMThinDiskLRURegionEntryOffHeap {
-  public VMThinDiskLRURegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapIntKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryOffHeapIntKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapIntKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryOffHeapIntKey.class,
+          "offHeapAddress");
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final int key;
+
+  public VMThinDiskLRURegionEntryOffHeapIntKey(final RegionEntryContext context, final int key,
+      @Retained final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -61,32 +96,6 @@ public class VMThinDiskLRURegionEntryOffHeapIntKey extends VMThinDiskLRURegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapIntKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryOffHeapIntKey.class,
-          "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapIntKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryOffHeapIntKey.class, "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -100,24 +109,24 @@ public class VMThinDiskLRURegionEntryOffHeapIntKey extends VMThinDiskLRURegionEn
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -128,61 +137,58 @@ public class VMThinDiskLRURegionEntryOffHeapIntKey extends VMThinDiskLRURegionEn
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof InternalRegion) {
+      isBackup = ((InternalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
-      throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
+      throw new IllegalArgumentException("expected a InternalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -191,48 +197,43 @@ public class VMThinDiskLRURegionEntryOffHeapIntKey extends VMThinDiskLRURegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -240,6 +241,7 @@ public class VMThinDiskLRURegionEntryOffHeapIntKey extends VMThinDiskLRURegionEn
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -249,48 +251,57 @@ public class VMThinDiskLRURegionEntryOffHeapIntKey extends VMThinDiskLRURegionEn
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -301,19 +312,17 @@ public class VMThinDiskLRURegionEntryOffHeapIntKey extends VMThinDiskLRURegionEn
     return null;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final int key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskLRURegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskLRURegionEntryOffHeapLongKey.java
@@ -19,12 +19,12 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.cache.Token;
@@ -34,26 +34,61 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskLRURegionEntryOffHeapLongKey extends VMThinDiskLRURegionEntryOffHeap {
-  public VMThinDiskLRURegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapLongKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryOffHeapLongKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapLongKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryOffHeapLongKey.class,
+          "offHeapAddress");
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long key;
+
+  public VMThinDiskLRURegionEntryOffHeapLongKey(final RegionEntryContext context, final long key,
+      @Retained final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -61,32 +96,6 @@ public class VMThinDiskLRURegionEntryOffHeapLongKey extends VMThinDiskLRURegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapLongKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryOffHeapLongKey.class,
-          "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapLongKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryOffHeapLongKey.class, "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -100,24 +109,24 @@ public class VMThinDiskLRURegionEntryOffHeapLongKey extends VMThinDiskLRURegionE
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -128,61 +137,58 @@ public class VMThinDiskLRURegionEntryOffHeapLongKey extends VMThinDiskLRURegionE
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof InternalRegion) {
+      isBackup = ((InternalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
-      throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
+      throw new IllegalArgumentException("expected a InternalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -191,48 +197,43 @@ public class VMThinDiskLRURegionEntryOffHeapLongKey extends VMThinDiskLRURegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -240,6 +241,7 @@ public class VMThinDiskLRURegionEntryOffHeapLongKey extends VMThinDiskLRURegionE
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -249,48 +251,57 @@ public class VMThinDiskLRURegionEntryOffHeapLongKey extends VMThinDiskLRURegionE
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -301,19 +312,17 @@ public class VMThinDiskLRURegionEntryOffHeapLongKey extends VMThinDiskLRURegionE
     return null;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskLRURegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskLRURegionEntryOffHeapObjectKey.java
@@ -19,12 +19,12 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.cache.Token;
@@ -34,26 +34,61 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskLRURegionEntryOffHeapObjectKey extends VMThinDiskLRURegionEntryOffHeap {
-  public VMThinDiskLRURegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapObjectKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryOffHeapObjectKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapObjectKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryOffHeapObjectKey.class,
+          "offHeapAddress");
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final Object key;
+
+  public VMThinDiskLRURegionEntryOffHeapObjectKey(final RegionEntryContext context,
+      final Object key, @Retained final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -61,33 +96,6 @@ public class VMThinDiskLRURegionEntryOffHeapObjectKey extends VMThinDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapObjectKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryOffHeapObjectKey.class,
-          "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapObjectKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryOffHeapObjectKey.class,
-          "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -101,24 +109,24 @@ public class VMThinDiskLRURegionEntryOffHeapObjectKey extends VMThinDiskLRURegio
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -129,61 +137,58 @@ public class VMThinDiskLRURegionEntryOffHeapObjectKey extends VMThinDiskLRURegio
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof InternalRegion) {
+      isBackup = ((InternalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
-      throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
+      throw new IllegalArgumentException("expected a InternalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -192,48 +197,43 @@ public class VMThinDiskLRURegionEntryOffHeapObjectKey extends VMThinDiskLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -241,6 +241,7 @@ public class VMThinDiskLRURegionEntryOffHeapObjectKey extends VMThinDiskLRURegio
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -250,48 +251,57 @@ public class VMThinDiskLRURegionEntryOffHeapObjectKey extends VMThinDiskLRURegio
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -302,10 +312,8 @@ public class VMThinDiskLRURegionEntryOffHeapObjectKey extends VMThinDiskLRURegio
     return getKey();
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final Object key;
-
   @Override
   public Object getKey() {
     return this.key;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskLRURegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskLRURegionEntryOffHeapStringKey1.java
@@ -19,12 +19,12 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.cache.Token;
@@ -34,77 +34,85 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskLRURegionEntryOffHeapStringKey1 extends VMThinDiskLRURegionEntryOffHeap {
-  public VMThinDiskLRURegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
-    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-    initialize(context, value);
-    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    if (byteEncode) {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
-        // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
-      }
-      tmpBits1 |= 1 << 6;
-    } else {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
-      }
-    }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapStringKey1> lastModifiedUpdater =
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapStringKey1> LAST_MODIFIED_UPDATER =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryOffHeapStringKey1.class,
           "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
    * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
    * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
    */
-  private final static AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapStringKey1> ohAddrUpdater =
+  private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapStringKey1> OFF_HEAP_ADDRESS_UPDATER =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryOffHeapStringKey1.class,
-          "ohAddress");
+          "offHeapAddress");
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long bits1;
 
+  public VMThinDiskLRURegionEntryOffHeapStringKey1(final RegionEntryContext context,
+      final String key, @Retained final Object value, final boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
+    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+    initialize(context, value);
+    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
+    long tempBits1 = 0L;
+    if (byteEncode) {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
+        // keep findbugs happy.
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
+      }
+      tempBits1 |= 1 << 6;
+    } else {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
+      }
+    }
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+  }
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -118,24 +126,24 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey1 extends VMThinDiskLRURegi
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -146,61 +154,58 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey1 extends VMThinDiskLRURegi
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof InternalRegion) {
+      isBackup = ((InternalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
-      throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
+      throw new IllegalArgumentException("expected a InternalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -209,48 +214,43 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey1 extends VMThinDiskLRURegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -258,6 +258,7 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey1 extends VMThinDiskLRURegi
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -267,48 +268,57 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey1 extends VMThinDiskLRURegi
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -319,10 +329,8 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey1 extends VMThinDiskLRURegi
     return null;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long bits1;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -335,18 +343,18 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey1 extends VMThinDiskLRURegi
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
     return new String(chars);
@@ -354,25 +362,25 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey1 extends VMThinDiskLRURegi
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskLRURegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskLRURegionEntryOffHeapStringKey2.java
@@ -19,12 +19,12 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.cache.Token;
@@ -34,89 +34,106 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskLRURegionEntryOffHeapStringKey2 extends VMThinDiskLRURegionEntryOffHeap {
-  public VMThinDiskLRURegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
-    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-    initialize(context, value);
-    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
-    if (byteEncode) {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
-        // keep findbugs happy.
-        if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
-        } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
-        }
-      }
-      tmpBits1 |= 1 << 6;
-    } else {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
-        } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
-        }
-      }
-    }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapStringKey2> lastModifiedUpdater =
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapStringKey2> LAST_MODIFIED_UPDATER =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryOffHeapStringKey2.class,
           "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
    * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
    * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
    */
-  private final static AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapStringKey2> ohAddrUpdater =
+  private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapStringKey2> OFF_HEAP_ADDRESS_UPDATER =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryOffHeapStringKey2.class,
-          "ohAddress");
+          "offHeapAddress");
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
+  private final long bits1;
+  /**
+   * bits2 encodes character data
+   */
+  private final long bits2;
 
+  public VMThinDiskLRURegionEntryOffHeapStringKey2(final RegionEntryContext context,
+      final String key, @Retained final Object value, final boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
+    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+    initialize(context, value);
+    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
+    if (byteEncode) {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
+        // keep findbugs happy.
+        if (i < 7) {
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
+        } else {
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
+        }
+      }
+      tempBits1 |= 1 << 6;
+    } else {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        if (i < 3) {
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
+        } else {
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
+        }
+      }
+    }
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
+  }
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -130,24 +147,24 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey2 extends VMThinDiskLRURegi
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -158,61 +175,58 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey2 extends VMThinDiskLRURegi
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof InternalRegion) {
+      isBackup = ((InternalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
-      throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
+      throw new IllegalArgumentException("expected a InternalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -221,48 +235,43 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey2 extends VMThinDiskLRURegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -270,6 +279,7 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey2 extends VMThinDiskLRURegi
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -279,48 +289,57 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey2 extends VMThinDiskLRURegi
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -331,15 +350,8 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey2 extends VMThinDiskLRURegi
     return null;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
-  private final long bits1;
-  // bits2 encodes character data
-  private final long bits2;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -352,28 +364,28 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey2 extends VMThinDiskLRURegi
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -382,38 +394,38 @@ public class VMThinDiskLRURegionEntryOffHeapStringKey2 extends VMThinDiskLRURegi
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskLRURegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskLRURegionEntryOffHeapUUIDKey.java
@@ -20,12 +20,12 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.cache.Token;
@@ -35,26 +35,62 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskLRURegionEntryOffHeapUUIDKey extends VMThinDiskLRURegionEntryOffHeap {
-  public VMThinDiskLRURegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapUUIDKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryOffHeapUUIDKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapUUIDKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryOffHeapUUIDKey.class,
+          "offHeapAddress");
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long keyMostSigBits;
+  private final long keyLeastSigBits;
+
+  public VMThinDiskLRURegionEntryOffHeapUUIDKey(final RegionEntryContext context, final UUID key,
+      @Retained final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -63,32 +99,6 @@ public class VMThinDiskLRURegionEntryOffHeapUUIDKey extends VMThinDiskLRURegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapUUIDKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryOffHeapUUIDKey.class,
-          "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VMThinDiskLRURegionEntryOffHeapUUIDKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinDiskLRURegionEntryOffHeapUUIDKey.class, "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -102,24 +112,24 @@ public class VMThinDiskLRURegionEntryOffHeapUUIDKey extends VMThinDiskLRURegionE
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -130,61 +140,58 @@ public class VMThinDiskLRURegionEntryOffHeapUUIDKey extends VMThinDiskLRURegionE
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof InternalRegion) {
+      isBackup = ((InternalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
-      throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
+      throw new IllegalArgumentException("expected a InternalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -193,48 +200,43 @@ public class VMThinDiskLRURegionEntryOffHeapUUIDKey extends VMThinDiskLRURegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -242,6 +244,7 @@ public class VMThinDiskLRURegionEntryOffHeapUUIDKey extends VMThinDiskLRURegionE
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -251,48 +254,57 @@ public class VMThinDiskLRURegionEntryOffHeapUUIDKey extends VMThinDiskLRURegionE
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -303,20 +315,17 @@ public class VMThinDiskLRURegionEntryOffHeapUUIDKey extends VMThinDiskLRURegionE
     return null;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long keyMostSigBits;
-  private final long keyLeastSigBits;
-
   @Override
   public Object getKey() {
     return new UUID(this.keyMostSigBits, this.keyLeastSigBits);
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskRegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskRegionEntryHeapIntKey.java
@@ -18,32 +18,47 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskRegionEntryHeapIntKey extends VMThinDiskRegionEntryHeap {
-  public VMThinDiskRegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryHeapIntKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryHeapIntKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final int key;
+
+  public VMThinDiskRegionEntryHeapIntKey(final RegionEntryContext context, final int key,
+      final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -51,108 +66,88 @@ public class VMThinDiskRegionEntryHeapIntKey extends VMThinDiskRegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryHeapIntKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryHeapIntKey.class, "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final int key;
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
 
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskRegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskRegionEntryHeapLongKey.java
@@ -18,32 +18,47 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskRegionEntryHeapLongKey extends VMThinDiskRegionEntryHeap {
-  public VMThinDiskRegionEntryHeapLongKey(RegionEntryContext context, long key, Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryHeapLongKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryHeapLongKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long key;
+
+  public VMThinDiskRegionEntryHeapLongKey(final RegionEntryContext context, final long key,
+      final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -51,108 +66,88 @@ public class VMThinDiskRegionEntryHeapLongKey extends VMThinDiskRegionEntryHeap 
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryHeapLongKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryHeapLongKey.class, "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long key;
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
 
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskRegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskRegionEntryHeapObjectKey.java
@@ -18,32 +18,47 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskRegionEntryHeapObjectKey extends VMThinDiskRegionEntryHeap {
-  public VMThinDiskRegionEntryHeapObjectKey(RegionEntryContext context, Object key, Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryHeapObjectKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryHeapObjectKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final Object key;
+
+  public VMThinDiskRegionEntryHeapObjectKey(final RegionEntryContext context, final Object key,
+      final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -51,99 +66,79 @@ public class VMThinDiskRegionEntryHeapObjectKey extends VMThinDiskRegionEntryHea
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryHeapObjectKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryHeapObjectKey.class, "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final Object key;
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
 
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   public Object getKey() {
     return this.key;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskRegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskRegionEntryHeapStringKey1.java
@@ -18,150 +18,144 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskRegionEntryHeapStringKey1 extends VMThinDiskRegionEntryHeap {
-  public VMThinDiskRegionEntryHeapStringKey1(RegionEntryContext context, String key, Object value,
-      boolean byteEncode) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryHeapStringKey1> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryHeapStringKey1.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long bits1;
+
+  public VMThinDiskRegionEntryHeapStringKey1(final RegionEntryContext context, final String key,
+      final Object value, final boolean byteEncode) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryHeapStringKey1> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryHeapStringKey1.class, "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long bits1;
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
 
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -174,18 +168,18 @@ public class VMThinDiskRegionEntryHeapStringKey1 extends VMThinDiskRegionEntryHe
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
     return new String(chars);
@@ -193,25 +187,25 @@ public class VMThinDiskRegionEntryHeapStringKey1 extends VMThinDiskRegionEntryHe
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskRegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskRegionEntryHeapStringKey2.java
@@ -18,167 +18,165 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskRegionEntryHeapStringKey2 extends VMThinDiskRegionEntryHeap {
-  public VMThinDiskRegionEntryHeapStringKey2(RegionEntryContext context, String key, Object value,
-      boolean byteEncode) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryHeapStringKey2> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryHeapStringKey2.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
+  private final long bits1;
+  /**
+   * bits2 encodes character data
+   */
+  private final long bits2;
+
+  public VMThinDiskRegionEntryHeapStringKey2(final RegionEntryContext context, final String key,
+      final Object value, final boolean byteEncode) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryHeapStringKey2> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryHeapStringKey2.class, "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
-  private final long bits1;
-  // bits2 encodes character data
-  private final long bits2;
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
 
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -191,28 +189,28 @@ public class VMThinDiskRegionEntryHeapStringKey2 extends VMThinDiskRegionEntryHe
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -221,38 +219,38 @@ public class VMThinDiskRegionEntryHeapStringKey2 extends VMThinDiskRegionEntryHe
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskRegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskRegionEntryHeapUUIDKey.java
@@ -19,32 +19,48 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskRegionEntryHeapUUIDKey extends VMThinDiskRegionEntryHeap {
-  public VMThinDiskRegionEntryHeapUUIDKey(RegionEntryContext context, UUID key, Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryHeapUUIDKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryHeapUUIDKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long keyMostSigBits;
+  private final long keyLeastSigBits;
+
+  public VMThinDiskRegionEntryHeapUUIDKey(final RegionEntryContext context, final UUID key,
+      final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -53,109 +69,88 @@ public class VMThinDiskRegionEntryHeapUUIDKey extends VMThinDiskRegionEntryHeap 
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryHeapUUIDKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryHeapUUIDKey.class, "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long keyMostSigBits;
-  private final long keyLeastSigBits;
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
 
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   public Object getKey() {
     return new UUID(this.keyMostSigBits, this.keyLeastSigBits);
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskRegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskRegionEntryOffHeapIntKey.java
@@ -18,11 +18,11 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.Token;
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
@@ -30,26 +30,59 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskRegionEntryOffHeapIntKey extends VMThinDiskRegionEntryOffHeap {
-  public VMThinDiskRegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapIntKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapIntKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapIntKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapIntKey.class, "offHeapAddress");
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final int key;
+
+  public VMThinDiskRegionEntryOffHeapIntKey(final RegionEntryContext context, final int key,
+      @Retained final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -57,31 +90,6 @@ public class VMThinDiskRegionEntryOffHeapIntKey extends VMThinDiskRegionEntryOff
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapIntKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapIntKey.class, "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapIntKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapIntKey.class, "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -95,24 +103,24 @@ public class VMThinDiskRegionEntryOffHeapIntKey extends VMThinDiskRegionEntryOff
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -123,92 +131,81 @@ public class VMThinDiskRegionEntryOffHeapIntKey extends VMThinDiskRegionEntryOff
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final int key;
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
 
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskRegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskRegionEntryOffHeapLongKey.java
@@ -18,11 +18,11 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.Token;
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
@@ -30,26 +30,60 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskRegionEntryOffHeapLongKey extends VMThinDiskRegionEntryOffHeap {
-  public VMThinDiskRegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapLongKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapLongKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapLongKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapLongKey.class,
+          "offHeapAddress");
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long key;
+
+  public VMThinDiskRegionEntryOffHeapLongKey(final RegionEntryContext context, final long key,
+      @Retained final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -57,31 +91,6 @@ public class VMThinDiskRegionEntryOffHeapLongKey extends VMThinDiskRegionEntryOf
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapLongKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapLongKey.class, "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapLongKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapLongKey.class, "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -95,24 +104,24 @@ public class VMThinDiskRegionEntryOffHeapLongKey extends VMThinDiskRegionEntryOf
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -123,92 +132,81 @@ public class VMThinDiskRegionEntryOffHeapLongKey extends VMThinDiskRegionEntryOf
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long key;
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
 
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskRegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskRegionEntryOffHeapObjectKey.java
@@ -18,11 +18,11 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.Token;
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
@@ -30,26 +30,61 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskRegionEntryOffHeapObjectKey extends VMThinDiskRegionEntryOffHeap {
-  public VMThinDiskRegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapObjectKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapObjectKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapObjectKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapObjectKey.class,
+          "offHeapAddress");
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final Object key;
+
+  public VMThinDiskRegionEntryOffHeapObjectKey(final RegionEntryContext context, final Object key,
+      @Retained final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -57,32 +92,6 @@ public class VMThinDiskRegionEntryOffHeapObjectKey extends VMThinDiskRegionEntry
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapObjectKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapObjectKey.class,
-          "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapObjectKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapObjectKey.class, "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -96,24 +105,24 @@ public class VMThinDiskRegionEntryOffHeapObjectKey extends VMThinDiskRegionEntry
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -124,83 +133,72 @@ public class VMThinDiskRegionEntryOffHeapObjectKey extends VMThinDiskRegionEntry
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final Object key;
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
 
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   public Object getKey() {
     return this.key;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskRegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskRegionEntryOffHeapStringKey1.java
@@ -18,11 +18,11 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.Token;
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
@@ -30,76 +30,85 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskRegionEntryOffHeapStringKey1 extends VMThinDiskRegionEntryOffHeap {
-  public VMThinDiskRegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
-    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-    initialize(context, value);
-    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    if (byteEncode) {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
-        // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
-      }
-      tmpBits1 |= 1 << 6;
-    } else {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
-      }
-    }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapStringKey1> lastModifiedUpdater =
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapStringKey1> LAST_MODIFIED_UPDATER =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapStringKey1.class,
           "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
    * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
    * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
    */
-  private final static AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapStringKey1> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapStringKey1.class, "ohAddress");
+  private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapStringKey1> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapStringKey1.class,
+          "offHeapAddress");
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long bits1;
 
+  public VMThinDiskRegionEntryOffHeapStringKey1(final RegionEntryContext context, final String key,
+      @Retained final Object value, final boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
+    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+    initialize(context, value);
+    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
+    long tempBits1 = 0L;
+    if (byteEncode) {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
+        // keep findbugs happy.
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
+      }
+      tempBits1 |= 1 << 6;
+    } else {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
+      }
+    }
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+  }
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -113,24 +122,24 @@ public class VMThinDiskRegionEntryOffHeapStringKey1 extends VMThinDiskRegionEntr
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -141,83 +150,72 @@ public class VMThinDiskRegionEntryOffHeapStringKey1 extends VMThinDiskRegionEntr
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long bits1;
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
 
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -230,18 +228,18 @@ public class VMThinDiskRegionEntryOffHeapStringKey1 extends VMThinDiskRegionEntr
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
     return new String(chars);
@@ -249,25 +247,25 @@ public class VMThinDiskRegionEntryOffHeapStringKey1 extends VMThinDiskRegionEntr
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskRegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskRegionEntryOffHeapStringKey2.java
@@ -18,11 +18,11 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.Token;
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
@@ -30,88 +30,106 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskRegionEntryOffHeapStringKey2 extends VMThinDiskRegionEntryOffHeap {
-  public VMThinDiskRegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
-    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-    initialize(context, value);
-    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
-    if (byteEncode) {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
-        // keep findbugs happy.
-        if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
-        } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
-        }
-      }
-      tmpBits1 |= 1 << 6;
-    } else {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
-        } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
-        }
-      }
-    }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapStringKey2> lastModifiedUpdater =
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapStringKey2> LAST_MODIFIED_UPDATER =
       AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapStringKey2.class,
           "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
    * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
    * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
    */
-  private final static AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapStringKey2> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapStringKey2.class, "ohAddress");
+  private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapStringKey2> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapStringKey2.class,
+          "offHeapAddress");
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
+  private final long bits1;
+  /**
+   * bits2 encodes character data
+   */
+  private final long bits2;
 
+  public VMThinDiskRegionEntryOffHeapStringKey2(final RegionEntryContext context, final String key,
+      @Retained final Object value, final boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
+    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+    initialize(context, value);
+    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
+    if (byteEncode) {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
+        // keep findbugs happy.
+        if (i < 7) {
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
+        } else {
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
+        }
+      }
+      tempBits1 |= 1 << 6;
+    } else {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        if (i < 3) {
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
+        } else {
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
+        }
+      }
+    }
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
+  }
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -125,24 +143,24 @@ public class VMThinDiskRegionEntryOffHeapStringKey2 extends VMThinDiskRegionEntr
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -153,88 +171,72 @@ public class VMThinDiskRegionEntryOffHeapStringKey2 extends VMThinDiskRegionEntr
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
-  private final long bits1;
-  // bits2 encodes character data
-  private final long bits2;
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
 
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -247,28 +249,28 @@ public class VMThinDiskRegionEntryOffHeapStringKey2 extends VMThinDiskRegionEntr
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -277,38 +279,38 @@ public class VMThinDiskRegionEntryOffHeapStringKey2 extends VMThinDiskRegionEntr
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskRegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskRegionEntryOffHeapUUIDKey.java
@@ -19,11 +19,11 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.Token;
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
@@ -31,26 +31,61 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinDiskRegionEntryOffHeapUUIDKey extends VMThinDiskRegionEntryOffHeap {
-  public VMThinDiskRegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapUUIDKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapUUIDKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapUUIDKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapUUIDKey.class,
+          "offHeapAddress");
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long keyMostSigBits;
+  private final long keyLeastSigBits;
+
+  public VMThinDiskRegionEntryOffHeapUUIDKey(final RegionEntryContext context, final UUID key,
+      @Retained final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -59,31 +94,6 @@ public class VMThinDiskRegionEntryOffHeapUUIDKey extends VMThinDiskRegionEntryOf
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapUUIDKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapUUIDKey.class, "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VMThinDiskRegionEntryOffHeapUUIDKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinDiskRegionEntryOffHeapUUIDKey.class, "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -97,24 +107,24 @@ public class VMThinDiskRegionEntryOffHeapUUIDKey extends VMThinDiskRegionEntryOf
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -125,93 +135,81 @@ public class VMThinDiskRegionEntryOffHeapUUIDKey extends VMThinDiskRegionEntryOf
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long keyMostSigBits;
-  private final long keyLeastSigBits;
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
 
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   public Object getKey() {
     return new UUID(this.keyMostSigBits, this.keyLeastSigBits);
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinLRURegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinLRURegionEntryHeapIntKey.java
@@ -19,103 +19,103 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinLRURegionEntryHeapIntKey extends VMThinLRURegionEntryHeap {
-  public VMThinLRURegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMThinLRURegionEntryHeapIntKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryHeapIntKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final int key;
+
+  public VMThinLRURegionEntryHeapIntKey(final RegionEntryContext context, final int key,
+      final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.key = key;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMThinLRURegionEntryHeapIntKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryHeapIntKey.class, "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
     // nothing needed for LRUs with no disk
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -123,6 +123,7 @@ public class VMThinLRURegionEntryHeapIntKey extends VMThinLRURegionEntryHeap {
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -132,48 +133,57 @@ public class VMThinLRURegionEntryHeapIntKey extends VMThinLRURegionEntryHeap {
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -184,19 +194,17 @@ public class VMThinLRURegionEntryHeapIntKey extends VMThinLRURegionEntryHeap {
     return null;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final int key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinLRURegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinLRURegionEntryHeapLongKey.java
@@ -19,103 +19,103 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinLRURegionEntryHeapLongKey extends VMThinLRURegionEntryHeap {
-  public VMThinLRURegionEntryHeapLongKey(RegionEntryContext context, long key, Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMThinLRURegionEntryHeapLongKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryHeapLongKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long key;
+
+  public VMThinLRURegionEntryHeapLongKey(final RegionEntryContext context, final long key,
+      final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.key = key;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMThinLRURegionEntryHeapLongKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryHeapLongKey.class, "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
     // nothing needed for LRUs with no disk
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -123,6 +123,7 @@ public class VMThinLRURegionEntryHeapLongKey extends VMThinLRURegionEntryHeap {
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -132,48 +133,57 @@ public class VMThinLRURegionEntryHeapLongKey extends VMThinLRURegionEntryHeap {
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -184,19 +194,17 @@ public class VMThinLRURegionEntryHeapLongKey extends VMThinLRURegionEntryHeap {
     return null;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinLRURegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinLRURegionEntryHeapObjectKey.java
@@ -19,103 +19,103 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinLRURegionEntryHeapObjectKey extends VMThinLRURegionEntryHeap {
-  public VMThinLRURegionEntryHeapObjectKey(RegionEntryContext context, Object key, Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMThinLRURegionEntryHeapObjectKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryHeapObjectKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final Object key;
+
+  public VMThinLRURegionEntryHeapObjectKey(final RegionEntryContext context, final Object key,
+      final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.key = key;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMThinLRURegionEntryHeapObjectKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryHeapObjectKey.class, "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
     // nothing needed for LRUs with no disk
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -123,6 +123,7 @@ public class VMThinLRURegionEntryHeapObjectKey extends VMThinLRURegionEntryHeap 
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -132,48 +133,57 @@ public class VMThinLRURegionEntryHeapObjectKey extends VMThinLRURegionEntryHeap 
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -184,10 +194,8 @@ public class VMThinLRURegionEntryHeapObjectKey extends VMThinLRURegionEntryHeap 
     return getKey();
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final Object key;
-
   @Override
   public Object getKey() {
     return this.key;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinLRURegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinLRURegionEntryHeapStringKey1.java
@@ -19,121 +19,120 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinLRURegionEntryHeapStringKey1 extends VMThinLRURegionEntryHeap {
-  public VMThinLRURegionEntryHeapStringKey1(RegionEntryContext context, String key, Object value,
-      boolean byteEncode) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMThinLRURegionEntryHeapStringKey1> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryHeapStringKey1.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long bits1;
+
+  public VMThinLRURegionEntryHeapStringKey1(final RegionEntryContext context, final String key,
+      final Object value, final boolean byteEncode) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMThinLRURegionEntryHeapStringKey1> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryHeapStringKey1.class, "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
     // nothing needed for LRUs with no disk
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -141,6 +140,7 @@ public class VMThinLRURegionEntryHeapStringKey1 extends VMThinLRURegionEntryHeap
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -150,48 +150,57 @@ public class VMThinLRURegionEntryHeapStringKey1 extends VMThinLRURegionEntryHeap
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -202,10 +211,8 @@ public class VMThinLRURegionEntryHeapStringKey1 extends VMThinLRURegionEntryHeap
     return null;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long bits1;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -218,18 +225,18 @@ public class VMThinLRURegionEntryHeapStringKey1 extends VMThinLRURegionEntryHeap
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
     return new String(chars);
@@ -237,25 +244,25 @@ public class VMThinLRURegionEntryHeapStringKey1 extends VMThinLRURegionEntryHeap
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinLRURegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinLRURegionEntryHeapStringKey2.java
@@ -19,133 +19,141 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinLRURegionEntryHeapStringKey2 extends VMThinLRURegionEntryHeap {
-  public VMThinLRURegionEntryHeapStringKey2(RegionEntryContext context, String key, Object value,
-      boolean byteEncode) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMThinLRURegionEntryHeapStringKey2> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryHeapStringKey2.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
+  private final long bits1;
+  /**
+   * bits2 encodes character data
+   */
+  private final long bits2;
+
+  public VMThinLRURegionEntryHeapStringKey2(final RegionEntryContext context, final String key,
+      final Object value, final boolean byteEncode) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMThinLRURegionEntryHeapStringKey2> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryHeapStringKey2.class, "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
     // nothing needed for LRUs with no disk
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -153,6 +161,7 @@ public class VMThinLRURegionEntryHeapStringKey2 extends VMThinLRURegionEntryHeap
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -162,48 +171,57 @@ public class VMThinLRURegionEntryHeapStringKey2 extends VMThinLRURegionEntryHeap
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -214,15 +232,8 @@ public class VMThinLRURegionEntryHeapStringKey2 extends VMThinLRURegionEntryHeap
     return null;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
-  private final long bits1;
-  // bits2 encodes character data
-  private final long bits2;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -235,28 +246,28 @@ public class VMThinLRURegionEntryHeapStringKey2 extends VMThinLRURegionEntryHeap
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -265,38 +276,38 @@ public class VMThinLRURegionEntryHeapStringKey2 extends VMThinLRURegionEntryHeap
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinLRURegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinLRURegionEntryHeapUUIDKey.java
@@ -20,30 +20,42 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinLRURegionEntryHeapUUIDKey extends VMThinLRURegionEntryHeap {
-  public VMThinLRURegionEntryHeapUUIDKey(RegionEntryContext context, UUID key, Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMThinLRURegionEntryHeapUUIDKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryHeapUUIDKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long keyMostSigBits;
+  private final long keyLeastSigBits;
+
+  public VMThinLRURegionEntryHeapUUIDKey(final RegionEntryContext context, final UUID key,
+      final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.keyMostSigBits = key.getMostSignificantBits();
@@ -51,73 +63,62 @@ public class VMThinLRURegionEntryHeapUUIDKey extends VMThinLRURegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMThinLRURegionEntryHeapUUIDKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryHeapUUIDKey.class, "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
     // nothing needed for LRUs with no disk
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -125,6 +126,7 @@ public class VMThinLRURegionEntryHeapUUIDKey extends VMThinLRURegionEntryHeap {
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -134,48 +136,57 @@ public class VMThinLRURegionEntryHeapUUIDKey extends VMThinLRURegionEntryHeap {
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -186,20 +197,17 @@ public class VMThinLRURegionEntryHeapUUIDKey extends VMThinLRURegionEntryHeap {
     return null;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long keyMostSigBits;
-  private final long keyLeastSigBits;
-
   @Override
   public Object getKey() {
     return new UUID(this.keyMostSigBits, this.keyLeastSigBits);
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinLRURegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinLRURegionEntryOffHeapIntKey.java
@@ -19,7 +19,8 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.cache.Token;
@@ -29,57 +30,60 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinLRURegionEntryOffHeapIntKey extends VMThinLRURegionEntryOffHeap {
-  public VMThinLRURegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapIntKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapIntKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapIntKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapIntKey.class, "offHeapAddress");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final int key;
+
+  public VMThinLRURegionEntryOffHeapIntKey(final RegionEntryContext context, final int key,
+      @Retained final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.key = key;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapIntKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapIntKey.class, "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapIntKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapIntKey.class, "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -93,24 +97,24 @@ public class VMThinLRURegionEntryOffHeapIntKey extends VMThinLRURegionEntryOffHe
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -121,57 +125,55 @@ public class VMThinLRURegionEntryOffHeapIntKey extends VMThinLRURegionEntryOffHe
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
     // nothing needed for LRUs with no disk
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -179,6 +181,7 @@ public class VMThinLRURegionEntryOffHeapIntKey extends VMThinLRURegionEntryOffHe
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -188,48 +191,57 @@ public class VMThinLRURegionEntryOffHeapIntKey extends VMThinLRURegionEntryOffHe
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -240,19 +252,17 @@ public class VMThinLRURegionEntryOffHeapIntKey extends VMThinLRURegionEntryOffHe
     return null;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final int key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinLRURegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinLRURegionEntryOffHeapLongKey.java
@@ -19,7 +19,8 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.cache.Token;
@@ -29,57 +30,60 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinLRURegionEntryOffHeapLongKey extends VMThinLRURegionEntryOffHeap {
-  public VMThinLRURegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapLongKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapLongKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapLongKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapLongKey.class, "offHeapAddress");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long key;
+
+  public VMThinLRURegionEntryOffHeapLongKey(final RegionEntryContext context, final long key,
+      @Retained final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.key = key;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapLongKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapLongKey.class, "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapLongKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapLongKey.class, "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -93,24 +97,24 @@ public class VMThinLRURegionEntryOffHeapLongKey extends VMThinLRURegionEntryOffH
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -121,57 +125,55 @@ public class VMThinLRURegionEntryOffHeapLongKey extends VMThinLRURegionEntryOffH
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
     // nothing needed for LRUs with no disk
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -179,6 +181,7 @@ public class VMThinLRURegionEntryOffHeapLongKey extends VMThinLRURegionEntryOffH
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -188,48 +191,57 @@ public class VMThinLRURegionEntryOffHeapLongKey extends VMThinLRURegionEntryOffH
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -240,19 +252,17 @@ public class VMThinLRURegionEntryOffHeapLongKey extends VMThinLRURegionEntryOffH
     return null;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinLRURegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinLRURegionEntryOffHeapObjectKey.java
@@ -19,7 +19,8 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.cache.Token;
@@ -29,57 +30,61 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinLRURegionEntryOffHeapObjectKey extends VMThinLRURegionEntryOffHeap {
-  public VMThinLRURegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapObjectKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapObjectKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapObjectKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapObjectKey.class,
+          "offHeapAddress");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final Object key;
+
+  public VMThinLRURegionEntryOffHeapObjectKey(final RegionEntryContext context, final Object key,
+      @Retained final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.key = key;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapObjectKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapObjectKey.class, "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapObjectKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapObjectKey.class, "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -93,24 +98,24 @@ public class VMThinLRURegionEntryOffHeapObjectKey extends VMThinLRURegionEntryOf
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -121,57 +126,55 @@ public class VMThinLRURegionEntryOffHeapObjectKey extends VMThinLRURegionEntryOf
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
     // nothing needed for LRUs with no disk
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -179,6 +182,7 @@ public class VMThinLRURegionEntryOffHeapObjectKey extends VMThinLRURegionEntryOf
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -188,48 +192,57 @@ public class VMThinLRURegionEntryOffHeapObjectKey extends VMThinLRURegionEntryOf
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -240,10 +253,8 @@ public class VMThinLRURegionEntryOffHeapObjectKey extends VMThinLRURegionEntryOf
     return getKey();
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final Object key;
-
   @Override
   public Object getKey() {
     return this.key;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinLRURegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinLRURegionEntryOffHeapStringKey1.java
@@ -19,7 +19,8 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.cache.Token;
@@ -29,75 +30,79 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinLRURegionEntryOffHeapStringKey1 extends VMThinLRURegionEntryOffHeap {
-  public VMThinLRURegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, value);
-    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    if (byteEncode) {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
-        // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
-      }
-      tmpBits1 |= 1 << 6;
-    } else {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
-      }
-    }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapStringKey1> lastModifiedUpdater =
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapStringKey1> LAST_MODIFIED_UPDATER =
       AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapStringKey1.class,
           "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
    * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
    * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
    */
-  private final static AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapStringKey1> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapStringKey1.class, "ohAddress");
+  private static final AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapStringKey1> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapStringKey1.class,
+          "offHeapAddress");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long bits1;
 
+  public VMThinLRURegionEntryOffHeapStringKey1(final RegionEntryContext context, final String key,
+      @Retained final Object value, final boolean byteEncode) {
+    super(context, value);
+    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
+    long tempBits1 = 0L;
+    if (byteEncode) {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
+        // keep findbugs happy.
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
+      }
+      tempBits1 |= 1 << 6;
+    } else {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
+      }
+    }
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+  }
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -111,24 +116,24 @@ public class VMThinLRURegionEntryOffHeapStringKey1 extends VMThinLRURegionEntryO
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -139,57 +144,55 @@ public class VMThinLRURegionEntryOffHeapStringKey1 extends VMThinLRURegionEntryO
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
     // nothing needed for LRUs with no disk
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -197,6 +200,7 @@ public class VMThinLRURegionEntryOffHeapStringKey1 extends VMThinLRURegionEntryO
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -206,48 +210,57 @@ public class VMThinLRURegionEntryOffHeapStringKey1 extends VMThinLRURegionEntryO
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -258,10 +271,8 @@ public class VMThinLRURegionEntryOffHeapStringKey1 extends VMThinLRURegionEntryO
     return null;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long bits1;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -274,18 +285,18 @@ public class VMThinLRURegionEntryOffHeapStringKey1 extends VMThinLRURegionEntryO
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
     return new String(chars);
@@ -293,25 +304,25 @@ public class VMThinLRURegionEntryOffHeapStringKey1 extends VMThinLRURegionEntryO
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinLRURegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinLRURegionEntryOffHeapStringKey2.java
@@ -19,7 +19,8 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.cache.Token;
@@ -29,87 +30,100 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinLRURegionEntryOffHeapStringKey2 extends VMThinLRURegionEntryOffHeap {
-  public VMThinLRURegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, value);
-    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
-    if (byteEncode) {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
-        // keep findbugs happy.
-        if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
-        } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
-        }
-      }
-      tmpBits1 |= 1 << 6;
-    } else {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
-        } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
-        }
-      }
-    }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapStringKey2> lastModifiedUpdater =
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapStringKey2> LAST_MODIFIED_UPDATER =
       AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapStringKey2.class,
           "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
    * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
    * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
    */
-  private final static AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapStringKey2> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapStringKey2.class, "ohAddress");
+  private static final AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapStringKey2> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapStringKey2.class,
+          "offHeapAddress");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
+  private final long bits1;
+  /**
+   * bits2 encodes character data
+   */
+  private final long bits2;
 
+  public VMThinLRURegionEntryOffHeapStringKey2(final RegionEntryContext context, final String key,
+      @Retained final Object value, final boolean byteEncode) {
+    super(context, value);
+    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
+    if (byteEncode) {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
+        // keep findbugs happy.
+        if (i < 7) {
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
+        } else {
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
+        }
+      }
+      tempBits1 |= 1 << 6;
+    } else {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        if (i < 3) {
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
+        } else {
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
+        }
+      }
+    }
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
+  }
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -123,24 +137,24 @@ public class VMThinLRURegionEntryOffHeapStringKey2 extends VMThinLRURegionEntryO
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -151,57 +165,55 @@ public class VMThinLRURegionEntryOffHeapStringKey2 extends VMThinLRURegionEntryO
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
     // nothing needed for LRUs with no disk
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -209,6 +221,7 @@ public class VMThinLRURegionEntryOffHeapStringKey2 extends VMThinLRURegionEntryO
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -218,48 +231,57 @@ public class VMThinLRURegionEntryOffHeapStringKey2 extends VMThinLRURegionEntryO
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -270,15 +292,8 @@ public class VMThinLRURegionEntryOffHeapStringKey2 extends VMThinLRURegionEntryO
     return null;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
-  private final long bits1;
-  // bits2 encodes character data
-  private final long bits2;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -291,28 +306,28 @@ public class VMThinLRURegionEntryOffHeapStringKey2 extends VMThinLRURegionEntryO
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -321,38 +336,38 @@ public class VMThinLRURegionEntryOffHeapStringKey2 extends VMThinLRURegionEntryO
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinLRURegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinLRURegionEntryOffHeapUUIDKey.java
@@ -20,7 +20,8 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.internal.cache.Token;
@@ -30,26 +31,55 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinLRURegionEntryOffHeapUUIDKey extends VMThinLRURegionEntryOffHeap {
-  public VMThinLRURegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapUUIDKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapUUIDKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapUUIDKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapUUIDKey.class, "offHeapAddress");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long keyMostSigBits;
+  private final long keyLeastSigBits;
+
+  public VMThinLRURegionEntryOffHeapUUIDKey(final RegionEntryContext context, final UUID key,
+      @Retained final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.keyMostSigBits = key.getMostSignificantBits();
@@ -57,31 +87,6 @@ public class VMThinLRURegionEntryOffHeapUUIDKey extends VMThinLRURegionEntryOffH
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapUUIDKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapUUIDKey.class, "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VMThinLRURegionEntryOffHeapUUIDKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinLRURegionEntryOffHeapUUIDKey.class, "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -95,24 +100,24 @@ public class VMThinLRURegionEntryOffHeapUUIDKey extends VMThinLRURegionEntryOffH
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -123,57 +128,55 @@ public class VMThinLRURegionEntryOffHeapUUIDKey extends VMThinLRURegionEntryOffH
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
     // nothing needed for LRUs with no disk
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -181,6 +184,7 @@ public class VMThinLRURegionEntryOffHeapUUIDKey extends VMThinLRURegionEntryOffH
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -190,48 +194,57 @@ public class VMThinLRURegionEntryOffHeapUUIDKey extends VMThinLRURegionEntryOffH
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -242,20 +255,17 @@ public class VMThinLRURegionEntryOffHeapUUIDKey extends VMThinLRURegionEntryOffH
     return null;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long keyMostSigBits;
-  private final long keyLeastSigBits;
-
   @Override
   public Object getKey() {
     return new UUID(this.keyMostSigBits, this.keyLeastSigBits);
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinRegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinRegionEntryHeapIntKey.java
@@ -19,96 +19,92 @@ import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinRegionEntryHeapIntKey extends VMThinRegionEntryHeap {
-  public VMThinRegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMThinRegionEntryHeapIntKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryHeapIntKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final int key;
+
+  public VMThinRegionEntryHeapIntKey(final RegionEntryContext context, final int key,
+      final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.key = key;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMThinRegionEntryHeapIntKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryHeapIntKey.class, "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final int key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinRegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinRegionEntryHeapLongKey.java
@@ -19,96 +19,92 @@ import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinRegionEntryHeapLongKey extends VMThinRegionEntryHeap {
-  public VMThinRegionEntryHeapLongKey(RegionEntryContext context, long key, Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMThinRegionEntryHeapLongKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryHeapLongKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long key;
+
+  public VMThinRegionEntryHeapLongKey(final RegionEntryContext context, final long key,
+      final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.key = key;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMThinRegionEntryHeapLongKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryHeapLongKey.class, "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinRegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinRegionEntryHeapObjectKey.java
@@ -19,87 +19,83 @@ import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinRegionEntryHeapObjectKey extends VMThinRegionEntryHeap {
-  public VMThinRegionEntryHeapObjectKey(RegionEntryContext context, Object key, Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMThinRegionEntryHeapObjectKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryHeapObjectKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final Object key;
+
+  public VMThinRegionEntryHeapObjectKey(final RegionEntryContext context, final Object key,
+      final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.key = key;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMThinRegionEntryHeapObjectKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryHeapObjectKey.class, "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final Object key;
-
   @Override
   public Object getKey() {
     return this.key;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinRegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinRegionEntryHeapStringKey1.java
@@ -19,105 +19,100 @@ import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinRegionEntryHeapStringKey1 extends VMThinRegionEntryHeap {
-  public VMThinRegionEntryHeapStringKey1(RegionEntryContext context, String key, Object value,
-      boolean byteEncode) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMThinRegionEntryHeapStringKey1> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryHeapStringKey1.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long bits1;
+
+  public VMThinRegionEntryHeapStringKey1(final RegionEntryContext context, final String key,
+      final Object value, final boolean byteEncode) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMThinRegionEntryHeapStringKey1> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryHeapStringKey1.class, "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long bits1;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -130,18 +125,18 @@ public class VMThinRegionEntryHeapStringKey1 extends VMThinRegionEntryHeap {
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
     return new String(chars);
@@ -149,25 +144,25 @@ public class VMThinRegionEntryHeapStringKey1 extends VMThinRegionEntryHeap {
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinRegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinRegionEntryHeapStringKey2.java
@@ -19,122 +19,121 @@ import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinRegionEntryHeapStringKey2 extends VMThinRegionEntryHeap {
-  public VMThinRegionEntryHeapStringKey2(RegionEntryContext context, String key, Object value,
-      boolean byteEncode) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMThinRegionEntryHeapStringKey2> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryHeapStringKey2.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
+  private final long bits1;
+  /**
+   * bits2 encodes character data
+   */
+  private final long bits2;
+
+  public VMThinRegionEntryHeapStringKey2(final RegionEntryContext context, final String key,
+      final Object value, final boolean byteEncode) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMThinRegionEntryHeapStringKey2> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryHeapStringKey2.class, "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
-  private final long bits1;
-  // bits2 encodes character data
-  private final long bits2;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -147,28 +146,28 @@ public class VMThinRegionEntryHeapStringKey2 extends VMThinRegionEntryHeap {
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -177,38 +176,38 @@ public class VMThinRegionEntryHeapStringKey2 extends VMThinRegionEntryHeap {
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinRegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinRegionEntryHeapUUIDKey.java
@@ -20,25 +20,36 @@ import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinRegionEntryHeapUUIDKey extends VMThinRegionEntryHeap {
-  public VMThinRegionEntryHeapUUIDKey(RegionEntryContext context, UUID key, Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMThinRegionEntryHeapUUIDKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryHeapUUIDKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long keyMostSigBits;
+  private final long keyLeastSigBits;
+
+  public VMThinRegionEntryHeapUUIDKey(final RegionEntryContext context, final UUID key,
+      final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.keyMostSigBits = key.getMostSignificantBits();
@@ -46,72 +57,57 @@ public class VMThinRegionEntryHeapUUIDKey extends VMThinRegionEntryHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMThinRegionEntryHeapUUIDKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryHeapUUIDKey.class, "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long keyMostSigBits;
-  private final long keyLeastSigBits;
-
   @Override
   public Object getKey() {
     return new UUID(this.keyMostSigBits, this.keyLeastSigBits);
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinRegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinRegionEntryOffHeapIntKey.java
@@ -24,57 +24,60 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinRegionEntryOffHeapIntKey extends VMThinRegionEntryOffHeap {
-  public VMThinRegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMThinRegionEntryOffHeapIntKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapIntKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VMThinRegionEntryOffHeapIntKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapIntKey.class, "offHeapAddress");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final int key;
+
+  public VMThinRegionEntryOffHeapIntKey(final RegionEntryContext context, final int key,
+      @Retained final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.key = key;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMThinRegionEntryOffHeapIntKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapIntKey.class, "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VMThinRegionEntryOffHeapIntKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapIntKey.class, "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -88,24 +91,24 @@ public class VMThinRegionEntryOffHeapIntKey extends VMThinRegionEntryOffHeap {
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -116,55 +119,50 @@ public class VMThinRegionEntryOffHeapIntKey extends VMThinRegionEntryOffHeap {
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final int key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinRegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinRegionEntryOffHeapLongKey.java
@@ -24,57 +24,60 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinRegionEntryOffHeapLongKey extends VMThinRegionEntryOffHeap {
-  public VMThinRegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMThinRegionEntryOffHeapLongKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapLongKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VMThinRegionEntryOffHeapLongKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapLongKey.class, "offHeapAddress");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long key;
+
+  public VMThinRegionEntryOffHeapLongKey(final RegionEntryContext context, final long key,
+      @Retained final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.key = key;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMThinRegionEntryOffHeapLongKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapLongKey.class, "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VMThinRegionEntryOffHeapLongKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapLongKey.class, "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -88,24 +91,24 @@ public class VMThinRegionEntryOffHeapLongKey extends VMThinRegionEntryOffHeap {
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -116,55 +119,50 @@ public class VMThinRegionEntryOffHeapLongKey extends VMThinRegionEntryOffHeap {
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinRegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinRegionEntryOffHeapObjectKey.java
@@ -24,57 +24,60 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinRegionEntryOffHeapObjectKey extends VMThinRegionEntryOffHeap {
-  public VMThinRegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMThinRegionEntryOffHeapObjectKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapObjectKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VMThinRegionEntryOffHeapObjectKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapObjectKey.class, "offHeapAddress");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final Object key;
+
+  public VMThinRegionEntryOffHeapObjectKey(final RegionEntryContext context, final Object key,
+      @Retained final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.key = key;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMThinRegionEntryOffHeapObjectKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapObjectKey.class, "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VMThinRegionEntryOffHeapObjectKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapObjectKey.class, "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -88,24 +91,24 @@ public class VMThinRegionEntryOffHeapObjectKey extends VMThinRegionEntryOffHeap 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -116,46 +119,41 @@ public class VMThinRegionEntryOffHeapObjectKey extends VMThinRegionEntryOffHeap 
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final Object key;
-
   @Override
   public Object getKey() {
     return this.key;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinRegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinRegionEntryOffHeapStringKey1.java
@@ -24,74 +24,77 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinRegionEntryOffHeapStringKey1 extends VMThinRegionEntryOffHeap {
-  public VMThinRegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, value);
-    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    if (byteEncode) {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
-        // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
-      }
-      tmpBits1 |= 1 << 6;
-    } else {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
-      }
-    }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMThinRegionEntryOffHeapStringKey1> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapStringKey1.class, "lastModified");
   protected int hash;
-  private HashEntry<Object, Object> next;
+  private HashEntry<Object, Object> nextEntry;
   @SuppressWarnings("unused")
   private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMThinRegionEntryOffHeapStringKey1> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapStringKey1.class, "lastModified");
+  // --------------------------------------- offheap fields ---------------------------------------
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
    * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
    * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
    */
-  private final static AtomicLongFieldUpdater<VMThinRegionEntryOffHeapStringKey1> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapStringKey1.class, "ohAddress");
+  private static final AtomicLongFieldUpdater<VMThinRegionEntryOffHeapStringKey1> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapStringKey1.class, "offHeapAddress");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long bits1;
 
+  public VMThinRegionEntryOffHeapStringKey1(final RegionEntryContext context, final String key,
+      @Retained final Object value, final boolean byteEncode) {
+    super(context, value);
+    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
+    long tempBits1 = 0L;
+    if (byteEncode) {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
+        // keep findbugs happy.
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
+      }
+      tempBits1 |= 1 << 6;
+    } else {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
+      }
+    }
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+  }
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -105,24 +108,24 @@ public class VMThinRegionEntryOffHeapStringKey1 extends VMThinRegionEntryOffHeap
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -133,46 +136,41 @@ public class VMThinRegionEntryOffHeapStringKey1 extends VMThinRegionEntryOffHeap
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long bits1;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -185,18 +183,18 @@ public class VMThinRegionEntryOffHeapStringKey1 extends VMThinRegionEntryOffHeap
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
     return new String(chars);
@@ -204,25 +202,25 @@ public class VMThinRegionEntryOffHeapStringKey1 extends VMThinRegionEntryOffHeap
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinRegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinRegionEntryOffHeapStringKey2.java
@@ -24,86 +24,98 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinRegionEntryOffHeapStringKey2 extends VMThinRegionEntryOffHeap {
-  public VMThinRegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, value);
-    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
-    if (byteEncode) {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
-        // keep findbugs happy.
-        if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
-        } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
-        }
-      }
-      tmpBits1 |= 1 << 6;
-    } else {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
-        } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
-        }
-      }
-    }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMThinRegionEntryOffHeapStringKey2> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapStringKey2.class, "lastModified");
   protected int hash;
-  private HashEntry<Object, Object> next;
+  private HashEntry<Object, Object> nextEntry;
   @SuppressWarnings("unused")
   private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMThinRegionEntryOffHeapStringKey2> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapStringKey2.class, "lastModified");
+  // --------------------------------------- offheap fields ---------------------------------------
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
    * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
    * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
    */
-  private final static AtomicLongFieldUpdater<VMThinRegionEntryOffHeapStringKey2> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapStringKey2.class, "ohAddress");
+  private static final AtomicLongFieldUpdater<VMThinRegionEntryOffHeapStringKey2> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapStringKey2.class, "offHeapAddress");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
+  private final long bits1;
+  /**
+   * bits2 encodes character data
+   */
+  private final long bits2;
 
+  public VMThinRegionEntryOffHeapStringKey2(final RegionEntryContext context, final String key,
+      @Retained final Object value, final boolean byteEncode) {
+    super(context, value);
+    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
+    if (byteEncode) {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
+        // keep findbugs happy.
+        if (i < 7) {
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
+        } else {
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
+        }
+      }
+      tempBits1 |= 1 << 6;
+    } else {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        if (i < 3) {
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
+        } else {
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
+        }
+      }
+    }
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
+  }
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -117,24 +129,24 @@ public class VMThinRegionEntryOffHeapStringKey2 extends VMThinRegionEntryOffHeap
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -145,51 +157,41 @@ public class VMThinRegionEntryOffHeapStringKey2 extends VMThinRegionEntryOffHeap
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
-  private final long bits1;
-  // bits2 encodes character data
-  private final long bits2;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -202,28 +204,28 @@ public class VMThinRegionEntryOffHeapStringKey2 extends VMThinRegionEntryOffHeap
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -232,38 +234,38 @@ public class VMThinRegionEntryOffHeapStringKey2 extends VMThinRegionEntryOffHeap
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinRegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinRegionEntryOffHeapUUIDKey.java
@@ -25,26 +25,55 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VMThinRegionEntryOffHeapUUIDKey extends VMThinRegionEntryOffHeap {
-  public VMThinRegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VMThinRegionEntryOffHeapUUIDKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapUUIDKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VMThinRegionEntryOffHeapUUIDKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapUUIDKey.class, "offHeapAddress");
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long keyMostSigBits;
+  private final long keyLeastSigBits;
+
+  public VMThinRegionEntryOffHeapUUIDKey(final RegionEntryContext context, final UUID key,
+      @Retained final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.keyMostSigBits = key.getMostSignificantBits();
@@ -52,31 +81,6 @@ public class VMThinRegionEntryOffHeapUUIDKey extends VMThinRegionEntryOffHeap {
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VMThinRegionEntryOffHeapUUIDKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapUUIDKey.class, "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VMThinRegionEntryOffHeapUUIDKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VMThinRegionEntryOffHeapUUIDKey.class, "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -90,24 +94,24 @@ public class VMThinRegionEntryOffHeapUUIDKey extends VMThinRegionEntryOffHeap {
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -118,56 +122,50 @@ public class VMThinRegionEntryOffHeapUUIDKey extends VMThinRegionEntryOffHeap {
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long keyMostSigBits;
-  private final long keyLeastSigBits;
-
   @Override
   public Object getKey() {
     return new UUID(this.keyMostSigBits, this.keyLeastSigBits);
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskLRURegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskLRURegionEntryHeapIntKey.java
@@ -18,16 +18,16 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -36,27 +36,60 @@ import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskLRURegionEntryHeapIntKey
     extends VersionedStatsDiskLRURegionEntryHeap {
-  public VersionedStatsDiskLRURegionEntryHeapIntKey(RegionEntryContext context, int key,
-      Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryHeapIntKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapIntKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryHeapIntKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapIntKey.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryHeapIntKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapIntKey.class,
+          "missCount");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final int key;
+
+  public VersionedStatsDiskLRURegionEntryHeapIntKey(final RegionEntryContext context, final int key,
+      final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -64,78 +97,65 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryHeapIntKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapIntKey.class,
-          "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof InternalRegion) {
+      isBackup = ((InternalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
-      throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
+      throw new IllegalArgumentException("expected a InternalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -144,48 +164,43 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -193,6 +208,7 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -202,48 +218,57 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -254,12 +279,12 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
     return null;
   }
 
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -267,22 +292,12 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryHeapIntKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapIntKey.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryHeapIntKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapIntKey.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -290,7 +305,7 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -305,24 +320,24 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -332,61 +347,63 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
     return true;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -395,8 +412,9 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -404,42 +422,43 @@ public class VersionedStatsDiskLRURegionEntryHeapIntKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final int key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskLRURegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskLRURegionEntryHeapObjectKey.java
@@ -18,16 +18,16 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -36,27 +36,60 @@ import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskLRURegionEntryHeapObjectKey
     extends VersionedStatsDiskLRURegionEntryHeap {
-  public VersionedStatsDiskLRURegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-      Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryHeapObjectKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapObjectKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryHeapObjectKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapObjectKey.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryHeapObjectKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapObjectKey.class,
+          "missCount");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final Object key;
+
+  public VersionedStatsDiskLRURegionEntryHeapObjectKey(final RegionEntryContext context,
+      final Object key, final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -64,78 +97,65 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryHeapObjectKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapObjectKey.class,
-          "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof InternalRegion) {
+      isBackup = ((InternalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
-      throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
+      throw new IllegalArgumentException("expected a InternalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -144,48 +164,43 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -193,6 +208,7 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -202,48 +218,57 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -254,12 +279,12 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
     return getKey();
   }
 
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -267,22 +292,12 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryHeapObjectKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapObjectKey.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryHeapObjectKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapObjectKey.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -290,7 +305,7 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -305,24 +320,24 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -332,61 +347,63 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
     return true;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -395,8 +412,9 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -404,33 +422,34 @@ public class VersionedStatsDiskLRURegionEntryHeapObjectKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final Object key;
-
   @Override
   public Object getKey() {
     return this.key;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskLRURegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskLRURegionEntryHeapStringKey1.java
@@ -18,16 +18,16 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -36,123 +36,143 @@ import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskLRURegionEntryHeapStringKey1
     extends VersionedStatsDiskLRURegionEntryHeap {
-  public VersionedStatsDiskLRURegionEntryHeapStringKey1(RegionEntryContext context, String key,
-      Object value, boolean byteEncode) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryHeapStringKey1> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapStringKey1.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryHeapStringKey1> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapStringKey1.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryHeapStringKey1> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapStringKey1.class,
+          "missCount");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long bits1;
+
+  public VersionedStatsDiskLRURegionEntryHeapStringKey1(final RegionEntryContext context,
+      final String key, final Object value, final boolean byteEncode) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryHeapStringKey1> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapStringKey1.class,
-          "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof InternalRegion) {
+      isBackup = ((InternalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
-      throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
+      throw new IllegalArgumentException("expected a InternalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -161,48 +181,43 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -210,6 +225,7 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -219,48 +235,57 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -271,12 +296,12 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
     return null;
   }
 
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -284,22 +309,12 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryHeapStringKey1> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapStringKey1.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryHeapStringKey1> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapStringKey1.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -307,7 +322,7 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -322,24 +337,24 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -349,61 +364,63 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
     return true;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -412,8 +429,9 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -421,33 +439,34 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long bits1;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -460,18 +479,18 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
     return new String(chars);
@@ -479,25 +498,25 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey1
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskLRURegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskLRURegionEntryHeapStringKey2.java
@@ -18,16 +18,16 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -36,135 +36,164 @@ import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskLRURegionEntryHeapStringKey2
     extends VersionedStatsDiskLRURegionEntryHeap {
-  public VersionedStatsDiskLRURegionEntryHeapStringKey2(RegionEntryContext context, String key,
-      Object value, boolean byteEncode) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryHeapStringKey2> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapStringKey2.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryHeapStringKey2> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapStringKey2.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryHeapStringKey2> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapStringKey2.class,
+          "missCount");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
+  private final long bits1;
+  /**
+   * bits2 encodes character data
+   */
+  private final long bits2;
+
+  public VersionedStatsDiskLRURegionEntryHeapStringKey2(final RegionEntryContext context,
+      final String key, final Object value, final boolean byteEncode) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryHeapStringKey2> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapStringKey2.class,
-          "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof InternalRegion) {
+      isBackup = ((InternalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
-      throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
+      throw new IllegalArgumentException("expected a InternalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -173,48 +202,43 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -222,6 +246,7 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -231,48 +256,57 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -283,12 +317,12 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
     return null;
   }
 
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -296,22 +330,12 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryHeapStringKey2> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapStringKey2.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryHeapStringKey2> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapStringKey2.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -319,7 +343,7 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -334,24 +358,24 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -361,61 +385,63 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
     return true;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -424,8 +450,9 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -433,38 +460,34 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
-  private final long bits1;
-  // bits2 encodes character data
-  private final long bits2;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -477,28 +500,28 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -507,38 +530,38 @@ public class VersionedStatsDiskLRURegionEntryHeapStringKey2
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskLRURegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskLRURegionEntryHeapUUIDKey.java
@@ -19,16 +19,16 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -37,27 +37,61 @@ import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
     extends VersionedStatsDiskLRURegionEntryHeap {
-  public VersionedStatsDiskLRURegionEntryHeapUUIDKey(RegionEntryContext context, UUID key,
-      Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryHeapUUIDKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapUUIDKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryHeapUUIDKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapUUIDKey.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryHeapUUIDKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapUUIDKey.class,
+          "missCount");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long keyMostSigBits;
+  private final long keyLeastSigBits;
+
+  public VersionedStatsDiskLRURegionEntryHeapUUIDKey(final RegionEntryContext context,
+      final UUID key, final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -66,78 +100,65 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryHeapUUIDKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapUUIDKey.class,
-          "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof InternalRegion) {
+      isBackup = ((InternalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
-      throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
+      throw new IllegalArgumentException("expected a InternalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -146,48 +167,43 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -195,6 +211,7 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -204,48 +221,57 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -256,12 +282,12 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
     return null;
   }
 
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -269,22 +295,12 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryHeapUUIDKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapUUIDKey.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryHeapUUIDKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryHeapUUIDKey.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -292,7 +308,7 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -307,24 +323,24 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -334,61 +350,63 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
     return true;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -397,8 +415,9 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -406,43 +425,43 @@ public class VersionedStatsDiskLRURegionEntryHeapUUIDKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long keyMostSigBits;
-  private final long keyLeastSigBits;
-
   @Override
   public Object getKey() {
     return new UUID(this.keyMostSigBits, this.keyLeastSigBits);
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskLRURegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskLRURegionEntryOffHeapIntKey.java
@@ -18,16 +18,16 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -41,27 +41,80 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
     extends VersionedStatsDiskLRURegionEntryOffHeap {
-  public VersionedStatsDiskLRURegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapIntKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapIntKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapIntKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapIntKey.class,
+          "offHeapAddress");
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapIntKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapIntKey.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapIntKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapIntKey.class,
+          "missCount");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final int key;
+
+  public VersionedStatsDiskLRURegionEntryOffHeapIntKey(final RegionEntryContext context,
+      final int key, @Retained final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -69,33 +122,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapIntKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapIntKey.class,
-          "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapIntKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapIntKey.class,
-          "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -109,24 +135,24 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -137,61 +163,58 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof InternalRegion) {
+      isBackup = ((InternalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
-      throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
+      throw new IllegalArgumentException("expected a InternalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -200,48 +223,43 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -249,6 +267,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -258,48 +277,57 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -310,12 +338,12 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
     return null;
   }
 
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -323,22 +351,12 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapIntKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapIntKey.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapIntKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapIntKey.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -346,7 +364,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -361,24 +379,24 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -388,61 +406,63 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
     return true;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -451,8 +471,9 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -460,42 +481,43 @@ public class VersionedStatsDiskLRURegionEntryOffHeapIntKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final int key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskLRURegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskLRURegionEntryOffHeapLongKey.java
@@ -18,16 +18,16 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -41,27 +41,80 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
     extends VersionedStatsDiskLRURegionEntryOffHeap {
-  public VersionedStatsDiskLRURegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapLongKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapLongKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapLongKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapLongKey.class,
+          "offHeapAddress");
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapLongKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapLongKey.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapLongKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapLongKey.class,
+          "missCount");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long key;
+
+  public VersionedStatsDiskLRURegionEntryOffHeapLongKey(final RegionEntryContext context,
+      final long key, @Retained final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -69,33 +122,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapLongKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapLongKey.class,
-          "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapLongKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapLongKey.class,
-          "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -109,24 +135,24 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -137,61 +163,58 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof InternalRegion) {
+      isBackup = ((InternalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
-      throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
+      throw new IllegalArgumentException("expected a InternalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -200,48 +223,43 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -249,6 +267,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -258,48 +277,57 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -310,12 +338,12 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
     return null;
   }
 
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -323,22 +351,12 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapLongKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapLongKey.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapLongKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapLongKey.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -346,7 +364,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -361,24 +379,24 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -388,61 +406,63 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
     return true;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -451,8 +471,9 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -460,42 +481,43 @@ public class VersionedStatsDiskLRURegionEntryOffHeapLongKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskLRURegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskLRURegionEntryOffHeapObjectKey.java
@@ -18,16 +18,16 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -41,27 +41,80 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
     extends VersionedStatsDiskLRURegionEntryOffHeap {
-  public VersionedStatsDiskLRURegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapObjectKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapObjectKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapObjectKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapObjectKey.class,
+          "offHeapAddress");
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapObjectKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapObjectKey.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapObjectKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapObjectKey.class,
+          "missCount");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final Object key;
+
+  public VersionedStatsDiskLRURegionEntryOffHeapObjectKey(final RegionEntryContext context,
+      final Object key, @Retained final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -69,33 +122,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapObjectKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapObjectKey.class,
-          "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapObjectKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapObjectKey.class,
-          "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -109,24 +135,24 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -137,61 +163,58 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof InternalRegion) {
+      isBackup = ((InternalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
-      throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
+      throw new IllegalArgumentException("expected a InternalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -200,48 +223,43 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -249,6 +267,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -258,48 +277,57 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -310,12 +338,12 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
     return getKey();
   }
 
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -323,22 +351,12 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapObjectKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapObjectKey.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapObjectKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapObjectKey.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -346,7 +364,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -361,24 +379,24 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -388,61 +406,63 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
     return true;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -451,8 +471,9 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -460,33 +481,34 @@ public class VersionedStatsDiskLRURegionEntryOffHeapObjectKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final Object key;
-
   @Override
   public Object getKey() {
     return this.key;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskLRURegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskLRURegionEntryOffHeapStringKey1.java
@@ -18,16 +18,16 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -41,78 +41,104 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
     extends VersionedStatsDiskLRURegionEntryOffHeap {
-  public VersionedStatsDiskLRURegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
-    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-    initialize(context, value);
-    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    if (byteEncode) {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
-        // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
-      }
-      tmpBits1 |= 1 << 6;
-    } else {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
-      }
-    }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapStringKey1> lastModifiedUpdater =
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapStringKey1> LAST_MODIFIED_UPDATER =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapStringKey1.class,
           "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
    * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
    * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapStringKey1> ohAddrUpdater =
+  private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapStringKey1> OFF_HEAP_ADDRESS_UPDATER =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapStringKey1.class,
-          "ohAddress");
+          "offHeapAddress");
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapStringKey1> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapStringKey1.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapStringKey1> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapStringKey1.class,
+          "missCount");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long bits1;
 
+  public VersionedStatsDiskLRURegionEntryOffHeapStringKey1(final RegionEntryContext context,
+      final String key, @Retained final Object value, final boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
+    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+    initialize(context, value);
+    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
+    long tempBits1 = 0L;
+    if (byteEncode) {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
+        // keep findbugs happy.
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
+      }
+      tempBits1 |= 1 << 6;
+    } else {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
+      }
+    }
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+  }
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -126,24 +152,24 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -154,61 +180,58 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof InternalRegion) {
+      isBackup = ((InternalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
-      throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
+      throw new IllegalArgumentException("expected a InternalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -217,48 +240,43 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -266,6 +284,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -275,48 +294,57 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -327,12 +355,12 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
     return null;
   }
 
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -340,22 +368,12 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapStringKey1> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapStringKey1.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapStringKey1> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapStringKey1.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -363,7 +381,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -378,24 +396,24 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -405,61 +423,63 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
     return true;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -468,8 +488,9 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -477,33 +498,34 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long bits1;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -516,18 +538,18 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
     return new String(chars);
@@ -535,25 +557,25 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey1
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskLRURegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskLRURegionEntryOffHeapStringKey2.java
@@ -18,16 +18,16 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -41,90 +41,125 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
     extends VersionedStatsDiskLRURegionEntryOffHeap {
-  public VersionedStatsDiskLRURegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
-    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-    initialize(context, value);
-    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
-    if (byteEncode) {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
-        // keep findbugs happy.
-        if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
-        } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
-        }
-      }
-      tmpBits1 |= 1 << 6;
-    } else {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
-        } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
-        }
-      }
-    }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapStringKey2> lastModifiedUpdater =
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapStringKey2> LAST_MODIFIED_UPDATER =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapStringKey2.class,
           "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
    * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
    * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapStringKey2> ohAddrUpdater =
+  private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapStringKey2> OFF_HEAP_ADDRESS_UPDATER =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapStringKey2.class,
-          "ohAddress");
+          "offHeapAddress");
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapStringKey2> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapStringKey2.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapStringKey2> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapStringKey2.class,
+          "missCount");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
+  private final long bits1;
+  /**
+   * bits2 encodes character data
+   */
+  private final long bits2;
 
+  public VersionedStatsDiskLRURegionEntryOffHeapStringKey2(final RegionEntryContext context,
+      final String key, @Retained final Object value, final boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
+    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+    initialize(context, value);
+    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
+    if (byteEncode) {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
+        // keep findbugs happy.
+        if (i < 7) {
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
+        } else {
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
+        }
+      }
+      tempBits1 |= 1 << 6;
+    } else {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        if (i < 3) {
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
+        } else {
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
+        }
+      }
+    }
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
+  }
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -138,24 +173,24 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -166,61 +201,58 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof InternalRegion) {
+      isBackup = ((InternalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
-      throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
+      throw new IllegalArgumentException("expected a InternalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -229,48 +261,43 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -278,6 +305,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -287,48 +315,57 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -339,12 +376,12 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
     return null;
   }
 
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -352,22 +389,12 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapStringKey2> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapStringKey2.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapStringKey2> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapStringKey2.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -375,7 +402,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -390,24 +417,24 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -417,61 +444,63 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
     return true;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -480,8 +509,9 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -489,38 +519,34 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
-  private final long bits1;
-  // bits2 encodes character data
-  private final long bits2;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -533,28 +559,28 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -563,38 +589,38 @@ public class VersionedStatsDiskLRURegionEntryOffHeapStringKey2
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskLRURegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskLRURegionEntryOffHeapUUIDKey.java
@@ -19,16 +19,16 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -42,27 +42,81 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
     extends VersionedStatsDiskLRURegionEntryOffHeap {
-  public VersionedStatsDiskLRURegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapUUIDKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapUUIDKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapUUIDKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapUUIDKey.class,
+          "offHeapAddress");
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapUUIDKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapUUIDKey.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapUUIDKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapUUIDKey.class,
+          "missCount");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long keyMostSigBits;
+  private final long keyLeastSigBits;
+
+  public VersionedStatsDiskLRURegionEntryOffHeapUUIDKey(final RegionEntryContext context,
+      final UUID key, @Retained final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -71,33 +125,6 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapUUIDKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapUUIDKey.class,
-          "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapUUIDKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapUUIDKey.class,
-          "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -111,24 +138,24 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -139,61 +166,58 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof InternalRegion) {
+      isBackup = ((InternalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
-      throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
+      throw new IllegalArgumentException("expected a InternalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -202,48 +226,43 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -251,6 +270,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -260,48 +280,57 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -312,12 +341,12 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
     return null;
   }
 
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -325,22 +354,12 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapUUIDKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapUUIDKey.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskLRURegionEntryOffHeapUUIDKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskLRURegionEntryOffHeapUUIDKey.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -348,7 +367,7 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -363,24 +382,24 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -390,61 +409,63 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
     return true;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -453,8 +474,9 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -462,43 +484,43 @@ public class VersionedStatsDiskLRURegionEntryOffHeapUUIDKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long keyMostSigBits;
-  private final long keyLeastSigBits;
-
   @Override
   public Object getKey() {
     return new UUID(this.keyMostSigBits, this.keyLeastSigBits);
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskRegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskRegionEntryHeapIntKey.java
@@ -18,14 +18,14 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
@@ -33,26 +33,59 @@ import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskRegionEntryHeapIntKey extends VersionedStatsDiskRegionEntryHeap {
-  public VersionedStatsDiskRegionEntryHeapIntKey(RegionEntryContext context, int key,
-      Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryHeapIntKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapIntKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryHeapIntKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapIntKey.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryHeapIntKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapIntKey.class,
+          "missCount");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final int key;
+
+  public VersionedStatsDiskRegionEntryHeapIntKey(final RegionEntryContext context, final int key,
+      final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -60,102 +93,83 @@ public class VersionedStatsDiskRegionEntryHeapIntKey extends VersionedStatsDiskR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryHeapIntKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapIntKey.class,
-          "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -163,22 +177,12 @@ public class VersionedStatsDiskRegionEntryHeapIntKey extends VersionedStatsDiskR
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryHeapIntKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapIntKey.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryHeapIntKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapIntKey.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -186,7 +190,7 @@ public class VersionedStatsDiskRegionEntryHeapIntKey extends VersionedStatsDiskR
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -201,24 +205,24 @@ public class VersionedStatsDiskRegionEntryHeapIntKey extends VersionedStatsDiskR
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -228,61 +232,63 @@ public class VersionedStatsDiskRegionEntryHeapIntKey extends VersionedStatsDiskR
     return true;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -291,8 +297,9 @@ public class VersionedStatsDiskRegionEntryHeapIntKey extends VersionedStatsDiskR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -300,42 +307,43 @@ public class VersionedStatsDiskRegionEntryHeapIntKey extends VersionedStatsDiskR
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final int key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskRegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskRegionEntryHeapLongKey.java
@@ -18,14 +18,14 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
@@ -33,26 +33,59 @@ import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskRegionEntryHeapLongKey extends VersionedStatsDiskRegionEntryHeap {
-  public VersionedStatsDiskRegionEntryHeapLongKey(RegionEntryContext context, long key,
-      Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryHeapLongKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapLongKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryHeapLongKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapLongKey.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryHeapLongKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapLongKey.class,
+          "missCount");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long key;
+
+  public VersionedStatsDiskRegionEntryHeapLongKey(final RegionEntryContext context, final long key,
+      final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -60,102 +93,83 @@ public class VersionedStatsDiskRegionEntryHeapLongKey extends VersionedStatsDisk
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryHeapLongKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapLongKey.class,
-          "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -163,22 +177,12 @@ public class VersionedStatsDiskRegionEntryHeapLongKey extends VersionedStatsDisk
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryHeapLongKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapLongKey.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryHeapLongKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapLongKey.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -186,7 +190,7 @@ public class VersionedStatsDiskRegionEntryHeapLongKey extends VersionedStatsDisk
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -201,24 +205,24 @@ public class VersionedStatsDiskRegionEntryHeapLongKey extends VersionedStatsDisk
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -228,61 +232,63 @@ public class VersionedStatsDiskRegionEntryHeapLongKey extends VersionedStatsDisk
     return true;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -291,8 +297,9 @@ public class VersionedStatsDiskRegionEntryHeapLongKey extends VersionedStatsDisk
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -300,42 +307,43 @@ public class VersionedStatsDiskRegionEntryHeapLongKey extends VersionedStatsDisk
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskRegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskRegionEntryHeapObjectKey.java
@@ -18,14 +18,14 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
@@ -33,26 +33,59 @@ import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskRegionEntryHeapObjectKey extends VersionedStatsDiskRegionEntryHeap {
-  public VersionedStatsDiskRegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-      Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryHeapObjectKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapObjectKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryHeapObjectKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapObjectKey.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryHeapObjectKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapObjectKey.class,
+          "missCount");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final Object key;
+
+  public VersionedStatsDiskRegionEntryHeapObjectKey(final RegionEntryContext context,
+      final Object key, final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -60,102 +93,83 @@ public class VersionedStatsDiskRegionEntryHeapObjectKey extends VersionedStatsDi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryHeapObjectKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapObjectKey.class,
-          "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -163,22 +177,12 @@ public class VersionedStatsDiskRegionEntryHeapObjectKey extends VersionedStatsDi
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryHeapObjectKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapObjectKey.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryHeapObjectKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapObjectKey.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -186,7 +190,7 @@ public class VersionedStatsDiskRegionEntryHeapObjectKey extends VersionedStatsDi
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -201,24 +205,24 @@ public class VersionedStatsDiskRegionEntryHeapObjectKey extends VersionedStatsDi
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -228,61 +232,63 @@ public class VersionedStatsDiskRegionEntryHeapObjectKey extends VersionedStatsDi
     return true;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -291,8 +297,9 @@ public class VersionedStatsDiskRegionEntryHeapObjectKey extends VersionedStatsDi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -300,33 +307,34 @@ public class VersionedStatsDiskRegionEntryHeapObjectKey extends VersionedStatsDi
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final Object key;
-
   @Override
   public Object getKey() {
     return this.key;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskRegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskRegionEntryHeapStringKey1.java
@@ -18,14 +18,14 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
@@ -33,146 +33,160 @@ import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsDiskRegionEntryHeap {
-  public VersionedStatsDiskRegionEntryHeapStringKey1(RegionEntryContext context, String key,
-      Object value, boolean byteEncode) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryHeapStringKey1> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapStringKey1.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryHeapStringKey1> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapStringKey1.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryHeapStringKey1> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapStringKey1.class,
+          "missCount");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long bits1;
+
+  public VersionedStatsDiskRegionEntryHeapStringKey1(final RegionEntryContext context,
+      final String key, final Object value, final boolean byteEncode) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryHeapStringKey1> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapStringKey1.class,
-          "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -180,22 +194,12 @@ public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsD
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryHeapStringKey1> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapStringKey1.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryHeapStringKey1> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapStringKey1.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -203,7 +207,7 @@ public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsD
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -218,24 +222,24 @@ public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsD
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -245,61 +249,63 @@ public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsD
     return true;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -308,8 +314,9 @@ public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsD
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -317,33 +324,34 @@ public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsD
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long bits1;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -356,18 +364,18 @@ public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsD
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
     return new String(chars);
@@ -375,25 +383,25 @@ public class VersionedStatsDiskRegionEntryHeapStringKey1 extends VersionedStatsD
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskRegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskRegionEntryHeapStringKey2.java
@@ -18,14 +18,14 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
@@ -33,158 +33,181 @@ import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsDiskRegionEntryHeap {
-  public VersionedStatsDiskRegionEntryHeapStringKey2(RegionEntryContext context, String key,
-      Object value, boolean byteEncode) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryHeapStringKey2> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapStringKey2.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryHeapStringKey2> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapStringKey2.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryHeapStringKey2> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapStringKey2.class,
+          "missCount");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
+  private final long bits1;
+  /**
+   * bits2 encodes character data
+   */
+  private final long bits2;
+
+  public VersionedStatsDiskRegionEntryHeapStringKey2(final RegionEntryContext context,
+      final String key, final Object value, final boolean byteEncode) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryHeapStringKey2> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapStringKey2.class,
-          "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -192,22 +215,12 @@ public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsD
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryHeapStringKey2> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapStringKey2.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryHeapStringKey2> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapStringKey2.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -215,7 +228,7 @@ public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsD
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -230,24 +243,24 @@ public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsD
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -257,61 +270,63 @@ public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsD
     return true;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -320,8 +335,9 @@ public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsD
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -329,38 +345,34 @@ public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsD
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
-  private final long bits1;
-  // bits2 encodes character data
-  private final long bits2;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -373,28 +385,28 @@ public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsD
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -403,38 +415,38 @@ public class VersionedStatsDiskRegionEntryHeapStringKey2 extends VersionedStatsD
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskRegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskRegionEntryHeapUUIDKey.java
@@ -19,14 +19,14 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
@@ -34,26 +34,60 @@ import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskRegionEntryHeapUUIDKey extends VersionedStatsDiskRegionEntryHeap {
-  public VersionedStatsDiskRegionEntryHeapUUIDKey(RegionEntryContext context, UUID key,
-      Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryHeapUUIDKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapUUIDKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryHeapUUIDKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapUUIDKey.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryHeapUUIDKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapUUIDKey.class,
+          "missCount");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long keyMostSigBits;
+  private final long keyLeastSigBits;
+
+  public VersionedStatsDiskRegionEntryHeapUUIDKey(final RegionEntryContext context, final UUID key,
+      final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -62,102 +96,83 @@ public class VersionedStatsDiskRegionEntryHeapUUIDKey extends VersionedStatsDisk
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryHeapUUIDKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapUUIDKey.class,
-          "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -165,22 +180,12 @@ public class VersionedStatsDiskRegionEntryHeapUUIDKey extends VersionedStatsDisk
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryHeapUUIDKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapUUIDKey.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryHeapUUIDKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryHeapUUIDKey.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -188,7 +193,7 @@ public class VersionedStatsDiskRegionEntryHeapUUIDKey extends VersionedStatsDisk
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -203,24 +208,24 @@ public class VersionedStatsDiskRegionEntryHeapUUIDKey extends VersionedStatsDisk
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -230,61 +235,63 @@ public class VersionedStatsDiskRegionEntryHeapUUIDKey extends VersionedStatsDisk
     return true;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -293,8 +300,9 @@ public class VersionedStatsDiskRegionEntryHeapUUIDKey extends VersionedStatsDisk
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -302,43 +310,43 @@ public class VersionedStatsDiskRegionEntryHeapUUIDKey extends VersionedStatsDisk
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long keyMostSigBits;
-  private final long keyLeastSigBits;
-
   @Override
   public Object getKey() {
     return new UUID(this.keyMostSigBits, this.keyLeastSigBits);
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskRegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskRegionEntryOffHeapIntKey.java
@@ -18,14 +18,14 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
@@ -38,27 +38,80 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskRegionEntryOffHeapIntKey
     extends VersionedStatsDiskRegionEntryOffHeap {
-  public VersionedStatsDiskRegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapIntKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapIntKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapIntKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapIntKey.class,
+          "offHeapAddress");
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryOffHeapIntKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapIntKey.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryOffHeapIntKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapIntKey.class,
+          "missCount");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final int key;
+
+  public VersionedStatsDiskRegionEntryOffHeapIntKey(final RegionEntryContext context, final int key,
+      @Retained final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -66,33 +119,6 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapIntKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapIntKey.class,
-          "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapIntKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapIntKey.class,
-          "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -106,24 +132,24 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -134,85 +160,76 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -220,22 +237,12 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryOffHeapIntKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapIntKey.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryOffHeapIntKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapIntKey.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -243,7 +250,7 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -258,24 +265,24 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -285,61 +292,63 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
     return true;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -348,8 +357,9 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -357,42 +367,43 @@ public class VersionedStatsDiskRegionEntryOffHeapIntKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final int key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskRegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskRegionEntryOffHeapLongKey.java
@@ -18,14 +18,14 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
@@ -38,27 +38,80 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskRegionEntryOffHeapLongKey
     extends VersionedStatsDiskRegionEntryOffHeap {
-  public VersionedStatsDiskRegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapLongKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapLongKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapLongKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapLongKey.class,
+          "offHeapAddress");
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryOffHeapLongKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapLongKey.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryOffHeapLongKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapLongKey.class,
+          "missCount");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long key;
+
+  public VersionedStatsDiskRegionEntryOffHeapLongKey(final RegionEntryContext context,
+      final long key, @Retained final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -66,33 +119,6 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapLongKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapLongKey.class,
-          "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapLongKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapLongKey.class,
-          "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -106,24 +132,24 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -134,85 +160,76 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -220,22 +237,12 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryOffHeapLongKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapLongKey.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryOffHeapLongKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapLongKey.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -243,7 +250,7 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -258,24 +265,24 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -285,61 +292,63 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
     return true;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -348,8 +357,9 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -357,42 +367,43 @@ public class VersionedStatsDiskRegionEntryOffHeapLongKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskRegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskRegionEntryOffHeapObjectKey.java
@@ -18,14 +18,14 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
@@ -38,27 +38,80 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskRegionEntryOffHeapObjectKey
     extends VersionedStatsDiskRegionEntryOffHeap {
-  public VersionedStatsDiskRegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapObjectKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapObjectKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapObjectKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapObjectKey.class,
+          "offHeapAddress");
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryOffHeapObjectKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapObjectKey.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryOffHeapObjectKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapObjectKey.class,
+          "missCount");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final Object key;
+
+  public VersionedStatsDiskRegionEntryOffHeapObjectKey(final RegionEntryContext context,
+      final Object key, @Retained final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -66,33 +119,6 @@ public class VersionedStatsDiskRegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapObjectKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapObjectKey.class,
-          "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapObjectKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapObjectKey.class,
-          "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -106,24 +132,24 @@ public class VersionedStatsDiskRegionEntryOffHeapObjectKey
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -134,85 +160,76 @@ public class VersionedStatsDiskRegionEntryOffHeapObjectKey
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -220,22 +237,12 @@ public class VersionedStatsDiskRegionEntryOffHeapObjectKey
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryOffHeapObjectKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapObjectKey.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryOffHeapObjectKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapObjectKey.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -243,7 +250,7 @@ public class VersionedStatsDiskRegionEntryOffHeapObjectKey
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -258,24 +265,24 @@ public class VersionedStatsDiskRegionEntryOffHeapObjectKey
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -285,61 +292,63 @@ public class VersionedStatsDiskRegionEntryOffHeapObjectKey
     return true;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -348,8 +357,9 @@ public class VersionedStatsDiskRegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -357,33 +367,34 @@ public class VersionedStatsDiskRegionEntryOffHeapObjectKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final Object key;
-
   @Override
   public Object getKey() {
     return this.key;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskRegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskRegionEntryOffHeapStringKey1.java
@@ -18,14 +18,14 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
@@ -38,78 +38,104 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskRegionEntryOffHeapStringKey1
     extends VersionedStatsDiskRegionEntryOffHeap {
-  public VersionedStatsDiskRegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
-    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-    initialize(context, value);
-    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    if (byteEncode) {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
-        // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
-      }
-      tmpBits1 |= 1 << 6;
-    } else {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
-      }
-    }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapStringKey1> lastModifiedUpdater =
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapStringKey1> LAST_MODIFIED_UPDATER =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapStringKey1.class,
           "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
    * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
    * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapStringKey1> ohAddrUpdater =
+  private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapStringKey1> OFF_HEAP_ADDRESS_UPDATER =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapStringKey1.class,
-          "ohAddress");
+          "offHeapAddress");
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryOffHeapStringKey1> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapStringKey1.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryOffHeapStringKey1> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapStringKey1.class,
+          "missCount");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long bits1;
 
+  public VersionedStatsDiskRegionEntryOffHeapStringKey1(final RegionEntryContext context,
+      final String key, @Retained final Object value, final boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
+    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+    initialize(context, value);
+    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
+    long tempBits1 = 0L;
+    if (byteEncode) {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
+        // keep findbugs happy.
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
+      }
+      tempBits1 |= 1 << 6;
+    } else {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
+      }
+    }
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+  }
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -123,24 +149,24 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -151,85 +177,76 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -237,22 +254,12 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryOffHeapStringKey1> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapStringKey1.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryOffHeapStringKey1> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapStringKey1.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -260,7 +267,7 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -275,24 +282,24 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -302,61 +309,63 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
     return true;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -365,8 +374,9 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -374,33 +384,34 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long bits1;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -413,18 +424,18 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
     return new String(chars);
@@ -432,25 +443,25 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey1
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskRegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskRegionEntryOffHeapStringKey2.java
@@ -18,14 +18,14 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
@@ -38,90 +38,125 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskRegionEntryOffHeapStringKey2
     extends VersionedStatsDiskRegionEntryOffHeap {
-  public VersionedStatsDiskRegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
-    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-    initialize(context, value);
-    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
-    if (byteEncode) {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
-        // keep findbugs happy.
-        if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
-        } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
-        }
-      }
-      tmpBits1 |= 1 << 6;
-    } else {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
-        } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
-        }
-      }
-    }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapStringKey2> lastModifiedUpdater =
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapStringKey2> LAST_MODIFIED_UPDATER =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapStringKey2.class,
           "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
    * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
    * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapStringKey2> ohAddrUpdater =
+  private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapStringKey2> OFF_HEAP_ADDRESS_UPDATER =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapStringKey2.class,
-          "ohAddress");
+          "offHeapAddress");
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryOffHeapStringKey2> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapStringKey2.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryOffHeapStringKey2> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapStringKey2.class,
+          "missCount");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
+  private final long bits1;
+  /**
+   * bits2 encodes character data
+   */
+  private final long bits2;
 
+  public VersionedStatsDiskRegionEntryOffHeapStringKey2(final RegionEntryContext context,
+      final String key, @Retained final Object value, final boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
+    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+    initialize(context, value);
+    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
+    if (byteEncode) {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
+        // keep findbugs happy.
+        if (i < 7) {
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
+        } else {
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
+        }
+      }
+      tempBits1 |= 1 << 6;
+    } else {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        if (i < 3) {
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
+        } else {
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
+        }
+      }
+    }
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
+  }
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -135,24 +170,24 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -163,85 +198,76 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -249,22 +275,12 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryOffHeapStringKey2> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapStringKey2.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryOffHeapStringKey2> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapStringKey2.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -272,7 +288,7 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -287,24 +303,24 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -314,61 +330,63 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
     return true;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -377,8 +395,9 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -386,38 +405,34 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
-  private final long bits1;
-  // bits2 encodes character data
-  private final long bits2;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -430,28 +445,28 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -460,38 +475,38 @@ public class VersionedStatsDiskRegionEntryOffHeapStringKey2
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskRegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskRegionEntryOffHeapUUIDKey.java
@@ -19,14 +19,14 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
@@ -39,27 +39,81 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
     extends VersionedStatsDiskRegionEntryOffHeap {
-  public VersionedStatsDiskRegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapUUIDKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapUUIDKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapUUIDKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapUUIDKey.class,
+          "offHeapAddress");
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryOffHeapUUIDKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapUUIDKey.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryOffHeapUUIDKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapUUIDKey.class,
+          "missCount");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long keyMostSigBits;
+  private final long keyLeastSigBits;
+
+  public VersionedStatsDiskRegionEntryOffHeapUUIDKey(final RegionEntryContext context,
+      final UUID key, @Retained final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -68,33 +122,6 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapUUIDKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapUUIDKey.class,
-          "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VersionedStatsDiskRegionEntryOffHeapUUIDKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapUUIDKey.class,
-          "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -108,24 +135,24 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -136,85 +163,76 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -222,22 +240,12 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryOffHeapUUIDKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapUUIDKey.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VersionedStatsDiskRegionEntryOffHeapUUIDKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsDiskRegionEntryOffHeapUUIDKey.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -245,7 +253,7 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -260,24 +268,24 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -287,61 +295,63 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
     return true;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -350,8 +360,9 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -359,43 +370,43 @@ public class VersionedStatsDiskRegionEntryOffHeapUUIDKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long keyMostSigBits;
-  private final long keyLeastSigBits;
-
   @Override
   public Object getKey() {
     return new UUID(this.keyMostSigBits, this.keyLeastSigBits);
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsLRURegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsLRURegionEntryHeapIntKey.java
@@ -18,11 +18,12 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -31,99 +32,116 @@ import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRURegionEntryHeap {
-  public VersionedStatsLRURegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryHeapIntKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapIntKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryHeapIntKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapIntKey.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryHeapIntKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapIntKey.class,
+          "missCount");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final int key;
+
+  public VersionedStatsLRURegionEntryHeapIntKey(final RegionEntryContext context, final int key,
+      final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.key = key;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryHeapIntKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapIntKey.class,
-          "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
     // nothing needed for LRUs with no disk
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -131,6 +149,7 @@ public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRUReg
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -140,48 +159,57 @@ public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRUReg
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -192,12 +220,12 @@ public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRUReg
     return null;
   }
 
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -205,22 +233,12 @@ public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRUReg
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryHeapIntKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapIntKey.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryHeapIntKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapIntKey.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -228,7 +246,7 @@ public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRUReg
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -243,24 +261,24 @@ public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRUReg
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -270,61 +288,63 @@ public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRUReg
     return true;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -333,8 +353,9 @@ public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRUReg
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -342,42 +363,43 @@ public class VersionedStatsLRURegionEntryHeapIntKey extends VersionedStatsLRUReg
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final int key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsLRURegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsLRURegionEntryHeapLongKey.java
@@ -18,11 +18,12 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -31,100 +32,116 @@ import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURegionEntryHeap {
-  public VersionedStatsLRURegionEntryHeapLongKey(RegionEntryContext context, long key,
-      Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryHeapLongKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapLongKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryHeapLongKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapLongKey.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryHeapLongKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapLongKey.class,
+          "missCount");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long key;
+
+  public VersionedStatsLRURegionEntryHeapLongKey(final RegionEntryContext context, final long key,
+      final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.key = key;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryHeapLongKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapLongKey.class,
-          "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
     // nothing needed for LRUs with no disk
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -132,6 +149,7 @@ public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURe
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -141,48 +159,57 @@ public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURe
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -193,12 +220,12 @@ public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURe
     return null;
   }
 
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -206,22 +233,12 @@ public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURe
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryHeapLongKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapLongKey.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryHeapLongKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapLongKey.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -229,7 +246,7 @@ public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURe
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -244,24 +261,24 @@ public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURe
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -271,61 +288,63 @@ public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURe
     return true;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -334,8 +353,9 @@ public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -343,42 +363,43 @@ public class VersionedStatsLRURegionEntryHeapLongKey extends VersionedStatsLRURe
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsLRURegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsLRURegionEntryHeapObjectKey.java
@@ -18,11 +18,12 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -31,100 +32,116 @@ import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsLRURegionEntryHeapObjectKey extends VersionedStatsLRURegionEntryHeap {
-  public VersionedStatsLRURegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-      Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryHeapObjectKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapObjectKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryHeapObjectKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapObjectKey.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryHeapObjectKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapObjectKey.class,
+          "missCount");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final Object key;
+
+  public VersionedStatsLRURegionEntryHeapObjectKey(final RegionEntryContext context,
+      final Object key, final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.key = key;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryHeapObjectKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapObjectKey.class,
-          "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
     // nothing needed for LRUs with no disk
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -132,6 +149,7 @@ public class VersionedStatsLRURegionEntryHeapObjectKey extends VersionedStatsLRU
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -141,48 +159,57 @@ public class VersionedStatsLRURegionEntryHeapObjectKey extends VersionedStatsLRU
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -193,12 +220,12 @@ public class VersionedStatsLRURegionEntryHeapObjectKey extends VersionedStatsLRU
     return getKey();
   }
 
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -206,22 +233,12 @@ public class VersionedStatsLRURegionEntryHeapObjectKey extends VersionedStatsLRU
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryHeapObjectKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapObjectKey.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryHeapObjectKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapObjectKey.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -229,7 +246,7 @@ public class VersionedStatsLRURegionEntryHeapObjectKey extends VersionedStatsLRU
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -244,24 +261,24 @@ public class VersionedStatsLRURegionEntryHeapObjectKey extends VersionedStatsLRU
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -271,61 +288,63 @@ public class VersionedStatsLRURegionEntryHeapObjectKey extends VersionedStatsLRU
     return true;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -334,8 +353,9 @@ public class VersionedStatsLRURegionEntryHeapObjectKey extends VersionedStatsLRU
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -343,33 +363,34 @@ public class VersionedStatsLRURegionEntryHeapObjectKey extends VersionedStatsLRU
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final Object key;
-
   @Override
   public Object getKey() {
     return this.key;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsLRURegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsLRURegionEntryHeapStringKey1.java
@@ -18,11 +18,12 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -31,117 +32,133 @@ import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLRURegionEntryHeap {
-  public VersionedStatsLRURegionEntryHeapStringKey1(RegionEntryContext context, String key,
-      Object value, boolean byteEncode) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryHeapStringKey1> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapStringKey1.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryHeapStringKey1> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapStringKey1.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryHeapStringKey1> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapStringKey1.class,
+          "missCount");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long bits1;
+
+  public VersionedStatsLRURegionEntryHeapStringKey1(final RegionEntryContext context,
+      final String key, final Object value, final boolean byteEncode) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryHeapStringKey1> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapStringKey1.class,
-          "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
     // nothing needed for LRUs with no disk
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -149,6 +166,7 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -158,48 +176,57 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -210,12 +237,12 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
     return null;
   }
 
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -223,22 +250,12 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryHeapStringKey1> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapStringKey1.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryHeapStringKey1> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapStringKey1.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -246,7 +263,7 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -261,24 +278,24 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -288,61 +305,63 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
     return true;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -351,8 +370,9 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -360,33 +380,34 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long bits1;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -399,18 +420,18 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
     return new String(chars);
@@ -418,25 +439,25 @@ public class VersionedStatsLRURegionEntryHeapStringKey1 extends VersionedStatsLR
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsLRURegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsLRURegionEntryHeapStringKey2.java
@@ -18,11 +18,12 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -31,129 +32,154 @@ import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLRURegionEntryHeap {
-  public VersionedStatsLRURegionEntryHeapStringKey2(RegionEntryContext context, String key,
-      Object value, boolean byteEncode) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryHeapStringKey2> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapStringKey2.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryHeapStringKey2> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapStringKey2.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryHeapStringKey2> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapStringKey2.class,
+          "missCount");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
+  private final long bits1;
+  /**
+   * bits2 encodes character data
+   */
+  private final long bits2;
+
+  public VersionedStatsLRURegionEntryHeapStringKey2(final RegionEntryContext context,
+      final String key, final Object value, final boolean byteEncode) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryHeapStringKey2> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapStringKey2.class,
-          "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
     // nothing needed for LRUs with no disk
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -161,6 +187,7 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -170,48 +197,57 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -222,12 +258,12 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
     return null;
   }
 
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -235,22 +271,12 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryHeapStringKey2> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapStringKey2.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryHeapStringKey2> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapStringKey2.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -258,7 +284,7 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -273,24 +299,24 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -300,61 +326,63 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
     return true;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -363,8 +391,9 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -372,38 +401,34 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
-  private final long bits1;
-  // bits2 encodes character data
-  private final long bits2;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -416,28 +441,28 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -446,38 +471,38 @@ public class VersionedStatsLRURegionEntryHeapStringKey2 extends VersionedStatsLR
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsLRURegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsLRURegionEntryHeapUUIDKey.java
@@ -19,11 +19,12 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -32,26 +33,55 @@ import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURegionEntryHeap {
-  public VersionedStatsLRURegionEntryHeapUUIDKey(RegionEntryContext context, UUID key,
-      Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryHeapUUIDKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapUUIDKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryHeapUUIDKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapUUIDKey.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryHeapUUIDKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapUUIDKey.class,
+          "missCount");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long keyMostSigBits;
+  private final long keyLeastSigBits;
+
+  public VersionedStatsLRURegionEntryHeapUUIDKey(final RegionEntryContext context, final UUID key,
+      final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.keyMostSigBits = key.getMostSignificantBits();
@@ -59,74 +89,62 @@ public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryHeapUUIDKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapUUIDKey.class,
-          "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
     // nothing needed for LRUs with no disk
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -134,6 +152,7 @@ public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURe
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -143,48 +162,57 @@ public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURe
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -195,12 +223,12 @@ public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURe
     return null;
   }
 
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -208,22 +236,12 @@ public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURe
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryHeapUUIDKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapUUIDKey.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryHeapUUIDKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryHeapUUIDKey.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -231,7 +249,7 @@ public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURe
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -246,24 +264,24 @@ public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURe
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -273,61 +291,63 @@ public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURe
     return true;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -336,8 +356,9 @@ public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -345,43 +366,43 @@ public class VersionedStatsLRURegionEntryHeapUUIDKey extends VersionedStatsLRURe
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long keyMostSigBits;
-  private final long keyLeastSigBits;
-
   @Override
   public Object getKey() {
     return new UUID(this.keyMostSigBits, this.keyLeastSigBits);
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsLRURegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsLRURegionEntryOffHeapIntKey.java
@@ -18,11 +18,12 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -36,59 +37,80 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRURegionEntryOffHeap {
-  public VersionedStatsLRURegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapIntKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapIntKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapIntKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapIntKey.class,
+          "offHeapAddress");
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryOffHeapIntKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapIntKey.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryOffHeapIntKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapIntKey.class,
+          "missCount");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final int key;
+
+  public VersionedStatsLRURegionEntryOffHeapIntKey(final RegionEntryContext context, final int key,
+      @Retained final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.key = key;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapIntKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapIntKey.class,
-          "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapIntKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapIntKey.class,
-          "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -102,24 +124,24 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -130,57 +152,55 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
     // nothing needed for LRUs with no disk
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -188,6 +208,7 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -197,48 +218,57 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -249,12 +279,12 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
     return null;
   }
 
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -262,22 +292,12 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryOffHeapIntKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapIntKey.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryOffHeapIntKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapIntKey.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -285,7 +305,7 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -300,24 +320,24 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -327,61 +347,63 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
     return true;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -390,8 +412,9 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -399,42 +422,43 @@ public class VersionedStatsLRURegionEntryOffHeapIntKey extends VersionedStatsLRU
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final int key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsLRURegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsLRURegionEntryOffHeapLongKey.java
@@ -18,11 +18,12 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -36,60 +37,81 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsLRURegionEntryOffHeapLongKey
     extends VersionedStatsLRURegionEntryOffHeap {
-  public VersionedStatsLRURegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapLongKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapLongKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapLongKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapLongKey.class,
+          "offHeapAddress");
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryOffHeapLongKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapLongKey.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryOffHeapLongKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapLongKey.class,
+          "missCount");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long key;
+
+  public VersionedStatsLRURegionEntryOffHeapLongKey(final RegionEntryContext context,
+      final long key, @Retained final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.key = key;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapLongKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapLongKey.class,
-          "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapLongKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapLongKey.class,
-          "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -103,24 +125,24 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -131,57 +153,55 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
     // nothing needed for LRUs with no disk
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -189,6 +209,7 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -198,48 +219,57 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -250,12 +280,12 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
     return null;
   }
 
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -263,22 +293,12 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryOffHeapLongKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapLongKey.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryOffHeapLongKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapLongKey.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -286,7 +306,7 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -301,24 +321,24 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -328,61 +348,63 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
     return true;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -391,8 +413,9 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -400,42 +423,43 @@ public class VersionedStatsLRURegionEntryOffHeapLongKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsLRURegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsLRURegionEntryOffHeapObjectKey.java
@@ -18,11 +18,12 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -36,60 +37,81 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsLRURegionEntryOffHeapObjectKey
     extends VersionedStatsLRURegionEntryOffHeap {
-  public VersionedStatsLRURegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapObjectKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapObjectKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapObjectKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapObjectKey.class,
+          "offHeapAddress");
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryOffHeapObjectKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapObjectKey.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryOffHeapObjectKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapObjectKey.class,
+          "missCount");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final Object key;
+
+  public VersionedStatsLRURegionEntryOffHeapObjectKey(final RegionEntryContext context,
+      final Object key, @Retained final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.key = key;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapObjectKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapObjectKey.class,
-          "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapObjectKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapObjectKey.class,
-          "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -103,24 +125,24 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -131,57 +153,55 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
     // nothing needed for LRUs with no disk
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -189,6 +209,7 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -198,48 +219,57 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -250,12 +280,12 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
     return getKey();
   }
 
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -263,22 +293,12 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryOffHeapObjectKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapObjectKey.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryOffHeapObjectKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapObjectKey.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -286,7 +306,7 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -301,24 +321,24 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -328,61 +348,63 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
     return true;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -391,8 +413,9 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -400,33 +423,34 @@ public class VersionedStatsLRURegionEntryOffHeapObjectKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final Object key;
-
   @Override
   public Object getKey() {
     return this.key;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsLRURegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsLRURegionEntryOffHeapStringKey1.java
@@ -18,11 +18,12 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -36,77 +37,98 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsLRURegionEntryOffHeapStringKey1
     extends VersionedStatsLRURegionEntryOffHeap {
-  public VersionedStatsLRURegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, value);
-    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    if (byteEncode) {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
-        // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
-      }
-      tmpBits1 |= 1 << 6;
-    } else {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
-      }
-    }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapStringKey1> lastModifiedUpdater =
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapStringKey1> LAST_MODIFIED_UPDATER =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapStringKey1.class,
           "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
    * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
    * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapStringKey1> ohAddrUpdater =
+  private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapStringKey1> OFF_HEAP_ADDRESS_UPDATER =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapStringKey1.class,
-          "ohAddress");
+          "offHeapAddress");
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryOffHeapStringKey1> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapStringKey1.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryOffHeapStringKey1> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapStringKey1.class,
+          "missCount");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long bits1;
 
+  public VersionedStatsLRURegionEntryOffHeapStringKey1(final RegionEntryContext context,
+      final String key, @Retained final Object value, final boolean byteEncode) {
+    super(context, value);
+    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
+    long tempBits1 = 0L;
+    if (byteEncode) {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
+        // keep findbugs happy.
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
+      }
+      tempBits1 |= 1 << 6;
+    } else {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
+      }
+    }
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+  }
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -120,24 +142,24 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -148,57 +170,55 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
     // nothing needed for LRUs with no disk
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -206,6 +226,7 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -215,48 +236,57 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -267,12 +297,12 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
     return null;
   }
 
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -280,22 +310,12 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryOffHeapStringKey1> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapStringKey1.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryOffHeapStringKey1> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapStringKey1.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -303,7 +323,7 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -318,24 +338,24 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -345,61 +365,63 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
     return true;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -408,8 +430,9 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -417,33 +440,34 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long bits1;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -456,18 +480,18 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
     return new String(chars);
@@ -475,25 +499,25 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey1
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsLRURegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsLRURegionEntryOffHeapStringKey2.java
@@ -18,11 +18,12 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -36,89 +37,119 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsLRURegionEntryOffHeapStringKey2
     extends VersionedStatsLRURegionEntryOffHeap {
-  public VersionedStatsLRURegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, value);
-    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
-    if (byteEncode) {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
-        // keep findbugs happy.
-        if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
-        } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
-        }
-      }
-      tmpBits1 |= 1 << 6;
-    } else {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
-        } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
-        }
-      }
-    }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapStringKey2> lastModifiedUpdater =
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapStringKey2> LAST_MODIFIED_UPDATER =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapStringKey2.class,
           "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
    * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
    * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapStringKey2> ohAddrUpdater =
+  private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapStringKey2> OFF_HEAP_ADDRESS_UPDATER =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapStringKey2.class,
-          "ohAddress");
+          "offHeapAddress");
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryOffHeapStringKey2> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapStringKey2.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryOffHeapStringKey2> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapStringKey2.class,
+          "missCount");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
+  private final long bits1;
+  /**
+   * bits2 encodes character data
+   */
+  private final long bits2;
 
+  public VersionedStatsLRURegionEntryOffHeapStringKey2(final RegionEntryContext context,
+      final String key, @Retained final Object value, final boolean byteEncode) {
+    super(context, value);
+    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
+    if (byteEncode) {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
+        // keep findbugs happy.
+        if (i < 7) {
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
+        } else {
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
+        }
+      }
+      tempBits1 |= 1 << 6;
+    } else {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        if (i < 3) {
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
+        } else {
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
+        }
+      }
+    }
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
+  }
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -132,24 +163,24 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -160,57 +191,55 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
     // nothing needed for LRUs with no disk
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -218,6 +247,7 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -227,48 +257,57 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -279,12 +318,12 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
     return null;
   }
 
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -292,22 +331,12 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryOffHeapStringKey2> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapStringKey2.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryOffHeapStringKey2> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapStringKey2.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -315,7 +344,7 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -330,24 +359,24 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -357,61 +386,63 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
     return true;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -420,8 +451,9 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -429,38 +461,34 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
-  private final long bits1;
-  // bits2 encodes character data
-  private final long bits2;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -473,28 +501,28 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -503,38 +531,38 @@ public class VersionedStatsLRURegionEntryOffHeapStringKey2
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsLRURegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsLRURegionEntryOffHeapUUIDKey.java
@@ -19,11 +19,12 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -37,27 +38,76 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsLRURegionEntryOffHeapUUIDKey
     extends VersionedStatsLRURegionEntryOffHeap {
-  public VersionedStatsLRURegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapUUIDKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapUUIDKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapUUIDKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapUUIDKey.class,
+          "offHeapAddress");
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryOffHeapUUIDKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapUUIDKey.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryOffHeapUUIDKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapUUIDKey.class,
+          "missCount");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long keyMostSigBits;
+  private final long keyLeastSigBits;
+
+  public VersionedStatsLRURegionEntryOffHeapUUIDKey(final RegionEntryContext context,
+      final UUID key, @Retained final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.keyMostSigBits = key.getMostSignificantBits();
@@ -65,33 +115,6 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapUUIDKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapUUIDKey.class,
-          "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VersionedStatsLRURegionEntryOffHeapUUIDKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapUUIDKey.class,
-          "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -105,24 +128,24 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -133,57 +156,55 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
     // nothing needed for LRUs with no disk
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -191,6 +212,7 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -200,48 +222,57 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -252,12 +283,12 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
     return null;
   }
 
+  // ---------------------------------------- stats code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -265,22 +296,12 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryOffHeapUUIDKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapUUIDKey.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VersionedStatsLRURegionEntryOffHeapUUIDKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsLRURegionEntryOffHeapUUIDKey.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -288,7 +309,7 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -303,24 +324,24 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -330,61 +351,63 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
     return true;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -393,8 +416,9 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -402,43 +426,43 @@ public class VersionedStatsLRURegionEntryOffHeapUUIDKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long keyMostSigBits;
-  private final long keyLeastSigBits;
-
   @Override
   public Object getKey() {
     return new UUID(this.keyMostSigBits, this.keyLeastSigBits);
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsRegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsRegionEntryHeapIntKey.java
@@ -18,7 +18,7 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -27,89 +27,103 @@ import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsRegionEntryHeapIntKey extends VersionedStatsRegionEntryHeap {
-  public VersionedStatsRegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryHeapIntKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapIntKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapIntKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapIntKey.class, "hitCount");
+  private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapIntKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapIntKey.class, "missCount");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final int key;
+
+  public VersionedStatsRegionEntryHeapIntKey(final RegionEntryContext context, final int key,
+      final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.key = key;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryHeapIntKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapIntKey.class, "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // ---------------------------------------- stats code ------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -117,20 +131,12 @@ public class VersionedStatsRegionEntryHeapIntKey extends VersionedStatsRegionEnt
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapIntKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapIntKey.class, "hitCount");
-  private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapIntKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapIntKey.class, "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -138,7 +144,7 @@ public class VersionedStatsRegionEntryHeapIntKey extends VersionedStatsRegionEnt
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -153,24 +159,24 @@ public class VersionedStatsRegionEntryHeapIntKey extends VersionedStatsRegionEnt
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -180,61 +186,63 @@ public class VersionedStatsRegionEntryHeapIntKey extends VersionedStatsRegionEnt
     return true;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -243,8 +251,9 @@ public class VersionedStatsRegionEntryHeapIntKey extends VersionedStatsRegionEnt
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -252,42 +261,43 @@ public class VersionedStatsRegionEntryHeapIntKey extends VersionedStatsRegionEnt
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final int key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsRegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsRegionEntryHeapLongKey.java
@@ -18,7 +18,7 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -27,89 +27,103 @@ import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsRegionEntryHeapLongKey extends VersionedStatsRegionEntryHeap {
-  public VersionedStatsRegionEntryHeapLongKey(RegionEntryContext context, long key, Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryHeapLongKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapLongKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapLongKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapLongKey.class, "hitCount");
+  private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapLongKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapLongKey.class, "missCount");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long key;
+
+  public VersionedStatsRegionEntryHeapLongKey(final RegionEntryContext context, final long key,
+      final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.key = key;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryHeapLongKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapLongKey.class, "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // ---------------------------------------- stats code ------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -117,20 +131,12 @@ public class VersionedStatsRegionEntryHeapLongKey extends VersionedStatsRegionEn
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapLongKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapLongKey.class, "hitCount");
-  private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapLongKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapLongKey.class, "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -138,7 +144,7 @@ public class VersionedStatsRegionEntryHeapLongKey extends VersionedStatsRegionEn
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -153,24 +159,24 @@ public class VersionedStatsRegionEntryHeapLongKey extends VersionedStatsRegionEn
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -180,61 +186,63 @@ public class VersionedStatsRegionEntryHeapLongKey extends VersionedStatsRegionEn
     return true;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -243,8 +251,9 @@ public class VersionedStatsRegionEntryHeapLongKey extends VersionedStatsRegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -252,42 +261,43 @@ public class VersionedStatsRegionEntryHeapLongKey extends VersionedStatsRegionEn
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsRegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsRegionEntryHeapObjectKey.java
@@ -18,7 +18,7 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -27,91 +27,106 @@ import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsRegionEntryHeapObjectKey extends VersionedStatsRegionEntryHeap {
-  public VersionedStatsRegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-      Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryHeapObjectKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapObjectKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapObjectKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapObjectKey.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapObjectKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapObjectKey.class,
+          "missCount");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final Object key;
+
+  public VersionedStatsRegionEntryHeapObjectKey(final RegionEntryContext context, final Object key,
+      final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.key = key;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryHeapObjectKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapObjectKey.class,
-          "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // ---------------------------------------- stats code ------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -119,22 +134,12 @@ public class VersionedStatsRegionEntryHeapObjectKey extends VersionedStatsRegion
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapObjectKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapObjectKey.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapObjectKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapObjectKey.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -142,7 +147,7 @@ public class VersionedStatsRegionEntryHeapObjectKey extends VersionedStatsRegion
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -157,24 +162,24 @@ public class VersionedStatsRegionEntryHeapObjectKey extends VersionedStatsRegion
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -184,61 +189,63 @@ public class VersionedStatsRegionEntryHeapObjectKey extends VersionedStatsRegion
     return true;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -247,8 +254,9 @@ public class VersionedStatsRegionEntryHeapObjectKey extends VersionedStatsRegion
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -256,33 +264,34 @@ public class VersionedStatsRegionEntryHeapObjectKey extends VersionedStatsRegion
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final Object key;
-
   @Override
   public Object getKey() {
     return this.key;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsRegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsRegionEntryHeapStringKey1.java
@@ -18,7 +18,7 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -27,108 +27,123 @@ import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsRegionEntryHeapStringKey1 extends VersionedStatsRegionEntryHeap {
-  public VersionedStatsRegionEntryHeapStringKey1(RegionEntryContext context, String key,
-      Object value, boolean byteEncode) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryHeapStringKey1> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapStringKey1.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapStringKey1> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapStringKey1.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapStringKey1> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapStringKey1.class,
+          "missCount");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long bits1;
+
+  public VersionedStatsRegionEntryHeapStringKey1(final RegionEntryContext context, final String key,
+      final Object value, final boolean byteEncode) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryHeapStringKey1> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapStringKey1.class,
-          "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // ---------------------------------------- stats code ------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -136,22 +151,12 @@ public class VersionedStatsRegionEntryHeapStringKey1 extends VersionedStatsRegio
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapStringKey1> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapStringKey1.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapStringKey1> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapStringKey1.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -159,7 +164,7 @@ public class VersionedStatsRegionEntryHeapStringKey1 extends VersionedStatsRegio
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -174,24 +179,24 @@ public class VersionedStatsRegionEntryHeapStringKey1 extends VersionedStatsRegio
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -201,61 +206,63 @@ public class VersionedStatsRegionEntryHeapStringKey1 extends VersionedStatsRegio
     return true;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -264,8 +271,9 @@ public class VersionedStatsRegionEntryHeapStringKey1 extends VersionedStatsRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -273,33 +281,34 @@ public class VersionedStatsRegionEntryHeapStringKey1 extends VersionedStatsRegio
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long bits1;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -312,18 +321,18 @@ public class VersionedStatsRegionEntryHeapStringKey1 extends VersionedStatsRegio
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
     return new String(chars);
@@ -331,25 +340,25 @@ public class VersionedStatsRegionEntryHeapStringKey1 extends VersionedStatsRegio
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsRegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsRegionEntryHeapStringKey2.java
@@ -18,7 +18,7 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -27,120 +27,144 @@ import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsRegionEntryHeapStringKey2 extends VersionedStatsRegionEntryHeap {
-  public VersionedStatsRegionEntryHeapStringKey2(RegionEntryContext context, String key,
-      Object value, boolean byteEncode) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryHeapStringKey2> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapStringKey2.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapStringKey2> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapStringKey2.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapStringKey2> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapStringKey2.class,
+          "missCount");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
+  private final long bits1;
+  /**
+   * bits2 encodes character data
+   */
+  private final long bits2;
+
+  public VersionedStatsRegionEntryHeapStringKey2(final RegionEntryContext context, final String key,
+      final Object value, final boolean byteEncode) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryHeapStringKey2> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapStringKey2.class,
-          "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // ---------------------------------------- stats code ------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -148,22 +172,12 @@ public class VersionedStatsRegionEntryHeapStringKey2 extends VersionedStatsRegio
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapStringKey2> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapStringKey2.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapStringKey2> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapStringKey2.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -171,7 +185,7 @@ public class VersionedStatsRegionEntryHeapStringKey2 extends VersionedStatsRegio
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -186,24 +200,24 @@ public class VersionedStatsRegionEntryHeapStringKey2 extends VersionedStatsRegio
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -213,61 +227,63 @@ public class VersionedStatsRegionEntryHeapStringKey2 extends VersionedStatsRegio
     return true;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -276,8 +292,9 @@ public class VersionedStatsRegionEntryHeapStringKey2 extends VersionedStatsRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -285,38 +302,34 @@ public class VersionedStatsRegionEntryHeapStringKey2 extends VersionedStatsRegio
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
-  private final long bits1;
-  // bits2 encodes character data
-  private final long bits2;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -329,28 +342,28 @@ public class VersionedStatsRegionEntryHeapStringKey2 extends VersionedStatsRegio
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -359,38 +372,38 @@ public class VersionedStatsRegionEntryHeapStringKey2 extends VersionedStatsRegio
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsRegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsRegionEntryHeapUUIDKey.java
@@ -19,7 +19,7 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -28,25 +28,52 @@ import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsRegionEntryHeapUUIDKey extends VersionedStatsRegionEntryHeap {
-  public VersionedStatsRegionEntryHeapUUIDKey(RegionEntryContext context, UUID key, Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryHeapUUIDKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapUUIDKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapUUIDKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapUUIDKey.class, "hitCount");
+  private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapUUIDKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapUUIDKey.class, "missCount");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long keyMostSigBits;
+  private final long keyLeastSigBits;
+
+  public VersionedStatsRegionEntryHeapUUIDKey(final RegionEntryContext context, final UUID key,
+      final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.keyMostSigBits = key.getMostSignificantBits();
@@ -54,64 +81,52 @@ public class VersionedStatsRegionEntryHeapUUIDKey extends VersionedStatsRegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryHeapUUIDKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapUUIDKey.class, "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // ---------------------------------------- stats code ------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -119,20 +134,12 @@ public class VersionedStatsRegionEntryHeapUUIDKey extends VersionedStatsRegionEn
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapUUIDKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapUUIDKey.class, "hitCount");
-  private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryHeapUUIDKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryHeapUUIDKey.class, "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -140,7 +147,7 @@ public class VersionedStatsRegionEntryHeapUUIDKey extends VersionedStatsRegionEn
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -155,24 +162,24 @@ public class VersionedStatsRegionEntryHeapUUIDKey extends VersionedStatsRegionEn
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -182,61 +189,63 @@ public class VersionedStatsRegionEntryHeapUUIDKey extends VersionedStatsRegionEn
     return true;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -245,8 +254,9 @@ public class VersionedStatsRegionEntryHeapUUIDKey extends VersionedStatsRegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -254,43 +264,43 @@ public class VersionedStatsRegionEntryHeapUUIDKey extends VersionedStatsRegionEn
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long keyMostSigBits;
-  private final long keyLeastSigBits;
-
   @Override
   public Object getKey() {
     return new UUID(this.keyMostSigBits, this.keyLeastSigBits);
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsRegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsRegionEntryOffHeapIntKey.java
@@ -18,7 +18,7 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -32,58 +32,80 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsRegionEntryOffHeapIntKey extends VersionedStatsRegionEntryOffHeap {
-  public VersionedStatsRegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapIntKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapIntKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapIntKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapIntKey.class,
+          "offHeapAddress");
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryOffHeapIntKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapIntKey.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryOffHeapIntKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapIntKey.class,
+          "missCount");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final int key;
+
+  public VersionedStatsRegionEntryOffHeapIntKey(final RegionEntryContext context, final int key,
+      @Retained final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.key = key;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapIntKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapIntKey.class,
-          "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapIntKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapIntKey.class, "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -97,24 +119,24 @@ public class VersionedStatsRegionEntryOffHeapIntKey extends VersionedStatsRegion
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -125,48 +147,45 @@ public class VersionedStatsRegionEntryOffHeapIntKey extends VersionedStatsRegion
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // ---------------------------------------- stats code ------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -174,22 +193,12 @@ public class VersionedStatsRegionEntryOffHeapIntKey extends VersionedStatsRegion
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryOffHeapIntKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapIntKey.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryOffHeapIntKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapIntKey.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -197,7 +206,7 @@ public class VersionedStatsRegionEntryOffHeapIntKey extends VersionedStatsRegion
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -212,24 +221,24 @@ public class VersionedStatsRegionEntryOffHeapIntKey extends VersionedStatsRegion
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -239,61 +248,63 @@ public class VersionedStatsRegionEntryOffHeapIntKey extends VersionedStatsRegion
     return true;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -302,8 +313,9 @@ public class VersionedStatsRegionEntryOffHeapIntKey extends VersionedStatsRegion
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -311,42 +323,43 @@ public class VersionedStatsRegionEntryOffHeapIntKey extends VersionedStatsRegion
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final int key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsRegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsRegionEntryOffHeapLongKey.java
@@ -18,7 +18,7 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -32,58 +32,80 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsRegionEntryOffHeapLongKey extends VersionedStatsRegionEntryOffHeap {
-  public VersionedStatsRegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapLongKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapLongKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapLongKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapLongKey.class,
+          "offHeapAddress");
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryOffHeapLongKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapLongKey.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryOffHeapLongKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapLongKey.class,
+          "missCount");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long key;
+
+  public VersionedStatsRegionEntryOffHeapLongKey(final RegionEntryContext context, final long key,
+      @Retained final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.key = key;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapLongKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapLongKey.class,
-          "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapLongKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapLongKey.class, "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -97,24 +119,24 @@ public class VersionedStatsRegionEntryOffHeapLongKey extends VersionedStatsRegio
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -125,48 +147,45 @@ public class VersionedStatsRegionEntryOffHeapLongKey extends VersionedStatsRegio
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // ---------------------------------------- stats code ------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -174,22 +193,12 @@ public class VersionedStatsRegionEntryOffHeapLongKey extends VersionedStatsRegio
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryOffHeapLongKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapLongKey.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryOffHeapLongKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapLongKey.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -197,7 +206,7 @@ public class VersionedStatsRegionEntryOffHeapLongKey extends VersionedStatsRegio
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -212,24 +221,24 @@ public class VersionedStatsRegionEntryOffHeapLongKey extends VersionedStatsRegio
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -239,61 +248,63 @@ public class VersionedStatsRegionEntryOffHeapLongKey extends VersionedStatsRegio
     return true;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -302,8 +313,9 @@ public class VersionedStatsRegionEntryOffHeapLongKey extends VersionedStatsRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -311,42 +323,43 @@ public class VersionedStatsRegionEntryOffHeapLongKey extends VersionedStatsRegio
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsRegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsRegionEntryOffHeapObjectKey.java
@@ -18,7 +18,7 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -32,59 +32,80 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsRegionEntryOffHeapObjectKey extends VersionedStatsRegionEntryOffHeap {
-  public VersionedStatsRegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapObjectKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapObjectKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapObjectKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapObjectKey.class,
+          "offHeapAddress");
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryOffHeapObjectKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapObjectKey.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryOffHeapObjectKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapObjectKey.class,
+          "missCount");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final Object key;
+
+  public VersionedStatsRegionEntryOffHeapObjectKey(final RegionEntryContext context,
+      final Object key, @Retained final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.key = key;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapObjectKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapObjectKey.class,
-          "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapObjectKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapObjectKey.class,
-          "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -98,24 +119,24 @@ public class VersionedStatsRegionEntryOffHeapObjectKey extends VersionedStatsReg
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -126,48 +147,45 @@ public class VersionedStatsRegionEntryOffHeapObjectKey extends VersionedStatsReg
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // ---------------------------------------- stats code ------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -175,22 +193,12 @@ public class VersionedStatsRegionEntryOffHeapObjectKey extends VersionedStatsReg
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryOffHeapObjectKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapObjectKey.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryOffHeapObjectKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapObjectKey.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -198,7 +206,7 @@ public class VersionedStatsRegionEntryOffHeapObjectKey extends VersionedStatsReg
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -213,24 +221,24 @@ public class VersionedStatsRegionEntryOffHeapObjectKey extends VersionedStatsReg
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -240,61 +248,63 @@ public class VersionedStatsRegionEntryOffHeapObjectKey extends VersionedStatsReg
     return true;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -303,8 +313,9 @@ public class VersionedStatsRegionEntryOffHeapObjectKey extends VersionedStatsReg
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -312,33 +323,34 @@ public class VersionedStatsRegionEntryOffHeapObjectKey extends VersionedStatsReg
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final Object key;
-
   @Override
   public Object getKey() {
     return this.key;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsRegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsRegionEntryOffHeapStringKey1.java
@@ -18,7 +18,7 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -32,76 +32,97 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRegionEntryOffHeap {
-  public VersionedStatsRegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, value);
-    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    if (byteEncode) {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
-        // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
-      }
-      tmpBits1 |= 1 << 6;
-    } else {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
-      }
-    }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapStringKey1> lastModifiedUpdater =
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapStringKey1> LAST_MODIFIED_UPDATER =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapStringKey1.class,
           "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
    * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
    * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapStringKey1> ohAddrUpdater =
+  private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapStringKey1> OFF_HEAP_ADDRESS_UPDATER =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapStringKey1.class,
-          "ohAddress");
+          "offHeapAddress");
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryOffHeapStringKey1> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapStringKey1.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryOffHeapStringKey1> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapStringKey1.class,
+          "missCount");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long bits1;
 
+  public VersionedStatsRegionEntryOffHeapStringKey1(final RegionEntryContext context,
+      final String key, @Retained final Object value, final boolean byteEncode) {
+    super(context, value);
+    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
+    long tempBits1 = 0L;
+    if (byteEncode) {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
+        // keep findbugs happy.
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
+      }
+      tempBits1 |= 1 << 6;
+    } else {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
+      }
+    }
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+  }
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -115,24 +136,24 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -143,48 +164,45 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // ---------------------------------------- stats code ------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -192,22 +210,12 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryOffHeapStringKey1> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapStringKey1.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryOffHeapStringKey1> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapStringKey1.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -215,7 +223,7 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -230,24 +238,24 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -257,61 +265,63 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
     return true;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -320,8 +330,9 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -329,33 +340,34 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long bits1;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -368,18 +380,18 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
     return new String(chars);
@@ -387,25 +399,25 @@ public class VersionedStatsRegionEntryOffHeapStringKey1 extends VersionedStatsRe
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsRegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsRegionEntryOffHeapStringKey2.java
@@ -18,7 +18,7 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -32,88 +32,118 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRegionEntryOffHeap {
-  public VersionedStatsRegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, value);
-    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
-    if (byteEncode) {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
-        // keep findbugs happy.
-        if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
-        } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
-        }
-      }
-      tmpBits1 |= 1 << 6;
-    } else {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
-        } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
-        }
-      }
-    }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapStringKey2> lastModifiedUpdater =
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapStringKey2> LAST_MODIFIED_UPDATER =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapStringKey2.class,
           "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
    * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
    * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapStringKey2> ohAddrUpdater =
+  private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapStringKey2> OFF_HEAP_ADDRESS_UPDATER =
       AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapStringKey2.class,
-          "ohAddress");
+          "offHeapAddress");
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryOffHeapStringKey2> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapStringKey2.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryOffHeapStringKey2> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapStringKey2.class,
+          "missCount");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
+  private final long bits1;
+  /**
+   * bits2 encodes character data
+   */
+  private final long bits2;
 
+  public VersionedStatsRegionEntryOffHeapStringKey2(final RegionEntryContext context,
+      final String key, @Retained final Object value, final boolean byteEncode) {
+    super(context, value);
+    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
+    if (byteEncode) {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
+        // keep findbugs happy.
+        if (i < 7) {
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
+        } else {
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
+        }
+      }
+      tempBits1 |= 1 << 6;
+    } else {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        if (i < 3) {
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
+        } else {
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
+        }
+      }
+    }
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
+  }
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -127,24 +157,24 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -155,48 +185,45 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // ---------------------------------------- stats code ------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -204,22 +231,12 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryOffHeapStringKey2> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapStringKey2.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryOffHeapStringKey2> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapStringKey2.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -227,7 +244,7 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -242,24 +259,24 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -269,61 +286,63 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
     return true;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -332,8 +351,9 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -341,38 +361,34 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
-  private final long bits1;
-  // bits2 encodes character data
-  private final long bits2;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -385,28 +401,28 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -415,38 +431,38 @@ public class VersionedStatsRegionEntryOffHeapStringKey2 extends VersionedStatsRe
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsRegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsRegionEntryOffHeapUUIDKey.java
@@ -19,7 +19,7 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -33,26 +33,75 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegionEntryOffHeap {
-  public VersionedStatsRegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapUUIDKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapUUIDKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapUUIDKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapUUIDKey.class,
+          "offHeapAddress");
+  // --------------------------------------- stats fields -----------------------------------------
+  private volatile long lastAccessed;
+  private volatile int hitCount;
+  private volatile int missCount;
+  private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryOffHeapUUIDKey> HIT_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapUUIDKey.class,
+          "hitCount");
+  private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryOffHeapUUIDKey> MISS_COUNT_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapUUIDKey.class,
+          "missCount");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long keyMostSigBits;
+  private final long keyLeastSigBits;
+
+  public VersionedStatsRegionEntryOffHeapUUIDKey(final RegionEntryContext context, final UUID key,
+      @Retained final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.keyMostSigBits = key.getMostSignificantBits();
@@ -60,32 +109,6 @@ public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapUUIDKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapUUIDKey.class,
-          "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VersionedStatsRegionEntryOffHeapUUIDKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapUUIDKey.class, "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -99,24 +122,24 @@ public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegio
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -127,48 +150,45 @@ public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegio
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // stats code
   @Override
-  public void updateStatsForGet(boolean hit, long time) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // ---------------------------------------- stats code ------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void updateStatsForGet(final boolean isHit, final long time) {
     setLastAccessed(time);
-    if (hit) {
+    if (isHit) {
       incrementHitCount();
     } else {
       incrementMissCount();
@@ -176,22 +196,12 @@ public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegio
   }
 
   @Override
-  protected void setLastModifiedAndAccessedTimes(long lastModified, long lastAccessed) {
+  protected void setLastModifiedAndAccessedTimes(final long lastModified, final long lastAccessed) {
     _setLastModified(lastModified);
     if (!DISABLE_ACCESS_TIME_UPDATE_ON_PUT) {
       setLastAccessed(lastAccessed);
     }
   }
-
-  private volatile long lastAccessed;
-  private volatile int hitCount;
-  private volatile int missCount;
-  private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryOffHeapUUIDKey> hitCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapUUIDKey.class,
-          "hitCount");
-  private static final AtomicIntegerFieldUpdater<VersionedStatsRegionEntryOffHeapUUIDKey> missCountUpdater =
-      AtomicIntegerFieldUpdater.newUpdater(VersionedStatsRegionEntryOffHeapUUIDKey.class,
-          "missCount");
 
   @Override
   public long getLastAccessed() throws InternalStatisticsDisabledException {
@@ -199,7 +209,7 @@ public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegio
   }
 
   @Override
-  public void setLastAccessed(long lastAccessed) {
+  public void setLastAccessed(final long lastAccessed) {
     this.lastAccessed = lastAccessed;
   }
 
@@ -214,24 +224,24 @@ public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegio
   }
 
   private void incrementHitCount() {
-    hitCountUpdater.incrementAndGet(this);
+    HIT_COUNT_UPDATER.incrementAndGet(this);
   }
 
   private void incrementMissCount() {
-    missCountUpdater.incrementAndGet(this);
+    MISS_COUNT_UPDATER.incrementAndGet(this);
   }
 
   @Override
   public void resetCounts() throws InternalStatisticsDisabledException {
-    hitCountUpdater.set(this, 0);
-    missCountUpdater.set(this, 0);
+    HIT_COUNT_UPDATER.set(this, 0);
+    MISS_COUNT_UPDATER.set(this, 0);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public void txDidDestroy(long currTime) {
-    setLastModified(currTime);
-    setLastAccessed(currTime);
+  public void txDidDestroy(long timeStamp) {
+    setLastModified(timeStamp);
+    setLastAccessed(timeStamp);
     this.hitCount = 0;
     this.missCount = 0;
   }
@@ -241,61 +251,63 @@ public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegio
     return true;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -304,8 +316,9 @@ public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -313,43 +326,43 @@ public class VersionedStatsRegionEntryOffHeapUUIDKey extends VersionedStatsRegio
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long keyMostSigBits;
-  private final long keyLeastSigBits;
-
   @Override
   public Object getKey() {
     return new UUID(this.keyMostSigBits, this.keyLeastSigBits);
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskLRURegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskLRURegionEntryHeapIntKey.java
@@ -18,15 +18,15 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -35,26 +35,49 @@ import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskLRURegionEntryHeapIntKey extends VersionedThinDiskLRURegionEntryHeap {
-  public VersionedThinDiskLRURegionEntryHeapIntKey(RegionEntryContext context, int key,
-      Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryHeapIntKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryHeapIntKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final int key;
+
+  public VersionedThinDiskLRURegionEntryHeapIntKey(final RegionEntryContext context, final int key,
+      final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -62,78 +85,65 @@ public class VersionedThinDiskLRURegionEntryHeapIntKey extends VersionedThinDisk
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryHeapIntKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryHeapIntKey.class,
-          "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof InternalRegion) {
+      isBackup = ((InternalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
-      throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
+      throw new IllegalArgumentException("expected a InternalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -142,48 +152,43 @@ public class VersionedThinDiskLRURegionEntryHeapIntKey extends VersionedThinDisk
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -191,6 +196,7 @@ public class VersionedThinDiskLRURegionEntryHeapIntKey extends VersionedThinDisk
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -200,48 +206,57 @@ public class VersionedThinDiskLRURegionEntryHeapIntKey extends VersionedThinDisk
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -252,61 +267,63 @@ public class VersionedThinDiskLRURegionEntryHeapIntKey extends VersionedThinDisk
     return null;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -315,8 +332,9 @@ public class VersionedThinDiskLRURegionEntryHeapIntKey extends VersionedThinDisk
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -324,42 +342,43 @@ public class VersionedThinDiskLRURegionEntryHeapIntKey extends VersionedThinDisk
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final int key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskLRURegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskLRURegionEntryHeapLongKey.java
@@ -18,15 +18,15 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -35,27 +35,50 @@ import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskLRURegionEntryHeapLongKey
     extends VersionedThinDiskLRURegionEntryHeap {
-  public VersionedThinDiskLRURegionEntryHeapLongKey(RegionEntryContext context, long key,
-      Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryHeapLongKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryHeapLongKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long key;
+
+  public VersionedThinDiskLRURegionEntryHeapLongKey(final RegionEntryContext context,
+      final long key, final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -63,78 +86,65 @@ public class VersionedThinDiskLRURegionEntryHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryHeapLongKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryHeapLongKey.class,
-          "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof InternalRegion) {
+      isBackup = ((InternalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
-      throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
+      throw new IllegalArgumentException("expected a InternalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -143,48 +153,43 @@ public class VersionedThinDiskLRURegionEntryHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -192,6 +197,7 @@ public class VersionedThinDiskLRURegionEntryHeapLongKey
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -201,48 +207,57 @@ public class VersionedThinDiskLRURegionEntryHeapLongKey
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -253,61 +268,63 @@ public class VersionedThinDiskLRURegionEntryHeapLongKey
     return null;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -316,8 +333,9 @@ public class VersionedThinDiskLRURegionEntryHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -325,42 +343,43 @@ public class VersionedThinDiskLRURegionEntryHeapLongKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskLRURegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskLRURegionEntryHeapObjectKey.java
@@ -18,15 +18,15 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -35,27 +35,50 @@ import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskLRURegionEntryHeapObjectKey
     extends VersionedThinDiskLRURegionEntryHeap {
-  public VersionedThinDiskLRURegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-      Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryHeapObjectKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryHeapObjectKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final Object key;
+
+  public VersionedThinDiskLRURegionEntryHeapObjectKey(final RegionEntryContext context,
+      final Object key, final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -63,78 +86,65 @@ public class VersionedThinDiskLRURegionEntryHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryHeapObjectKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryHeapObjectKey.class,
-          "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof InternalRegion) {
+      isBackup = ((InternalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
-      throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
+      throw new IllegalArgumentException("expected a InternalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -143,48 +153,43 @@ public class VersionedThinDiskLRURegionEntryHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -192,6 +197,7 @@ public class VersionedThinDiskLRURegionEntryHeapObjectKey
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -201,48 +207,57 @@ public class VersionedThinDiskLRURegionEntryHeapObjectKey
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -253,61 +268,63 @@ public class VersionedThinDiskLRURegionEntryHeapObjectKey
     return getKey();
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -316,8 +333,9 @@ public class VersionedThinDiskLRURegionEntryHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -325,33 +343,34 @@ public class VersionedThinDiskLRURegionEntryHeapObjectKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final Object key;
-
   @Override
   public Object getKey() {
     return this.key;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskLRURegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskLRURegionEntryHeapStringKey1.java
@@ -18,15 +18,15 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -35,123 +35,133 @@ import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskLRURegionEntryHeapStringKey1
     extends VersionedThinDiskLRURegionEntryHeap {
-  public VersionedThinDiskLRURegionEntryHeapStringKey1(RegionEntryContext context, String key,
-      Object value, boolean byteEncode) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryHeapStringKey1> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryHeapStringKey1.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long bits1;
+
+  public VersionedThinDiskLRURegionEntryHeapStringKey1(final RegionEntryContext context,
+      final String key, final Object value, final boolean byteEncode) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryHeapStringKey1> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryHeapStringKey1.class,
-          "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof InternalRegion) {
+      isBackup = ((InternalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
-      throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
+      throw new IllegalArgumentException("expected a InternalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -160,48 +170,43 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -209,6 +214,7 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey1
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -218,48 +224,57 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey1
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -270,61 +285,63 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey1
     return null;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -333,8 +350,9 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -342,33 +360,34 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey1
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long bits1;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -381,18 +400,18 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey1
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
     return new String(chars);
@@ -400,25 +419,25 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey1
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskLRURegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskLRURegionEntryHeapStringKey2.java
@@ -18,15 +18,15 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -35,135 +35,154 @@ import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskLRURegionEntryHeapStringKey2
     extends VersionedThinDiskLRURegionEntryHeap {
-  public VersionedThinDiskLRURegionEntryHeapStringKey2(RegionEntryContext context, String key,
-      Object value, boolean byteEncode) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryHeapStringKey2> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryHeapStringKey2.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
+  private final long bits1;
+  /**
+   * bits2 encodes character data
+   */
+  private final long bits2;
+
+  public VersionedThinDiskLRURegionEntryHeapStringKey2(final RegionEntryContext context,
+      final String key, final Object value, final boolean byteEncode) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryHeapStringKey2> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryHeapStringKey2.class,
-          "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof InternalRegion) {
+      isBackup = ((InternalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
-      throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
+      throw new IllegalArgumentException("expected a InternalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -172,48 +191,43 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -221,6 +235,7 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey2
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -230,48 +245,57 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey2
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -282,61 +306,63 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey2
     return null;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -345,8 +371,9 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -354,38 +381,34 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey2
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
-  private final long bits1;
-  // bits2 encodes character data
-  private final long bits2;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -398,28 +421,28 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey2
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -428,38 +451,38 @@ public class VersionedThinDiskLRURegionEntryHeapStringKey2
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskLRURegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskLRURegionEntryHeapUUIDKey.java
@@ -19,15 +19,15 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -36,27 +36,51 @@ import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskLRURegionEntryHeapUUIDKey
     extends VersionedThinDiskLRURegionEntryHeap {
-  public VersionedThinDiskLRURegionEntryHeapUUIDKey(RegionEntryContext context, UUID key,
-      Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryHeapUUIDKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryHeapUUIDKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long keyMostSigBits;
+  private final long keyLeastSigBits;
+
+  public VersionedThinDiskLRURegionEntryHeapUUIDKey(final RegionEntryContext context,
+      final UUID key, final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -65,78 +89,65 @@ public class VersionedThinDiskLRURegionEntryHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryHeapUUIDKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryHeapUUIDKey.class,
-          "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof InternalRegion) {
+      isBackup = ((InternalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
-      throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
+      throw new IllegalArgumentException("expected a InternalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -145,48 +156,43 @@ public class VersionedThinDiskLRURegionEntryHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -194,6 +200,7 @@ public class VersionedThinDiskLRURegionEntryHeapUUIDKey
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -203,48 +210,57 @@ public class VersionedThinDiskLRURegionEntryHeapUUIDKey
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -255,61 +271,63 @@ public class VersionedThinDiskLRURegionEntryHeapUUIDKey
     return null;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -318,8 +336,9 @@ public class VersionedThinDiskLRURegionEntryHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -327,43 +346,43 @@ public class VersionedThinDiskLRURegionEntryHeapUUIDKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long keyMostSigBits;
-  private final long keyLeastSigBits;
-
   @Override
   public Object getKey() {
     return new UUID(this.keyMostSigBits, this.keyLeastSigBits);
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskLRURegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskLRURegionEntryOffHeapIntKey.java
@@ -18,15 +18,15 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -40,27 +40,70 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskLRURegionEntryOffHeapIntKey
     extends VersionedThinDiskLRURegionEntryOffHeap {
-  public VersionedThinDiskLRURegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapIntKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryOffHeapIntKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapIntKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryOffHeapIntKey.class,
+          "offHeapAddress");
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final int key;
+
+  public VersionedThinDiskLRURegionEntryOffHeapIntKey(final RegionEntryContext context,
+      final int key, @Retained final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -68,33 +111,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapIntKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryOffHeapIntKey.class,
-          "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapIntKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryOffHeapIntKey.class,
-          "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -108,24 +124,24 @@ public class VersionedThinDiskLRURegionEntryOffHeapIntKey
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -136,61 +152,58 @@ public class VersionedThinDiskLRURegionEntryOffHeapIntKey
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof InternalRegion) {
+      isBackup = ((InternalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
-      throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
+      throw new IllegalArgumentException("expected a InternalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -199,48 +212,43 @@ public class VersionedThinDiskLRURegionEntryOffHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -248,6 +256,7 @@ public class VersionedThinDiskLRURegionEntryOffHeapIntKey
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -257,48 +266,57 @@ public class VersionedThinDiskLRURegionEntryOffHeapIntKey
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -309,61 +327,63 @@ public class VersionedThinDiskLRURegionEntryOffHeapIntKey
     return null;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -372,8 +392,9 @@ public class VersionedThinDiskLRURegionEntryOffHeapIntKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -381,42 +402,43 @@ public class VersionedThinDiskLRURegionEntryOffHeapIntKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final int key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskLRURegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskLRURegionEntryOffHeapLongKey.java
@@ -18,15 +18,15 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -40,27 +40,70 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskLRURegionEntryOffHeapLongKey
     extends VersionedThinDiskLRURegionEntryOffHeap {
-  public VersionedThinDiskLRURegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapLongKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryOffHeapLongKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapLongKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryOffHeapLongKey.class,
+          "offHeapAddress");
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long key;
+
+  public VersionedThinDiskLRURegionEntryOffHeapLongKey(final RegionEntryContext context,
+      final long key, @Retained final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -68,33 +111,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapLongKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryOffHeapLongKey.class,
-          "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapLongKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryOffHeapLongKey.class,
-          "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -108,24 +124,24 @@ public class VersionedThinDiskLRURegionEntryOffHeapLongKey
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -136,61 +152,58 @@ public class VersionedThinDiskLRURegionEntryOffHeapLongKey
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof InternalRegion) {
+      isBackup = ((InternalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
-      throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
+      throw new IllegalArgumentException("expected a InternalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -199,48 +212,43 @@ public class VersionedThinDiskLRURegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -248,6 +256,7 @@ public class VersionedThinDiskLRURegionEntryOffHeapLongKey
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -257,48 +266,57 @@ public class VersionedThinDiskLRURegionEntryOffHeapLongKey
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -309,61 +327,63 @@ public class VersionedThinDiskLRURegionEntryOffHeapLongKey
     return null;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -372,8 +392,9 @@ public class VersionedThinDiskLRURegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -381,42 +402,43 @@ public class VersionedThinDiskLRURegionEntryOffHeapLongKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskLRURegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskLRURegionEntryOffHeapObjectKey.java
@@ -18,15 +18,15 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -40,27 +40,70 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskLRURegionEntryOffHeapObjectKey
     extends VersionedThinDiskLRURegionEntryOffHeap {
-  public VersionedThinDiskLRURegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapObjectKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryOffHeapObjectKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapObjectKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryOffHeapObjectKey.class,
+          "offHeapAddress");
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final Object key;
+
+  public VersionedThinDiskLRURegionEntryOffHeapObjectKey(final RegionEntryContext context,
+      final Object key, @Retained final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -68,33 +111,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapObjectKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryOffHeapObjectKey.class,
-          "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapObjectKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryOffHeapObjectKey.class,
-          "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -108,24 +124,24 @@ public class VersionedThinDiskLRURegionEntryOffHeapObjectKey
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -136,61 +152,58 @@ public class VersionedThinDiskLRURegionEntryOffHeapObjectKey
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof InternalRegion) {
+      isBackup = ((InternalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
-      throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
+      throw new IllegalArgumentException("expected a InternalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -199,48 +212,43 @@ public class VersionedThinDiskLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -248,6 +256,7 @@ public class VersionedThinDiskLRURegionEntryOffHeapObjectKey
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -257,48 +266,57 @@ public class VersionedThinDiskLRURegionEntryOffHeapObjectKey
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -309,61 +327,63 @@ public class VersionedThinDiskLRURegionEntryOffHeapObjectKey
     return getKey();
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -372,8 +392,9 @@ public class VersionedThinDiskLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -381,33 +402,34 @@ public class VersionedThinDiskLRURegionEntryOffHeapObjectKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final Object key;
-
   @Override
   public Object getKey() {
     return this.key;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskLRURegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskLRURegionEntryOffHeapStringKey1.java
@@ -18,15 +18,15 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -40,78 +40,94 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
     extends VersionedThinDiskLRURegionEntryOffHeap {
-  public VersionedThinDiskLRURegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
-    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-    initialize(context, value);
-    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    if (byteEncode) {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
-        // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
-      }
-      tmpBits1 |= 1 << 6;
-    } else {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
-      }
-    }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapStringKey1> lastModifiedUpdater =
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapStringKey1> LAST_MODIFIED_UPDATER =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryOffHeapStringKey1.class,
           "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
    * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
    * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapStringKey1> ohAddrUpdater =
+  private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapStringKey1> OFF_HEAP_ADDRESS_UPDATER =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryOffHeapStringKey1.class,
-          "ohAddress");
+          "offHeapAddress");
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long bits1;
 
+  public VersionedThinDiskLRURegionEntryOffHeapStringKey1(final RegionEntryContext context,
+      final String key, @Retained final Object value, final boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
+    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+    initialize(context, value);
+    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
+    long tempBits1 = 0L;
+    if (byteEncode) {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
+        // keep findbugs happy.
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
+      }
+      tempBits1 |= 1 << 6;
+    } else {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
+      }
+    }
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+  }
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -125,24 +141,24 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -153,61 +169,58 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof InternalRegion) {
+      isBackup = ((InternalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
-      throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
+      throw new IllegalArgumentException("expected a InternalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -216,48 +229,43 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -265,6 +273,7 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -274,48 +283,57 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -326,61 +344,63 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
     return null;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -389,8 +409,9 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -398,33 +419,34 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long bits1;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -437,18 +459,18 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
     return new String(chars);
@@ -456,25 +478,25 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey1
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskLRURegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskLRURegionEntryOffHeapStringKey2.java
@@ -18,15 +18,15 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -40,90 +40,115 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
     extends VersionedThinDiskLRURegionEntryOffHeap {
-  public VersionedThinDiskLRURegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
-    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-    initialize(context, value);
-    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
-    if (byteEncode) {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
-        // keep findbugs happy.
-        if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
-        } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
-        }
-      }
-      tmpBits1 |= 1 << 6;
-    } else {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
-        } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
-        }
-      }
-    }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapStringKey2> lastModifiedUpdater =
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapStringKey2> LAST_MODIFIED_UPDATER =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryOffHeapStringKey2.class,
           "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
    * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
    * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapStringKey2> ohAddrUpdater =
+  private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapStringKey2> OFF_HEAP_ADDRESS_UPDATER =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryOffHeapStringKey2.class,
-          "ohAddress");
+          "offHeapAddress");
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
+  private final long bits1;
+  /**
+   * bits2 encodes character data
+   */
+  private final long bits2;
 
+  public VersionedThinDiskLRURegionEntryOffHeapStringKey2(final RegionEntryContext context,
+      final String key, @Retained final Object value, final boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
+    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+    initialize(context, value);
+    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
+    if (byteEncode) {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
+        // keep findbugs happy.
+        if (i < 7) {
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
+        } else {
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
+        }
+      }
+      tempBits1 |= 1 << 6;
+    } else {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        if (i < 3) {
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
+        } else {
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
+        }
+      }
+    }
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
+  }
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -137,24 +162,24 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -165,61 +190,58 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof InternalRegion) {
+      isBackup = ((InternalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
-      throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
+      throw new IllegalArgumentException("expected a InternalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -228,48 +250,43 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -277,6 +294,7 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -286,48 +304,57 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -338,61 +365,63 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
     return null;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -401,8 +430,9 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -410,38 +440,34 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
-  private final long bits1;
-  // bits2 encodes character data
-  private final long bits2;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -454,28 +480,28 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -484,38 +510,38 @@ public class VersionedThinDiskLRURegionEntryOffHeapStringKey2
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskLRURegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskLRURegionEntryOffHeapUUIDKey.java
@@ -19,15 +19,15 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -41,27 +41,71 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
     extends VersionedThinDiskLRURegionEntryOffHeap {
-  public VersionedThinDiskLRURegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapUUIDKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryOffHeapUUIDKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapUUIDKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryOffHeapUUIDKey.class,
+          "offHeapAddress");
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long keyMostSigBits;
+  private final long keyLeastSigBits;
+
+  public VersionedThinDiskLRURegionEntryOffHeapUUIDKey(final RegionEntryContext context,
+      final UUID key, @Retained final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -70,33 +114,6 @@ public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapUUIDKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryOffHeapUUIDKey.class,
-          "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VersionedThinDiskLRURegionEntryOffHeapUUIDKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskLRURegionEntryOffHeapUUIDKey.class,
-          "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -110,24 +127,24 @@ public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -138,61 +155,58 @@ public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext drs, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     boolean isBackup;
-    if (drs instanceof LocalRegion) {
-      isBackup = ((LocalRegion) drs).getDiskRegion().isBackup();
-    } else if (drs instanceof PlaceHolderDiskRegion) {
+    if (context instanceof InternalRegion) {
+      isBackup = ((InternalRegion) context).getDiskRegion().isBackup();
+    } else if (context instanceof PlaceHolderDiskRegion) {
       isBackup = true;
     } else {
-      throw new IllegalArgumentException("expected a LocalRegion or PlaceHolderDiskRegion");
+      throw new IllegalArgumentException("expected a InternalRegion or PlaceHolderDiskRegion");
     }
     // Delay the initialization of DiskID if overflow only
     if (isBackup) {
-      diskInitialize(drs, value);
+      diskInitialize(context, value);
     }
   }
 
   @Override
-  public synchronized int updateAsyncEntrySize(EnableLRU capacityController) {
+  public synchronized int updateAsyncEntrySize(final EnableLRU capacityController) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), null);
     setEntrySize(newSize);
@@ -201,48 +215,43 @@ public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
-    DiskStoreImpl ds = r.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    this.id = DiskId.createDiskId(maxOplogSize, false /* over flow only */, ds.needsLinkedList());
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    this.id = DiskId.createDiskId(maxOplogSize, false, diskStore.needsLinkedList());
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -250,6 +259,7 @@ public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -259,48 +269,57 @@ public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -311,61 +330,63 @@ public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
     return null;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -374,8 +395,9 @@ public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -383,43 +405,43 @@ public class VersionedThinDiskLRURegionEntryOffHeapUUIDKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long keyMostSigBits;
-  private final long keyLeastSigBits;
-
   @Override
   public Object getKey() {
     return new UUID(this.keyMostSigBits, this.keyLeastSigBits);
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskRegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskRegionEntryHeapIntKey.java
@@ -17,39 +17,63 @@ package org.apache.geode.internal.cache.entries;
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskRegionEntryHeapIntKey extends VersionedThinDiskRegionEntryHeap {
-  public VersionedThinDiskRegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryHeapIntKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryHeapIntKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final int key;
+
+  public VersionedThinDiskRegionEntryHeapIntKey(final RegionEntryContext context, final int key,
+      final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -57,151 +81,134 @@ public class VersionedThinDiskRegionEntryHeapIntKey extends VersionedThinDiskReg
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryHeapIntKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryHeapIntKey.class,
-          "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
 
+  // -------------------------------------- versioned code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -210,8 +217,9 @@ public class VersionedThinDiskRegionEntryHeapIntKey extends VersionedThinDiskReg
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -219,42 +227,43 @@ public class VersionedThinDiskRegionEntryHeapIntKey extends VersionedThinDiskReg
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final int key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskRegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskRegionEntryHeapLongKey.java
@@ -17,40 +17,63 @@ package org.apache.geode.internal.cache.entries;
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskRegionEntryHeapLongKey extends VersionedThinDiskRegionEntryHeap {
-  public VersionedThinDiskRegionEntryHeapLongKey(RegionEntryContext context, long key,
-      Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryHeapLongKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryHeapLongKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long key;
+
+  public VersionedThinDiskRegionEntryHeapLongKey(final RegionEntryContext context, final long key,
+      final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -58,151 +81,134 @@ public class VersionedThinDiskRegionEntryHeapLongKey extends VersionedThinDiskRe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryHeapLongKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryHeapLongKey.class,
-          "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
 
+  // -------------------------------------- versioned code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -211,8 +217,9 @@ public class VersionedThinDiskRegionEntryHeapLongKey extends VersionedThinDiskRe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -220,42 +227,43 @@ public class VersionedThinDiskRegionEntryHeapLongKey extends VersionedThinDiskRe
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskRegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskRegionEntryHeapObjectKey.java
@@ -17,40 +17,63 @@ package org.apache.geode.internal.cache.entries;
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskRegionEntryHeapObjectKey extends VersionedThinDiskRegionEntryHeap {
-  public VersionedThinDiskRegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-      Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryHeapObjectKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryHeapObjectKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final Object key;
+
+  public VersionedThinDiskRegionEntryHeapObjectKey(final RegionEntryContext context,
+      final Object key, final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -58,151 +81,134 @@ public class VersionedThinDiskRegionEntryHeapObjectKey extends VersionedThinDisk
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryHeapObjectKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryHeapObjectKey.class,
-          "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
 
+  // -------------------------------------- versioned code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -211,8 +217,9 @@ public class VersionedThinDiskRegionEntryHeapObjectKey extends VersionedThinDisk
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -220,33 +227,34 @@ public class VersionedThinDiskRegionEntryHeapObjectKey extends VersionedThinDisk
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final Object key;
-
   @Override
   public Object getKey() {
     return this.key;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskRegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskRegionEntryHeapStringKey1.java
@@ -17,209 +17,215 @@ package org.apache.geode.internal.cache.entries;
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskRegionEntryHeapStringKey1 extends VersionedThinDiskRegionEntryHeap {
-  public VersionedThinDiskRegionEntryHeapStringKey1(RegionEntryContext context, String key,
-      Object value, boolean byteEncode) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryHeapStringKey1> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryHeapStringKey1.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long bits1;
+
+  public VersionedThinDiskRegionEntryHeapStringKey1(final RegionEntryContext context,
+      final String key, final Object value, final boolean byteEncode) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryHeapStringKey1> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryHeapStringKey1.class,
-          "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
 
+  // -------------------------------------- versioned code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -228,8 +234,9 @@ public class VersionedThinDiskRegionEntryHeapStringKey1 extends VersionedThinDis
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -237,33 +244,34 @@ public class VersionedThinDiskRegionEntryHeapStringKey1 extends VersionedThinDis
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long bits1;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -276,18 +284,18 @@ public class VersionedThinDiskRegionEntryHeapStringKey1 extends VersionedThinDis
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
     return new String(chars);
@@ -295,25 +303,25 @@ public class VersionedThinDiskRegionEntryHeapStringKey1 extends VersionedThinDis
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskRegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskRegionEntryHeapStringKey2.java
@@ -17,221 +17,236 @@ package org.apache.geode.internal.cache.entries;
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskRegionEntryHeapStringKey2 extends VersionedThinDiskRegionEntryHeap {
-  public VersionedThinDiskRegionEntryHeapStringKey2(RegionEntryContext context, String key,
-      Object value, boolean byteEncode) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryHeapStringKey2> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryHeapStringKey2.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
+  private final long bits1;
+  /**
+   * bits2 encodes character data
+   */
+  private final long bits2;
+
+  public VersionedThinDiskRegionEntryHeapStringKey2(final RegionEntryContext context,
+      final String key, final Object value, final boolean byteEncode) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryHeapStringKey2> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryHeapStringKey2.class,
-          "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
 
+  // -------------------------------------- versioned code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -240,8 +255,9 @@ public class VersionedThinDiskRegionEntryHeapStringKey2 extends VersionedThinDis
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -249,38 +265,34 @@ public class VersionedThinDiskRegionEntryHeapStringKey2 extends VersionedThinDis
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
-  private final long bits1;
-  // bits2 encodes character data
-  private final long bits2;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -293,28 +305,28 @@ public class VersionedThinDiskRegionEntryHeapStringKey2 extends VersionedThinDis
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -323,38 +335,38 @@ public class VersionedThinDiskRegionEntryHeapStringKey2 extends VersionedThinDis
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskRegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskRegionEntryHeapUUIDKey.java
@@ -18,40 +18,64 @@ package org.apache.geode.internal.cache.entries;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskRegionEntryHeapUUIDKey extends VersionedThinDiskRegionEntryHeap {
-  public VersionedThinDiskRegionEntryHeapUUIDKey(RegionEntryContext context, UUID key,
-      Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryHeapUUIDKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryHeapUUIDKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long keyMostSigBits;
+  private final long keyLeastSigBits;
+
+  public VersionedThinDiskRegionEntryHeapUUIDKey(final RegionEntryContext context, final UUID key,
+      final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -60,151 +84,134 @@ public class VersionedThinDiskRegionEntryHeapUUIDKey extends VersionedThinDiskRe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryHeapUUIDKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryHeapUUIDKey.class,
-          "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
 
+  // -------------------------------------- versioned code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -213,8 +220,9 @@ public class VersionedThinDiskRegionEntryHeapUUIDKey extends VersionedThinDiskRe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -222,43 +230,43 @@ public class VersionedThinDiskRegionEntryHeapUUIDKey extends VersionedThinDiskRe
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long keyMostSigBits;
-  private final long keyLeastSigBits;
-
   @Override
   public Object getKey() {
     return new UUID(this.keyMostSigBits, this.keyLeastSigBits);
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskRegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskRegionEntryOffHeapIntKey.java
@@ -17,14 +17,14 @@ package org.apache.geode.internal.cache.entries;
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
@@ -36,26 +36,69 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskRegionEntryOffHeapIntKey extends VersionedThinDiskRegionEntryOffHeap {
-  public VersionedThinDiskRegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapIntKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryOffHeapIntKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapIntKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryOffHeapIntKey.class,
+          "offHeapAddress");
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final int key;
+
+  public VersionedThinDiskRegionEntryOffHeapIntKey(final RegionEntryContext context, final int key,
+      @Retained final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -63,33 +106,6 @@ public class VersionedThinDiskRegionEntryOffHeapIntKey extends VersionedThinDisk
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapIntKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryOffHeapIntKey.class,
-          "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapIntKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryOffHeapIntKey.class,
-          "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -103,24 +119,24 @@ public class VersionedThinDiskRegionEntryOffHeapIntKey extends VersionedThinDisk
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -131,134 +147,127 @@ public class VersionedThinDiskRegionEntryOffHeapIntKey extends VersionedThinDisk
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
 
+  // -------------------------------------- versioned code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -267,8 +276,9 @@ public class VersionedThinDiskRegionEntryOffHeapIntKey extends VersionedThinDisk
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -276,42 +286,43 @@ public class VersionedThinDiskRegionEntryOffHeapIntKey extends VersionedThinDisk
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final int key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskRegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskRegionEntryOffHeapLongKey.java
@@ -17,14 +17,14 @@ package org.apache.geode.internal.cache.entries;
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
@@ -36,27 +36,70 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskRegionEntryOffHeapLongKey
     extends VersionedThinDiskRegionEntryOffHeap {
-  public VersionedThinDiskRegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapLongKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryOffHeapLongKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapLongKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryOffHeapLongKey.class,
+          "offHeapAddress");
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long key;
+
+  public VersionedThinDiskRegionEntryOffHeapLongKey(final RegionEntryContext context,
+      final long key, @Retained final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -64,33 +107,6 @@ public class VersionedThinDiskRegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapLongKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryOffHeapLongKey.class,
-          "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapLongKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryOffHeapLongKey.class,
-          "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -104,24 +120,24 @@ public class VersionedThinDiskRegionEntryOffHeapLongKey
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -132,134 +148,127 @@ public class VersionedThinDiskRegionEntryOffHeapLongKey
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
 
+  // -------------------------------------- versioned code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -268,8 +277,9 @@ public class VersionedThinDiskRegionEntryOffHeapLongKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -277,42 +287,43 @@ public class VersionedThinDiskRegionEntryOffHeapLongKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskRegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskRegionEntryOffHeapObjectKey.java
@@ -17,14 +17,14 @@ package org.apache.geode.internal.cache.entries;
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
@@ -36,27 +36,70 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskRegionEntryOffHeapObjectKey
     extends VersionedThinDiskRegionEntryOffHeap {
-  public VersionedThinDiskRegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapObjectKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryOffHeapObjectKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapObjectKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryOffHeapObjectKey.class,
+          "offHeapAddress");
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final Object key;
+
+  public VersionedThinDiskRegionEntryOffHeapObjectKey(final RegionEntryContext context,
+      final Object key, @Retained final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -64,33 +107,6 @@ public class VersionedThinDiskRegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapObjectKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryOffHeapObjectKey.class,
-          "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapObjectKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryOffHeapObjectKey.class,
-          "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -104,24 +120,24 @@ public class VersionedThinDiskRegionEntryOffHeapObjectKey
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -132,134 +148,127 @@ public class VersionedThinDiskRegionEntryOffHeapObjectKey
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
 
+  // -------------------------------------- versioned code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -268,8 +277,9 @@ public class VersionedThinDiskRegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -277,33 +287,34 @@ public class VersionedThinDiskRegionEntryOffHeapObjectKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final Object key;
-
   @Override
   public Object getKey() {
     return this.key;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskRegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskRegionEntryOffHeapStringKey1.java
@@ -17,14 +17,14 @@ package org.apache.geode.internal.cache.entries;
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
@@ -36,78 +36,94 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskRegionEntryOffHeapStringKey1
     extends VersionedThinDiskRegionEntryOffHeap {
-  public VersionedThinDiskRegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
-    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-    initialize(context, value);
-    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    if (byteEncode) {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
-        // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
-      }
-      tmpBits1 |= 1 << 6;
-    } else {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
-      }
-    }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapStringKey1> lastModifiedUpdater =
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapStringKey1> LAST_MODIFIED_UPDATER =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryOffHeapStringKey1.class,
           "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
    * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
    * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapStringKey1> ohAddrUpdater =
+  private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapStringKey1> OFF_HEAP_ADDRESS_UPDATER =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryOffHeapStringKey1.class,
-          "ohAddress");
+          "offHeapAddress");
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long bits1;
 
+  public VersionedThinDiskRegionEntryOffHeapStringKey1(final RegionEntryContext context,
+      final String key, @Retained final Object value, final boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
+    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+    initialize(context, value);
+    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
+    long tempBits1 = 0L;
+    if (byteEncode) {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
+        // keep findbugs happy.
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
+      }
+      tempBits1 |= 1 << 6;
+    } else {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
+      }
+    }
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+  }
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -121,24 +137,24 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey1
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -149,134 +165,127 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey1
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
 
+  // -------------------------------------- versioned code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -285,8 +294,9 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -294,33 +304,34 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey1
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long bits1;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -333,18 +344,18 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey1
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
     return new String(chars);
@@ -352,25 +363,25 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey1
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskRegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskRegionEntryOffHeapStringKey2.java
@@ -17,14 +17,14 @@ package org.apache.geode.internal.cache.entries;
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
@@ -36,90 +36,115 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskRegionEntryOffHeapStringKey2
     extends VersionedThinDiskRegionEntryOffHeap {
-  public VersionedThinDiskRegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, (value instanceof RecoveredEntry ? null : value));
-    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-    initialize(context, value);
-    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
-    if (byteEncode) {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
-        // keep findbugs happy.
-        if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
-        } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
-        }
-      }
-      tmpBits1 |= 1 << 6;
-    } else {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
-        } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
-        }
-      }
-    }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapStringKey2> lastModifiedUpdater =
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapStringKey2> LAST_MODIFIED_UPDATER =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryOffHeapStringKey2.class,
           "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
    * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
    * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapStringKey2> ohAddrUpdater =
+  private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapStringKey2> OFF_HEAP_ADDRESS_UPDATER =
       AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryOffHeapStringKey2.class,
-          "ohAddress");
+          "offHeapAddress");
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
+  private final long bits1;
+  /**
+   * bits2 encodes character data
+   */
+  private final long bits2;
 
+  public VersionedThinDiskRegionEntryOffHeapStringKey2(final RegionEntryContext context,
+      final String key, @Retained final Object value, final boolean byteEncode) {
+    super(context, (value instanceof RecoveredEntry ? null : value));
+    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+    initialize(context, value);
+    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
+    if (byteEncode) {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
+        // keep findbugs happy.
+        if (i < 7) {
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
+        } else {
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
+        }
+      }
+      tempBits1 |= 1 << 6;
+    } else {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        if (i < 3) {
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
+        } else {
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
+        }
+      }
+    }
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
+  }
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -133,24 +158,24 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey2
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -161,134 +186,127 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey2
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
 
+  // -------------------------------------- versioned code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -297,8 +315,9 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -306,38 +325,34 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey2
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
-  private final long bits1;
-  // bits2 encodes character data
-  private final long bits2;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -350,28 +365,28 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey2
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -380,38 +395,38 @@ public class VersionedThinDiskRegionEntryOffHeapStringKey2
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskRegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskRegionEntryOffHeapUUIDKey.java
@@ -18,14 +18,14 @@ package org.apache.geode.internal.cache.entries;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.DiskId;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.PlaceHolderDiskRegion;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
@@ -37,27 +37,71 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinDiskRegionEntryOffHeapUUIDKey
     extends VersionedThinDiskRegionEntryOffHeap {
-  public VersionedThinDiskRegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapUUIDKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryOffHeapUUIDKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapUUIDKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryOffHeapUUIDKey.class,
+          "offHeapAddress");
+  // ---------------------------------------- disk fields -----------------------------------------
+  /**
+   * @since GemFire 5.1
+   */
+  protected DiskId id;
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long keyMostSigBits;
+  private final long keyLeastSigBits;
+
+  public VersionedThinDiskRegionEntryOffHeapUUIDKey(final RegionEntryContext context,
+      final UUID key, @Retained final Object value) {
     super(context, (value instanceof RecoveredEntry ? null : value));
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     initialize(context, value);
@@ -66,33 +110,6 @@ public class VersionedThinDiskRegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapUUIDKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryOffHeapUUIDKey.class,
-          "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VersionedThinDiskRegionEntryOffHeapUUIDKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinDiskRegionEntryOffHeapUUIDKey.class,
-          "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -106,24 +123,24 @@ public class VersionedThinDiskRegionEntryOffHeapUUIDKey
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -134,134 +151,127 @@ public class VersionedThinDiskRegionEntryOffHeapUUIDKey
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // ----------------------------------------- disk code ------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // disk code
-  protected void initialize(RegionEntryContext context, Object value) {
+  protected void initialize(final RegionEntryContext context, final Object value) {
     diskInitialize(context, value);
   }
 
   @Override
-  public int updateAsyncEntrySize(EnableLRU capacityController) {
+  public int updateAsyncEntrySize(final EnableLRU capacityController) {
     throw new IllegalStateException("should never be called");
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  private void diskInitialize(RegionEntryContext context, Object value) {
-    DiskRecoveryStore drs = (DiskRecoveryStore) context;
-    DiskStoreImpl ds = drs.getDiskStore();
-    long maxOplogSize = ds.getMaxOplogSize();
-    // get appropriate instance of DiskId implementation based on maxOplogSize
-    this.id = DiskId.createDiskId(maxOplogSize, true/* is persistence */, ds.needsLinkedList());
-    Helper.initialize(this, drs, value);
-  }
-
-  /**
-   * DiskId
-   * 
-   * @since GemFire 5.1
-   */
-  protected DiskId id;// = new DiskId();
-
+  @Override
   public DiskId getDiskId() {
     return this.id;
   }
 
   @Override
-  public void setDiskId(RegionEntry old) {
-    this.id = ((AbstractDiskRegionEntry) old).getDiskId();
+  public void setDiskId(final RegionEntry oldEntry) {
+    this.id = ((DiskEntry) oldEntry).getDiskId();
   }
 
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
+  private void diskInitialize(final RegionEntryContext context, final Object value) {
+    DiskRecoveryStore diskRecoveryStore = (DiskRecoveryStore) context;
+    DiskStoreImpl diskStore = diskRecoveryStore.getDiskStore();
+    long maxOplogSize = diskStore.getMaxOplogSize();
+    // get appropriate instance of DiskId implementation based on maxOplogSize
+    this.id = DiskId.createDiskId(maxOplogSize, true, diskStore.needsLinkedList());
+    Helper.initialize(this, diskRecoveryStore, value);
+  }
 
+  // -------------------------------------- versioned code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -270,8 +280,9 @@ public class VersionedThinDiskRegionEntryOffHeapUUIDKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -279,43 +290,43 @@ public class VersionedThinDiskRegionEntryOffHeapUUIDKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long keyMostSigBits;
-  private final long keyLeastSigBits;
-
   @Override
   public Object getKey() {
     return new UUID(this.keyMostSigBits, this.keyLeastSigBits);
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinLRURegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinLRURegionEntryHeapIntKey.java
@@ -18,10 +18,11 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -30,99 +31,106 @@ import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinLRURegionEntryHeapIntKey extends VersionedThinLRURegionEntryHeap {
-  public VersionedThinLRURegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryHeapIntKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryHeapIntKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final int key;
+
+  public VersionedThinLRURegionEntryHeapIntKey(final RegionEntryContext context, final int key,
+      final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.key = key;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryHeapIntKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryHeapIntKey.class,
-          "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
     // nothing needed for LRUs with no disk
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -130,6 +138,7 @@ public class VersionedThinLRURegionEntryHeapIntKey extends VersionedThinLRURegio
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -139,48 +148,57 @@ public class VersionedThinLRURegionEntryHeapIntKey extends VersionedThinLRURegio
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -191,61 +209,63 @@ public class VersionedThinLRURegionEntryHeapIntKey extends VersionedThinLRURegio
     return null;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -254,8 +274,9 @@ public class VersionedThinLRURegionEntryHeapIntKey extends VersionedThinLRURegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -263,42 +284,43 @@ public class VersionedThinLRURegionEntryHeapIntKey extends VersionedThinLRURegio
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final int key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinLRURegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinLRURegionEntryHeapLongKey.java
@@ -18,10 +18,11 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -30,100 +31,106 @@ import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinLRURegionEntryHeapLongKey extends VersionedThinLRURegionEntryHeap {
-  public VersionedThinLRURegionEntryHeapLongKey(RegionEntryContext context, long key,
-      Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryHeapLongKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryHeapLongKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long key;
+
+  public VersionedThinLRURegionEntryHeapLongKey(final RegionEntryContext context, final long key,
+      final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.key = key;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryHeapLongKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryHeapLongKey.class,
-          "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
     // nothing needed for LRUs with no disk
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -131,6 +138,7 @@ public class VersionedThinLRURegionEntryHeapLongKey extends VersionedThinLRURegi
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -140,48 +148,57 @@ public class VersionedThinLRURegionEntryHeapLongKey extends VersionedThinLRURegi
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -192,61 +209,63 @@ public class VersionedThinLRURegionEntryHeapLongKey extends VersionedThinLRURegi
     return null;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -255,8 +274,9 @@ public class VersionedThinLRURegionEntryHeapLongKey extends VersionedThinLRURegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -264,42 +284,43 @@ public class VersionedThinLRURegionEntryHeapLongKey extends VersionedThinLRURegi
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinLRURegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinLRURegionEntryHeapObjectKey.java
@@ -18,10 +18,11 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -30,100 +31,106 @@ import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinLRURegionEntryHeapObjectKey extends VersionedThinLRURegionEntryHeap {
-  public VersionedThinLRURegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-      Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryHeapObjectKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryHeapObjectKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final Object key;
+
+  public VersionedThinLRURegionEntryHeapObjectKey(final RegionEntryContext context,
+      final Object key, final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.key = key;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryHeapObjectKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryHeapObjectKey.class,
-          "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
     // nothing needed for LRUs with no disk
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -131,6 +138,7 @@ public class VersionedThinLRURegionEntryHeapObjectKey extends VersionedThinLRURe
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -140,48 +148,57 @@ public class VersionedThinLRURegionEntryHeapObjectKey extends VersionedThinLRURe
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -192,61 +209,63 @@ public class VersionedThinLRURegionEntryHeapObjectKey extends VersionedThinLRURe
     return getKey();
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -255,8 +274,9 @@ public class VersionedThinLRURegionEntryHeapObjectKey extends VersionedThinLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -264,33 +284,34 @@ public class VersionedThinLRURegionEntryHeapObjectKey extends VersionedThinLRURe
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final Object key;
-
   @Override
   public Object getKey() {
     return this.key;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinLRURegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinLRURegionEntryHeapStringKey1.java
@@ -18,10 +18,11 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -30,117 +31,123 @@ import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinLRURegionEntryHeapStringKey1 extends VersionedThinLRURegionEntryHeap {
-  public VersionedThinLRURegionEntryHeapStringKey1(RegionEntryContext context, String key,
-      Object value, boolean byteEncode) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryHeapStringKey1> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryHeapStringKey1.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long bits1;
+
+  public VersionedThinLRURegionEntryHeapStringKey1(final RegionEntryContext context,
+      final String key, final Object value, final boolean byteEncode) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryHeapStringKey1> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryHeapStringKey1.class,
-          "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
     // nothing needed for LRUs with no disk
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -148,6 +155,7 @@ public class VersionedThinLRURegionEntryHeapStringKey1 extends VersionedThinLRUR
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -157,48 +165,57 @@ public class VersionedThinLRURegionEntryHeapStringKey1 extends VersionedThinLRUR
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -209,61 +226,63 @@ public class VersionedThinLRURegionEntryHeapStringKey1 extends VersionedThinLRUR
     return null;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -272,8 +291,9 @@ public class VersionedThinLRURegionEntryHeapStringKey1 extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -281,33 +301,34 @@ public class VersionedThinLRURegionEntryHeapStringKey1 extends VersionedThinLRUR
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long bits1;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -320,18 +341,18 @@ public class VersionedThinLRURegionEntryHeapStringKey1 extends VersionedThinLRUR
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
     return new String(chars);
@@ -339,25 +360,25 @@ public class VersionedThinLRURegionEntryHeapStringKey1 extends VersionedThinLRUR
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinLRURegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinLRURegionEntryHeapStringKey2.java
@@ -18,10 +18,11 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -30,129 +31,144 @@ import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinLRURegionEntryHeapStringKey2 extends VersionedThinLRURegionEntryHeap {
-  public VersionedThinLRURegionEntryHeapStringKey2(RegionEntryContext context, String key,
-      Object value, boolean byteEncode) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryHeapStringKey2> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryHeapStringKey2.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
+  private final long bits1;
+  /**
+   * bits2 encodes character data
+   */
+  private final long bits2;
+
+  public VersionedThinLRURegionEntryHeapStringKey2(final RegionEntryContext context,
+      final String key, final Object value, final boolean byteEncode) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryHeapStringKey2> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryHeapStringKey2.class,
-          "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
     // nothing needed for LRUs with no disk
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -160,6 +176,7 @@ public class VersionedThinLRURegionEntryHeapStringKey2 extends VersionedThinLRUR
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -169,48 +186,57 @@ public class VersionedThinLRURegionEntryHeapStringKey2 extends VersionedThinLRUR
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -221,61 +247,63 @@ public class VersionedThinLRURegionEntryHeapStringKey2 extends VersionedThinLRUR
     return null;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -284,8 +312,9 @@ public class VersionedThinLRURegionEntryHeapStringKey2 extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -293,38 +322,34 @@ public class VersionedThinLRURegionEntryHeapStringKey2 extends VersionedThinLRUR
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
-  private final long bits1;
-  // bits2 encodes character data
-  private final long bits2;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -337,28 +362,28 @@ public class VersionedThinLRURegionEntryHeapStringKey2 extends VersionedThinLRUR
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -367,38 +392,38 @@ public class VersionedThinLRURegionEntryHeapStringKey2 extends VersionedThinLRUR
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinLRURegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinLRURegionEntryHeapUUIDKey.java
@@ -19,10 +19,11 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -31,26 +32,45 @@ import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinLRURegionEntryHeapUUIDKey extends VersionedThinLRURegionEntryHeap {
-  public VersionedThinLRURegionEntryHeapUUIDKey(RegionEntryContext context, UUID key,
-      Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryHeapUUIDKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryHeapUUIDKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long keyMostSigBits;
+  private final long keyLeastSigBits;
+
+  public VersionedThinLRURegionEntryHeapUUIDKey(final RegionEntryContext context, final UUID key,
+      final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.keyMostSigBits = key.getMostSignificantBits();
@@ -58,74 +78,62 @@ public class VersionedThinLRURegionEntryHeapUUIDKey extends VersionedThinLRURegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryHeapUUIDKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryHeapUUIDKey.class,
-          "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
     // nothing needed for LRUs with no disk
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -133,6 +141,7 @@ public class VersionedThinLRURegionEntryHeapUUIDKey extends VersionedThinLRURegi
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -142,48 +151,57 @@ public class VersionedThinLRURegionEntryHeapUUIDKey extends VersionedThinLRURegi
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -194,61 +212,63 @@ public class VersionedThinLRURegionEntryHeapUUIDKey extends VersionedThinLRURegi
     return null;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -257,8 +277,9 @@ public class VersionedThinLRURegionEntryHeapUUIDKey extends VersionedThinLRURegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -266,43 +287,43 @@ public class VersionedThinLRURegionEntryHeapUUIDKey extends VersionedThinLRURegi
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long keyMostSigBits;
-  private final long keyLeastSigBits;
-
   @Override
   public Object getKey() {
     return new UUID(this.keyMostSigBits, this.keyLeastSigBits);
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinLRURegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinLRURegionEntryOffHeapIntKey.java
@@ -18,10 +18,11 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -35,59 +36,70 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinLRURegionEntryOffHeapIntKey extends VersionedThinLRURegionEntryOffHeap {
-  public VersionedThinLRURegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapIntKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryOffHeapIntKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapIntKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryOffHeapIntKey.class,
+          "offHeapAddress");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final int key;
+
+  public VersionedThinLRURegionEntryOffHeapIntKey(final RegionEntryContext context, final int key,
+      @Retained final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.key = key;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapIntKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryOffHeapIntKey.class,
-          "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapIntKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryOffHeapIntKey.class,
-          "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -101,24 +113,24 @@ public class VersionedThinLRURegionEntryOffHeapIntKey extends VersionedThinLRURe
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -129,57 +141,55 @@ public class VersionedThinLRURegionEntryOffHeapIntKey extends VersionedThinLRURe
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
     // nothing needed for LRUs with no disk
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -187,6 +197,7 @@ public class VersionedThinLRURegionEntryOffHeapIntKey extends VersionedThinLRURe
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -196,48 +207,57 @@ public class VersionedThinLRURegionEntryOffHeapIntKey extends VersionedThinLRURe
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -248,61 +268,63 @@ public class VersionedThinLRURegionEntryOffHeapIntKey extends VersionedThinLRURe
     return null;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -311,8 +333,9 @@ public class VersionedThinLRURegionEntryOffHeapIntKey extends VersionedThinLRURe
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -320,42 +343,43 @@ public class VersionedThinLRURegionEntryOffHeapIntKey extends VersionedThinLRURe
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final int key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinLRURegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinLRURegionEntryOffHeapLongKey.java
@@ -18,10 +18,11 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -35,59 +36,70 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinLRURegionEntryOffHeapLongKey extends VersionedThinLRURegionEntryOffHeap {
-  public VersionedThinLRURegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapLongKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryOffHeapLongKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapLongKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryOffHeapLongKey.class,
+          "offHeapAddress");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long key;
+
+  public VersionedThinLRURegionEntryOffHeapLongKey(final RegionEntryContext context, final long key,
+      @Retained final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.key = key;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapLongKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryOffHeapLongKey.class,
-          "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapLongKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryOffHeapLongKey.class,
-          "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -101,24 +113,24 @@ public class VersionedThinLRURegionEntryOffHeapLongKey extends VersionedThinLRUR
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -129,57 +141,55 @@ public class VersionedThinLRURegionEntryOffHeapLongKey extends VersionedThinLRUR
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
     // nothing needed for LRUs with no disk
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -187,6 +197,7 @@ public class VersionedThinLRURegionEntryOffHeapLongKey extends VersionedThinLRUR
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -196,48 +207,57 @@ public class VersionedThinLRURegionEntryOffHeapLongKey extends VersionedThinLRUR
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -248,61 +268,63 @@ public class VersionedThinLRURegionEntryOffHeapLongKey extends VersionedThinLRUR
     return null;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -311,8 +333,9 @@ public class VersionedThinLRURegionEntryOffHeapLongKey extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -320,42 +343,43 @@ public class VersionedThinLRURegionEntryOffHeapLongKey extends VersionedThinLRUR
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinLRURegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinLRURegionEntryOffHeapObjectKey.java
@@ -18,10 +18,11 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -35,60 +36,71 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinLRURegionEntryOffHeapObjectKey
     extends VersionedThinLRURegionEntryOffHeap {
-  public VersionedThinLRURegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapObjectKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryOffHeapObjectKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapObjectKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryOffHeapObjectKey.class,
+          "offHeapAddress");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final Object key;
+
+  public VersionedThinLRURegionEntryOffHeapObjectKey(final RegionEntryContext context,
+      final Object key, @Retained final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.key = key;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapObjectKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryOffHeapObjectKey.class,
-          "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapObjectKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryOffHeapObjectKey.class,
-          "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -102,24 +114,24 @@ public class VersionedThinLRURegionEntryOffHeapObjectKey
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -130,57 +142,55 @@ public class VersionedThinLRURegionEntryOffHeapObjectKey
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
     // nothing needed for LRUs with no disk
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -188,6 +198,7 @@ public class VersionedThinLRURegionEntryOffHeapObjectKey
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -197,48 +208,57 @@ public class VersionedThinLRURegionEntryOffHeapObjectKey
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -249,61 +269,63 @@ public class VersionedThinLRURegionEntryOffHeapObjectKey
     return getKey();
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -312,8 +334,9 @@ public class VersionedThinLRURegionEntryOffHeapObjectKey
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -321,33 +344,34 @@ public class VersionedThinLRURegionEntryOffHeapObjectKey
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final Object key;
-
   @Override
   public Object getKey() {
     return this.key;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinLRURegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinLRURegionEntryOffHeapStringKey1.java
@@ -18,10 +18,11 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -35,77 +36,88 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinLRURegionEntryOffHeapStringKey1
     extends VersionedThinLRURegionEntryOffHeap {
-  public VersionedThinLRURegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, value);
-    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    if (byteEncode) {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
-        // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
-      }
-      tmpBits1 |= 1 << 6;
-    } else {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
-      }
-    }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapStringKey1> lastModifiedUpdater =
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapStringKey1> LAST_MODIFIED_UPDATER =
       AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryOffHeapStringKey1.class,
           "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
    * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
    * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapStringKey1> ohAddrUpdater =
+  private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapStringKey1> OFF_HEAP_ADDRESS_UPDATER =
       AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryOffHeapStringKey1.class,
-          "ohAddress");
+          "offHeapAddress");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long bits1;
 
+  public VersionedThinLRURegionEntryOffHeapStringKey1(final RegionEntryContext context,
+      final String key, @Retained final Object value, final boolean byteEncode) {
+    super(context, value);
+    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
+    long tempBits1 = 0L;
+    if (byteEncode) {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
+        // keep findbugs happy.
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
+      }
+      tempBits1 |= 1 << 6;
+    } else {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
+      }
+    }
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+  }
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -119,24 +131,24 @@ public class VersionedThinLRURegionEntryOffHeapStringKey1
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -147,57 +159,55 @@ public class VersionedThinLRURegionEntryOffHeapStringKey1
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
     // nothing needed for LRUs with no disk
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -205,6 +215,7 @@ public class VersionedThinLRURegionEntryOffHeapStringKey1
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -214,48 +225,57 @@ public class VersionedThinLRURegionEntryOffHeapStringKey1
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -266,61 +286,63 @@ public class VersionedThinLRURegionEntryOffHeapStringKey1
     return null;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -329,8 +351,9 @@ public class VersionedThinLRURegionEntryOffHeapStringKey1
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -338,33 +361,34 @@ public class VersionedThinLRURegionEntryOffHeapStringKey1
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long bits1;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -377,18 +401,18 @@ public class VersionedThinLRURegionEntryOffHeapStringKey1
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
     return new String(chars);
@@ -396,25 +420,25 @@ public class VersionedThinLRURegionEntryOffHeapStringKey1
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinLRURegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinLRURegionEntryOffHeapStringKey2.java
@@ -18,10 +18,11 @@ package org.apache.geode.internal.cache.entries;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -35,89 +36,109 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinLRURegionEntryOffHeapStringKey2
     extends VersionedThinLRURegionEntryOffHeap {
-  public VersionedThinLRURegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, value);
-    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
-    if (byteEncode) {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
-        // keep findbugs happy.
-        if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
-        } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
-        }
-      }
-      tmpBits1 |= 1 << 6;
-    } else {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
-        } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
-        }
-      }
-    }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapStringKey2> lastModifiedUpdater =
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapStringKey2> LAST_MODIFIED_UPDATER =
       AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryOffHeapStringKey2.class,
           "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
    * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
    * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapStringKey2> ohAddrUpdater =
+  private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapStringKey2> OFF_HEAP_ADDRESS_UPDATER =
       AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryOffHeapStringKey2.class,
-          "ohAddress");
+          "offHeapAddress");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
+  private final long bits1;
+  /**
+   * bits2 encodes character data
+   */
+  private final long bits2;
 
+  public VersionedThinLRURegionEntryOffHeapStringKey2(final RegionEntryContext context,
+      final String key, @Retained final Object value, final boolean byteEncode) {
+    super(context, value);
+    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
+    if (byteEncode) {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
+        // keep findbugs happy.
+        if (i < 7) {
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
+        } else {
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
+        }
+      }
+      tempBits1 |= 1 << 6;
+    } else {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        if (i < 3) {
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
+        } else {
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
+        }
+      }
+    }
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
+  }
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -131,24 +152,24 @@ public class VersionedThinLRURegionEntryOffHeapStringKey2
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -159,57 +180,55 @@ public class VersionedThinLRURegionEntryOffHeapStringKey2
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
     // nothing needed for LRUs with no disk
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -217,6 +236,7 @@ public class VersionedThinLRURegionEntryOffHeapStringKey2
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -226,48 +246,57 @@ public class VersionedThinLRURegionEntryOffHeapStringKey2
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -278,61 +307,63 @@ public class VersionedThinLRURegionEntryOffHeapStringKey2
     return null;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -341,8 +372,9 @@ public class VersionedThinLRURegionEntryOffHeapStringKey2
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -350,38 +382,34 @@ public class VersionedThinLRURegionEntryOffHeapStringKey2
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
-  private final long bits1;
-  // bits2 encodes character data
-  private final long bits2;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -394,28 +422,28 @@ public class VersionedThinLRURegionEntryOffHeapStringKey2
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -424,38 +452,38 @@ public class VersionedThinLRURegionEntryOffHeapStringKey2
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinLRURegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinLRURegionEntryOffHeapUUIDKey.java
@@ -19,10 +19,11 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.lru.EnableLRU;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.lru.LRUClockNode;
 import org.apache.geode.internal.cache.lru.NewLRUClockHand;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -36,26 +37,65 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinLRURegionEntryOffHeapUUIDKey extends VersionedThinLRURegionEntryOffHeap {
-  public VersionedThinLRURegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapUUIDKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryOffHeapUUIDKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapUUIDKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryOffHeapUUIDKey.class,
+          "offHeapAddress");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long keyMostSigBits;
+  private final long keyLeastSigBits;
+
+  public VersionedThinLRURegionEntryOffHeapUUIDKey(final RegionEntryContext context, final UUID key,
+      @Retained final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.keyMostSigBits = key.getMostSignificantBits();
@@ -63,33 +103,6 @@ public class VersionedThinLRURegionEntryOffHeapUUIDKey extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapUUIDKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryOffHeapUUIDKey.class,
-          "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VersionedThinLRURegionEntryOffHeapUUIDKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinLRURegionEntryOffHeapUUIDKey.class,
-          "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -103,24 +116,24 @@ public class VersionedThinLRURegionEntryOffHeapUUIDKey extends VersionedThinLRUR
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -131,57 +144,55 @@ public class VersionedThinLRURegionEntryOffHeapUUIDKey extends VersionedThinLRUR
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
-  }
-
-  /**
-   * @see HashEntry#getNextEntry()
-   */
-  public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
-  }
-
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // lru code
   @Override
-  public void setDelayedDiskId(LocalRegion r) {
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
+  }
+
+  @Override
+  public HashEntry<Object, Object> getNextEntry() {
+    return this.nextEntry;
+  }
+
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
+  }
+
+  // --------------------------------------- eviction code ----------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
+  public void setDelayedDiskId(final DiskRecoveryStore diskRecoveryStore) {
     // nothing needed for LRUs with no disk
   }
 
-  public synchronized int updateEntrySize(EnableLRU capacityController) {
-    return updateEntrySize(capacityController, _getValue()); // OFHEAP: _getValue ok w/o incing
-                                                             // refcount because we are synced and
-                                                             // only getting the size
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController) {
+    // OFFHEAP: getValue ok w/o incing refcount because we are synced and only getting the size
+    return updateEntrySize(capacityController, getValue());
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public synchronized int updateEntrySize(EnableLRU capacityController, Object value) {
+  @Override
+  public synchronized int updateEntrySize(final EnableLRU capacityController, final Object value) {
     int oldSize = getEntrySize();
     int newSize = capacityController.entrySize(getKeyForSizing(), value);
     setEntrySize(newSize);
@@ -189,6 +200,7 @@ public class VersionedThinLRURegionEntryOffHeapUUIDKey extends VersionedThinLRUR
     return delta;
   }
 
+  @Override
   public boolean testRecentlyUsed() {
     return areAnyBitsSet(RECENTLY_USED);
   }
@@ -198,48 +210,57 @@ public class VersionedThinLRURegionEntryOffHeapUUIDKey extends VersionedThinLRUR
     setBits(RECENTLY_USED);
   }
 
+  @Override
   public void unsetRecentlyUsed() {
     clearBits(~RECENTLY_USED);
   }
 
+  @Override
   public boolean testEvicted() {
     return areAnyBitsSet(EVICTED);
   }
 
+  @Override
   public void setEvicted() {
     setBits(EVICTED);
   }
 
+  @Override
   public void unsetEvicted() {
     clearBits(~EVICTED);
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   private LRUClockNode nextLRU;
-  private LRUClockNode prevLRU;
+  private LRUClockNode previousLRU;
   private int size;
 
-  public void setNextLRUNode(LRUClockNode next) {
-    this.nextLRU = next;
+  @Override
+  public void setNextLRUNode(final LRUClockNode nextLRU) {
+    this.nextLRU = nextLRU;
   }
 
+  @Override
   public LRUClockNode nextLRUNode() {
     return this.nextLRU;
   }
 
-  public void setPrevLRUNode(LRUClockNode prev) {
-    this.prevLRU = prev;
+  @Override
+  public void setPrevLRUNode(final LRUClockNode previousLRU) {
+    this.previousLRU = previousLRU;
   }
 
+  @Override
   public LRUClockNode prevLRUNode() {
-    return this.prevLRU;
+    return this.previousLRU;
   }
 
+  @Override
   public int getEntrySize() {
     return this.size;
   }
 
-  protected void setEntrySize(int size) {
+  protected void setEntrySize(final int size) {
     this.size = size;
   }
 
@@ -250,61 +271,63 @@ public class VersionedThinLRURegionEntryOffHeapUUIDKey extends VersionedThinLRUR
     return null;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -313,8 +336,9 @@ public class VersionedThinLRURegionEntryOffHeapUUIDKey extends VersionedThinLRUR
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -322,43 +346,43 @@ public class VersionedThinLRURegionEntryOffHeapUUIDKey extends VersionedThinLRUR
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long keyMostSigBits;
-  private final long keyLeastSigBits;
-
   @Override
   public Object getKey() {
     return new UUID(this.keyMostSigBits, this.keyLeastSigBits);
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinRegionEntryHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinRegionEntryHeapIntKey.java
@@ -17,7 +17,7 @@ package org.apache.geode.internal.cache.entries;
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
@@ -25,138 +25,146 @@ import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinRegionEntryHeapIntKey extends VersionedThinRegionEntryHeap {
-  public VersionedThinRegionEntryHeapIntKey(RegionEntryContext context, int key, Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedThinRegionEntryHeapIntKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryHeapIntKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final int key;
+
+  public VersionedThinRegionEntryHeapIntKey(final RegionEntryContext context, final int key,
+      final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.key = key;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedThinRegionEntryHeapIntKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryHeapIntKey.class, "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -165,8 +173,9 @@ public class VersionedThinRegionEntryHeapIntKey extends VersionedThinRegionEntry
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -174,42 +183,43 @@ public class VersionedThinRegionEntryHeapIntKey extends VersionedThinRegionEntry
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final int key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinRegionEntryHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinRegionEntryHeapLongKey.java
@@ -17,7 +17,7 @@ package org.apache.geode.internal.cache.entries;
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
@@ -25,138 +25,146 @@ import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinRegionEntryHeapLongKey extends VersionedThinRegionEntryHeap {
-  public VersionedThinRegionEntryHeapLongKey(RegionEntryContext context, long key, Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedThinRegionEntryHeapLongKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryHeapLongKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long key;
+
+  public VersionedThinRegionEntryHeapLongKey(final RegionEntryContext context, final long key,
+      final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.key = key;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedThinRegionEntryHeapLongKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryHeapLongKey.class, "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -165,8 +173,9 @@ public class VersionedThinRegionEntryHeapLongKey extends VersionedThinRegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -174,42 +183,43 @@ public class VersionedThinRegionEntryHeapLongKey extends VersionedThinRegionEntr
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinRegionEntryHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinRegionEntryHeapObjectKey.java
@@ -17,7 +17,7 @@ package org.apache.geode.internal.cache.entries;
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
@@ -25,140 +25,147 @@ import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinRegionEntryHeapObjectKey extends VersionedThinRegionEntryHeap {
-  public VersionedThinRegionEntryHeapObjectKey(RegionEntryContext context, Object key,
-      Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedThinRegionEntryHeapObjectKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryHeapObjectKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final Object key;
+
+  public VersionedThinRegionEntryHeapObjectKey(final RegionEntryContext context, final Object key,
+      final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.key = key;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedThinRegionEntryHeapObjectKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryHeapObjectKey.class,
-          "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -167,8 +174,9 @@ public class VersionedThinRegionEntryHeapObjectKey extends VersionedThinRegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -176,33 +184,34 @@ public class VersionedThinRegionEntryHeapObjectKey extends VersionedThinRegionEn
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final Object key;
-
   @Override
   public Object getKey() {
     return this.key;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinRegionEntryHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinRegionEntryHeapStringKey1.java
@@ -17,7 +17,7 @@ package org.apache.geode.internal.cache.entries;
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
@@ -25,157 +25,164 @@ import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinRegionEntryHeapStringKey1 extends VersionedThinRegionEntryHeap {
-  public VersionedThinRegionEntryHeapStringKey1(RegionEntryContext context, String key,
-      Object value, boolean byteEncode) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedThinRegionEntryHeapStringKey1> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryHeapStringKey1.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long bits1;
+
+  public VersionedThinRegionEntryHeapStringKey1(final RegionEntryContext context, final String key,
+      final Object value, final boolean byteEncode) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
+    long tempBits1 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedThinRegionEntryHeapStringKey1> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryHeapStringKey1.class,
-          "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -184,8 +191,9 @@ public class VersionedThinRegionEntryHeapStringKey1 extends VersionedThinRegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -193,33 +201,34 @@ public class VersionedThinRegionEntryHeapStringKey1 extends VersionedThinRegionE
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long bits1;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -232,18 +241,18 @@ public class VersionedThinRegionEntryHeapStringKey1 extends VersionedThinRegionE
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
     return new String(chars);
@@ -251,25 +260,25 @@ public class VersionedThinRegionEntryHeapStringKey1 extends VersionedThinRegionE
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinRegionEntryHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinRegionEntryHeapStringKey2.java
@@ -17,7 +17,7 @@ package org.apache.geode.internal.cache.entries;
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
@@ -25,169 +25,185 @@ import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinRegionEntryHeapStringKey2 extends VersionedThinRegionEntryHeap {
-  public VersionedThinRegionEntryHeapStringKey2(RegionEntryContext context, String key,
-      Object value, boolean byteEncode) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedThinRegionEntryHeapStringKey2> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryHeapStringKey2.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
+  private final long bits1;
+  /**
+   * bits2 encodes character data
+   */
+  private final long bits2;
+
+  public VersionedThinRegionEntryHeapStringKey2(final RegionEntryContext context, final String key,
+      final Object value, final boolean byteEncode) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
     if (byteEncode) {
       for (int i = key.length() - 1; i >= 0; i--) {
         // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
         // keep findbugs happy.
         if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
         } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
         }
       }
-      tmpBits1 |= 1 << 6;
+      tempBits1 |= 1 << 6;
     } else {
       for (int i = key.length() - 1; i >= 0; i--) {
         if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
         } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
         }
       }
     }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedThinRegionEntryHeapStringKey2> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryHeapStringKey2.class,
-          "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -196,8 +212,9 @@ public class VersionedThinRegionEntryHeapStringKey2 extends VersionedThinRegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -205,38 +222,34 @@ public class VersionedThinRegionEntryHeapStringKey2 extends VersionedThinRegionE
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
-  private final long bits1;
-  // bits2 encodes character data
-  private final long bits2;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -249,28 +262,28 @@ public class VersionedThinRegionEntryHeapStringKey2 extends VersionedThinRegionE
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -279,38 +292,38 @@ public class VersionedThinRegionEntryHeapStringKey2 extends VersionedThinRegionE
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinRegionEntryHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinRegionEntryHeapUUIDKey.java
@@ -18,7 +18,7 @@ package org.apache.geode.internal.cache.entries;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
@@ -26,25 +26,44 @@ import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinRegionEntryHeapUUIDKey extends VersionedThinRegionEntryHeap {
-  public VersionedThinRegionEntryHeapUUIDKey(RegionEntryContext context, UUID key, Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedThinRegionEntryHeapUUIDKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryHeapUUIDKey.class, "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  private volatile Object value;
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long keyMostSigBits;
+  private final long keyLeastSigBits;
+
+  public VersionedThinRegionEntryHeapUUIDKey(final RegionEntryContext context, final UUID key,
+      final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.keyMostSigBits = key.getMostSignificantBits();
@@ -52,113 +71,103 @@ public class VersionedThinRegionEntryHeapUUIDKey extends VersionedThinRegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedThinRegionEntryHeapUUIDKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryHeapUUIDKey.class, "lastModified");
-  private volatile Object value;
-
   @Override
   protected Object getValueField() {
     return this.value;
   }
 
   @Override
-  protected void setValueField(Object v) {
-    this.value = v;
+  protected void setValueField(final Object value) {
+    this.value = value;
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -167,8 +176,9 @@ public class VersionedThinRegionEntryHeapUUIDKey extends VersionedThinRegionEntr
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -176,43 +186,43 @@ public class VersionedThinRegionEntryHeapUUIDKey extends VersionedThinRegionEntr
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long keyMostSigBits;
-  private final long keyLeastSigBits;
-
   @Override
   public Object getKey() {
     return new UUID(this.keyMostSigBits, this.keyLeastSigBits);
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinRegionEntryOffHeapIntKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinRegionEntryOffHeapIntKey.java
@@ -17,7 +17,7 @@ package org.apache.geode.internal.cache.entries;
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
@@ -30,58 +30,70 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinRegionEntryOffHeapIntKey extends VersionedThinRegionEntryOffHeap {
-  public VersionedThinRegionEntryOffHeapIntKey(RegionEntryContext context, int key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapIntKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryOffHeapIntKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapIntKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryOffHeapIntKey.class,
+          "offHeapAddress");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final int key;
+
+  public VersionedThinRegionEntryOffHeapIntKey(final RegionEntryContext context, final int key,
+      @Retained final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.key = key;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapIntKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryOffHeapIntKey.class,
-          "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapIntKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryOffHeapIntKey.class, "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -95,24 +107,24 @@ public class VersionedThinRegionEntryOffHeapIntKey extends VersionedThinRegionEn
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -123,97 +135,96 @@ public class VersionedThinRegionEntryOffHeapIntKey extends VersionedThinRegionEn
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -222,8 +233,9 @@ public class VersionedThinRegionEntryOffHeapIntKey extends VersionedThinRegionEn
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -231,42 +243,43 @@ public class VersionedThinRegionEntryOffHeapIntKey extends VersionedThinRegionEn
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final int key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Integer) {
-      return ((Integer) k).intValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Integer) {
+      return ((Integer) key).intValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinRegionEntryOffHeapLongKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinRegionEntryOffHeapLongKey.java
@@ -17,7 +17,7 @@ package org.apache.geode.internal.cache.entries;
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
@@ -30,58 +30,70 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinRegionEntryOffHeapLongKey extends VersionedThinRegionEntryOffHeap {
-  public VersionedThinRegionEntryOffHeapLongKey(RegionEntryContext context, long key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapLongKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryOffHeapLongKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapLongKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryOffHeapLongKey.class,
+          "offHeapAddress");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long key;
+
+  public VersionedThinRegionEntryOffHeapLongKey(final RegionEntryContext context, final long key,
+      @Retained final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.key = key;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapLongKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryOffHeapLongKey.class,
-          "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapLongKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryOffHeapLongKey.class, "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -95,24 +107,24 @@ public class VersionedThinRegionEntryOffHeapLongKey extends VersionedThinRegionE
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -123,97 +135,96 @@ public class VersionedThinRegionEntryOffHeapLongKey extends VersionedThinRegionE
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -222,8 +233,9 @@ public class VersionedThinRegionEntryOffHeapLongKey extends VersionedThinRegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -231,42 +243,43 @@ public class VersionedThinRegionEntryOffHeapLongKey extends VersionedThinRegionE
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long key;
-
   @Override
   public Object getKey() {
     return this.key;
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof Long) {
-      return ((Long) k).longValue() == this.key;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof Long) {
+      return ((Long) key).longValue() == this.key;
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinRegionEntryOffHeapObjectKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinRegionEntryOffHeapObjectKey.java
@@ -17,7 +17,7 @@ package org.apache.geode.internal.cache.entries;
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
@@ -30,59 +30,70 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinRegionEntryOffHeapObjectKey extends VersionedThinRegionEntryOffHeap {
-  public VersionedThinRegionEntryOffHeapObjectKey(RegionEntryContext context, Object key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapObjectKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryOffHeapObjectKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapObjectKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryOffHeapObjectKey.class,
+          "offHeapAddress");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final Object key;
+
+  public VersionedThinRegionEntryOffHeapObjectKey(final RegionEntryContext context,
+      final Object key, @Retained final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.key = key;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapObjectKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryOffHeapObjectKey.class,
-          "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapObjectKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryOffHeapObjectKey.class,
-          "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -96,24 +107,24 @@ public class VersionedThinRegionEntryOffHeapObjectKey extends VersionedThinRegio
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -124,97 +135,96 @@ public class VersionedThinRegionEntryOffHeapObjectKey extends VersionedThinRegio
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -223,8 +233,9 @@ public class VersionedThinRegionEntryOffHeapObjectKey extends VersionedThinRegio
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -232,33 +243,34 @@ public class VersionedThinRegionEntryOffHeapObjectKey extends VersionedThinRegio
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final Object key;
-
   @Override
   public Object getKey() {
     return this.key;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinRegionEntryOffHeapStringKey1.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinRegionEntryOffHeapStringKey1.java
@@ -17,7 +17,7 @@ package org.apache.geode.internal.cache.entries;
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
@@ -30,76 +30,87 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinRegionEntryOffHeapStringKey1 extends VersionedThinRegionEntryOffHeap {
-  public VersionedThinRegionEntryOffHeapStringKey1(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, value);
-    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    if (byteEncode) {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
-        // keep findbugs happy.
-        tmpBits1 |= (byte) key.charAt(i) & 0xff;
-        tmpBits1 <<= 8;
-      }
-      tmpBits1 |= 1 << 6;
-    } else {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        tmpBits1 |= key.charAt(i);
-        tmpBits1 <<= 16;
-      }
-    }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapStringKey1> lastModifiedUpdater =
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapStringKey1> LAST_MODIFIED_UPDATER =
       AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryOffHeapStringKey1.class,
           "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
    * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
    * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapStringKey1> ohAddrUpdater =
+  private static final AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapStringKey1> OFF_HEAP_ADDRESS_UPDATER =
       AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryOffHeapStringKey1.class,
-          "ohAddress");
+          "offHeapAddress");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long bits1;
 
+  public VersionedThinRegionEntryOffHeapStringKey1(final RegionEntryContext context,
+      final String key, @Retained final Object value, final boolean byteEncode) {
+    super(context, value);
+    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
+    long tempBits1 = 0L;
+    if (byteEncode) {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
+        // keep findbugs happy.
+        tempBits1 |= (byte) key.charAt(i) & 0xff;
+        tempBits1 <<= 8;
+      }
+      tempBits1 |= 1 << 6;
+    } else {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        tempBits1 |= key.charAt(i);
+        tempBits1 <<= 16;
+      }
+    }
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+  }
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -113,24 +124,24 @@ public class VersionedThinRegionEntryOffHeapStringKey1 extends VersionedThinRegi
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -141,97 +152,96 @@ public class VersionedThinRegionEntryOffHeapStringKey1 extends VersionedThinRegi
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -240,8 +250,9 @@ public class VersionedThinRegionEntryOffHeapStringKey1 extends VersionedThinRegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -249,33 +260,34 @@ public class VersionedThinRegionEntryOffHeapStringKey1 extends VersionedThinRegi
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long bits1;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -288,18 +300,18 @@ public class VersionedThinRegionEntryOffHeapStringKey1 extends VersionedThinRegi
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 8;
-        chars[i] = (char) (tmpBits1 & 0x00ff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 8;
+        chars[i] = (char) (tempBits1 & 0x00ff);
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
-        tmpBits1 >>= 16;
-        chars[i] = (char) (tmpBits1 & 0x00FFff);
+      for (int i = 0; i < keyLength; i++) {
+        tempBits1 >>= 16;
+        chars[i] = (char) (tempBits1 & 0x00FFff);
       }
     }
     return new String(chars);
@@ -307,25 +319,25 @@ public class VersionedThinRegionEntryOffHeapStringKey1 extends VersionedThinRegi
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 8;
-            char c = (char) (tmpBits1 & 0x00ff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 8;
+            char character = (char) (tempBits1 & 0x00ff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            tmpBits1 >>= 16;
-            char c = (char) (tmpBits1 & 0x00FFff);
-            if (str.charAt(i) != c) {
+          for (int i = 0; i < keyLength; i++) {
+            tempBits1 >>= 16;
+            char character = (char) (tempBits1 & 0x00FFff);
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinRegionEntryOffHeapStringKey2.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinRegionEntryOffHeapStringKey2.java
@@ -17,7 +17,7 @@ package org.apache.geode.internal.cache.entries;
 // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
@@ -30,88 +30,108 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinRegionEntryOffHeapStringKey2 extends VersionedThinRegionEntryOffHeap {
-  public VersionedThinRegionEntryOffHeapStringKey2(RegionEntryContext context, String key,
-      @Retained Object value, boolean byteEncode) {
-    super(context, value);
-    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
-    long tmpBits1 = 0L;
-    long tmpBits2 = 0L;
-    if (byteEncode) {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
-        // keep findbugs happy.
-        if (i < 7) {
-          tmpBits1 |= (byte) key.charAt(i) & 0xff;
-          tmpBits1 <<= 8;
-        } else {
-          tmpBits2 <<= 8;
-          tmpBits2 |= (byte) key.charAt(i) & 0xff;
-        }
-      }
-      tmpBits1 |= 1 << 6;
-    } else {
-      for (int i = key.length() - 1; i >= 0; i--) {
-        if (i < 3) {
-          tmpBits1 |= key.charAt(i);
-          tmpBits1 <<= 16;
-        } else {
-          tmpBits2 <<= 16;
-          tmpBits2 |= key.charAt(i);
-        }
-      }
-    }
-    tmpBits1 |= key.length();
-    this.bits1 = tmpBits1;
-    this.bits2 = tmpBits2;
-  }
-
-  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapStringKey2> lastModifiedUpdater =
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapStringKey2> LAST_MODIFIED_UPDATER =
       AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryOffHeapStringKey2.class,
           "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
   /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
    */
   @SuppressWarnings("unused")
   @Retained
   @Released
-  private volatile long ohAddress;
+  private volatile long offHeapAddress;
   /**
    * I needed to add this because I wanted clear to call setValue which normally can only be called
    * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
    * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
    * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
    */
-  private final static AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapStringKey2> ohAddrUpdater =
+  private static final AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapStringKey2> OFF_HEAP_ADDRESS_UPDATER =
       AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryOffHeapStringKey2.class,
-          "ohAddress");
+          "offHeapAddress");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  /**
+   * strlen is encoded in lowest 6 bits (max strlen is 63)<br>
+   * character encoding info is in bits 7 and 8<br>
+   * The other bits are used to encoded character data.
+   */
+  private final long bits1;
+  /**
+   * bits2 encodes character data
+   */
+  private final long bits2;
 
+  public VersionedThinRegionEntryOffHeapStringKey2(final RegionEntryContext context,
+      final String key, @Retained final Object value, final boolean byteEncode) {
+    super(context, value);
+    // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+    // caller has already confirmed that key.length <= MAX_INLINE_STRING_KEY
+    long tempBits1 = 0L;
+    long tempBits2 = 0L;
+    if (byteEncode) {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        // Note: we know each byte is <= 0x7f so the "& 0xff" is not needed. But I added it in to
+        // keep findbugs happy.
+        if (i < 7) {
+          tempBits1 |= (byte) key.charAt(i) & 0xff;
+          tempBits1 <<= 8;
+        } else {
+          tempBits2 <<= 8;
+          tempBits2 |= (byte) key.charAt(i) & 0xff;
+        }
+      }
+      tempBits1 |= 1 << 6;
+    } else {
+      for (int i = key.length() - 1; i >= 0; i--) {
+        if (i < 3) {
+          tempBits1 |= key.charAt(i);
+          tempBits1 <<= 16;
+        } else {
+          tempBits2 <<= 16;
+          tempBits2 |= key.charAt(i);
+        }
+      }
+    }
+    tempBits1 |= key.length();
+    this.bits1 = tempBits1;
+    this.bits2 = tempBits2;
+  }
+
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -125,24 +145,24 @@ public class VersionedThinRegionEntryOffHeapStringKey2 extends VersionedThinRegi
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -153,97 +173,96 @@ public class VersionedThinRegionEntryOffHeapStringKey2 extends VersionedThinRegi
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -252,8 +271,9 @@ public class VersionedThinRegionEntryOffHeapStringKey2 extends VersionedThinRegi
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -261,38 +281,34 @@ public class VersionedThinRegionEntryOffHeapStringKey2 extends VersionedThinRegi
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  // strlen is encoded in lowest 6 bits (max strlen is 63)
-  // character encoding info is in bits 7 and 8
-  // The other bits are used to encoded character data.
-  private final long bits1;
-  // bits2 encodes character data
-  private final long bits2;
-
   private int getKeyLength() {
     return (int) (this.bits1 & 0x003fL);
   }
@@ -305,28 +321,28 @@ public class VersionedThinRegionEntryOffHeapStringKey2 extends VersionedThinRegi
 
   @Override
   public Object getKey() {
-    int keylen = getKeyLength();
-    char[] chars = new char[keylen];
-    long tmpBits1 = this.bits1;
-    long tmpBits2 = this.bits2;
+    int keyLength = getKeyLength();
+    char[] chars = new char[keyLength];
+    long tempBits1 = this.bits1;
+    long tempBits2 = this.bits2;
     if (getEncoding() == 1) {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 7) {
-          tmpBits1 >>= 8;
-          chars[i] = (char) (tmpBits1 & 0x00ff);
+          tempBits1 >>= 8;
+          chars[i] = (char) (tempBits1 & 0x00ff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00ff);
-          tmpBits2 >>= 8;
+          chars[i] = (char) (tempBits2 & 0x00ff);
+          tempBits2 >>= 8;
         }
       }
     } else {
-      for (int i = 0; i < keylen; i++) {
+      for (int i = 0; i < keyLength; i++) {
         if (i < 3) {
-          tmpBits1 >>= 16;
-          chars[i] = (char) (tmpBits1 & 0x00FFff);
+          tempBits1 >>= 16;
+          chars[i] = (char) (tempBits1 & 0x00FFff);
         } else {
-          chars[i] = (char) (tmpBits2 & 0x00FFff);
-          tmpBits2 >>= 16;
+          chars[i] = (char) (tempBits2 & 0x00FFff);
+          tempBits2 >>= 16;
         }
       }
     }
@@ -335,38 +351,38 @@ public class VersionedThinRegionEntryOffHeapStringKey2 extends VersionedThinRegi
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof String) {
-      String str = (String) k;
-      int keylen = getKeyLength();
-      if (str.length() == keylen) {
-        long tmpBits1 = this.bits1;
-        long tmpBits2 = this.bits2;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof String) {
+      String stringKey = (String) key;
+      int keyLength = getKeyLength();
+      if (stringKey.length() == keyLength) {
+        long tempBits1 = this.bits1;
+        long tempBits2 = this.bits2;
         if (getEncoding() == 1) {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 7) {
-              tmpBits1 >>= 8;
-              c = (char) (tmpBits1 & 0x00ff);
+              tempBits1 >>= 8;
+              character = (char) (tempBits1 & 0x00ff);
             } else {
-              c = (char) (tmpBits2 & 0x00ff);
-              tmpBits2 >>= 8;
+              character = (char) (tempBits2 & 0x00ff);
+              tempBits2 >>= 8;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }
         } else {
-          for (int i = 0; i < keylen; i++) {
-            char c;
+          for (int i = 0; i < keyLength; i++) {
+            char character;
             if (i < 3) {
-              tmpBits1 >>= 16;
-              c = (char) (tmpBits1 & 0x00FFff);
+              tempBits1 >>= 16;
+              character = (char) (tempBits1 & 0x00FFff);
             } else {
-              c = (char) (tmpBits2 & 0x00FFff);
-              tmpBits2 >>= 16;
+              character = (char) (tempBits2 & 0x00FFff);
+              tempBits2 >>= 16;
             }
-            if (str.charAt(i) != c) {
+            if (stringKey.charAt(i) != character) {
               return false;
             }
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinRegionEntryOffHeapUUIDKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinRegionEntryOffHeapUUIDKey.java
@@ -18,7 +18,7 @@ package org.apache.geode.internal.cache.entries;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionSource;
@@ -31,26 +31,65 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 
-// macros whose definition changes this class:
-// disk: DISK
-// lru: LRU
-// stats: STATS
-// versioned: VERSIONED
-// offheap: OFFHEAP
-// One of the following key macros must be defined:
-// key object: KEY_OBJECT
-// key int: KEY_INT
-// key long: KEY_LONG
-// key uuid: KEY_UUID
-// key string1: KEY_STRING1
-// key string2: KEY_STRING2
+/*
+ * macros whose definition changes this class:
+ *
+ * disk: DISK lru: LRU stats: STATS versioned: VERSIONED offheap: OFFHEAP
+ *
+ * One of the following key macros must be defined:
+ *
+ * key object: KEY_OBJECT key int: KEY_INT key long: KEY_LONG key uuid: KEY_UUID key string1:
+ * KEY_STRING1 key string2: KEY_STRING2
+ */
 /**
  * Do not modify this class. It was generated. Instead modify LeafRegionEntry.cpp and then run
  * ./dev-tools/generateRegionEntryClasses.sh (it must be run from the top level directory).
  */
 public class VersionedThinRegionEntryOffHeapUUIDKey extends VersionedThinRegionEntryOffHeap {
-  public VersionedThinRegionEntryOffHeapUUIDKey(RegionEntryContext context, UUID key,
-      @Retained Object value) {
+  // --------------------------------------- common fields ----------------------------------------
+  private static final AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapUUIDKey> LAST_MODIFIED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryOffHeapUUIDKey.class,
+          "lastModified");
+  protected int hash;
+  private HashEntry<Object, Object> nextEntry;
+  @SuppressWarnings("unused")
+  private volatile long lastModified;
+  // --------------------------------------- offheap fields ---------------------------------------
+  /**
+   * All access done using OFF_HEAP_ADDRESS_UPDATER so it is used even though the compiler can not
+   * tell it is.
+   */
+  @SuppressWarnings("unused")
+  @Retained
+  @Released
+  private volatile long offHeapAddress;
+  /**
+   * I needed to add this because I wanted clear to call setValue which normally can only be called
+   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
+   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
+   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
+   * RegionEntry and we will once again be deadlocked. I don't know if we support any of the
+   * hardware platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk
+   * regions.
+   */
+  private static final AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapUUIDKey> OFF_HEAP_ADDRESS_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryOffHeapUUIDKey.class,
+          "offHeapAddress");
+  // ------------------------------------- versioned fields ---------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private VersionSource memberId;
+  private short entryVersionLowBytes;
+  private short regionVersionHighBytes;
+  private int regionVersionLowBytes;
+  private byte entryVersionHighByte;
+  private byte distributedSystemId;
+  // ----------------------------------------- key code -------------------------------------------
+  // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  private final long keyMostSigBits;
+  private final long keyLeastSigBits;
+
+  public VersionedThinRegionEntryOffHeapUUIDKey(final RegionEntryContext context, final UUID key,
+      @Retained final Object value) {
     super(context, value);
     // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
     this.keyMostSigBits = key.getMostSignificantBits();
@@ -58,32 +97,6 @@ public class VersionedThinRegionEntryOffHeapUUIDKey extends VersionedThinRegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // common code
-  protected int hash;
-  private HashEntry<Object, Object> next;
-  @SuppressWarnings("unused")
-  private volatile long lastModified;
-  private static final AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapUUIDKey> lastModifiedUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryOffHeapUUIDKey.class,
-          "lastModified");
-  /**
-   * All access done using ohAddrUpdater so it is used even though the compiler can not tell it is.
-   */
-  @SuppressWarnings("unused")
-  @Retained
-  @Released
-  private volatile long ohAddress;
-  /**
-   * I needed to add this because I wanted clear to call setValue which normally can only be called
-   * while the re is synced. But if I sync in that code it causes a lock ordering deadlock with the
-   * disk regions because they also get a rw lock in clear. Some hardware platforms do not support
-   * CAS on a long. If gemfire is run on one of those the AtomicLongFieldUpdater does a sync on the
-   * re and we will once again be deadlocked. I don't know if we support any of the hardware
-   * platforms that do not have a 64bit CAS. If we do then we can expect deadlocks on disk regions.
-   */
-  private final static AtomicLongFieldUpdater<VersionedThinRegionEntryOffHeapUUIDKey> ohAddrUpdater =
-      AtomicLongFieldUpdater.newUpdater(VersionedThinRegionEntryOffHeapUUIDKey.class, "ohAddress");
-
   @Override
   public Token getValueAsToken() {
     return OffHeapRegionEntryHelper.getValueAsToken(this);
@@ -97,24 +110,24 @@ public class VersionedThinRegionEntryOffHeapUUIDKey extends VersionedThinRegionE
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
   @Override
   @Unretained
-  protected void setValueField(@Unretained Object v) {
-    OffHeapRegionEntryHelper.setValue(this, v);
+  protected void setValueField(@Unretained final Object value) {
+    OffHeapRegionEntryHelper.setValue(this, value);
   }
 
   @Override
   @Retained
-  public Object _getValueRetain(RegionEntryContext context, boolean decompress) {
+  public Object getValueRetain(final RegionEntryContext context, final boolean decompress) {
     return OffHeapRegionEntryHelper._getValueRetain(this, decompress, context);
   }
 
   @Override
   public long getAddress() {
-    return ohAddrUpdater.get(this);
+    return OFF_HEAP_ADDRESS_UPDATER.get(this);
   }
 
   @Override
-  public boolean setAddress(long expectedAddr, long newAddr) {
-    return ohAddrUpdater.compareAndSet(this, expectedAddr, newAddr);
+  public boolean setAddress(final long expectedAddress, long newAddress) {
+    return OFF_HEAP_ADDRESS_UPDATER.compareAndSet(this, expectedAddress, newAddress);
   }
 
   @Override
@@ -125,97 +138,96 @@ public class VersionedThinRegionEntryOffHeapUUIDKey extends VersionedThinRegionE
 
   @Override
   public void returnToPool() {
-    // Deadcoded for now; never was working
+    // never implemented
   }
 
+  @Override
   protected long getLastModifiedField() {
-    return lastModifiedUpdater.get(this);
+    return LAST_MODIFIED_UPDATER.get(this);
   }
 
-  protected boolean compareAndSetLastModifiedField(long expectedValue, long newValue) {
-    return lastModifiedUpdater.compareAndSet(this, expectedValue, newValue);
+  @Override
+  protected boolean compareAndSetLastModifiedField(final long expectedValue, final long newValue) {
+    return LAST_MODIFIED_UPDATER.compareAndSet(this, expectedValue, newValue);
   }
 
-  /**
-   * @see HashEntry#getEntryHash()
-   */
+  @Override
   public int getEntryHash() {
     return this.hash;
   }
 
-  protected void setEntryHash(int v) {
-    this.hash = v;
+  @Override
+  protected void setEntryHash(final int hash) {
+    this.hash = hash;
   }
 
-  /**
-   * @see HashEntry#getNextEntry()
-   */
+  @Override
   public HashEntry<Object, Object> getNextEntry() {
-    return this.next;
+    return this.nextEntry;
   }
 
-  /**
-   * @see HashEntry#setNextEntry
-   */
-  public void setNextEntry(final HashEntry<Object, Object> n) {
-    this.next = n;
+  @Override
+  public void setNextEntry(final HashEntry<Object, Object> nextEntry) {
+    this.nextEntry = nextEntry;
   }
 
+  // -------------------------------------- versioned code ----------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // versioned code
-  private VersionSource memberID;
-  private short entryVersionLowBytes;
-  private short regionVersionHighBytes;
-  private int regionVersionLowBytes;
-  private byte entryVersionHighByte;
-  private byte distributedSystemId;
-
+  @Override
   public int getEntryVersion() {
     return ((entryVersionHighByte << 16) & 0xFF0000) | (entryVersionLowBytes & 0xFFFF);
   }
 
+  @Override
   public long getRegionVersion() {
     return (((long) regionVersionHighBytes) << 32) | (regionVersionLowBytes & 0x00000000FFFFFFFFL);
   }
 
+  @Override
   public long getVersionTimeStamp() {
     return getLastModified();
   }
 
-  public void setVersionTimeStamp(long time) {
-    setLastModified(time);
+  @Override
+  public void setVersionTimeStamp(final long timeStamp) {
+    setLastModified(timeStamp);
   }
 
+  @Override
   public VersionSource getMemberID() {
-    return this.memberID;
+    return this.memberId;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return this.distributedSystemId;
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  public void setVersions(VersionTag tag) {
-    this.memberID = tag.getMemberID();
-    int eVersion = tag.getEntryVersion();
+  @Override
+  public void setVersions(final VersionTag versionTag) {
+    this.memberId = versionTag.getMemberID();
+    int eVersion = versionTag.getEntryVersion();
     this.entryVersionLowBytes = (short) (eVersion & 0xffff);
     this.entryVersionHighByte = (byte) ((eVersion & 0xff0000) >> 16);
-    this.regionVersionHighBytes = tag.getRegionVersionHighBytes();
-    this.regionVersionLowBytes = tag.getRegionVersionLowBytes();
-    if (!(tag.isGatewayTag()) && this.distributedSystemId == tag.getDistributedSystemId()) {
-      if (getVersionTimeStamp() <= tag.getVersionTimeStamp()) {
-        setVersionTimeStamp(tag.getVersionTimeStamp());
+    this.regionVersionHighBytes = versionTag.getRegionVersionHighBytes();
+    this.regionVersionLowBytes = versionTag.getRegionVersionLowBytes();
+    if (!versionTag.isGatewayTag()
+        && this.distributedSystemId == versionTag.getDistributedSystemId()) {
+      if (getVersionTimeStamp() <= versionTag.getVersionTimeStamp()) {
+        setVersionTimeStamp(versionTag.getVersionTimeStamp());
       } else {
-        tag.setVersionTimeStamp(getVersionTimeStamp());
+        versionTag.setVersionTimeStamp(getVersionTimeStamp());
       }
     } else {
-      setVersionTimeStamp(tag.getVersionTimeStamp());
+      setVersionTimeStamp(versionTag.getVersionTimeStamp());
     }
-    this.distributedSystemId = (byte) (tag.getDistributedSystemId() & 0xff);
+    this.distributedSystemId = (byte) (versionTag.getDistributedSystemId() & 0xff);
   }
 
-  public void setMemberID(VersionSource memberID) {
-    this.memberID = memberID;
+  @Override
+  public void setMemberID(final VersionSource memberId) {
+    this.memberId = memberId;
   }
 
   @Override
@@ -224,8 +236,9 @@ public class VersionedThinRegionEntryOffHeapUUIDKey extends VersionedThinRegionE
   }
 
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
+  @Override
   public VersionTag asVersionTag() {
-    VersionTag tag = VersionTag.create(memberID);
+    VersionTag tag = VersionTag.create(memberId);
     tag.setEntryVersion(getEntryVersion());
     tag.setRegionVersion(this.regionVersionHighBytes, this.regionVersionLowBytes);
     tag.setVersionTimeStamp(getVersionTimeStamp());
@@ -233,43 +246,43 @@ public class VersionedThinRegionEntryOffHeapUUIDKey extends VersionedThinRegionE
     return tag;
   }
 
-  public void processVersionTag(LocalRegion r, VersionTag tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
-      boolean checkForConflicts) {
-    basicProcessVersionTag(r, tag, isTombstoneFromGII, hasDelta, thisVM, sender, checkForConflicts);
+  @Override
+  public void processVersionTag(final InternalRegion region, final VersionTag versionTag,
+      final boolean isTombstoneFromGII, final boolean hasDelta, final VersionSource versionSource,
+      final InternalDistributedMember sender, final boolean checkForConflicts) {
+    basicProcessVersionTag(region, versionTag, isTombstoneFromGII, hasDelta, versionSource, sender,
+        checkForConflicts);
   }
 
   @Override
-  public void processVersionTag(EntryEvent cacheEvent) {
-    // this keeps Eclipse happy. without it the sender chain becomes confused
-    // while browsing this code
+  public void processVersionTag(final EntryEvent cacheEvent) {
+    // this keeps IDE happy. without it the sender chain becomes confused while browsing this code
     super.processVersionTag(cacheEvent);
   }
 
   /** get rvv internal high byte. Used by region entries for transferring to storage */
+  @Override
   public short getRegionVersionHighBytes() {
     return this.regionVersionHighBytes;
   }
 
   /** get rvv internal low bytes. Used by region entries for transferring to storage */
+  @Override
   public int getRegionVersionLowBytes() {
     return this.regionVersionLowBytes;
   }
 
+  // ----------------------------------------- key code -------------------------------------------
   // DO NOT modify this class. It was generated from LeafRegionEntry.cpp
-  // key code
-  private final long keyMostSigBits;
-  private final long keyLeastSigBits;
-
   @Override
   public Object getKey() {
     return new UUID(this.keyMostSigBits, this.keyLeastSigBits);
   }
 
   @Override
-  public boolean isKeyEqual(Object k) {
-    if (k instanceof UUID) {
-      UUID uuid = (UUID) k;
+  public boolean isKeyEqual(final Object key) {
+    if (key instanceof UUID) {
+      UUID uuid = (UUID) key;
       return uuid.getLeastSignificantBits() == this.keyLeastSigBits
           && uuid.getMostSignificantBits() == this.keyMostSigBits;
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/lru/LRUEntry.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/lru/LRUEntry.java
@@ -14,8 +14,8 @@
  */
 package org.apache.geode.internal.cache.lru;
 
-import org.apache.geode.internal.cache.LocalRegion;
 import org.apache.geode.internal.cache.RegionEntry;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 
 /**
  * Represents an entry in an LRU map
@@ -25,7 +25,7 @@ public interface LRUEntry extends LRUClockNode, RegionEntry {
    * If the key is stored as an Object then returns that object; but if the key is stored as
    * primitives then returns null.
    */
-  public Object getKeyForSizing();
+  Object getKeyForSizing();
 
-  public void setDelayedDiskId(LocalRegion r);
+  void setDelayedDiskId(DiskRecoveryStore diskRecoveryStore);
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/Bucket.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/Bucket.java
@@ -18,14 +18,14 @@ import java.util.Set;
 
 import org.apache.geode.internal.cache.BucketAdvisor;
 import org.apache.geode.internal.cache.CacheDistributionAdvisee;
-import org.apache.geode.internal.cache.DiskRegion;
+import org.apache.geode.internal.cache.HasDiskRegion;
 import org.apache.geode.internal.cache.persistence.PersistenceAdvisor;
 import org.apache.geode.internal.cache.PartitionedRegion;
 
 /**
  * Represents a storage or meta-data container for a <code>PartitionedRegion</code>.
  */
-public interface Bucket extends CacheDistributionAdvisee {
+public interface Bucket extends CacheDistributionAdvisee, HasDiskRegion {
 
   /**
    * Returns the distribution and metadata <code>BucketAdvisor</code> for this bucket.
@@ -65,8 +65,6 @@ public interface Bucket extends CacheDistributionAdvisee {
   public Set/* InternalDistributedMembers */ getBucketOwners();
 
   public PersistenceAdvisor getPersistenceAdvisor();
-
-  public DiskRegion getDiskRegion();
 
   /**
    * Returns the parent {@link PartitionedRegion} of this bucket.

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/FetchEntriesMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/FetchEntriesMessage.java
@@ -295,7 +295,7 @@ public class FetchEntriesMessage extends PartitionMessage {
           LocalRegion.NonTXEntry entry = (LocalRegion.NonTXEntry) it.next();
           RegionEntry re = entry.getRegionEntry();
           synchronized (re) {
-            Object value = re._getValueRetain(map, true);
+            Object value = re.getValueRetain(map, true);
             try {
               if (value == null) {
                 // only possible for disk entry

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/DiskRecoveryStore.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/DiskRecoveryStore.java
@@ -29,7 +29,6 @@ import org.apache.geode.internal.cache.versions.VersionTag;
  * Used by the disk code to store recovered data into the cache. The primary implementor of this
  * interface is LocalRegion.
  *
- *
  * @since GemFire prPersistSprint3
  */
 public interface DiskRecoveryStore {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/BaseCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/BaseCommand.java
@@ -1262,7 +1262,7 @@ public abstract class BaseCommand implements Command {
           VersionStamp vs = ((NonTXEntry) entry).getRegionEntry().getVersionStamp();
           vt = vs == null ? null : vs.asVersionTag();
           key = entry.getKey();
-          value = ((NonTXEntry) entry).getRegionEntry()._getValueRetain(region, true);
+          value = ((NonTXEntry) entry).getRegionEntry().getValueRetain(region, true);
           try {
             updateValues(values, key, value, vt);
           } finally {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/versions/VersionSource.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/versions/VersionSource.java
@@ -14,7 +14,6 @@
  */
 package org.apache.geode.internal.cache.versions;
 
-import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 
@@ -28,11 +27,8 @@ import org.apache.geode.internal.DataSerializableFixedID;
  * (for a persistent region).
  * 
  * VersionMembers should implement equals and hashcode.
- * 
- *
  */
 public interface VersionSource<T> extends DataSerializableFixedID, Comparable<T> {
 
-  public void writeEssentialData(DataOutput out) throws IOException;
-
+  void writeEssentialData(DataOutput out) throws IOException;
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/versions/VersionStamp.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/versions/VersionStamp.java
@@ -15,27 +15,15 @@
 package org.apache.geode.internal.cache.versions;
 
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 
-/**
- *
- */
-public interface VersionStamp<T extends VersionSource> extends VersionHolder<T> {
-
-
+public interface VersionStamp<T extends VersionSource<T>> extends VersionHolder<T> {
 
   /**
-   * set the time stamp from the given clock value
+   * Sets the time stamp from the given clock value
    */
   void setVersionTimeStamp(long time);
-
-  // /**
-  // * @return the ID of the previous member that last changed the corresponding entry.
-  // */
-  // DistributedMember getPreviousMemberID();
-
 
   /**
    * Sets the version information with what is in the tag
@@ -49,44 +37,36 @@ public interface VersionStamp<T extends VersionSource> extends VersionHolder<T> 
    */
   void setMemberID(VersionSource memberID);
 
-  // /**
-  // * @param previousMemberID the previousMemberID to set
-  // */
-  // void setPreviousMemberID(DistributedMember previousMemberID);
-
   /**
-   * returns a VersionTag carrying this stamps information. This is used for transmission of the
+   * Returns a VersionTag carrying this stamps information. This is used for transmission of the
    * stamp in initial image transfer
    */
   VersionTag<T> asVersionTag();
 
-
   /**
    * Perform a versioning check with the incoming event. Throws a
    * ConcurrentCacheModificationException if there is a problem.
-   * 
-   * @param event
    */
-  public void processVersionTag(EntryEvent event);
+  void processVersionTag(EntryEvent event);
 
   /**
    * Perform a versioning check with the given GII information. Throws a
    * ConcurrentCacheModificationException if there is a problem.
    * 
-   * @param r the region being modified
+   * @param region the region being modified
    * @param tag the version info for the modification
    * @param isTombstoneFromGII it's a tombstone
    * @param hasDelta it has delta
-   * @param thisVM this cache's DM identifier
+   * @param versionSource this cache's DM identifier
    * @param sender the identifier of the member providing the entry
    * @param checkConflicts true if conflict checks should be performed
    */
-  public void processVersionTag(LocalRegion r, VersionTag<T> tag, boolean isTombstoneFromGII,
-      boolean hasDelta, VersionSource thisVM, InternalDistributedMember sender,
+  void processVersionTag(InternalRegion region, VersionTag<T> tag, boolean isTombstoneFromGII,
+      boolean hasDelta, VersionSource<T> versionSource, InternalDistributedMember sender,
       boolean checkConflicts);
 
   /**
-   * return true if this stamp has valid entry/region version information, false if not
+   * Returns true if this stamp has valid entry/region version information, false if not
    */
-  public boolean hasValidVersion();
+  boolean hasValidVersion();
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/offheap/MemoryAllocatorImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/offheap/MemoryAllocatorImpl.java
@@ -285,7 +285,7 @@ public class MemoryAllocatorImpl implements MemoryAllocator {
          * value could be GATEWAY_SENDER_EVENT_IMPL_VALUE or region entry value.
          */
         @Unretained(OffHeapIdentifier.GATEWAY_SENDER_EVENT_IMPL_VALUE)
-        Object value = re._getValue();
+        Object value = re.getValue();
         if (value instanceof OffHeapStoredObject) {
           result.add((OffHeapStoredObject) value);
         }

--- a/geode-core/src/main/java/org/apache/geode/internal/util/concurrent/CustomEntryConcurrentHashMap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/util/concurrent/CustomEntryConcurrentHashMap.java
@@ -1040,8 +1040,8 @@ public class CustomEntryConcurrentHashMap<K, V> extends AbstractMap<K, V>
                   if (p instanceof RegionEntry) {
                     // It is ok to call GatewaySenderEventImpl release without being synced
                     // on the region entry. It will not create an orphan.
-                    GatewaySenderEventImpl.release(((RegionEntry) p)._getValue()); // OFFHEAP
-                                                                                   // _getValue ok
+                    GatewaySenderEventImpl.release(((RegionEntry) p).getValue()); // OFFHEAP
+                                                                                  // _getValue ok
                   }
                 }
               }

--- a/geode-core/src/test/java/org/apache/geode/cache30/MultiVMRegionTestCase.java
+++ b/geode-core/src/test/java/org/apache/geode/cache30/MultiVMRegionTestCase.java
@@ -1912,7 +1912,7 @@ public abstract class MultiVMRegionTestCase extends RegionTestCase {
           LocalRegion reRegion;
           reRegion = (LocalRegion) region;
           RegionEntry re = reRegion.getRegionEntry(key2);
-          StoredObject so = (StoredObject) re._getValue();
+          StoredObject so = (StoredObject) re.getValue();
           assertEquals(1, so.getRefCount());
           assertEquals(1, ma.getStats().getObjects());
         }
@@ -2000,7 +2000,7 @@ public abstract class MultiVMRegionTestCase extends RegionTestCase {
           assertEquals(2, ma.getStats().getObjects());
           LocalRegion reRegion;
           reRegion = (LocalRegion) region;
-          StoredObject so = (StoredObject) reRegion.getRegionEntry(key)._getValue();
+          StoredObject so = (StoredObject) reRegion.getRegionEntry(key).getValue();
           assertEquals(1, so.getRefCount());
         }
       }
@@ -2067,7 +2067,7 @@ public abstract class MultiVMRegionTestCase extends RegionTestCase {
             assertEquals(2, ma.getStats().getObjects());
             LocalRegion reRegion;
             reRegion = (LocalRegion) region;
-            StoredObject so = (StoredObject) reRegion.getRegionEntry(key)._getValue();
+            StoredObject so = (StoredObject) reRegion.getRegionEntry(key).getValue();
             assertEquals(1, so.getRefCount());
           }
         }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/AbstractRegionJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/AbstractRegionJUnitTest.java
@@ -29,6 +29,7 @@ import java.util.concurrent.locks.Lock;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import org.apache.geode.CancelCriterion;
 import org.apache.geode.cache.AttributesMutator;
 import org.apache.geode.cache.CacheLoaderException;
 import org.apache.geode.cache.CacheWriterException;
@@ -39,6 +40,7 @@ import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionAttributes;
 import org.apache.geode.cache.RegionExistsException;
 import org.apache.geode.cache.TimeoutException;
+import org.apache.geode.cache.client.internal.ServerRegionProxy;
 import org.apache.geode.cache.query.FunctionDomainException;
 import org.apache.geode.cache.query.NameResolutionException;
 import org.apache.geode.cache.query.QueryInvocationTargetException;
@@ -49,6 +51,9 @@ import org.apache.geode.distributed.internal.membership.InternalDistributedMembe
 import org.apache.geode.internal.Version;
 import org.apache.geode.internal.cache.extension.ExtensionPoint;
 import org.apache.geode.internal.cache.extension.SimpleExtensionPoint;
+import org.apache.geode.internal.cache.versions.RegionVersionVector;
+import org.apache.geode.internal.cache.versions.VersionSource;
+import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.test.junit.categories.UnitTest;
 
 /**
@@ -469,6 +474,117 @@ public class AbstractRegionJUnitTest {
     }
 
     @Override
+    public RegionEntry getRegionEntry(final Object key) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RegionVersionVector getVersionVector() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object getValueInVM(Object key) throws EntryNotFoundException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object getValueOnDisk(Object key) throws EntryNotFoundException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void dispatchListenerEvent(EnumListenerEvent op, InternalCacheEvent event) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isUsedForPartitionedRegionAdmin() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ImageState getImageState() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public VersionSource getVersionMember() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long updateStatsForPut(RegionEntry entry, long lastModified, boolean lruRecentUse) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public FilterProfile getFilterProfile() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ServerRegionProxy getServerProxy() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void unscheduleTombstone(RegionEntry entry) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void scheduleTombstone(RegionEntry entry, VersionTag destroyedVersion) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void addExpiryTaskIfAbsent(RegionEntry entry) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void generateAndSetVersionTag(InternalCacheEvent event, RegionEntry entry) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean cacheWriteBeforeDestroy(EntryEventImpl event, Object expectedOldValue)
+        throws CacheWriterException, EntryNotFoundException, TimeoutException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void recordEvent(InternalCacheEvent event) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isConcurrencyChecksEnabled() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isThisRegionBeingClosedOrDestroyed() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public DiskRegion getDiskRegion() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CancelCriterion getCancelCriterion() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int updateSizeOnEvict(Object key, int oldSize) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
     Object get(Object key, Object aCallbackArgument, boolean generateCallbacks,
         EntryEventImpl clientEvent) throws TimeoutException, CacheLoaderException {
       throw new UnsupportedOperationException();
@@ -501,6 +617,24 @@ public class AbstractRegionJUnitTest {
 
     @Override
     public RegionEntry basicGetEntry(Object key) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void invokePutCallbacks(EnumListenerEvent eventType, EntryEventImpl event,
+        boolean callDispatchListenerEvent, boolean notifyGateways) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void invokeDestroyCallbacks(EnumListenerEvent eventType, EntryEventImpl event,
+        boolean callDispatchListenerEvent, boolean notifyGateways) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void invokeInvalidateCallbacks(EnumListenerEvent eventType, EntryEventImpl event,
+        boolean callDispatchListenerEvent) {
       throw new UnsupportedOperationException();
     }
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/Bug37377DUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/Bug37377DUnitTest.java
@@ -170,8 +170,6 @@ public class Bug37377DUnitTest extends JUnit4CacheTestCase {
 
   /**
    * This method clears the region and notifies the other member when complete
-   * 
-   * @throws InterruptedException
    */
   private static void invokeRemoteClearAndWait(VM remoteVM, VM thisVM) {
     remoteVM.invoke(() -> clearRegionAndNotify(thisVM));
@@ -289,7 +287,7 @@ public class Bug37377DUnitTest extends JUnit4CacheTestCase {
      * Overridden setValue method to call clear Region before actually writing the entry
      */
     @Override
-    public boolean initialImageInit(final LocalRegion r, final long lastModifiedTime,
+    public boolean initialImageInit(final InternalRegion r, final long lastModifiedTime,
         final Object newValue, final boolean create, final boolean wasRecovered,
         final boolean versionTagAccepted) throws RegionClearedException {
       synchronized (clearOccurred) {

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/PRDataStoreMemoryJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/PRDataStoreMemoryJUnitTest.java
@@ -78,7 +78,7 @@ public class PRDataStoreMemoryJUnitTest {
     Integer val1 = new Integer(16);
     regionAck1.put(new Integer(1), val1);
     Object storedVal =
-        regionAck1.getBucketRegion(new Integer(1)).getRegionEntry(new Integer(1))._getValue();
+        regionAck1.getBucketRegion(new Integer(1)).getRegionEntry(new Integer(1)).getValue();
     final int size1 = CachedDeserializableFactory.calcMemSize(storedVal);
     int size = size1;
     assertEquals(size, regionAck1.getDataStore().currentAllocatedMemory());
@@ -86,7 +86,7 @@ public class PRDataStoreMemoryJUnitTest {
     byte[] val2 = new byte[1000];
     regionAck1.put(new Integer(2), val2);
     storedVal =
-        regionAck1.getBucketRegion(new Integer(2)).getRegionEntry(new Integer(2))._getValue();
+        regionAck1.getBucketRegion(new Integer(2)).getRegionEntry(new Integer(2)).getValue();
     final int size2 = CachedDeserializableFactory.calcMemSize(storedVal);
     size += size2;
     assertEquals(size, regionAck1.getDataStore().currentAllocatedMemory());
@@ -94,7 +94,7 @@ public class PRDataStoreMemoryJUnitTest {
     String val3 = "0123456789";
     regionAck1.put(new Integer(3), val3);
     storedVal =
-        regionAck1.getBucketRegion(new Integer(3)).getRegionEntry(new Integer(3))._getValue();
+        regionAck1.getBucketRegion(new Integer(3)).getRegionEntry(new Integer(3)).getValue();
     final int size3 = CachedDeserializableFactory.calcMemSize(storedVal);
     size += size3;
     assertEquals(size, regionAck1.getDataStore().currentAllocatedMemory());

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/RemoteTransactionDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/RemoteTransactionDUnitTest.java
@@ -4400,7 +4400,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
 
   public Object getEntryValue(final CustId custId0, PartitionedRegion cust) {
     RegionEntry entry = cust.getBucketRegion(custId0).getRegionEntry(custId0);
-    Object value = entry._getValue();
+    Object value = entry.getValue();
     return value;
   }
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/Bug43684DUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/Bug43684DUnitTest.java
@@ -353,7 +353,7 @@ public class Bug43684DUnitTest extends JUnit4DistributedTestCase {
     LocalRegion r = (LocalRegion) cache.getRegion(REGION_NAME);
     for (int i = 0; i < numBuckets; i++) {
       RegionEntry e = r.getRegionEntry("KEY_" + i);
-      cache.getLoggerI18n().info(LocalizedStrings.DEBUG, e._getValue());
+      cache.getLoggerI18n().info(LocalizedStrings.DEBUG, e.getValue());
     }
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/offheap/OffHeapValidationJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/offheap/OffHeapValidationJUnitTest.java
@@ -279,7 +279,7 @@ public class OffHeapValidationJUnitTest {
   }
 
   private long getMemoryAddress(Region region, String key) {
-    Object entry = ((LocalRegion) region).getRegionEntry(key)._getValue();
+    Object entry = ((LocalRegion) region).getRegionEntry(key).getValue();
     assertTrue(entry instanceof OffHeapStoredObject);
     long memoryAddress = ((OffHeapStoredObject) entry).getAddress();
     assertTrue(memoryAddress > 0);


### PR DESCRIPTION
* cleanup variable names and types
* fix formatting and white space
* add @Override annotations and fix parameter names
* use interfaces instead of concrete implementations
* move member variables and constants to the top