### PR TITLE
Fix for GEODE-3938

### DIFF
--- a/geode-core/src/main/antlr/org/apache/geode/cache/query/internal/parse/oql.g
+++ b/geode-core/src/main/antlr/org/apache/geode/cache/query/internal/parse/oql.g
@@ -917,7 +917,7 @@ conversionExpr :
                "to_date"^<AST=org.apache.geode.cache.query.internal.parse.ASTConversionExpr>
               )
               TOK_LPAREN!
-              stringLiteral TOK_COMMA! stringLiteral
+              (stringLiteral | queryParam) TOK_COMMA! stringLiteral
               TOK_RPAREN! 
            )    
 	)

--- a/geode-core/src/test/java/org/apache/geode/cache/query/QueryServiceJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/QueryServiceJUnitTest.java
@@ -71,6 +71,22 @@ public class QueryServiceJUnitTest {
   }
 
   @Test
+  public void testNewQueryWithToDatePresetFunction() throws Exception {
+    String testDate = "01/01/2000";
+    QueryService queryService = CacheUtils.getQueryService();
+
+    try {
+      queryService
+          .newQuery("SELECT * FROM /Portfolios WHERE createDate >= to_date($1, 'MM/dd/yyyy')");
+      queryService.newQuery("SELECT * FROM /Portfolios WHERE createDate >= to_date('" + testDate
+          + "', 'MM/dd/yyyy')");
+    } catch (Exception exception) {
+      exception.printStackTrace();
+      fail("Unexpected Exception, both queries are valid: " + exception.getMessage());
+    }
+  }
+
+  @Test
   public void testCreateIndex() throws Exception {
     CacheUtils.log("testCreateIndex");
     QueryService qs = CacheUtils.getQueryService();

--- a/geode-core/src/test/java/org/apache/geode/cache/query/QueryServiceJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/QueryServiceJUnitTest.java
@@ -71,18 +71,50 @@ public class QueryServiceJUnitTest {
   }
 
   @Test
-  public void testNewQueryWithToDatePresetFunction() throws Exception {
+  public void toDateWithPresetDateShouldExecuteWithoutExceptions() throws Exception {
     String testDate = "01/01/2000";
     QueryService queryService = CacheUtils.getQueryService();
+    Query query = queryService.newQuery(
+        "SELECT * FROM /Portfolios WHERE createDate >= to_date('" + testDate + "', 'MM/dd/yyyy')");
+    query.execute();
+  }
 
+  @Test
+  public void toDateWithValidBindParameterDateShouldExecuteWithoutExceptions() throws Exception {
+    String testDate = "01/01/2000";
+    QueryService queryService = CacheUtils.getQueryService();
+    Query query = queryService
+        .newQuery("SELECT * FROM /Portfolios WHERE createDate >= to_date($1, 'MM/dd/yyyy')");
+    query.execute(testDate);
+  }
+
+  @Test
+  public void toDateWithInValidStringBindParameterDateShouldThrowQueryInvalidException()
+      throws Exception {
+    String invalid = "someInvalidString";
+    QueryService queryService = CacheUtils.getQueryService();
+    Query query = queryService
+        .newQuery("SELECT * FROM /Portfolios WHERE createDate >= to_date($1, 'MM/dd/yyyy')");
     try {
-      queryService
-          .newQuery("SELECT * FROM /Portfolios WHERE createDate >= to_date($1, 'MM/dd/yyyy')");
-      queryService.newQuery("SELECT * FROM /Portfolios WHERE createDate >= to_date('" + testDate
-          + "', 'MM/dd/yyyy')");
-    } catch (Exception exception) {
-      exception.printStackTrace();
-      fail("Unexpected Exception, both queries are valid: " + exception.getMessage());
+      query.execute(invalid);
+      fail();
+    } catch (QueryInvalidException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void toDateWithRegionAsBindParameterDateShouldThrowQueryInvalidException()
+      throws Exception {
+    Object invalid = CacheUtils.getRegion("Portfolios");
+    QueryService queryService = CacheUtils.getQueryService();
+    Query query = queryService
+        .newQuery("SELECT * FROM /Portfolios WHERE createDate >= to_date($1, 'MM/dd/yyyy')");
+    try {
+      query.execute(invalid);
+      fail();
+    } catch (QueryInvalidException e) {
+      // expected
     }
   }
 

--- a/geode-core/src/test/java/org/apache/geode/cache/query/internal/parse/OQLParserTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/internal/parse/OQLParserTest.java
@@ -14,15 +14,14 @@
  */
 package org.apache.geode.cache.query.internal.parse;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.StringReader;
 
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import org.apache.geode.test.junit.categories.UnitTest;
-
-import static org.assertj.core.api.Assertions.fail;
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * TODO: class created to fix GEODE-3938. Add more tests for other queries, parameters, etc.
@@ -37,12 +36,8 @@ public class OQLParserTest {
     OQLLexer lexer = new OQLLexer(new StringReader(oqlSource));
     OQLParser parser = new OQLParser(lexer);
 
-    try {
-      parser.queryProgram();
-      assertThat(parser.getAST()).isNotNull();
-    } catch (Exception exception) {
-      fail("Unexpected Exception, the query grammar is correct.", exception);
-    }
+    parser.queryProgram();
+    assertThat(parser.getAST()).isNotNull();
   }
 
   @Test
@@ -51,11 +46,7 @@ public class OQLParserTest {
     OQLLexer lexer = new OQLLexer(new StringReader(oqlSource));
     OQLParser parser = new OQLParser(lexer);
 
-    try {
-      parser.queryProgram();
-      assertThat(parser.getAST()).isNotNull();
-    } catch (Exception exception) {
-      fail("Unexpected Exception, the query grammar is correct.", exception);
-    }
+    parser.queryProgram();
+    assertThat(parser.getAST()).isNotNull();
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/cache/query/internal/parse/OQLParserTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/internal/parse/OQLParserTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache.query.internal.parse;
+
+import java.io.StringReader;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.test.junit.categories.UnitTest;
+
+import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * TODO: class created to fix GEODE-3938. Add more tests for other queries, parameters, etc.
+ */
+@Category(UnitTest.class)
+public class OQLParserTest {
+
+  @Test
+  public void testToDatePresetQueryFunction() throws Exception {
+    String oqlSource =
+        "SELECT * FROM /Portfolios WHERE createDate >= to_date('01/01/2000', 'MM/dd/yyyy')";
+    OQLLexer lexer = new OQLLexer(new StringReader(oqlSource));
+    OQLParser parser = new OQLParser(lexer);
+
+    try {
+      parser.queryProgram();
+      assertThat(parser.getAST()).isNotNull();
+    } catch (Exception exception) {
+      fail("Unexpected Exception, the query grammar is correct.", exception);
+    }
+  }
+
+  @Test
+  public void testToDatePresetQueryFunctionWithQueryParameter() throws Exception {
+    String oqlSource = "SELECT * FROM /Portfolios WHERE createDate >= to_date($1, 'MM/dd/yyyy')";
+    OQLLexer lexer = new OQLLexer(new StringReader(oqlSource));
+    OQLParser parser = new OQLParser(lexer);
+
+    try {
+      parser.queryProgram();
+      assertThat(parser.getAST()).isNotNull();
+    } catch (Exception exception) {
+      fail("Unexpected Exception, the query grammar is correct.", exception);
+    }
+  }
+}


### PR DESCRIPTION
GEODE-3938: Allow query parameters within the to_date preset query function.
  . Added unit tests.
  . Changed oql.g to allow both 'stringLiteral' and 'queryParam' within the do_date preset function definition.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
