### PR TITLE
GEODE-3539: LocatorServerStartupRule enhancement

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/internal/cache/extension/ExtensionClusterConfigurationDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/extension/ExtensionClusterConfigurationDUnitTest.java
@@ -18,8 +18,6 @@ import static org.apache.geode.test.dunit.Assert.assertNotNull;
 import static org.apache.geode.test.dunit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 
-import java.io.Serializable;
-
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -88,7 +86,7 @@ public class ExtensionClusterConfigurationDUnitTest {
     // Verify the config creation on this member
     MemberVM newMember = locatorServerStartupRule.startServerVM(2, locator.getPort());
     newMember.invoke(() -> {
-      InternalCache cache = LocatorServerStartupRule.serverStarter.getCache();
+      InternalCache cache = LocatorServerStartupRule.getCache();
       assertNotNull(cache);
 
       Region<?, ?> region1 = cache.getRegion(REPLICATE_REGION);
@@ -143,7 +141,7 @@ public class ExtensionClusterConfigurationDUnitTest {
     // Verify the config creation on this member
     MemberVM newMember = locatorServerStartupRule.startServerVM(2, locator.getPort());
     newMember.invoke(() -> {
-      InternalCache cache = LocatorServerStartupRule.serverStarter.getCache();
+      InternalCache cache = LocatorServerStartupRule.getCache();
       assertNotNull(cache);
 
       Region<?, ?> region1 = cache.getRegion(REPLICATE_REGION);

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateRegionCommandDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateRegionCommandDUnitTest.java
@@ -18,11 +18,7 @@ package org.apache.geode.management.internal.cli.commands;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
 
-import org.json.JSONArray;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -36,7 +32,6 @@ import org.apache.geode.cache.Region;
 import org.apache.geode.compression.SnappyCompressor;
 import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.internal.cache.RegionEntryContext;
-import org.apache.geode.management.internal.cli.result.CommandResult;
 import org.apache.geode.test.compiler.JarBuilder;
 import org.apache.geode.test.dunit.rules.LocatorServerStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
@@ -78,7 +73,7 @@ public class CreateRegionCommandDUnitTest {
         .statusIsSuccess();
 
     server.invoke(() -> {
-      Cache cache = LocatorServerStartupRule.serverStarter.getCache();
+      Cache cache = LocatorServerStartupRule.getCache();
       Region region = cache.getRegion(regionName);
       assertThat(region).isNotNull();
       assertThat(region.getAttributes().getCompressor())
@@ -94,7 +89,7 @@ public class CreateRegionCommandDUnitTest {
         .statusIsError();
 
     server.invoke(() -> {
-      Cache cache = LocatorServerStartupRule.serverStarter.getCache();
+      Cache cache = LocatorServerStartupRule.getCache();
       Region region = cache.getRegion(regionName);
       assertThat(region).isNull();
     });
@@ -107,7 +102,7 @@ public class CreateRegionCommandDUnitTest {
         .statusIsSuccess();
 
     server.invoke(() -> {
-      Cache cache = LocatorServerStartupRule.serverStarter.getCache();
+      Cache cache = LocatorServerStartupRule.getCache();
       Region region = cache.getRegion(regionName);
       assertThat(region).isNotNull();
       assertThat(region.getAttributes().getCompressor()).isNull();
@@ -133,7 +128,7 @@ public class CreateRegionCommandDUnitTest {
         .statusIsSuccess();
 
     server.invoke(() -> {
-      Cache cache = LocatorServerStartupRule.serverStarter.getCache();
+      Cache cache = LocatorServerStartupRule.getCache();
       PartitionedRegion region = (PartitionedRegion) cache.getRegion(regionName);
       PartitionResolver resolver = region.getPartitionAttributes().getPartitionResolver();
       assertThat(resolver).isNotNull();

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DestroyRegionCommandDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DestroyRegionCommandDUnitTest.java
@@ -74,7 +74,7 @@ public class DestroyRegionCommandDUnitTest {
   @Test
   public void testDestroyDistributedRegion() {
     MemberVM.invokeInEveryMember(() -> {
-      Cache cache = LocatorServerStartupRule.serverStarter.getCache();
+      Cache cache = LocatorServerStartupRule.getCache();
       RegionFactory<Object, Object> factory = cache.createRegionFactory(RegionShortcut.PARTITION);
       factory.create("Customer");
 
@@ -106,7 +106,7 @@ public class DestroyRegionCommandDUnitTest {
   @Test
   public void testDestroyLocalRegions() {
     MemberVM.invokeInEveryMember(() -> {
-      Cache cache = LocatorServerStartupRule.serverStarter.getCache();
+      Cache cache = LocatorServerStartupRule.getCache();
       RegionFactory<Object, Object> factory = cache.createRegionFactory(RegionShortcut.REPLICATE);
       factory.setScope(Scope.LOCAL);
       factory.create("Customer");
@@ -118,7 +118,7 @@ public class DestroyRegionCommandDUnitTest {
         .containsOutput("destroyed successfully");
 
     MemberVM.invokeInEveryMember(() -> {
-      Cache cache = LocatorServerStartupRule.serverStarter.getCache();
+      Cache cache = LocatorServerStartupRule.getCache();
       assertThat(cache.getRegion("Customer")).isNull();
     }, server1, server2, server3);
   }
@@ -126,7 +126,7 @@ public class DestroyRegionCommandDUnitTest {
   @Test
   public void testDestroyLocalAndDistributedRegions() {
     MemberVM.invokeInEveryMember(() -> {
-      Cache cache = LocatorServerStartupRule.serverStarter.getCache();
+      Cache cache = LocatorServerStartupRule.getCache();
       RegionFactory<Object, Object> factory = cache.createRegionFactory(RegionShortcut.PARTITION);
       factory.create("Customer");
       factory.create("Customer_2");
@@ -134,7 +134,7 @@ public class DestroyRegionCommandDUnitTest {
     }, server1, server2);
 
     server3.invoke(() -> {
-      Cache cache = LocatorServerStartupRule.serverStarter.getCache();
+      Cache cache = LocatorServerStartupRule.getCache();
       RegionFactory<Object, Object> factory = cache.createRegionFactory(RegionShortcut.REPLICATE);
       factory.setScope(Scope.LOCAL);
       factory.create("Customer");
@@ -154,7 +154,7 @@ public class DestroyRegionCommandDUnitTest {
         .containsOutput("destroyed successfully");
 
     MemberVM.invokeInEveryMember(() -> {
-      Cache cache = LocatorServerStartupRule.serverStarter.getCache();
+      Cache cache = LocatorServerStartupRule.getCache();
       assertThat(cache.getRegion("Customer")).isNull();
       assertThat(cache.getRegion("Customer_2")).isNull();
       assertThat(cache.getRegion("Customer_3")).isNull();
@@ -175,7 +175,7 @@ public class DestroyRegionCommandDUnitTest {
 
     // make sure region does exists
     MemberVM.invokeInEveryMember(() -> {
-      Cache cache = LocatorServerStartupRule.serverStarter.getCache();
+      Cache cache = LocatorServerStartupRule.getCache();
       assertThat(cache.getRegion("Customer")).isNotNull();
     }, server1, server2, server3);
 
@@ -197,7 +197,7 @@ public class DestroyRegionCommandDUnitTest {
 
     // make sure region does not exist
     MemberVM.invokeInEveryMember(() -> {
-      Cache cache = LocatorServerStartupRule.serverStarter.getCache();
+      Cache cache = LocatorServerStartupRule.getCache();
       assertThat(cache.getRegion("Customer")).isNull();
     }, server1, server2, server3);
   }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ExecuteFunctionCommandSecurityTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ExecuteFunctionCommandSecurityTest.java
@@ -76,7 +76,7 @@ public class ExecuteFunctionCommandSecurityTest implements Serializable {
       FunctionService.registerFunction(new ReadFunction());
       FunctionService.registerFunction(new WriteFunction());
 
-      InternalCache cache = LocatorServerStartupRule.serverStarter.getCache();
+      InternalCache cache = LocatorServerStartupRule.getCache();
       cache.createRegionFactory(RegionShortcut.REPLICATE).create(REPLICATED_REGION);
       cache.createRegionFactory(RegionShortcut.PARTITION).create(PARTITIONED_REGION);
     }));

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/FunctionCommandsDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/FunctionCommandsDUnitTest.java
@@ -17,14 +17,12 @@ package org.apache.geode.management.internal.cli.commands;
 
 import static org.apache.geode.internal.cache.functions.TestFunction.TEST_FUNCTION1;
 import static org.apache.geode.internal.cache.functions.TestFunction.TEST_FUNCTION_RETURN_ARGS;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 import org.assertj.core.util.Strings;
-import org.json.JSONArray;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -39,8 +37,6 @@ import org.apache.geode.cache.execute.FunctionService;
 import org.apache.geode.internal.cache.functions.TestFunction;
 import org.apache.geode.management.DistributedSystemMXBean;
 import org.apache.geode.management.ManagementService;
-import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.result.CommandResult;
 import org.apache.geode.test.dunit.rules.LocatorServerStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.junit.categories.DistributedTest;
@@ -71,7 +67,7 @@ public class FunctionCommandsDUnitTest {
     server2 = lsRule.startServerVM(2, locator.getPort());
 
     server1.invoke(() -> {
-      Cache cache = LocatorServerStartupRule.serverStarter.getCache();
+      Cache cache = LocatorServerStartupRule.getCache();
 
       RegionFactory<Integer, Integer> dataRegionFactory =
           cache.createRegionFactory(RegionShortcut.PARTITION);
@@ -86,7 +82,7 @@ public class FunctionCommandsDUnitTest {
     });
 
     server2.invoke(() -> {
-      Cache cache = LocatorServerStartupRule.serverStarter.getCache();
+      Cache cache = LocatorServerStartupRule.getCache();
       RegionFactory<Integer, Integer> dataRegionFactory =
           cache.createRegionFactory(RegionShortcut.PARTITION);
       Region region = dataRegionFactory.create(REGION_ONE);
@@ -103,7 +99,7 @@ public class FunctionCommandsDUnitTest {
     registerFunction(new TestFunction(true, TEST_FUNCTION_RETURN_ARGS), locator, server1, server2);
 
     locator.invoke(() -> {
-      Cache cache = LocatorServerStartupRule.locatorStarter.getLocator().getCache();
+      Cache cache = LocatorServerStartupRule.getCache();
       ManagementService managementService = ManagementService.getManagementService(cache);
       DistributedSystemMXBean dsMXBean = managementService.getDistributedSystemMXBean();
 

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/IndexCommandsShareConfigurationDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/IndexCommandsShareConfigurationDUnitTest.java
@@ -92,7 +92,7 @@ public class IndexCommandsShareConfigurationDUnitTest {
     props.setProperty(GROUPS, groupName);
     serverVM = startupRule.startServerVM(1, props, locator.getPort());
     serverVM.invoke(() -> {
-      InternalCache cache = LocatorServerStartupRule.serverStarter.getCache();
+      InternalCache cache = LocatorServerStartupRule.getCache();
       Region parReg =
           createPartitionedRegion(partitionedRegionName, cache, String.class, Stock.class);
       parReg.put("VMW", new Stock("VMW", 98));
@@ -148,7 +148,7 @@ public class IndexCommandsShareConfigurationDUnitTest {
     serverVM = startupRule.startServerVM(1, props, locator.getPort());
 
     serverVM.invoke(() -> {
-      InternalCache restartedCache = LocatorServerStartupRule.serverStarter.getCache();
+      InternalCache restartedCache = LocatorServerStartupRule.getCache();
       assertNotNull(restartedCache);
       Region region = restartedCache.getRegion(partitionedRegionName);
       assertNotNull(region);

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ListIndexCommandDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ListIndexCommandDUnitTest.java
@@ -15,8 +15,6 @@
 
 package org.apache.geode.management.internal.cli.commands;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -54,7 +52,7 @@ public class ListIndexCommandDUnitTest {
     server = lsRule.startServerVM(1, locator.getPort());
 
     server.invoke(() -> {
-      Cache cache = LocatorServerStartupRule.serverStarter.getCache();
+      Cache cache = LocatorServerStartupRule.getCache();
       RegionFactory factory = cache.createRegionFactory(RegionShortcut.REPLICATE);
       Region region = factory.create(REGION_1);
 

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ShowDeadlockDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ShowDeadlockDUnitTest.java
@@ -133,7 +133,7 @@ public class ShowDeadlockDUnitTest {
   }
 
   private static InternalDistributedMember getInternalDistributedMember(MemberVM memberVM) {
-    return memberVM.getVM().invoke(() -> LocatorServerStartupRule.serverStarter.getCache()
+    return memberVM.getVM().invoke(() -> LocatorServerStartupRule.getCache()
         .getInternalDistributedSystem().getDistributedMember());
   }
 

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ShowMetricsDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ShowMetricsDUnitTest.java
@@ -63,7 +63,7 @@ public class ShowMetricsDUnitTest {
     server = lsRule.startServerVM(1, locator.getPort());
     int serverPort = server.getPort();
     server.invoke(() -> {
-      Cache cache = LocatorServerStartupRule.serverStarter.getCache();
+      Cache cache = LocatorServerStartupRule.getCache();
       RegionFactory<Integer, Integer> dataRegionFactory =
           cache.createRegionFactory(RegionShortcut.REPLICATE);
       dataRegionFactory.create("REGION1");
@@ -73,7 +73,7 @@ public class ShowMetricsDUnitTest {
     });
 
     locator.invoke(() -> {
-      Cache cache = LocatorServerStartupRule.locatorStarter.getLocator().getCache();
+      Cache cache = LocatorServerStartupRule.getCache();
       // Wait for all of the relevant beans to be ready
       await().atMost(120, SECONDS).until(() -> isBeanReady(cache, 1, "", null, 0));
       await().atMost(120, SECONDS).until(() -> isBeanReady(cache, 2, "REGION1", null, 0));

--- a/geode-core/src/test/java/org/apache/geode/management/internal/configuration/ClusterConfig.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/configuration/ClusterConfig.java
@@ -92,7 +92,7 @@ public class ClusterConfig implements Serializable {
 
     // verify info exists in memory
     locatorVM.invoke(() -> {
-      InternalLocator internalLocator = LocatorServerStartupRule.locatorStarter.getLocator();
+      InternalLocator internalLocator = LocatorServerStartupRule.getLocator();
       ClusterConfigurationService sc = internalLocator.getSharedConfiguration();
 
       // verify no extra configs exist in memory

--- a/geode-core/src/test/java/org/apache/geode/management/internal/configuration/ClusterConfigDistributionDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/configuration/ClusterConfigDistributionDUnitTest.java
@@ -122,7 +122,7 @@ public class ClusterConfigDistributionDUnitTest {
     MemberVM server = lsRule.startServerVM(2, new Properties(), locator.getPort());
 
     server.invoke(() -> {
-      Cache cache = LocatorServerStartupRule.serverStarter.getCache();
+      Cache cache = LocatorServerStartupRule.getCache();
       assertNotNull(cache);
       assertTrue(cache.getCopyOnRead());
 

--- a/geode-core/src/test/java/org/apache/geode/management/internal/configuration/ClusterConfigImportDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/configuration/ClusterConfigImportDUnitTest.java
@@ -69,7 +69,7 @@ public class ClusterConfigImportDUnitTest extends ClusterConfigTestBase {
     String regionName = "regionA";
     server1.invoke(() -> {
       // this region will be created on both servers, but we should only be getting the name once.
-      Cache cache = LocatorServerStartupRule.serverStarter.getCache();
+      Cache cache = LocatorServerStartupRule.getCache();
       cache.createRegionFactory(RegionShortcut.REPLICATE).create(regionName);
     });
 

--- a/geode-core/src/test/java/org/apache/geode/management/internal/configuration/ClusterConfigWithSecurityDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/configuration/ClusterConfigWithSecurityDUnitTest.java
@@ -79,7 +79,7 @@ public class ClusterConfigWithSecurityDUnitTest {
 
     // the second locator should inherit the first locator's security props
     locator1.invoke(() -> {
-      InternalLocator locator = LocatorServerStartupRule.locatorStarter.getLocator();
+      InternalLocator locator = LocatorServerStartupRule.getLocator();
       ClusterConfigurationService sc = locator.getSharedConfiguration();
       Properties clusterConfigProps = sc.getConfiguration("cluster").getGemfireProperties();
       assertThat(clusterConfigProps.getProperty(SECURITY_MANAGER))
@@ -99,7 +99,7 @@ public class ClusterConfigWithSecurityDUnitTest {
         .statusIsSuccess();
 
     locator0.invoke(() -> {
-      InternalLocator locator = LocatorServerStartupRule.locatorStarter.getLocator();
+      InternalLocator locator = LocatorServerStartupRule.getLocator();
       ClusterConfigurationService sc = locator.getSharedConfiguration();
       Properties properties = sc.getConfiguration("cluster").getGemfireProperties();
       assertThat(properties.getProperty(MCAST_PORT)).isEqualTo("0");
@@ -121,7 +121,7 @@ public class ClusterConfigWithSecurityDUnitTest {
 
     // cluster config specifies a security-manager so integrated security should be enabled
     server.invoke(() -> {
-      InternalCache cache = LocatorServerStartupRule.serverStarter.getCache();
+      InternalCache cache = LocatorServerStartupRule.getCache();
       Properties properties = cache.getDistributedSystem().getSecurityProperties();
       assertThat(properties.getProperty(SECURITY_MANAGER))
           .isEqualTo(SimpleTestSecurityManager.class.getName());

--- a/geode-core/src/test/java/org/apache/geode/management/internal/configuration/ImportOldClusterConfigDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/configuration/ImportOldClusterConfigDUnitTest.java
@@ -96,7 +96,7 @@ public class ImportOldClusterConfigDUnitTest {
   }
 
   private static void regionExists(String regionName) {
-    Cache cache = LocatorServerStartupRule.serverStarter.getCache();
+    Cache cache = LocatorServerStartupRule.getCache();
     assertThat(cache).isNotNull();
     Region<Object, Object> one = cache.getRegion(regionName);
     assertThat(one).isNotNull();

--- a/geode-core/src/test/java/org/apache/geode/security/PDXGfshPostProcessorOnRemoteServerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/security/PDXGfshPostProcessorOnRemoteServerTest.java
@@ -18,7 +18,6 @@ import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_MANA
 import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_POST_PROCESSOR;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
@@ -74,7 +73,7 @@ public class PDXGfshPostProcessorOnRemoteServerTest {
     MemberVM serverVM = lsRule.startServerVM(1, serverProps, locatorVM.getPort());
 
     serverVM.invoke(() -> {
-      InternalCache cache = LocatorServerStartupRule.serverStarter.getCache();
+      InternalCache cache = LocatorServerStartupRule.getCache();
       assertThat(cache.getSecurityService()).isNotNull();
       assertThat(cache.getSecurityService().getSecurityManager()).isNotNull();
       assertThat(cache.getSecurityService().getPostProcessor()).isNotNull();
@@ -107,7 +106,7 @@ public class PDXGfshPostProcessorOnRemoteServerTest {
     gfsh.executeAndAssertThat("query --query=\"select * from /AuthRegion\"").statusIsSuccess();
 
     serverVM.invoke(() -> {
-      PDXPostProcessor pp = (PDXPostProcessor) LocatorServerStartupRule.serverStarter.getCache()
+      PDXPostProcessor pp = (PDXPostProcessor) LocatorServerStartupRule.getCache()
           .getSecurityService().getPostProcessor();
       // verify that the post processor is called 6 times. (5 for the query, 1 for the get)
       assertEquals(pp.getCount(), 6);

--- a/geode-core/src/test/java/org/apache/geode/security/PeerAuthenticatorDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/security/PeerAuthenticatorDUnitTest.java
@@ -62,7 +62,7 @@ public class PeerAuthenticatorDUnitTest {
 
     server2.invoke(() -> {
       ServerStarterRule serverStarter = new ServerStarterRule();
-      LocatorServerStartupRule.serverStarter = serverStarter;
+      LocatorServerStartupRule.memberStarter = serverStarter;
       assertThatThrownBy(() -> serverStarter.startServer(server2Props, locatorPort))
           .isInstanceOf(GemFireSecurityException.class).hasMessageContaining("Invalid user name");
 

--- a/geode-core/src/test/java/org/apache/geode/security/PeerSecurityWithEmbeddedLocatorDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/security/PeerSecurityWithEmbeddedLocatorDUnitTest.java
@@ -63,7 +63,7 @@ public class PeerSecurityWithEmbeddedLocatorDUnitTest {
     VM server2 = getHost(0).getVM(2);
     server2.invoke(() -> {
       ServerStarterRule serverStarter = new ServerStarterRule();
-      LocatorServerStartupRule.serverStarter = serverStarter;
+      LocatorServerStartupRule.memberStarter = serverStarter;
       assertThatThrownBy(() -> serverStarter.startServer(server2Props, locatorPort))
           .isInstanceOf(GemFireSecurityException.class)
           .hasMessageContaining("Security check failed. Authentication error");
@@ -94,7 +94,7 @@ public class PeerSecurityWithEmbeddedLocatorDUnitTest {
     VM server2 = getHost(0).getVM(2);
     server2.invoke(() -> {
       ServerStarterRule serverStarter = new ServerStarterRule();
-      LocatorServerStartupRule.serverStarter = serverStarter;
+      LocatorServerStartupRule.memberStarter = serverStarter;
       assertThatThrownBy(() -> serverStarter.startServer(server2Props, locatorPort))
           .isInstanceOf(GemFireSecurityException.class).hasMessageContaining("Invalid user name");
     });

--- a/geode-core/src/test/java/org/apache/geode/test/dunit/rules/MemberVM.java
+++ b/geode-core/src/test/java/org/apache/geode/test/dunit/rules/MemberVM.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 
 import org.apache.commons.io.FileUtils;
 
+import org.apache.geode.cache.Cache;
 import org.apache.geode.test.dunit.AsyncInvocation;
 import org.apache.geode.test.dunit.SerializableCallableIF;
 import org.apache.geode.test.dunit.SerializableRunnableIF;
@@ -65,6 +66,13 @@ public class MemberVM implements Member {
 
   public Member getMember() {
     return member;
+  }
+
+  /**
+   * this should only be called inside the vm
+   */
+  public Cache getCache() {
+    return getMember().getCache();
   }
 
   @Override

--- a/geode-core/src/test/java/org/apache/geode/test/dunit/rules/MemberVM.java
+++ b/geode-core/src/test/java/org/apache/geode/test/dunit/rules/MemberVM.java
@@ -20,7 +20,6 @@ import java.util.Arrays;
 
 import org.apache.commons.io.FileUtils;
 
-import org.apache.geode.cache.Cache;
 import org.apache.geode.test.dunit.AsyncInvocation;
 import org.apache.geode.test.dunit.SerializableCallableIF;
 import org.apache.geode.test.dunit.SerializableRunnableIF;
@@ -66,13 +65,6 @@ public class MemberVM implements Member {
 
   public Member getMember() {
     return member;
-  }
-
-  /**
-   * this should only be called inside the vm
-   */
-  public Cache getCache() {
-    return getMember().getCache();
   }
 
   @Override
@@ -129,5 +121,15 @@ public class MemberVM implements Member {
 
   public static void invokeInEveryMember(SerializableRunnableIF runnableIF, MemberVM... members) {
     Arrays.stream(members).forEach(member -> member.invoke(runnableIF));
+  }
+
+  /**
+   * this should called on a locatorVM or a serverVM with jmxManager enabled
+   */
+  public void waitTillRegionsAreReadyOnServers(String regionPath, int serverCount) {
+    vm.invoke(() -> {
+      LocatorServerStartupRule.memberStarter.waitTillRegionIsReadyOnServers(regionPath,
+          serverCount);
+    });
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/test/junit/rules/Locator.java
+++ b/geode-core/src/test/java/org/apache/geode/test/junit/rules/Locator.java
@@ -17,6 +17,5 @@ package org.apache.geode.test.junit.rules;
 import org.apache.geode.distributed.internal.InternalLocator;
 
 public interface Locator extends Member {
-
   InternalLocator getLocator();
 }

--- a/geode-core/src/test/java/org/apache/geode/test/junit/rules/Locator.java
+++ b/geode-core/src/test/java/org/apache/geode/test/junit/rules/Locator.java
@@ -15,7 +15,10 @@
 package org.apache.geode.test.junit.rules;
 
 import org.apache.geode.distributed.internal.InternalLocator;
+import org.apache.geode.internal.cache.InternalCache;
 
 public interface Locator extends Member {
+  InternalCache getCache();
+
   InternalLocator getLocator();
 }

--- a/geode-core/src/test/java/org/apache/geode/test/junit/rules/LocatorStarterRule.java
+++ b/geode-core/src/test/java/org/apache/geode/test/junit/rules/LocatorStarterRule.java
@@ -23,9 +23,9 @@ import java.util.concurrent.TimeUnit;
 
 import org.awaitility.Awaitility;
 
-import org.apache.geode.cache.Cache;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.InternalLocator;
+import org.apache.geode.internal.cache.InternalCache;
 
 /**
  * This is a rule to start up a locator in your current VM. It's useful for your Integration Tests.
@@ -92,7 +92,7 @@ public class LocatorStarterRule extends MemberStarterRule<LocatorStarterRule> im
   }
 
   @Override
-  public Cache getCache() {
+  public InternalCache getCache() {
     return locator.getCache();
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/test/junit/rules/LocatorStarterRule.java
+++ b/geode-core/src/test/java/org/apache/geode/test/junit/rules/LocatorStarterRule.java
@@ -23,6 +23,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.awaitility.Awaitility;
 
+import org.apache.geode.cache.Cache;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.InternalLocator;
 
@@ -45,7 +46,6 @@ import org.apache.geode.distributed.internal.InternalLocator;
  * use {@code LocatorServerStartupRule}.
  */
 public class LocatorStarterRule extends MemberStarterRule<LocatorStarterRule> implements Locator {
-
   private transient InternalLocator locator;
 
   @Override
@@ -89,5 +89,10 @@ public class LocatorStarterRule extends MemberStarterRule<LocatorStarterRule> im
       Awaitility.await().atMost(65, TimeUnit.SECONDS)
           .until(() -> assertTrue(locator.isSharedConfigurationRunning()));
     }
+  }
+
+  @Override
+  public Cache getCache() {
+    return locator.getCache();
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/test/junit/rules/Member.java
+++ b/geode-core/src/test/java/org/apache/geode/test/junit/rules/Member.java
@@ -17,11 +17,7 @@ package org.apache.geode.test.junit.rules;
 import java.io.File;
 import java.io.Serializable;
 
-import org.apache.geode.cache.Cache;
-
 public interface Member extends Serializable {
-  Cache getCache();
-
   File getWorkingDir();
 
   int getPort();

--- a/geode-core/src/test/java/org/apache/geode/test/junit/rules/Member.java
+++ b/geode-core/src/test/java/org/apache/geode/test/junit/rules/Member.java
@@ -17,7 +17,10 @@ package org.apache.geode.test.junit.rules;
 import java.io.File;
 import java.io.Serializable;
 
+import org.apache.geode.cache.Cache;
+
 public interface Member extends Serializable {
+  Cache getCache();
 
   File getWorkingDir();
 

--- a/geode-core/src/test/java/org/apache/geode/test/junit/rules/MemberStarterRule.java
+++ b/geode-core/src/test/java/org/apache/geode/test/junit/rules/MemberStarterRule.java
@@ -36,6 +36,7 @@ import org.junit.rules.TemporaryFolder;
 import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.internal.AvailablePortHelper;
+import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.net.SocketCreatorFactory;
 import org.apache.geode.management.DistributedRegionMXBean;
 import org.apache.geode.management.ManagementService;
@@ -228,17 +229,21 @@ public abstract class MemberStarterRule<T> extends SerializableExternalResource 
     return getManagementService().getDistributedRegionMXBean(regionName);
   }
 
-  public ManagementService getManagementService(){
-    ManagementService managementService = ManagementService.getExistingManagementService(getCache());
-    if(managementService == null){
+  public ManagementService getManagementService() {
+    ManagementService managementService =
+        ManagementService.getExistingManagementService(getCache());
+    if (managementService == null) {
       throw new IllegalStateException("Management service is not available on this member");
     }
     return managementService;
   }
 
-  public void waitTillRegionIsReadyOnServers(String regionName, int serverCount){
-    await().atMost(2, TimeUnit.SECONDS).until(()->getRegionMBean(regionName) != null);
-    await().atMost(2, TimeUnit.SECONDS).until(()->getRegionMBean(regionName).getMembers().length == serverCount);
+  public abstract InternalCache getCache();
+
+  public void waitTillRegionIsReadyOnServers(String regionName, int serverCount) {
+    await().atMost(2, TimeUnit.SECONDS).until(() -> getRegionMBean(regionName) != null);
+    await().atMost(2, TimeUnit.SECONDS)
+        .until(() -> getRegionMBean(regionName).getMembers().length == serverCount);
   }
 
   abstract void stopMember();

--- a/geode-core/src/test/java/org/apache/geode/test/junit/rules/Server.java
+++ b/geode-core/src/test/java/org/apache/geode/test/junit/rules/Server.java
@@ -14,13 +14,9 @@
  */
 package org.apache.geode.test.junit.rules;
 
-import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.server.CacheServer;
 
 public interface Server extends Member {
-
-  Cache getCache();
-
   CacheServer getServer();
 
   int getEmbeddedLocatorPort();

--- a/geode-core/src/test/java/org/apache/geode/test/junit/rules/Server.java
+++ b/geode-core/src/test/java/org/apache/geode/test/junit/rules/Server.java
@@ -15,8 +15,11 @@
 package org.apache.geode.test.junit.rules;
 
 import org.apache.geode.cache.server.CacheServer;
+import org.apache.geode.internal.cache.InternalCache;
 
 public interface Server extends Member {
+  InternalCache getCache();
+
   CacheServer getServer();
 
   int getEmbeddedLocatorPort();

--- a/geode-core/src/test/java/org/apache/geode/test/junit/rules/ServerStarterRule.java
+++ b/geode-core/src/test/java/org/apache/geode/test/junit/rules/ServerStarterRule.java
@@ -51,7 +51,6 @@ import org.apache.geode.internal.cache.InternalCache;
  * use {@code LocatorServerStartupRule}.
  */
 public class ServerStarterRule extends MemberStarterRule<ServerStarterRule> implements Server {
-
   private transient InternalCache cache;
   private transient CacheServer server;
   private int embeddedLocatorPort = -1;

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexCommandsDUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexCommandsDUnitTest.java
@@ -18,7 +18,6 @@ import static org.apache.geode.cache.lucene.test.LuceneTestUtilities.INDEX_NAME;
 import static org.apache.geode.cache.lucene.test.LuceneTestUtilities.REGION_NAME;
 import static org.apache.geode.test.dunit.Assert.assertArrayEquals;
 import static org.apache.geode.test.dunit.Assert.assertEquals;
-import static org.apache.geode.test.dunit.Assert.assertTrue;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.Serializable;
@@ -663,8 +662,7 @@ public class LuceneIndexCommandsDUnitTest implements Serializable {
 
   private void createIndex() {
     serverVM.invoke(() -> {
-      LuceneService luceneService =
-          LuceneServiceProvider.get(LocatorServerStartupRule.serverStarter.getCache());
+      LuceneService luceneService = LuceneServiceProvider.get(LocatorServerStartupRule.getCache());
       Map<String, Analyzer> fieldAnalyzers = new HashMap();
       fieldAnalyzers.put("field1", new StandardAnalyzer());
       fieldAnalyzers.put("field2", new KeywordAnalyzer());
@@ -676,8 +674,7 @@ public class LuceneIndexCommandsDUnitTest implements Serializable {
 
   private void createIndexWithoutRegion() {
     serverVM.invoke(() -> {
-      LuceneService luceneService =
-          LuceneServiceProvider.get(LocatorServerStartupRule.serverStarter.getCache());
+      LuceneService luceneService = LuceneServiceProvider.get(LocatorServerStartupRule.getCache());
       Map<String, Analyzer> fieldAnalyzers = new HashMap();
       fieldAnalyzers.put("field1", new StandardAnalyzer());
       fieldAnalyzers.put("field2", new KeywordAnalyzer());
@@ -720,7 +717,7 @@ public class LuceneIndexCommandsDUnitTest implements Serializable {
   }
 
   private static Cache getCache() {
-    return LocatorServerStartupRule.serverStarter.getCache();
+    return LocatorServerStartupRule.getCache();
   }
 
   protected class TestObject implements Serializable {

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/configuration/LuceneClusterConfigurationDUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/configuration/LuceneClusterConfigurationDUnitTest.java
@@ -83,8 +83,7 @@ public class LuceneClusterConfigurationDUnitTest {
     // configuration.
     MemberVM vm2 = ls.startServerVM(2, locator.getPort());
     vm2.invoke(() -> {
-      LuceneService luceneService =
-          LuceneServiceProvider.get(LocatorServerStartupRule.serverStarter.getCache());
+      LuceneService luceneService = LuceneServiceProvider.get(LocatorServerStartupRule.getCache());
       final LuceneIndex index = luceneService.getIndex(INDEX_NAME, REGION_NAME);
       assertNotNull(index);
       validateIndexFields(new String[] {"field1", "field2", "field3"}, index);
@@ -108,8 +107,7 @@ public class LuceneClusterConfigurationDUnitTest {
     // configuration.
     MemberVM vm2 = ls.startServerVM(2, locator.getPort());
     vm2.invoke(() -> {
-      LuceneService luceneService =
-          LuceneServiceProvider.get(LocatorServerStartupRule.serverStarter.getCache());
+      LuceneService luceneService = LuceneServiceProvider.get(LocatorServerStartupRule.getCache());
       final LuceneIndex index = luceneService.getIndex(INDEX_NAME, REGION_NAME);
       assertNotNull(index);
       String[] fields = new String[] {"field1", "field2", "field3"};
@@ -139,8 +137,7 @@ public class LuceneClusterConfigurationDUnitTest {
     // configuration.
     MemberVM vm2 = ls.startServerVM(2, locator.getPort());
     vm2.invoke(() -> {
-      LuceneService luceneService =
-          LuceneServiceProvider.get(LocatorServerStartupRule.serverStarter.getCache());
+      LuceneService luceneService = LuceneServiceProvider.get(LocatorServerStartupRule.getCache());
       final LuceneIndex index = luceneService.getIndex(INDEX_NAME, REGION_NAME);
       assertNotNull(index);
       String[] fields = new String[] {"field1", "field2", "field3"};
@@ -242,7 +239,7 @@ public class LuceneClusterConfigurationDUnitTest {
 
   private SerializableRunnableIF verifyClusterConfiguration(boolean verifyIndexesExist) {
     return () -> {
-      InternalLocator internalLocator = LocatorServerStartupRule.locatorStarter.getLocator();
+      InternalLocator internalLocator = LocatorServerStartupRule.getLocator();
       ClusterConfigurationService sc = internalLocator.getSharedConfiguration();
       Configuration config = sc.getConfiguration(ClusterConfigurationService.CLUSTER_CONFIG);
       String xmlContent = config.getCacheXmlContent();

--- a/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/wancommand/WANCommandUtils.java
+++ b/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/wancommand/WANCommandUtils.java
@@ -60,7 +60,7 @@ public class WANCommandUtils implements Serializable {
     File persistentDirectory =
         new File(dsName + "_disk_" + System.currentTimeMillis() + "_" + VM.getCurrentVMNum());
     persistentDirectory.mkdir();
-    Cache cache = LocatorServerStartupRule.serverStarter.getCache();
+    Cache cache = LocatorServerStartupRule.getCache();
     DiskStoreFactory dsf = cache.createDiskStoreFactory();
     File[] dirs1 = new File[] {persistentDirectory};
     if (isParallel) {
@@ -105,7 +105,7 @@ public class WANCommandUtils implements Serializable {
   public static void startSender(String senderId) {
     final IgnoredException exln = IgnoredException.addIgnoredException("Could not connect");
     try {
-      Cache cache = LocatorServerStartupRule.serverStarter.getCache();
+      Cache cache = LocatorServerStartupRule.getCache();
       Set<GatewaySender> senders = cache.getGatewaySenders();
       AbstractGatewaySender sender = (AbstractGatewaySender) senders.stream()
           .filter(s -> s.getId().equalsIgnoreCase(senderId)).findFirst().orElse(null);
@@ -118,7 +118,7 @@ public class WANCommandUtils implements Serializable {
   public static void pauseSender(String senderId) {
     final IgnoredException exln = IgnoredException.addIgnoredException("Could not connect");
     try {
-      Cache cache = LocatorServerStartupRule.serverStarter.getCache();
+      Cache cache = LocatorServerStartupRule.getCache();
       Set<GatewaySender> senders = cache.getGatewaySenders();
       AbstractGatewaySender sender = (AbstractGatewaySender) senders.stream()
           .filter(s -> s.getId().equalsIgnoreCase(senderId)).findFirst().orElse(null);
@@ -131,8 +131,7 @@ public class WANCommandUtils implements Serializable {
   public static void verifySenderState(String senderId, boolean isRunning, boolean isPaused) {
     final IgnoredException exln = IgnoredException.addIgnoredException("Could not connect");
     try {
-      Set<GatewaySender> senders =
-          LocatorServerStartupRule.serverStarter.getCache().getGatewaySenders();
+      Set<GatewaySender> senders = LocatorServerStartupRule.getCache().getGatewaySenders();
       for (GatewaySender sender : senders) {
         assertEquals(isRunning, sender.isRunning());
         assertEquals(isPaused, sender.isPaused());
@@ -149,8 +148,7 @@ public class WANCommandUtils implements Serializable {
       int dispatcherThreads, GatewaySender.OrderPolicy orderPolicy,
       List<String> expectedGatewayEventFilters, List<String> expectedGatewayTransportFilters) {
 
-    Set<GatewaySender> senders =
-        LocatorServerStartupRule.serverStarter.getCache().getGatewaySenders();
+    Set<GatewaySender> senders = LocatorServerStartupRule.getCache().getGatewaySenders();
     for (GatewaySender sender : senders) {
       assertEquals("remoteDistributedSystemId", remoteDsID, sender.getRemoteDSId());
       assertEquals("isParallel", isParallel, sender.isParallel());
@@ -211,7 +209,7 @@ public class WANCommandUtils implements Serializable {
   }
 
   public static void verifySenderDestroyed(String senderId, boolean isParallel) {
-    Cache cache = LocatorServerStartupRule.serverStarter.getCache();
+    Cache cache = LocatorServerStartupRule.getCache();
     Set<GatewaySender> senders = cache.getGatewaySenders();
     AbstractGatewaySender sender = (AbstractGatewaySender) senders.stream()
         .filter(s -> s.getId().equalsIgnoreCase(senderId)).findFirst().orElse(null);
@@ -232,7 +230,7 @@ public class WANCommandUtils implements Serializable {
 
   public static void startReceiver() {
     try {
-      Cache cache = LocatorServerStartupRule.serverStarter.getCache();
+      Cache cache = LocatorServerStartupRule.getCache();
       Set<GatewayReceiver> receivers = cache.getGatewayReceivers();
       for (GatewayReceiver receiver : receivers) {
         receiver.start();
@@ -245,7 +243,7 @@ public class WANCommandUtils implements Serializable {
   }
 
   public static void stopReceiver() {
-    Cache cache = LocatorServerStartupRule.serverStarter.getCache();
+    Cache cache = LocatorServerStartupRule.getCache();
     Set<GatewayReceiver> receivers = cache.getGatewayReceivers();
     for (GatewayReceiver receiver : receivers) {
       receiver.stop();
@@ -258,7 +256,7 @@ public class WANCommandUtils implements Serializable {
   }
 
   public static void createReceiver(int locPort) {
-    Cache cache = LocatorServerStartupRule.serverStarter.getCache();
+    Cache cache = LocatorServerStartupRule.getCache();
     GatewayReceiverFactory fact = cache.createGatewayReceiverFactory();
     fact.setStartPort(AvailablePort.AVAILABLE_PORTS_LOWER_BOUND);
     fact.setEndPort(AvailablePort.AVAILABLE_PORTS_UPPER_BOUND);
@@ -267,8 +265,7 @@ public class WANCommandUtils implements Serializable {
   }
 
   public static void verifyReceiverState(boolean isRunning) {
-    Set<GatewayReceiver> receivers =
-        LocatorServerStartupRule.serverStarter.getCache().getGatewayReceivers();
+    Set<GatewayReceiver> receivers = LocatorServerStartupRule.getCache().getGatewayReceivers();
     for (GatewayReceiver receiver : receivers) {
       assertEquals(isRunning, receiver.isRunning());
     }
@@ -288,7 +285,7 @@ public class WANCommandUtils implements Serializable {
 
   public static void verifyGatewayReceiverProfile(String expected) {
     Set<GatewayReceiver> receivers =
-        ((Cache) LocatorServerStartupRule.serverStarter.getCache()).getGatewayReceivers();
+        ((Cache) LocatorServerStartupRule.getCache()).getGatewayReceivers();
     for (GatewayReceiver receiver : receivers) {
       CacheServerImpl server = (CacheServerImpl) receiver.getServer();
       CacheServerAdvisor.CacheServerProfile profile =
@@ -302,7 +299,7 @@ public class WANCommandUtils implements Serializable {
       List<String> expectedGatewayTransportFilters, String hostnameForSenders) {
 
     Set<GatewayReceiver> receivers =
-        ((Cache) LocatorServerStartupRule.serverStarter.getCache()).getGatewayReceivers();
+        ((Cache) LocatorServerStartupRule.getCache()).getGatewayReceivers();
     assertEquals("Number of receivers is incorrect", 1, receivers.size());
     for (GatewayReceiver receiver : receivers) {
       assertEquals("isRunning", isRunning, receiver.isRunning());
@@ -337,7 +334,6 @@ public class WANCommandUtils implements Serializable {
   }
 
   public static SerializableCallableIF<DistributedMember> getMemberIdCallable() {
-    return () -> LocatorServerStartupRule.serverStarter.getCache().getDistributedSystem()
-        .getDistributedMember();
+    return () -> LocatorServerStartupRule.getCache().getDistributedSystem().getDistributedMember();
   }
 }

--- a/geode-wan/src/test/java/org/apache/geode/management/internal/configuration/WANClusterConfigurationDUnitTest.java
+++ b/geode-wan/src/test/java/org/apache/geode/management/internal/configuration/WANClusterConfigurationDUnitTest.java
@@ -121,7 +121,7 @@ public class WANClusterConfigurationDUnitTest {
     // verify GatewayReceiver attributes saved in cluster config
     newMember.invoke(() -> {
       Set<GatewayReceiver> gatewayReceivers =
-          LocatorServerStartupRule.serverStarter.getCache().getGatewayReceivers();
+          LocatorServerStartupRule.getCache().getGatewayReceivers();
       assertNotNull(gatewayReceivers);
       assertFalse(gatewayReceivers.isEmpty());
       assertTrue(gatewayReceivers.size() == 1);
@@ -136,7 +136,7 @@ public class WANClusterConfigurationDUnitTest {
 
     // verify GatewaySender attributes saved in cluster config
     newMember.invoke(() -> {
-      GatewaySender gs = LocatorServerStartupRule.serverStarter.getCache().getGatewaySender(gsId);
+      GatewaySender gs = LocatorServerStartupRule.getCache().getGatewaySender(gsId);
       assertNotNull(gs);
       assertTrue(alertThreshold.equals(Integer.toString(gs.getAlertThreshold())));
       assertTrue(batchSize.equals(Integer.toString(gs.getBatchSize())));

--- a/geode-web/src/test/java/org/apache/geode/management/internal/cli/commands/AlterRuntimeCommandDUnitTest.java
+++ b/geode-web/src/test/java/org/apache/geode/management/internal/cli/commands/AlterRuntimeCommandDUnitTest.java
@@ -59,7 +59,7 @@ public class AlterRuntimeCommandDUnitTest {
   private void verifyDefaultConfig(MemberVM[] servers) {
     for (MemberVM server : servers) {
       server.invoke(() -> {
-        InternalCache cache = LocatorServerStartupRule.serverStarter.getCache();
+        InternalCache cache = LocatorServerStartupRule.getCache();
         DistributionConfig config = cache.getInternalDistributedSystem().getConfig();
         assertThat(config.getLogLevel()).isEqualTo(LogWriterImpl.ERROR_LEVEL);
         assertThat(config.getLogFileSizeLimit()).isEqualTo(0);
@@ -103,7 +103,7 @@ public class AlterRuntimeCommandDUnitTest {
     gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
 
     server0.invoke(() -> {
-      InternalCache cache = LocatorServerStartupRule.serverStarter.getCache();
+      InternalCache cache = LocatorServerStartupRule.getCache();
       DistributionConfig config = cache.getInternalDistributedSystem().getConfig();
       assertThat(config.getLogLevel()).isEqualTo(LogWriterImpl.INFO_LEVEL);
       assertThat(config.getLogFileSizeLimit()).isEqualTo(50);
@@ -149,7 +149,7 @@ public class AlterRuntimeCommandDUnitTest {
 
     for (MemberVM server : new MemberVM[] {server1, server2}) {
       server.invoke(() -> {
-        InternalCache cache = LocatorServerStartupRule.serverStarter.getCache();
+        InternalCache cache = LocatorServerStartupRule.getCache();
         DistributionConfig config = cache.getInternalDistributedSystem().getConfig();
         assertThat(config.getLogFileSizeLimit()).isEqualTo(0);
         assertThat(config.getArchiveDiskSpaceLimit()).isEqualTo(0);
@@ -184,7 +184,7 @@ public class AlterRuntimeCommandDUnitTest {
     gfsh.executeAndAssertThat(csbSetFileSizeLimit.toString()).statusIsSuccess();
 
     server2.invoke(() -> {
-      InternalCache cache = LocatorServerStartupRule.serverStarter.getCache();
+      InternalCache cache = LocatorServerStartupRule.getCache();
       DistributionConfig config = cache.getInternalDistributedSystem().getConfig();
       assertThat(config.getLogFileSizeLimit()).isEqualTo(50);
       assertThat(config.getLogDiskSpaceLimit()).isEqualTo(0);
@@ -198,7 +198,7 @@ public class AlterRuntimeCommandDUnitTest {
 
     for (MemberVM server : new MemberVM[] {server1, server2}) {
       server.invoke(() -> {
-        InternalCache cache = LocatorServerStartupRule.serverStarter.getCache();
+        InternalCache cache = LocatorServerStartupRule.getCache();
         DistributionConfig config = cache.getInternalDistributedSystem().getConfig();
         assertThat(config.getLogFileSizeLimit()).isEqualTo(50);
         assertThat(config.getLogDiskSpaceLimit()).isEqualTo(10);
@@ -240,7 +240,7 @@ public class AlterRuntimeCommandDUnitTest {
         expectedLimit = 0;
       }
       server.invoke(() -> {
-        InternalCache cache = LocatorServerStartupRule.serverStarter.getCache();
+        InternalCache cache = LocatorServerStartupRule.getCache();
         DistributionConfig config = cache.getInternalDistributedSystem().getConfig();
         assertThat(config.getLogFileSizeLimit()).isEqualTo(0);
         assertThat(config.getLogDiskSpaceLimit()).isEqualTo(expectedLimit);
@@ -289,7 +289,7 @@ public class AlterRuntimeCommandDUnitTest {
         expectedGroup = "";
       }
       server.invoke(() -> {
-        InternalCache cache = LocatorServerStartupRule.serverStarter.getCache();
+        InternalCache cache = LocatorServerStartupRule.getCache();
         DistributionConfig config = cache.getInternalDistributedSystem().getConfig();
         assertThat(config.getGroups()).isEqualTo(expectedGroup);
         assertThat(config.getLogFileSizeLimit()).isEqualTo(0);
@@ -326,7 +326,7 @@ public class AlterRuntimeCommandDUnitTest {
 
     for (MemberVM server : new MemberVM[] {server1, server2}) {
       server.invoke(() -> {
-        InternalCache cache = LocatorServerStartupRule.serverStarter.getCache();
+        InternalCache cache = LocatorServerStartupRule.getCache();
         DistributionConfig config = cache.getInternalDistributedSystem().getConfig();
         assertThat(config.getLogFileSizeLimit()).isEqualTo(11);
         assertThat(config.getArchiveDiskSpaceLimit()).isEqualTo(0);
@@ -436,7 +436,7 @@ public class AlterRuntimeCommandDUnitTest {
 
     for (MemberVM server : new MemberVM[] {server1, server2}) {
       server.invoke(() -> {
-        InternalCache cache = LocatorServerStartupRule.serverStarter.getCache();
+        InternalCache cache = LocatorServerStartupRule.getCache();
         DistributionConfig config = cache.getInternalDistributedSystem().getConfig();
         assertThat(config.getLogFileSizeLimit()).isEqualTo(0);
         assertThat(config.getArchiveDiskSpaceLimit()).isEqualTo(0);
@@ -480,7 +480,7 @@ public class AlterRuntimeCommandDUnitTest {
         expectedName = "";
       }
       server.invoke(() -> {
-        InternalCache cache = LocatorServerStartupRule.serverStarter.getCache();
+        InternalCache cache = LocatorServerStartupRule.getCache();
         DistributionConfig config = cache.getInternalDistributedSystem().getConfig();
         assertThat(config.getLogFileSizeLimit()).isEqualTo(0);
         assertThat(config.getArchiveDiskSpaceLimit()).isEqualTo(0);
@@ -525,7 +525,7 @@ public class AlterRuntimeCommandDUnitTest {
         expectedName = "";
       }
       server.invoke(() -> {
-        InternalCache cache = LocatorServerStartupRule.serverStarter.getCache();
+        InternalCache cache = LocatorServerStartupRule.getCache();
         DistributionConfig config = cache.getInternalDistributedSystem().getConfig();
         assertThat(config.getLogFileSizeLimit()).isEqualTo(0);
         assertThat(config.getArchiveDiskSpaceLimit()).isEqualTo(0);
@@ -561,7 +561,7 @@ public class AlterRuntimeCommandDUnitTest {
 
     for (MemberVM server : new MemberVM[] {server1, server2}) {
       server.invoke(() -> {
-        InternalCache cache = LocatorServerStartupRule.serverStarter.getCache();
+        InternalCache cache = LocatorServerStartupRule.getCache();
         DistributionConfig config = cache.getInternalDistributedSystem().getConfig();
         assertThat(config.getLogFileSizeLimit()).isEqualTo(0);
         assertThat(config.getArchiveDiskSpaceLimit()).isEqualTo(0);
@@ -606,7 +606,7 @@ public class AlterRuntimeCommandDUnitTest {
         expectedSampleRate = 1000;
       }
       server.invoke(() -> {
-        InternalCache cache = LocatorServerStartupRule.serverStarter.getCache();
+        InternalCache cache = LocatorServerStartupRule.getCache();
         DistributionConfig config = cache.getInternalDistributedSystem().getConfig();
         assertThat(config.getLogFileSizeLimit()).isEqualTo(0);
         assertThat(config.getArchiveDiskSpaceLimit()).isEqualTo(0);
@@ -652,7 +652,7 @@ public class AlterRuntimeCommandDUnitTest {
         expectedSampleRate = 1000;
       }
       server.invoke(() -> {
-        InternalCache cache = LocatorServerStartupRule.serverStarter.getCache();
+        InternalCache cache = LocatorServerStartupRule.getCache();
         DistributionConfig config = cache.getInternalDistributedSystem().getConfig();
         assertThat(config.getLogFileSizeLimit()).isEqualTo(0);
         assertThat(config.getArchiveDiskSpaceLimit()).isEqualTo(0);
@@ -727,7 +727,7 @@ public class AlterRuntimeCommandDUnitTest {
 
     for (MemberVM server : new MemberVM[] {server1, server2}) {
       server.invoke(() -> {
-        InternalCache cache = LocatorServerStartupRule.serverStarter.getCache();
+        InternalCache cache = LocatorServerStartupRule.getCache();
         DistributionConfig config = cache.getInternalDistributedSystem().getConfig();
         assertThat(config.getLogFileSizeLimit()).isEqualTo(0);
         assertThat(config.getArchiveDiskSpaceLimit()).isEqualTo(TEST_LIMIT);
@@ -773,7 +773,7 @@ public class AlterRuntimeCommandDUnitTest {
         expectedLimit = 0;
       }
       server.invoke(() -> {
-        InternalCache cache = LocatorServerStartupRule.serverStarter.getCache();
+        InternalCache cache = LocatorServerStartupRule.getCache();
         DistributionConfig config = cache.getInternalDistributedSystem().getConfig();
         assertThat(config.getLogFileSizeLimit()).isEqualTo(0);
         assertThat(config.getArchiveDiskSpaceLimit()).isEqualTo(expectedLimit);
@@ -820,7 +820,7 @@ public class AlterRuntimeCommandDUnitTest {
         expectedLimit = 0;
       }
       server.invoke(() -> {
-        InternalCache cache = LocatorServerStartupRule.serverStarter.getCache();
+        InternalCache cache = LocatorServerStartupRule.getCache();
         DistributionConfig config = cache.getInternalDistributedSystem().getConfig();
         assertThat(config.getLogFileSizeLimit()).isEqualTo(0);
         assertThat(config.getArchiveDiskSpaceLimit()).isEqualTo(expectedLimit);
@@ -870,7 +870,7 @@ public class AlterRuntimeCommandDUnitTest {
 
     for (MemberVM server : new MemberVM[] {server1, server2}) {
       server.invoke(() -> {
-        InternalCache cache = LocatorServerStartupRule.serverStarter.getCache();
+        InternalCache cache = LocatorServerStartupRule.getCache();
         DistributionConfig config = cache.getInternalDistributedSystem().getConfig();
         assertThat(config.getLogFileSizeLimit()).isEqualTo(0);
         assertThat(config.getArchiveDiskSpaceLimit()).isEqualTo(0);
@@ -909,7 +909,7 @@ public class AlterRuntimeCommandDUnitTest {
 
     for (MemberVM server : new MemberVM[] {server1, server2}) {
       server.invoke(() -> {
-        InternalCache cache = LocatorServerStartupRule.serverStarter.getCache();
+        InternalCache cache = LocatorServerStartupRule.getCache();
         DistributionConfig config = cache.getInternalDistributedSystem().getConfig();
         assertThat(config.getLogFileSizeLimit()).isEqualTo(0);
         assertThat(config.getArchiveDiskSpaceLimit()).isEqualTo(0);
@@ -955,7 +955,7 @@ public class AlterRuntimeCommandDUnitTest {
         expectedLimit = 0;
       }
       server.invoke(() -> {
-        InternalCache cache = LocatorServerStartupRule.serverStarter.getCache();
+        InternalCache cache = LocatorServerStartupRule.getCache();
         DistributionConfig config = cache.getInternalDistributedSystem().getConfig();
         assertThat(config.getLogFileSizeLimit()).isEqualTo(0);
         assertThat(config.getArchiveDiskSpaceLimit()).isEqualTo(0);
@@ -1002,7 +1002,7 @@ public class AlterRuntimeCommandDUnitTest {
         expectedLimit = 0;
       }
       server.invoke(() -> {
-        InternalCache cache = LocatorServerStartupRule.serverStarter.getCache();
+        InternalCache cache = LocatorServerStartupRule.getCache();
         DistributionConfig config = cache.getInternalDistributedSystem().getConfig();
         assertThat(config.getLogFileSizeLimit()).isEqualTo(0);
         assertThat(config.getArchiveDiskSpaceLimit()).isEqualTo(0);
@@ -1076,7 +1076,7 @@ public class AlterRuntimeCommandDUnitTest {
 
     for (MemberVM server : new MemberVM[] {server1, server2}) {
       server.invoke(() -> {
-        InternalCache cache = LocatorServerStartupRule.serverStarter.getCache();
+        InternalCache cache = LocatorServerStartupRule.getCache();
         DistributionConfig config = cache.getInternalDistributedSystem().getConfig();
         assertThat(config.getLogFileSizeLimit()).isEqualTo(0);
         assertThat(config.getArchiveDiskSpaceLimit()).isEqualTo(0);
@@ -1111,7 +1111,7 @@ public class AlterRuntimeCommandDUnitTest {
     }
 
     server2.invoke(() -> {
-      InternalCache cache = LocatorServerStartupRule.serverStarter.getCache();
+      InternalCache cache = LocatorServerStartupRule.getCache();
       DistributionConfig config = cache.getInternalDistributedSystem().getConfig();
       assertThat(config.getGroups()).isEqualTo("G1");
     });
@@ -1125,7 +1125,7 @@ public class AlterRuntimeCommandDUnitTest {
         .contains(CliStrings.ALTER_RUNTIME_CONFIG__RELEVANT__OPTION__MESSAGE);
 
     server1.invoke(() -> {
-      InternalCache cache = LocatorServerStartupRule.serverStarter.getCache();
+      InternalCache cache = LocatorServerStartupRule.getCache();
       DistributionConfig config = cache.getInternalDistributedSystem().getConfig();
       assertThat(config.getLogFileSizeLimit()).isEqualTo(0);
       assertThat(config.getLogDiskSpaceLimit()).isEqualTo(0);
@@ -1165,7 +1165,7 @@ public class AlterRuntimeCommandDUnitTest {
         .contains(CliStrings.ALTER_RUNTIME_CONFIG__RELEVANT__OPTION__MESSAGE);
 
     server1.invoke(() -> {
-      InternalCache cache = LocatorServerStartupRule.serverStarter.getCache();
+      InternalCache cache = LocatorServerStartupRule.getCache();
       DistributionConfig config = cache.getInternalDistributedSystem().getConfig();
       assertThat(config.getLogFileSizeLimit()).isEqualTo(0);
       assertThat(config.getLogDiskSpaceLimit()).isEqualTo(0);
@@ -1197,7 +1197,7 @@ public class AlterRuntimeCommandDUnitTest {
 
     locator.invoke(() -> {
       ClusterConfigurationService sharedConfig =
-          LocatorServerStartupRule.locatorStarter.getLocator().getSharedConfiguration();
+          LocatorServerStartupRule.getLocator().getSharedConfiguration();
       Properties properties = sharedConfig.getConfiguration("Group1").getGemfireProperties();
       assertThat(properties.get(LOG_LEVEL)).isEqualTo("fine");
     });

--- a/geode-web/src/test/java/org/apache/geode/management/internal/cli/commands/DescribeConfigCommandDUnitTest.java
+++ b/geode-web/src/test/java/org/apache/geode/management/internal/cli/commands/DescribeConfigCommandDUnitTest.java
@@ -67,7 +67,7 @@ public class DescribeConfigCommandDUnitTest {
     }
 
     server0.invoke(() -> {
-      InternalCache cache = LocatorServerStartupRule.serverStarter.getCache();
+      InternalCache cache = LocatorServerStartupRule.getCache();
       InternalDistributedSystem system = cache.getInternalDistributedSystem();
       DistributionConfig config = system.getConfig();
       config.setArchiveFileSizeLimit(1000);


### PR DESCRIPTION
* get rid of the redundant variable that refers to either a LocatorStarter or a ServerStarter
* add methods in MemberVM to wait till the region beans are ready