### PR TITLE
GEODE-3593: remove call to getInstance

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DM.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DM.java
@@ -24,6 +24,8 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 
 import org.apache.geode.CancelCriterion;
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.CacheClosedException;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.Role;
 import org.apache.geode.distributed.internal.locks.ElderState;
@@ -464,7 +466,22 @@ public interface DM extends ReplySender {
 
   int getDMType();
 
+  /**
+   * The returned cache will be null if the cache does not yet exist. Note that the returned cache
+   * may be one that is already closed. Callers of GemFireCacheImpl.getInstance() should try to use
+   * this method.
+   */
   InternalCache getCache();
+
+  /**
+   * Returns an existing non-closed cache associated with this DM. Callers of
+   * CacheFactory.getAnyInstance(), CacheFactory.getInstance(DistributedSystem) or
+   * GemFireCacheImpl.getExisting() should try to use this method.
+   *
+   * @throws CacheClosedException if a cache has not yet been associated with this DM or it has been
+   *         {@link Cache#isClosed closed}.
+   */
+  InternalCache getExistingCache();
 
   void setCache(InternalCache instance);
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
@@ -676,7 +676,12 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
   /** Map of Futures used to track Regions that are being reinitialized */
   private final ConcurrentMap reinitializingRegions = new ConcurrentHashMap();
 
-  /** Returns the last created instance of GemFireCache */
+  /**
+   * Returns the last created instance of GemFireCache
+   *
+   * @deprecated: use DM.getCache instead
+   */
+  @Deprecated
   public static GemFireCacheImpl getInstance() {
     return instance;
   }
@@ -695,7 +700,9 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
    *
    * @return the existing cache
    * @throws CacheClosedException if an existing cache can not be found.
+   * @deprecated use DM.getExistingCache instead.
    */
+  @Deprecated
   public static GemFireCacheImpl getExisting() {
     final GemFireCacheImpl result = instance;
     if (result != null && !result.isClosing) {
@@ -715,7 +722,9 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
    * @param reason the reason an existing cache is being requested.
    * @return the existing cache
    * @throws CacheClosedException if an existing cache can not be found.
+   * @deprecated use DM.getExistingCache instead.
    */
+  @Deprecated
   public static GemFireCacheImpl getExisting(String reason) {
     GemFireCacheImpl result = getInstance();
     if (result == null) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXCommitMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXCommitMessage.java
@@ -598,14 +598,13 @@ public class TXCommitMessage extends PooledDistributionMessage
     if (logger.isDebugEnabled()) {
       logger.debug("begin processing TXCommitMessage for {}", this.txIdent);
     }
-    // do this before CacheFactory.getInstance for bug 33471
     final int oldLevel =
         LocalRegion.setThreadInitLevelRequirement(LocalRegion.BEFORE_INITIAL_IMAGE);
     boolean forceListener = false; // this gets flipped if we need to fire tx listener
     // it needs to default to false because we don't want to fire listeners on pr replicates
     try {
       TXRmtEvent txEvent = null;
-      final Cache cache = CacheFactory.getInstance(dm.getSystem());
+      final Cache cache = dm.getCache();
       if (cache == null) {
         addProcessingException(new CacheClosedException());
         // return ... this cache is closed so we can't do anything.

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXCommitMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXCommitMessage.java
@@ -604,7 +604,7 @@ public class TXCommitMessage extends PooledDistributionMessage
     // it needs to default to false because we don't want to fire listeners on pr replicates
     try {
       TXRmtEvent txEvent = null;
-      final Cache cache = dm.getCache();
+      final Cache cache = dm.getExistingCache();
       if (cache == null) {
         addProcessingException(new CacheClosedException());
         // return ... this cache is closed so we can't do anything.

--- a/geode-core/src/test/java/org/apache/geode/test/fake/Fakes.java
+++ b/geode-core/src/test/java/org/apache/geode/test/fake/Fakes.java
@@ -98,6 +98,7 @@ public class Fakes {
     when(distributionManager.getSystem()).thenReturn(system);
     when(distributionManager.getCancelCriterion()).thenReturn(systemCancelCriterion);
     when(distributionManager.getCache()).thenReturn(cache);
+    when(distributionManager.getExistingCache()).thenReturn(cache);
 
     return cache;
   }


### PR DESCRIPTION
DM.getCache is now used instead of getInstance

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
