### PR TITLE
Fix for GEODE-3898: Defined Indexes are not Persisted in Cluster Configuration.

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/CreateDefinedIndexesFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/CreateDefinedIndexesFunction.java
@@ -95,19 +95,28 @@ public class CreateDefinedIndexesFunction extends FunctionAdapter implements Int
         }
 
         sender.lastResult(functionResults.get(resultsSize - 1));
+      } else {
+        // If we reach this point, it means that the QueryService returned an empty list without
+        // throwing any exceptions. It should never happen, the check is just to be on the safer
+        // side and make sure the function returns.
+        sender.lastResult(new CliFunctionResult(memberId, false,
+            "Index creation failed. Check logs for errors."));
       }
-    } catch (MultiIndexCreationException e) {
+    } catch (MultiIndexCreationException multiIndexCreationException) {
       StringBuffer sb = new StringBuffer();
       sb.append("Index creation failed for indexes: ").append("\n");
-      for (Map.Entry<String, Exception> failedIndex : e.getExceptionsMap().entrySet()) {
+      for (Map.Entry<String, Exception> failedIndex : multiIndexCreationException.getExceptionsMap()
+          .entrySet()) {
         sb.append(failedIndex.getKey()).append(" : ").append(failedIndex.getValue().getMessage())
             .append("\n");
       }
-      context.getResultSender().lastResult(new CliFunctionResult(memberId, e, sb.toString()));
-    } catch (Exception e) {
+      context.getResultSender()
+          .lastResult(new CliFunctionResult(memberId, multiIndexCreationException, sb.toString()));
+    } catch (Exception exception) {
       String exceptionMessage = CliStrings.format(CliStrings.EXCEPTION_CLASS_AND_MESSAGE,
-          e.getClass().getName(), e.getMessage());
-      context.getResultSender().lastResult(new CliFunctionResult(memberId, e, exceptionMessage));
+          exception.getClass().getName(), exception.getMessage());
+      context.getResultSender()
+          .lastResult(new CliFunctionResult(memberId, exception, exceptionMessage));
     }
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateDefinedIndexesCommandDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateDefinedIndexesCommandDUnitTest.java
@@ -1,0 +1,218 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.management.internal.cli.commands;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Properties;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TestName;
+
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.query.QueryService;
+import org.apache.geode.distributed.ConfigurationProperties;
+import org.apache.geode.distributed.Locator;
+import org.apache.geode.distributed.internal.ClusterConfigurationService;
+import org.apache.geode.distributed.internal.InternalLocator;
+import org.apache.geode.test.dunit.rules.LocatorServerStartupRule;
+import org.apache.geode.test.dunit.rules.MemberVM;
+import org.apache.geode.test.junit.categories.DistributedTest;
+import org.apache.geode.test.junit.rules.GfshShellConnectionRule;
+import org.apache.geode.test.junit.rules.serializable.SerializableTestName;
+
+@Category(DistributedTest.class)
+public class CreateDefinedIndexesCommandDUnitTest {
+  private MemberVM locator, server1, server2, server3;
+
+  @Rule
+  public GfshShellConnectionRule gfsh = new GfshShellConnectionRule();
+
+  @Rule
+  public LocatorServerStartupRule locatorServerStartupRule = new LocatorServerStartupRule();
+
+  @Rule
+  public TestName testName = new SerializableTestName();
+
+  @Before
+  public void before() throws Exception {
+    locator = locatorServerStartupRule.startLocatorVM(0);
+    server1 = locatorServerStartupRule.startServerVM(1, locator.getPort());
+    server2 = locatorServerStartupRule.startServerVM(2, locator.getPort());
+
+    Properties server3Properties = new Properties();
+    server3Properties.setProperty(ConfigurationProperties.LOCATORS,
+        "localhost[" + locator.getPort() + "]");
+    server3Properties.setProperty(ConfigurationProperties.GROUPS, "group1");
+    server3 = locatorServerStartupRule.startServerVM(3, server3Properties);
+
+    gfsh.connectAndVerify(locator);
+    gfsh.executeAndAssertThat("clear defined indexes").statusIsSuccess()
+        .containsOutput("Index definitions successfully cleared");
+  }
+
+  @Test
+  public void noDefinitions() {
+    gfsh.executeAndAssertThat("create defined indexes").statusIsSuccess()
+        .containsOutput("No indexes defined");
+  }
+
+  @Test
+  public void nonexistentRegion() {
+    String regionName = testName.getMethodName();
+
+    MemberVM.invokeInEveryMember(() -> {
+      Cache cache = LocatorServerStartupRule.serverStarter.getCache();
+      assertThat(cache.getRegion(regionName)).isNull();
+    }, server1, server2, server3);
+
+    gfsh.executeAndAssertThat("define index --name=index_" + regionName
+        + " --expression=value1 --region=" + regionName + "1").statusIsSuccess()
+        .containsOutput("Index successfully defined");
+
+    gfsh.executeAndAssertThat("create defined indexes").statusIsError()
+        .containsOutput("RegionNotFoundException");
+
+    MemberVM.invokeInEveryMember(() -> {
+      Cache cache = LocatorServerStartupRule.serverStarter.getCache();
+      QueryService queryService = cache.getQueryService();
+
+      assertThat(queryService.getIndexes().isEmpty()).isTrue();
+    }, server1, server2, server3);
+  }
+
+  @Test
+  public void multipleIndexesOnMultipleRegionsClusterWide() {
+    String region1Name = testName.getMethodName() + "1";
+    String region2Name = testName.getMethodName() + "2";
+    String index1Name = "index_" + region1Name;
+    String index2Name = "index_" + region2Name;
+
+    gfsh.executeAndAssertThat("create region --name=" + region1Name + " --type=REPLICATE")
+        .statusIsSuccess().containsOutput("Region \"/" + region1Name + "\" created on \"server-1\"")
+        .containsOutput("Region \"/" + region1Name + "\" created on \"server-2\"")
+        .containsOutput("Region \"/" + region1Name + "\" created on \"server-3\"");
+
+    gfsh.executeAndAssertThat("create region --name=" + region2Name + " --type=REPLICATE")
+        .statusIsSuccess().containsOutput("Region \"/" + region2Name + "\" created on \"server-1\"")
+        .containsOutput("Region \"/" + region2Name + "\" created on \"server-2\"")
+        .containsOutput("Region \"/" + region2Name + "\" created on \"server-3\"");
+
+    MemberVM.invokeInEveryMember(() -> {
+      Cache cache = LocatorServerStartupRule.serverStarter.getCache();
+      assertThat(cache.getRegion(region1Name)).isNotNull();
+      assertThat(cache.getRegion(region2Name)).isNotNull();
+    }, server1, server2, server3);
+
+    gfsh.executeAndAssertThat(
+        "define index --name=" + index1Name + " --expression=value1 --region=" + region1Name)
+        .statusIsSuccess().containsOutput("Index successfully defined");
+
+    gfsh.executeAndAssertThat(
+        "define index --name=" + index2Name + " --expression=value2 --region=" + region2Name)
+        .statusIsSuccess().containsOutput("Index successfully defined");
+
+    gfsh.executeAndAssertThat("create defined indexes").statusIsSuccess()
+        .containsOutput("Indexes successfully created");
+
+    MemberVM.invokeInEveryMember(() -> {
+      Cache cache = LocatorServerStartupRule.serverStarter.getCache();
+      QueryService queryService = cache.getQueryService();
+      Region region1 = cache.getRegion(region1Name);
+      Region region2 = cache.getRegion(region2Name);
+
+      assertThat(queryService.getIndexes(region1).size()).isEqualTo(1);
+      assertThat(queryService.getIndexes(region2).size()).isEqualTo(1);
+      assertThat(queryService.getIndex(region1, index1Name)).isNotNull();
+      assertThat(queryService.getIndex(region2, index2Name)).isNotNull();
+    }, server1, server2, server3);
+
+    locator.invoke(() -> {
+      // Make sure the indexes exist in the cluster config
+      ClusterConfigurationService sharedConfig =
+          ((InternalLocator) Locator.getLocator()).getSharedConfiguration();
+      assertThat(sharedConfig.getConfiguration("cluster").getCacheXmlContent()).contains(index1Name,
+          index2Name);
+      assertThat(sharedConfig.getConfiguration("group1")).isNull();
+    });
+  }
+
+  @Test
+  public void multipleIndexesOnMultipleRegionsInMemberGroup() {
+    String region1Name = testName.getMethodName() + "1";
+    String region2Name = testName.getMethodName() + "2";
+    String index1Name = "index_" + region1Name;
+    String index2Name = "index_" + region2Name;
+
+    gfsh.executeAndAssertThat(
+        "create region --name=" + region1Name + " --type=REPLICATE --group=group1")
+        .statusIsSuccess()
+        .containsOutput("Region \"/" + region1Name + "\" created on \"server-3\"");
+
+    gfsh.executeAndAssertThat(
+        "create region --name=" + region2Name + " --type=REPLICATE --group=group1")
+        .statusIsSuccess()
+        .containsOutput("Region \"/" + region2Name + "\" created on \"server-3\"");
+
+    MemberVM.invokeInEveryMember(() -> {
+      Cache cache = LocatorServerStartupRule.serverStarter.getCache();
+      assertThat(cache.getRegion(region1Name)).isNull();
+      assertThat(cache.getRegion(region2Name)).isNull();
+    }, server1, server2);
+
+    MemberVM.invokeInEveryMember(() -> {
+      Cache cache = LocatorServerStartupRule.serverStarter.getCache();
+      assertThat(cache.getRegion(region1Name)).isNotNull();
+      assertThat(cache.getRegion(region2Name)).isNotNull();
+    }, server3);
+
+    gfsh.executeAndAssertThat(
+        "define index --name=" + index1Name + " --expression=value1 --region=" + region1Name)
+        .statusIsSuccess().containsOutput("Index successfully defined");
+
+    gfsh.executeAndAssertThat(
+        "define index --name=" + index2Name + " --expression=value1 --region=" + region2Name)
+        .statusIsSuccess().containsOutput("Index successfully defined");
+
+    gfsh.executeAndAssertThat("create defined indexes --group=group1").statusIsSuccess()
+        .containsOutput("Indexes successfully created");
+
+    MemberVM.invokeInEveryMember(() -> {
+      Cache cache = LocatorServerStartupRule.serverStarter.getCache();
+      QueryService queryService = cache.getQueryService();
+      Region region1 = cache.getRegion(region1Name);
+      Region region2 = cache.getRegion(region2Name);
+
+      assertThat(queryService.getIndexes(region1).size()).isEqualTo(1);
+      assertThat(queryService.getIndexes(region2).size()).isEqualTo(1);
+      assertThat(queryService.getIndex(region1, index1Name)).isNotNull();
+      assertThat(queryService.getIndex(region2, index2Name)).isNotNull();
+    }, server3);
+
+    locator.invoke(() -> {
+      // Make sure the indexes exist in the cluster config
+      ClusterConfigurationService sharedConfig =
+          ((InternalLocator) Locator.getLocator()).getSharedConfiguration();
+      assertThat(sharedConfig.getConfiguration("group1").getCacheXmlContent()).contains(index2Name,
+          index1Name);
+      assertThat(sharedConfig.getConfiguration("cluster").getCacheXmlContent()).isNullOrEmpty();
+    });
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateDefinedIndexesCommandDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateDefinedIndexesCommandDUnitTest.java
@@ -79,7 +79,7 @@ public class CreateDefinedIndexesCommandDUnitTest {
     String regionName = testName.getMethodName();
 
     MemberVM.invokeInEveryMember(() -> {
-      Cache cache = LocatorServerStartupRule.serverStarter.getCache();
+      Cache cache = LocatorServerStartupRule.getCache();
       assertThat(cache.getRegion(regionName)).isNull();
     }, server1, server2, server3);
 
@@ -91,7 +91,7 @@ public class CreateDefinedIndexesCommandDUnitTest {
         .containsOutput("RegionNotFoundException");
 
     MemberVM.invokeInEveryMember(() -> {
-      Cache cache = LocatorServerStartupRule.serverStarter.getCache();
+      Cache cache = LocatorServerStartupRule.getCache();
       QueryService queryService = cache.getQueryService();
 
       assertThat(queryService.getIndexes().isEmpty()).isTrue();
@@ -116,7 +116,7 @@ public class CreateDefinedIndexesCommandDUnitTest {
         .containsOutput("Region \"/" + region2Name + "\" created on \"server-3\"");
 
     MemberVM.invokeInEveryMember(() -> {
-      Cache cache = LocatorServerStartupRule.serverStarter.getCache();
+      Cache cache = LocatorServerStartupRule.getCache();
       assertThat(cache.getRegion(region1Name)).isNotNull();
       assertThat(cache.getRegion(region2Name)).isNotNull();
     }, server1, server2, server3);
@@ -133,7 +133,7 @@ public class CreateDefinedIndexesCommandDUnitTest {
         .containsOutput("Indexes successfully created");
 
     MemberVM.invokeInEveryMember(() -> {
-      Cache cache = LocatorServerStartupRule.serverStarter.getCache();
+      Cache cache = LocatorServerStartupRule.getCache();
       QueryService queryService = cache.getQueryService();
       Region region1 = cache.getRegion(region1Name);
       Region region2 = cache.getRegion(region2Name);
@@ -172,13 +172,13 @@ public class CreateDefinedIndexesCommandDUnitTest {
         .containsOutput("Region \"/" + region2Name + "\" created on \"server-3\"");
 
     MemberVM.invokeInEveryMember(() -> {
-      Cache cache = LocatorServerStartupRule.serverStarter.getCache();
+      Cache cache = LocatorServerStartupRule.getCache();
       assertThat(cache.getRegion(region1Name)).isNull();
       assertThat(cache.getRegion(region2Name)).isNull();
     }, server1, server2);
 
     MemberVM.invokeInEveryMember(() -> {
-      Cache cache = LocatorServerStartupRule.serverStarter.getCache();
+      Cache cache = LocatorServerStartupRule.getCache();
       assertThat(cache.getRegion(region1Name)).isNotNull();
       assertThat(cache.getRegion(region2Name)).isNotNull();
     }, server3);
@@ -195,7 +195,7 @@ public class CreateDefinedIndexesCommandDUnitTest {
         .containsOutput("Indexes successfully created");
 
     MemberVM.invokeInEveryMember(() -> {
-      Cache cache = LocatorServerStartupRule.serverStarter.getCache();
+      Cache cache = LocatorServerStartupRule.getCache();
       QueryService queryService = cache.getQueryService();
       Region region1 = cache.getRegion(region1Name);
       Region region2 = cache.getRegion(region2Name);

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateDefinedIndexesCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateDefinedIndexesCommandTest.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.management.internal.cli.commands;
+
+import static org.apache.geode.management.cli.Result.Status.ERROR;
+import static org.apache.geode.management.cli.Result.Status.OK;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import org.apache.geode.cache.execute.ResultCollector;
+import org.apache.geode.cache.query.IndexType;
+import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.distributed.internal.ClusterConfigurationService;
+import org.apache.geode.management.internal.cli.domain.IndexInfo;
+import org.apache.geode.management.internal.cli.functions.CliFunctionResult;
+import org.apache.geode.management.internal.cli.result.CommandResult;
+import org.apache.geode.management.internal.configuration.domain.XmlEntity;
+import org.apache.geode.test.junit.categories.UnitTest;
+import org.apache.geode.test.junit.rules.GfshParserRule;
+
+@Category(UnitTest.class)
+public class CreateDefinedIndexesCommandTest {
+  @Rule
+  public GfshParserRule gfshParser = new GfshParserRule();
+
+  private CommandResult result;
+  private ResultCollector resultCollector;
+  private CreateDefinedIndexesCommand command;
+
+  @Before
+  public void setUp() throws Exception {
+    IndexDefinition.indexDefinitions.clear();
+    resultCollector = mock(ResultCollector.class);
+    command = spy(CreateDefinedIndexesCommand.class);
+    doReturn(resultCollector).when(command).createIndexesOnMembers(any());
+  }
+
+  @Test
+  public void noDefinitions() throws Exception {
+    result = gfshParser.executeCommandWithInstance(command, "create defined indexes");
+    assertThat(result.getStatus()).isEqualTo(OK);
+    assertThat(result.getContent().toString()).contains("No indexes defined");
+  }
+
+  @Test
+  public void noMembers() throws Exception {
+    IndexDefinition.indexDefinitions
+        .add(new IndexInfo("indexName", "indexedExpression", "TestRegion", IndexType.FUNCTIONAL));
+    doReturn(Collections.EMPTY_SET).when(command).findMembers(any(), any());
+    result = gfshParser.executeCommandWithInstance(command, "create defined indexes");
+    assertThat(result.getStatus()).isEqualTo(ERROR);
+    assertThat(result.getContent().toString()).contains("No Members Found");
+  }
+
+  @Test
+  public void creationFailure() throws Exception {
+    DistributedMember member = mock(DistributedMember.class);
+    when(member.getId()).thenReturn("memberId");
+    ClusterConfigurationService mockService = mock(ClusterConfigurationService.class);
+
+    doReturn(mockService).when(command).getSharedConfiguration();
+    doReturn(Collections.singleton(member)).when(command).findMembers(any(), any());
+    doReturn(Arrays.asList(new CliFunctionResult(member.getId(), new Exception("MockException"),
+        "Exception Message."))).when(resultCollector).getResult();
+
+    IndexDefinition.indexDefinitions
+        .add(new IndexInfo("index1", "value1", "TestRegion", IndexType.FUNCTIONAL));
+    result = gfshParser.executeCommandWithInstance(command, "create defined indexes");
+
+    assertThat(result.getStatus()).isEqualTo(ERROR);
+    verify(command, never()).persistClusterConfiguration(any(), any());
+  }
+
+  @Test
+  public void creationSuccess() throws Exception {
+    XmlEntity xmlEntity = mock(XmlEntity.class);
+    DistributedMember member = mock(DistributedMember.class);
+    when(member.getId()).thenReturn("memberId");
+    ClusterConfigurationService mockService = mock(ClusterConfigurationService.class);
+
+    doReturn(mockService).when(command).getSharedConfiguration();
+    doReturn(Collections.singleton(member)).when(command).findMembers(any(), any());
+    doReturn(Arrays.asList(new CliFunctionResult(member.getId(), xmlEntity))).when(resultCollector)
+        .getResult();
+
+    IndexDefinition.indexDefinitions
+        .add(new IndexInfo("index1", "value1", "TestRegion", IndexType.FUNCTIONAL));
+    result = gfshParser.executeCommandWithInstance(command, "create defined indexes");
+
+    assertThat(result.getStatus()).isEqualTo(OK);
+    assertThat(result.failedToPersist()).isFalse();
+    verify(command, Mockito.times(1)).persistClusterConfiguration(any(), any());
+    assertThat(result.getContent().toString()).contains("Indexes successfully created");
+  }
+
+  @Test
+  public void multipleIndexesOnMultipleRegions() throws Exception {
+    XmlEntity xmlEntityRegion1 = mock(XmlEntity.class);
+    XmlEntity xmlEntityRegion2 = mock(XmlEntity.class);
+    DistributedMember member1 = mock(DistributedMember.class);
+    DistributedMember member2 = mock(DistributedMember.class);
+    when(member1.getId()).thenReturn("memberId_1");
+    when(member2.getId()).thenReturn("memberId_2");
+
+    ClusterConfigurationService mockService = mock(ClusterConfigurationService.class);
+    CliFunctionResult member1Region1Result =
+        new CliFunctionResult(member1.getId(), xmlEntityRegion1);
+    CliFunctionResult member1Region2Result =
+        new CliFunctionResult(member1.getId(), xmlEntityRegion2);
+    CliFunctionResult member2Region1Result =
+        new CliFunctionResult(member2.getId(), xmlEntityRegion2);
+    CliFunctionResult member2Region2Result =
+        new CliFunctionResult(member2.getId(), xmlEntityRegion2);
+
+    doReturn(mockService).when(command).getSharedConfiguration();
+    doReturn(new HashSet<>(Arrays.asList(new DistributedMember[] {member1, member2}))).when(command)
+        .findMembers(any(), any());
+    doReturn(Arrays.asList(new CliFunctionResult[] {member1Region1Result, member1Region2Result,
+        member2Region1Result, member2Region2Result})).when(resultCollector).getResult();
+
+    IndexDefinition.indexDefinitions
+        .add(new IndexInfo("index1", "value1", "TestRegion1", IndexType.FUNCTIONAL));
+    IndexDefinition.indexDefinitions
+        .add(new IndexInfo("index2", "value2", "TestRegion2", IndexType.FUNCTIONAL));
+
+    result = gfshParser.executeCommandWithInstance(command, "create defined indexes");
+
+    assertThat(result.getStatus()).isEqualTo(OK);
+    assertThat(result.failedToPersist()).isFalse();
+
+    // The command will receive 4 results from 2 members, but we need to persist only 2 (#regions)
+    // of them.
+    verify(command, Mockito.times(2)).persistClusterConfiguration(any(), any());
+    assertThat(result.getContent().toString()).contains("Indexes successfully created");
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateDefinedIndexesCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateDefinedIndexesCommandTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.when;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Set;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -61,7 +62,7 @@ public class CreateDefinedIndexesCommandTest {
     IndexDefinition.indexDefinitions.clear();
     resultCollector = mock(ResultCollector.class);
     command = spy(CreateDefinedIndexesCommand.class);
-    doReturn(resultCollector).when(command).createIndexesOnMembers(any());
+    doReturn(resultCollector).when(command).executeFunction(any(), any(), any(Set.class));
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/functions/CreateDefinedIndexesFunctionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/functions/CreateDefinedIndexesFunctionTest.java
@@ -85,7 +85,12 @@ public class CreateDefinedIndexesFunctionTest {
     List<?> results = resultSender.getResults();
 
     assertThat(results).isNotNull();
-    assertThat(results.size()).isEqualTo(0);
+    assertThat(results.size()).isEqualTo(1);
+    Object firstResult = results.get(0);
+    assertThat(firstResult).isInstanceOf(CliFunctionResult.class);
+    assertThat(((CliFunctionResult) firstResult).isSuccessful()).isTrue();
+    assertThat(((CliFunctionResult) firstResult).getMessage()).isNotEmpty();
+    assertThat(((CliFunctionResult) firstResult).getMessage()).contains("No indexes defined");
   }
 
   @Test
@@ -98,7 +103,12 @@ public class CreateDefinedIndexesFunctionTest {
     List<?> results = resultSender.getResults();
 
     assertThat(results).isNotNull();
-    assertThat(results.size()).isEqualTo(0);
+    assertThat(results.size()).isEqualTo(1);
+    Object firstResult = results.get(0);
+    assertThat(firstResult).isInstanceOf(CliFunctionResult.class);
+    assertThat(((CliFunctionResult) firstResult).isSuccessful()).isTrue();
+    assertThat(((CliFunctionResult) firstResult).getMessage()).isNotEmpty();
+    assertThat(((CliFunctionResult) firstResult).getMessage()).contains("No indexes defined");
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/functions/CreateDefinedIndexesFunctionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/functions/CreateDefinedIndexesFunctionTest.java
@@ -1,0 +1,216 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.management.internal.cli.functions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.execute.FunctionContext;
+import org.apache.geode.cache.execute.ResultSender;
+import org.apache.geode.cache.query.Index;
+import org.apache.geode.cache.query.IndexCreationException;
+import org.apache.geode.cache.query.IndexType;
+import org.apache.geode.cache.query.MultiIndexCreationException;
+import org.apache.geode.cache.query.QueryService;
+import org.apache.geode.cache.query.internal.InternalQueryService;
+import org.apache.geode.cache.query.internal.index.CompactMapRangeIndex;
+import org.apache.geode.cache.query.internal.index.HashIndex;
+import org.apache.geode.cache.query.internal.index.PrimaryKeyIndex;
+import org.apache.geode.internal.cache.execute.FunctionContextImpl;
+import org.apache.geode.management.internal.cli.domain.IndexInfo;
+import org.apache.geode.management.internal.configuration.domain.XmlEntity;
+import org.apache.geode.test.fake.Fakes;
+import org.apache.geode.test.junit.categories.UnitTest;
+
+@Category(UnitTest.class)
+public class CreateDefinedIndexesFunctionTest {
+  private Cache cache;
+  private Region region1;
+  private Region region2;
+  private FunctionContext context;
+  private QueryService queryService;
+  private TestResultSender resultSender;
+  private Set<IndexInfo> indexDefinitions;
+  private CreateDefinedIndexesFunction function;
+
+  @Before
+  public void setUp() throws Exception {
+    cache = Fakes.cache();
+    resultSender = new TestResultSender();
+    queryService = spy(InternalQueryService.class);
+    region1 = Fakes.region("Region1", cache);
+    region2 = Fakes.region("Region2", cache);
+    function = spy(CreateDefinedIndexesFunction.class);
+    doReturn(queryService).when(cache).getQueryService();
+
+    indexDefinitions = new HashSet<>();
+    indexDefinitions.add(new IndexInfo("index1", "value1", "/Region1", IndexType.HASH));
+    indexDefinitions.add(new IndexInfo("index2", "value2", "/Region2", IndexType.FUNCTIONAL));
+    indexDefinitions.add(new IndexInfo("index3", "value3", "/Region1", IndexType.PRIMARY_KEY));
+  }
+
+  @Test
+  public void noIndexDefinitionsAsFunctionArgument() throws Exception {
+    context = new FunctionContextImpl(cache, CreateDefinedIndexesFunction.class.getName(),
+        Collections.emptySet(), resultSender);
+
+    function.execute(context);
+    List<?> results = resultSender.getResults();
+
+    assertThat(results).isNotNull();
+    assertThat(results.size()).isEqualTo(0);
+  }
+
+  @Test
+  public void noIndexPreviouslyDefinedInQueryService() throws Exception {
+    when(queryService.createDefinedIndexes()).thenReturn(Collections.emptyList());
+    context = new FunctionContextImpl(cache, CreateDefinedIndexesFunction.class.getName(),
+        indexDefinitions, resultSender);
+
+    function.execute(context);
+    List<?> results = resultSender.getResults();
+
+    assertThat(results).isNotNull();
+    assertThat(results.size()).isEqualTo(0);
+  }
+
+  @Test
+  public void multiIndexCreationExceptionThrowByQueryService() throws Exception {
+    HashMap<String, Exception> exceptions = new HashMap<>();
+    exceptions.put("index1", new IndexCreationException("Mock Failure."));
+    exceptions.put("index3", new IndexCreationException("Another Mock Failure."));
+    when(queryService.createDefinedIndexes())
+        .thenThrow(new MultiIndexCreationException(exceptions));
+    context = new FunctionContextImpl(cache, CreateDefinedIndexesFunction.class.getName(),
+        indexDefinitions, resultSender);
+
+    function.execute(context);
+    List<?> results = resultSender.getResults();
+
+    assertThat(results).isNotNull();
+    assertThat(results.size()).isEqualTo(1);
+    Object firstResult = results.get(0);
+    assertThat(firstResult).isNotNull();
+    assertThat(firstResult).isInstanceOf(CliFunctionResult.class);
+    assertThat(((CliFunctionResult) firstResult).isSuccessful()).isFalse();
+    assertThat(((CliFunctionResult) firstResult).getSerializables().length).isEqualTo(1);
+    assertThat(((CliFunctionResult) firstResult).getSerializables()[0]).isNotNull();
+    assertThat(((CliFunctionResult) firstResult).getSerializables()[0].toString()).contains(
+        "Index creation failed for indexes", "index1", "Mock Failure", "index3",
+        "Another Mock Failure");
+  }
+
+  @Test
+  public void unexpectedExceptionThrowByQueryService() throws Exception {
+    when(queryService.createDefinedIndexes()).thenThrow(new RuntimeException("Mock Exception"));
+    context = new FunctionContextImpl(cache, CreateDefinedIndexesFunction.class.getName(),
+        indexDefinitions, resultSender);
+
+    function.execute(context);
+    List<?> results = resultSender.getResults();
+
+    assertThat(results).isNotNull();
+    assertThat(results.size()).isEqualTo(1);
+    Object firstResult = results.get(0);
+    assertThat(firstResult).isNotNull();
+    assertThat(firstResult).isInstanceOf(CliFunctionResult.class);
+    assertThat(((CliFunctionResult) firstResult).isSuccessful()).isFalse();
+    assertThat(((CliFunctionResult) firstResult).getSerializables().length).isEqualTo(1);
+    assertThat(((CliFunctionResult) firstResult).getSerializables()[0]).isNotNull();
+    assertThat(((CliFunctionResult) firstResult).getSerializables()[0].toString())
+        .contains("RuntimeException", "Mock Exception");
+  }
+
+  @Test
+  public void creationSuccess() throws Exception {
+    Index index1 = mock(HashIndex.class);
+    when(index1.getName()).thenReturn("index1");
+    when(index1.getRegion()).thenReturn(region1);
+
+    Index index2 = mock(CompactMapRangeIndex.class);
+    when(index2.getName()).thenReturn("index2");
+    when(index2.getRegion()).thenReturn(region2);
+
+    Index index3 = mock(PrimaryKeyIndex.class);
+    when(index3.getName()).thenReturn("index3");
+    when(index3.getRegion()).thenReturn(region1);
+
+    doReturn(mock(XmlEntity.class)).when(function).createXmlEntity(any());
+    when(queryService.createDefinedIndexes()).thenReturn(Arrays.asList(index1, index2, index3));
+    context = new FunctionContextImpl(cache, CreateDefinedIndexesFunction.class.getName(),
+        indexDefinitions, resultSender);
+
+    function.execute(context);
+    List<?> results = resultSender.getResults();
+
+    assertThat(results).isNotNull();
+    assertThat(results.size()).isEqualTo(2);
+
+    Object firstIndex = results.get(0);
+    assertThat(firstIndex).isNotNull();
+    assertThat(firstIndex).isInstanceOf(CliFunctionResult.class);
+    assertThat(((CliFunctionResult) firstIndex).isSuccessful());
+
+    Object secondIndex = results.get(0);
+    assertThat(secondIndex).isNotNull();
+    assertThat(secondIndex).isInstanceOf(CliFunctionResult.class);
+    assertThat(((CliFunctionResult) secondIndex).isSuccessful()).isTrue();
+    assertThat(((CliFunctionResult) secondIndex).getXmlEntity()).isNotNull();
+  }
+
+  private static class TestResultSender implements ResultSender {
+
+    private final List<Object> results = new LinkedList<>();
+
+    private Exception t;
+
+    protected List<Object> getResults() throws Exception {
+      if (t != null) {
+        throw t;
+      }
+      return Collections.unmodifiableList(results);
+    }
+
+    @Override
+    public void lastResult(final Object lastResult) {
+      results.add(lastResult);
+    }
+
+    @Override
+    public void sendResult(final Object oneResult) {
+      results.add(oneResult);
+    }
+
+    @Override
+    public void sendException(final Throwable t) {
+      this.t = (Exception) t;
+    }
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/test/fake/Fakes.java
+++ b/geode-core/src/test/java/org/apache/geode/test/fake/Fakes.java
@@ -120,6 +120,8 @@ public class Fakes {
     when(attributes.getDataPolicy()).thenReturn(policy);
     when(region.getCache()).thenReturn(cache);
     when(region.getRegionService()).thenReturn(cache);
+    when(region.getName()).thenReturn(name);
+
     return region;
   }
 


### PR DESCRIPTION
GEODE-3898: Defined Indexes are not Persisted in Cluster Configuration.
  . Added JUnit and DUnit tests.
  . CreateDefinedIndexesFunction returns a list of CliFunctionResult and XmlEntity with the indexes created.
  . CreateDefinedIndexesCommand parses the list of results and persists the changes in the cluster configuration service. This is done only once per region whenever at least one member was able to successfully create the index on the region.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
