### PR TITLE
GEODE-3539: Restore test coverage for 'describe connection' command.

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DescribeConnectionCommandJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DescribeConnectionCommandJUnitTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.management.internal.cli.commands;
+
+import org.apache.logging.log4j.Logger;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.internal.logging.LogService;
+import org.apache.geode.test.junit.categories.IntegrationTest;
+import org.apache.geode.test.junit.rules.GfshCommandRule;
+import org.apache.geode.test.junit.rules.GfshCommandRule.PortType;
+import org.apache.geode.test.junit.rules.LocatorStarterRule;
+
+/**
+ * The GfshCommandJUnitTest class is a test suite of test cases testing the contract and
+ * functionality of the GfshCommand class for implementing GemFire shell (Gfsh) commands.
+ *
+ * @see org.apache.geode.management.internal.cli.commands.GfshCommand
+ * @see org.jmock.Expectations
+ * @see org.jmock.Mockery
+ * @see org.jmock.lib.legacy.ClassImposteriser
+ * @see org.junit.Assert
+ * @see org.junit.Test
+ * @since GemFire 7.0
+ */
+
+@Category(IntegrationTest.class)
+public class DescribeConnectionCommandJUnitTest {
+  public static Logger logger = LogService.getLogger();
+
+  @ClassRule
+  public static LocatorStarterRule locator = new LocatorStarterRule().withAutoStart();
+
+  @Rule
+  public GfshCommandRule gfsh = new GfshCommandRule();
+
+  @Test
+  public void describeConnectionTest() throws Exception {
+    gfsh.connectAndVerify(locator.getJmxPort(), PortType.jmxManager);
+    gfsh.executeAndAssertThat("describe connection").tableHasColumnWithValuesContaining(
+        "Connection Endpoints", gfsh.getGfsh().getOperationInvoker().toString());
+  }
+
+  @Test
+  public void executeWhileNotConnected() throws Exception {
+    gfsh.executeAndAssertThat("describe connection")
+        .tableHasColumnWithValuesContaining("Connection Endpoints", "Not connected");
+  }
+
+}


### PR DESCRIPTION
Due to a critical oversight on my part, the test committed in ``a1b9725a7cb351299a5239a79f96daed9d88865b` and reverted in `70b4327b196630c638a6e7aef608405d2d73db98` did not account for testing environments that resolve the host address to an alias given in `/etc/hosts`.

This commit restores the test, accounting for this possible output.

Precheckin running.

--

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
