### PR TITLE
GEODE-3335: Fix expected member count

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/management/RegionManagementDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/RegionManagementDUnitTest.java
@@ -68,7 +68,6 @@ import org.apache.geode.management.internal.MBeanJMXAdapter;
 import org.apache.geode.management.internal.SystemManagementService;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.junit.categories.DistributedTest;
-import org.apache.geode.test.junit.categories.FlakyTest;
 
 /**
  * Distributed tests for {@link RegionMXBean}.
@@ -217,7 +216,6 @@ public class RegionManagementDUnitTest implements Serializable {
    * asynchronously.
    */
   @Test
-  @Category(FlakyTest.class) // GEODE-1930
   public void testRegionAggregate() throws Exception {
     createManagersAndThenMembers();
 
@@ -247,7 +245,6 @@ public class RegionManagementDUnitTest implements Serializable {
   }
 
   @Test
-  @Category(FlakyTest.class) // GEODE-3335
   public void testNavigationAPIS() throws Exception {
     createManagersAndThenMembers();
 
@@ -299,7 +296,6 @@ public class RegionManagementDUnitTest implements Serializable {
   }
 
   @Test
-  @Category(FlakyTest.class) // GEODE-1930
   public void testLruStats() throws Exception {
     createMembersAndThenManagers();
     for (VM memberVM : this.memberVMs) {
@@ -407,7 +403,8 @@ public class RegionManagementDUnitTest implements Serializable {
       ManagementService service = getManagementService();
       assertThat(service.getDistributedSystemMXBean()).isNotNull();
 
-      awaitMemberCount(4);
+      // With the DUnit framework there is a locator, a manager and 3 members
+      awaitMemberCount(5);
 
       DistributedSystemMXBean distributedSystemMXBean = service.getDistributedSystemMXBean();
       assertThat(distributedSystemMXBean.listDistributedRegionObjectNames()).hasSize(2);
@@ -520,7 +517,7 @@ public class RegionManagementDUnitTest implements Serializable {
     assertThat(fixedPartitionAttributesData).isNotNull();
     assertThat(fixedPartitionAttributesData).hasSize(3);
 
-    for (int i = 0; i < fixedPartitionAttributesData.length; i++) {
+    for (FixedPartitionAttributesData aFixedPartitionAttributesData : fixedPartitionAttributesData) {
       // TODO: add real assertions
       // LogWriterUtils.getLogWriter().info("<ExpectedString> Fixed PR Data is " +
       // fixedPartitionAttributesData[i] + "</ExpectedString> ");
@@ -971,7 +968,7 @@ public class RegionManagementDUnitTest implements Serializable {
         assertThat(fixedPrData).isNotNull();
         assertThat(fixedPrData).hasSize(3);
 
-        for (int i = 0; i < fixedPrData.length; i++) {
+        for (FixedPartitionAttributesData aFixedPrData : fixedPrData) {
           // TODO: add real assertions
           // LogWriterUtils.getLogWriter().info("<ExpectedString> Remote PR Data is " +
           // fixedPrData[i] + "</ExpectedString> ");


### PR DESCRIPTION
With the DUnit test framework there should be a locator, and a manager
and 3 members created in the test. (expectedCount = 5)

Remove Flaky tags

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
