### PR TITLE
GEODE-3592: remove getAnyInstance call

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/internal/cache/CommitFunction.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/CommitFunction.java
@@ -74,6 +74,7 @@ public class CommitFunction implements Function {
 
   public void execute(FunctionContext context) {
     Cache cache = context.getCache();
+    cache.getCancelCriterion().checkCancelInProgress(null);
     TXId txId = null;
     try {
       txId = (TXId) context.getArguments();

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/CommitFunction.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/CommitFunction.java
@@ -73,7 +73,7 @@ public class CommitFunction implements Function {
   }
 
   public void execute(FunctionContext context) {
-    Cache cache = CacheFactory.getAnyInstance();
+    Cache cache = context.getCache();
     TXId txId = null;
     try {
       txId = (TXId) context.getArguments();


### PR DESCRIPTION
Now uses FunctionContext.getCache instead.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
