### PR TITLE
GEODE-3919: Changed test to wait for the appropriate queue size since…

### DIFF
--- a/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/WANTestBase.java
+++ b/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/WANTestBase.java
@@ -2547,13 +2547,7 @@ public class WANTestBase extends JUnit4DistributedTestCase {
   }
 
   public static void testQueueSize(String senderId, int numQueueEntries) {
-    GatewaySender sender = null;
-    for (GatewaySender s : cache.getGatewaySenders()) {
-      if (s.getId().equals(senderId)) {
-        sender = s;
-        break;
-      }
-    }
+    GatewaySender sender = cache.getGatewaySender(senderId);
     if (sender.isParallel()) {
       int totalSize = 0;
       Set<RegionQueue> queues = ((AbstractGatewaySender) sender).getQueues();

--- a/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/parallel/ParallelWANStatsDUnitTest.java
+++ b/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/parallel/ParallelWANStatsDUnitTest.java
@@ -505,8 +505,8 @@ public class ParallelWANStatsDUnitTest extends WANTestBase {
     int numIterations = 100;
     vm1.invoke(() -> putSameEntry(regionName, numIterations));
 
-    // Verify queue size (no need to wait)
-    vm1.invoke(() -> testQueueSize(senderId, 2));
+    // Wait for appropriate queue size
+    vm1.invoke(() -> checkQueueSize(senderId, 2));
 
     // Verify the conflation indexes size stat
     verifyConflationIndexesSize(senderId, 1, vm1);


### PR DESCRIPTION
… conflation is async

Since conflation is asynchronous to the put operation, the test needs to wait for the queue to reach the correct size rather than just checking it immediately.