### PR TITLE
GEODE-3935: Closing down the cache after each test.

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/security/query/QuerySecurityBase.java
+++ b/geode-core/src/test/java/org/apache/geode/security/query/QuerySecurityBase.java
@@ -20,7 +20,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -39,6 +38,7 @@ import org.apache.geode.cache.query.Query;
 import org.apache.geode.cache.query.QueryInvocationTargetException;
 import org.apache.geode.cache.query.QueryService;
 import org.apache.geode.cache.query.TypeMismatchException;
+import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.security.SecurityTestUtil;
 import org.apache.geode.security.TestSecurityManager;
 import org.apache.geode.test.dunit.Host;
@@ -81,6 +81,12 @@ public class QuerySecurityBase extends JUnit4DistributedTestCase {
     createProxyRegion(superUserClient, regionName);
   }
 
+  public void closeAnyPollutedCache() {
+    if (GemFireCacheImpl.getInstance() != null) {
+      GemFireCacheImpl.getInstance().close();
+    }
+  }
+
   public void setClientCache(ClientCache cache) {
     clientCache = cache;
   }
@@ -91,6 +97,7 @@ public class QuerySecurityBase extends JUnit4DistributedTestCase {
 
   public void createClientCache(VM vm, String userName, String password) {
     vm.invoke(() -> {
+      closeAnyPollutedCache();
       ClientCache cache = SecurityTestUtil.createClientCache(userName, password, server.getPort());
       setClientCache(cache);
     });

--- a/geode-cq/src/test/java/org/apache/geode/cache/query/cq/dunit/CqSecurityAuthorizedUserDUnitTest.java
+++ b/geode-cq/src/test/java/org/apache/geode/cache/query/cq/dunit/CqSecurityAuthorizedUserDUnitTest.java
@@ -17,12 +17,9 @@ package org.apache.geode.cache.query.cq.dunit;
 import static org.apache.geode.internal.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeTrue;
 
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import junitparams.Parameters;
 import org.awaitility.Awaitility;
 import org.junit.Before;
 import org.junit.Test;


### PR DESCRIPTION
	* Test failure was attributed to an incompatible cache present in the system.
	* The @After method will close the cache after each test.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
