### PR TITLE
GEODE-3940: fix deadlock in backup messages

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/admin/internal/FinishBackupRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/FinishBackupRequest.java
@@ -32,14 +32,13 @@ import org.apache.geode.DataSerializer;
 import org.apache.geode.cache.persistence.PersistentID;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.internal.DM;
-import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.distributed.internal.DistributionMessage;
 import org.apache.geode.distributed.internal.ReplyException;
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.admin.remote.AdminFailureResponse;
 import org.apache.geode.internal.admin.remote.AdminMultipleReplyProcessor;
 import org.apache.geode.internal.admin.remote.AdminResponse;
 import org.apache.geode.internal.admin.remote.CliLegacyMessage;
-import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.i18n.LocalizedStrings;
 import org.apache.geode.internal.logging.LogService;
@@ -48,34 +47,52 @@ import org.apache.geode.internal.logging.log4j.LocalizedMessage;
 /**
  * A request send from an admin VM to all of the peers to indicate that that should complete the
  * backup operation.
- *
- *
  */
 public class FinishBackupRequest extends CliLegacyMessage {
   private static final Logger logger = LogService.getLogger();
 
+  private final DM dm;
+  private final FinishBackupReplyProcessor replyProcessor;
   private File targetDir;
   private File baselineDir;
   private boolean abort;
 
   public FinishBackupRequest() {
     super();
+    this.dm = null;
+    this.replyProcessor = null;
   }
 
-  public FinishBackupRequest(File targetDir, File baselineDir, boolean abort) {
+  private FinishBackupRequest(DM dm, Set<InternalDistributedMember> recipients, File targetDir,
+      File baselineDir, boolean abort) {
+    this(dm, recipients, new FinishBackupReplyProcessor(dm, recipients), targetDir, baselineDir,
+        abort);
+  }
+
+  FinishBackupRequest(DM dm, Set<InternalDistributedMember> recipients,
+      FinishBackupReplyProcessor replyProcessor, File targetDir, File baselineDir, boolean abort) {
+    this.dm = dm;
     this.targetDir = targetDir;
     this.baselineDir = baselineDir;
     this.abort = abort;
+    setRecipients(recipients);
+    this.replyProcessor = replyProcessor;
+    this.msgId = this.replyProcessor.getProcessorId();
   }
 
   public static Map<DistributedMember, Set<PersistentID>> send(DM dm, Set recipients,
       File targetDir, File baselineDir, boolean abort) {
-    FinishBackupRequest request = new FinishBackupRequest(targetDir, baselineDir, abort);
-    request.setRecipients(recipients);
+    FinishBackupRequest request =
+        new FinishBackupRequest(dm, recipients, targetDir, baselineDir, abort);
+    return request.send();
+  }
 
-    FinishBackupReplyProcessor replyProcessor = new FinishBackupReplyProcessor(dm, recipients);
-    request.msgId = replyProcessor.getProcessorId();
-    dm.putOutgoing(request);
+  Map<DistributedMember, Set<PersistentID>> send() {
+    dm.putOutgoing(this);
+
+    // invokes doBackup and releases BackupLock
+    AdminResponse response = createResponse(dm);
+
     try {
       replyProcessor.waitForReplies();
     } catch (ReplyException e) {
@@ -83,33 +100,39 @@ public class FinishBackupRequest extends CliLegacyMessage {
         throw e;
       }
     } catch (InterruptedException e) {
-      e.printStackTrace();
+      logger.warn(e.getMessage(), e);
     }
-    AdminResponse response = request.createResponse((DistributionManager) dm);
+
+    // adding local member to the results
     response.setSender(dm.getDistributionManagerId());
     replyProcessor.process(response);
-    return replyProcessor.results;
+    return replyProcessor.getResults();
   }
 
   @Override
-  protected AdminResponse createResponse(DistributionManager dm) {
+  protected AdminResponse createResponse(DM dm) {
+    HashSet<PersistentID> persistentIds;
+    try {
+      persistentIds = doBackup(dm);
+    } catch (IOException e) {
+      logger.error(LocalizedMessage.create(LocalizedStrings.CliLegacyMessage_ERROR, getClass()), e);
+      return AdminFailureResponse.create(getSender(), e);
+    }
+    return new FinishBackupResponse(getSender(), persistentIds);
+  }
+
+  private HashSet<PersistentID> doBackup(DM dm) throws IOException {
     InternalCache cache = dm.getCache();
     HashSet<PersistentID> persistentIds;
     if (cache == null || cache.getBackupManager() == null) {
-      persistentIds = new HashSet<PersistentID>();
+      persistentIds = new HashSet<>();
     } else {
-      try {
-        persistentIds = cache.getBackupManager().doBackup(targetDir, baselineDir, abort);
-      } catch (IOException e) {
-        logger.error(
-            LocalizedMessage.create(LocalizedStrings.CliLegacyMessage_ERROR, this.getClass()), e);
-        return AdminFailureResponse.create(dm, getSender(), e);
-      }
+      persistentIds = cache.getBackupManager().doBackup(targetDir, baselineDir, abort);
     }
-
-    return new FinishBackupResponse(this.getSender(), persistentIds);
+    return persistentIds;
   }
 
+  @Override
   public int getDSFID() {
     return FINISH_BACKUP_REQUEST;
   }
@@ -130,11 +153,12 @@ public class FinishBackupRequest extends CliLegacyMessage {
     DataSerializer.writeBoolean(abort, out);
   }
 
-  private static class FinishBackupReplyProcessor extends AdminMultipleReplyProcessor {
-    Map<DistributedMember, Set<PersistentID>> results =
+  static class FinishBackupReplyProcessor extends AdminMultipleReplyProcessor {
+
+    private Map<DistributedMember, Set<PersistentID>> results =
         Collections.synchronizedMap(new HashMap<DistributedMember, Set<PersistentID>>());
 
-    public FinishBackupReplyProcessor(DM dm, Collection initMembers) {
+    FinishBackupReplyProcessor(DM dm, Collection initMembers) {
       super(dm, initMembers);
     }
 
@@ -142,8 +166,6 @@ public class FinishBackupRequest extends CliLegacyMessage {
     protected boolean stopBecauseOfExceptions() {
       return false;
     }
-
-
 
     @Override
     protected int getAckWaitThreshold() {
@@ -158,17 +180,23 @@ public class FinishBackupRequest extends CliLegacyMessage {
     }
 
     @Override
-    protected void process(DistributionMessage msg, boolean warn) {
-      if (msg instanceof FinishBackupResponse) {
-        final HashSet<PersistentID> persistentIds = ((FinishBackupResponse) msg).getPersistentIds();
+    protected void process(DistributionMessage message, boolean warn) {
+      if (message instanceof FinishBackupResponse) {
+        HashSet<PersistentID> persistentIds = ((FinishBackupResponse) message).getPersistentIds();
         if (persistentIds != null && !persistentIds.isEmpty()) {
-          results.put(msg.getSender(), persistentIds);
+          results.put(message.getSender(), persistentIds);
         }
       }
-      super.process(msg, warn);
+      super.process(message, warn);
     }
 
+    @Override
+    protected InternalDistributedMember[] getMembers() {
+      return super.getMembers();
+    }
 
-
+    Map<DistributedMember, Set<PersistentID>> getResults() {
+      return results;
+    }
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/FinishBackupRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/FinishBackupRequest.java
@@ -105,7 +105,7 @@ public class FinishBackupRequest extends CliLegacyMessage {
 
     // adding local member to the results
     response.setSender(dm.getDistributionManagerId());
-    replyProcessor.process(response);
+    replyProcessor.process(response, false);
     return replyProcessor.getResults();
   }
 
@@ -155,7 +155,7 @@ public class FinishBackupRequest extends CliLegacyMessage {
 
   static class FinishBackupReplyProcessor extends AdminMultipleReplyProcessor {
 
-    private Map<DistributedMember, Set<PersistentID>> results =
+    private final Map<DistributedMember, Set<PersistentID>> results =
         Collections.synchronizedMap(new HashMap<DistributedMember, Set<PersistentID>>());
 
     FinishBackupReplyProcessor(DM dm, Collection initMembers) {
@@ -188,11 +188,6 @@ public class FinishBackupRequest extends CliLegacyMessage {
         }
       }
       super.process(message, warn);
-    }
-
-    @Override
-    protected InternalDistributedMember[] getMembers() {
-      return super.getMembers();
     }
 
     Map<DistributedMember, Set<PersistentID>> getResults() {

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/FinishBackupResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/FinishBackupResponse.java
@@ -27,8 +27,6 @@ import org.apache.geode.internal.admin.remote.AdminResponse;
 /**
  * The reply for a {@link FinishBackupRequest}. The reply contains the persistent ids of the disk
  * stores that were backed up on this member.
- *
- *
  */
 public class FinishBackupResponse extends AdminResponse {
 

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/FlushToDiskRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/FlushToDiskRequest.java
@@ -22,12 +22,11 @@ import org.apache.logging.log4j.Logger;
 import org.apache.geode.CancelException;
 import org.apache.geode.cache.DiskStore;
 import org.apache.geode.distributed.internal.DM;
-import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.distributed.internal.ReplyException;
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.admin.remote.AdminMultipleReplyProcessor;
 import org.apache.geode.internal.admin.remote.AdminResponse;
 import org.apache.geode.internal.admin.remote.CliLegacyMessage;
-import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.logging.LogService;
 
@@ -39,17 +38,37 @@ import org.apache.geode.internal.logging.LogService;
 public class FlushToDiskRequest extends CliLegacyMessage {
   private static final Logger logger = LogService.getLogger();
 
+  private final DM dm;
+  private final FlushToDiskProcessor replyProcessor;
+
   public FlushToDiskRequest() {
-    // nothing
+    super();
+    this.dm = null;
+    this.replyProcessor = null;
+  }
+
+  private FlushToDiskRequest(DM dm, Set<InternalDistributedMember> recipients) {
+    this(dm, recipients, new FlushToDiskProcessor(dm, recipients));
+  }
+
+  FlushToDiskRequest(DM dm, Set<InternalDistributedMember> recipients,
+      FlushToDiskProcessor replyProcessor) {
+    this.dm = dm;
+    setRecipients(recipients);
+    this.replyProcessor = replyProcessor;
+    this.msgId = this.replyProcessor.getProcessorId();
   }
 
   public static void send(DM dm, Set recipients) {
-    FlushToDiskRequest request = new FlushToDiskRequest();
-    request.setRecipients(recipients);
+    FlushToDiskRequest request = new FlushToDiskRequest(dm, recipients);
+    request.send();
+  }
 
-    FlushToDiskProcessor replyProcessor = new FlushToDiskProcessor(dm, recipients);
-    request.msgId = replyProcessor.getProcessorId();
-    dm.putOutgoing(request);
+  void send() {
+    dm.putOutgoing(this);
+
+    AdminResponse response = createResponse(dm);
+
     try {
       replyProcessor.waitForReplies();
     } catch (ReplyException e) {
@@ -57,21 +76,21 @@ public class FlushToDiskRequest extends CliLegacyMessage {
         throw e;
       }
     } catch (InterruptedException e) {
-      logger.debug(e);
+      logger.warn(e);
     }
-    AdminResponse response = request.createResponse((DistributionManager) dm);
+
     response.setSender(dm.getDistributionManagerId());
     replyProcessor.process(response);
   }
 
   @Override
-  protected AdminResponse createResponse(DistributionManager dm) {
+  protected AdminResponse createResponse(DM dm) {
     InternalCache cache = dm.getCache();
     if (cache != null) {
       cache.listDiskStoresIncludingRegionOwned().forEach(DiskStore::flush);
     }
 
-    return new FlushToDiskResponse(this.getSender());
+    return new FlushToDiskResponse(getSender());
   }
 
   @Override
@@ -79,8 +98,9 @@ public class FlushToDiskRequest extends CliLegacyMessage {
     return FLUSH_TO_DISK_REQUEST;
   }
 
-  private static class FlushToDiskProcessor extends AdminMultipleReplyProcessor {
-    public FlushToDiskProcessor(DM dm, Collection initMembers) {
+  static class FlushToDiskProcessor extends AdminMultipleReplyProcessor {
+
+    FlushToDiskProcessor(DM dm, Collection initMembers) {
       super(dm, initMembers);
     }
 

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/FlushToDiskRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/FlushToDiskRequest.java
@@ -22,6 +22,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.geode.CancelException;
 import org.apache.geode.cache.DiskStore;
 import org.apache.geode.distributed.internal.DM;
+import org.apache.geode.distributed.internal.DistributionMessage;
 import org.apache.geode.distributed.internal.ReplyException;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.admin.remote.AdminMultipleReplyProcessor;
@@ -80,7 +81,7 @@ public class FlushToDiskRequest extends CliLegacyMessage {
     }
 
     response.setSender(dm.getDistributionManagerId());
-    replyProcessor.process(response);
+    replyProcessor.process(response, false);
   }
 
   @Override
@@ -107,6 +108,11 @@ public class FlushToDiskRequest extends CliLegacyMessage {
     @Override
     protected boolean stopBecauseOfExceptions() {
       return false;
+    }
+
+    @Override
+    protected void process(DistributionMessage message, boolean warn) {
+      super.process(message, warn);
     }
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/PrepareBackupRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/PrepareBackupRequest.java
@@ -90,7 +90,7 @@ public class PrepareBackupRequest extends CliLegacyMessage {
     }
 
     response.setSender(dm.getDistributionManagerId());
-    replyProcessor.process(response);
+    replyProcessor.process(response, false);
     return replyProcessor.getResults();
   }
 
@@ -124,7 +124,7 @@ public class PrepareBackupRequest extends CliLegacyMessage {
 
   static class PrepareBackupReplyProcessor extends AdminMultipleReplyProcessor {
 
-    private Map<DistributedMember, Set<PersistentID>> results =
+    private final Map<DistributedMember, Set<PersistentID>> results =
         Collections.synchronizedMap(new HashMap<DistributedMember, Set<PersistentID>>());
 
     PrepareBackupReplyProcessor(DM dm, Collection initMembers) {

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/PrepareBackupRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/PrepareBackupRequest.java
@@ -28,15 +28,13 @@ import org.apache.geode.CancelException;
 import org.apache.geode.cache.persistence.PersistentID;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.internal.DM;
-import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.distributed.internal.DistributionMessage;
 import org.apache.geode.distributed.internal.ReplyException;
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.admin.remote.AdminFailureResponse;
 import org.apache.geode.internal.admin.remote.AdminMultipleReplyProcessor;
 import org.apache.geode.internal.admin.remote.AdminResponse;
 import org.apache.geode.internal.admin.remote.CliLegacyMessage;
-import org.apache.geode.internal.cache.BackupManager;
-import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.i18n.LocalizedStrings;
 import org.apache.geode.internal.logging.LogService;
@@ -46,23 +44,41 @@ import org.apache.geode.internal.logging.log4j.LocalizedMessage;
  * A request to from an admin VM to all non admin members to start a backup. In the prepare phase of
  * the backup, the members will suspend bucket destroys to make sure buckets aren't missed during
  * the backup.
- *
- *
  */
 public class PrepareBackupRequest extends CliLegacyMessage {
   private static final Logger logger = LogService.getLogger();
 
-  public PrepareBackupRequest() {
+  private final DM dm;
+  private final PrepareBackupReplyProcessor replyProcessor;
 
+  public PrepareBackupRequest() {
+    super();
+    this.dm = null;
+    this.replyProcessor = null;
+  }
+
+  private PrepareBackupRequest(DM dm, Set<InternalDistributedMember> recipients) {
+    this(dm, recipients, new PrepareBackupReplyProcessor(dm, recipients));
+  }
+
+  PrepareBackupRequest(DM dm, Set<InternalDistributedMember> recipients,
+      PrepareBackupReplyProcessor replyProcessor) {
+    this.dm = dm;
+    setRecipients(recipients);
+    this.replyProcessor = replyProcessor;
+    this.msgId = this.replyProcessor.getProcessorId();
   }
 
   public static Map<DistributedMember, Set<PersistentID>> send(DM dm, Set recipients) {
-    PrepareBackupRequest request = new PrepareBackupRequest();
-    request.setRecipients(recipients);
+    PrepareBackupRequest request = new PrepareBackupRequest(dm, recipients);
+    return request.send();
+  }
 
-    PrepareBackupReplyProcessor replyProcessor = new PrepareBackupReplyProcessor(dm, recipients);
-    request.msgId = replyProcessor.getProcessorId();
-    dm.putOutgoing(request);
+  Map<DistributedMember, Set<PersistentID>> send() {
+    dm.putOutgoing(this);
+
+    AdminResponse response = createResponse(dm);
+
     try {
       replyProcessor.waitForReplies();
     } catch (ReplyException e) {
@@ -70,44 +86,48 @@ public class PrepareBackupRequest extends CliLegacyMessage {
         throw e;
       }
     } catch (InterruptedException e) {
-      e.printStackTrace();
+      logger.warn(e.getMessage(), e);
     }
-    AdminResponse response = request.createResponse((DistributionManager) dm);
+
     response.setSender(dm.getDistributionManagerId());
     replyProcessor.process(response);
-    return replyProcessor.results;
+    return replyProcessor.getResults();
   }
 
   @Override
-  protected AdminResponse createResponse(DistributionManager dm) {
+  protected AdminResponse createResponse(DM dm) {
+    HashSet<PersistentID> persistentIds;
+    try {
+      persistentIds = prepareForBackup(dm);
+    } catch (IOException e) {
+      logger.error(LocalizedMessage.create(LocalizedStrings.CliLegacyMessage_ERROR, getClass()), e);
+      return AdminFailureResponse.create(getSender(), e);
+    }
+    return new PrepareBackupResponse(getSender(), persistentIds);
+  }
+
+  HashSet<PersistentID> prepareForBackup(DM dm) throws IOException {
     InternalCache cache = dm.getCache();
     HashSet<PersistentID> persistentIds;
     if (cache == null) {
       persistentIds = new HashSet<>();
     } else {
-      try {
-        BackupManager manager = cache.startBackup(getSender());
-        persistentIds = manager.prepareForBackup();
-      } catch (IOException e) {
-        logger.error(
-            LocalizedMessage.create(LocalizedStrings.CliLegacyMessage_ERROR, this.getClass()), e);
-        return AdminFailureResponse.create(dm, getSender(), e);
-      }
+      persistentIds = cache.startBackup(getSender()).prepareForBackup();
     }
-
-
-    return new PrepareBackupResponse(this.getSender(), persistentIds);
+    return persistentIds;
   }
 
+  @Override
   public int getDSFID() {
     return PREPARE_BACKUP_REQUEST;
   }
 
-  private static class PrepareBackupReplyProcessor extends AdminMultipleReplyProcessor {
-    Map<DistributedMember, Set<PersistentID>> results =
+  static class PrepareBackupReplyProcessor extends AdminMultipleReplyProcessor {
+
+    private Map<DistributedMember, Set<PersistentID>> results =
         Collections.synchronizedMap(new HashMap<DistributedMember, Set<PersistentID>>());
 
-    public PrepareBackupReplyProcessor(DM dm, Collection initMembers) {
+    PrepareBackupReplyProcessor(DM dm, Collection initMembers) {
       super(dm, initMembers);
     }
 
@@ -117,18 +137,18 @@ public class PrepareBackupRequest extends CliLegacyMessage {
     }
 
     @Override
-    protected void process(DistributionMessage msg, boolean warn) {
-      if (msg instanceof PrepareBackupResponse) {
-        final HashSet<PersistentID> persistentIds =
-            ((PrepareBackupResponse) msg).getPersistentIds();
+    protected void process(DistributionMessage message, boolean warn) {
+      if (message instanceof PrepareBackupResponse) {
+        HashSet<PersistentID> persistentIds = ((PrepareBackupResponse) message).getPersistentIds();
         if (persistentIds != null && !persistentIds.isEmpty()) {
-          results.put(msg.getSender(), persistentIds);
+          results.put(message.getSender(), persistentIds);
         }
       }
-      super.process(msg, warn);
+      super.process(message, warn);
     }
 
-
-
+    Map<DistributedMember, Set<PersistentID>> getResults() {
+      return results;
+    }
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DM.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DM.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 
 import org.apache.geode.CancelCriterion;
+import org.apache.geode.admin.GemFireHealthConfig;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.Role;
 import org.apache.geode.distributed.internal.locks.ElderState;
@@ -37,31 +38,31 @@ import org.apache.geode.internal.cache.InternalCache;
  */
 public interface DM extends ReplySender {
 
-  public boolean shutdownInProgress();
+  boolean shutdownInProgress();
 
   /**
    * Returns the current "cache time" in milliseconds since the epoch. The "cache time" takes into
    * account skew among the local clocks on the various machines involved in the cache.
    */
-  public long cacheTimeMillis();
+  long cacheTimeMillis();
 
   /**
    * Returns the id of this distribution manager.
    */
-  public InternalDistributedMember getDistributionManagerId();
+  InternalDistributedMember getDistributionManagerId();
 
   /**
    * Get a set of all other members (both admin ones and normal).
    *
    * @since GemFire 5.7
    */
-  public Set getAllOtherMembers();
+  Set getAllOtherMembers();
 
   /**
    * Returns the ID in the membership view that is equal to the argument. If the ID is not in the
    * view, the argument is returned.
    */
-  public InternalDistributedMember getCanonicalId(DistributedMember id);
+  InternalDistributedMember getCanonicalId(DistributedMember id);
 
   /**
    * removes members that have older versions from the given collection, typically a Set from a
@@ -69,7 +70,7 @@ public interface DM extends ReplySender {
    *
    * @since GemFire 8.0
    */
-  public void retainMembersWithSameOrNewerVersion(Collection<InternalDistributedMember> members,
+  void retainMembersWithSameOrNewerVersion(Collection<InternalDistributedMember> members,
       Version version);
 
   /**
@@ -78,20 +79,20 @@ public interface DM extends ReplySender {
    *
    * @since GemFire 8.0
    */
-  public void removeMembersWithSameOrNewerVersion(Collection<InternalDistributedMember> members,
+  void removeMembersWithSameOrNewerVersion(Collection<InternalDistributedMember> members,
       Version version);
 
   /**
    * Returns an unmodifiable set containing the identities of all of the known distribution
    * managers. As of 7.0 this includes locators since they have a cache.
    */
-  public Set getDistributionManagerIds();
+  Set getDistributionManagerIds();
 
   /**
    * Returns an unmodifiable set containing the identities of all of the known "normal" distribution
    * managers. This does not include locators or admin members.
    */
-  public Set getNormalDistributionManagerIds();
+  Set getNormalDistributionManagerIds();
 
   /**
    * Returns an unmodifiable set containing the identities of all of the known distribution managers
@@ -99,22 +100,22 @@ public interface DM extends ReplySender {
    *
    * @since GemFire 5.7
    */
-  public Set getDistributionManagerIdsIncludingAdmin();
+  Set getDistributionManagerIdsIncludingAdmin();
 
   /**
    * Returns a private-memory list containing getDistributionManagerIds() minus our id.
    */
-  public Set getOtherDistributionManagerIds();
+  Set getOtherDistributionManagerIds();
 
   /**
    * Returns a private-memory list containing getNormalDistributionManagerIds() minus our id.
    */
-  public Set getOtherNormalDistributionManagerIds();
+  Set getOtherNormalDistributionManagerIds();
 
   /**
    * Add a membership listener and return other DistribtionManagerIds as an atomic operation
    */
-  public Set addMembershipListenerAndGetDistributionManagerIds(MembershipListener l);
+  Set addMembershipListenerAndGetDistributionManagerIds(MembershipListener l);
 
   /**
    * Add a membership listener for all members and return other DistribtionManagerIds as an atomic
@@ -122,19 +123,19 @@ public interface DM extends ReplySender {
    *
    * @since GemFire 5.7
    */
-  public Set addAllMembershipListenerAndGetAllIds(MembershipListener l);
+  Set addAllMembershipListenerAndGetAllIds(MembershipListener l);
 
   /**
    * Returns the identity of this <code>DistributionManager</code>
    */
-  public InternalDistributedMember getId();
+  InternalDistributedMember getId();
 
   /**
    * Return true if no other distribution manager was in this group when he joined.
    *
    * @since GemFire 4.0
    */
-  public boolean isAdam();
+  boolean isAdam();
 
   /**
    * Returns the identity of the oldest DM in this group.
@@ -144,19 +145,19 @@ public interface DM extends ReplySender {
    * @return the elder member, possibly null
    * @since GemFire 4.0
    */
-  public InternalDistributedMember getElderId();
+  InternalDistributedMember getElderId();
 
   /**
    * Return true if this is the oldest DM in this group.
    *
    * @since GemFire 5.0
    */
-  public boolean isElder();
+  boolean isElder();
 
   /**
    * Return true if this DM is a loner that is not part of a real distributed system.
    */
-  public boolean isLoner();
+  boolean isLoner();
 
   /**
    * Returns the elder state or null if this DM is not the elder.
@@ -169,14 +170,14 @@ public interface DM extends ReplySender {
    * @throws IllegalStateException if elder try lock fails
    * @since GemFire 4.0
    */
-  public ElderState getElderState(boolean force, boolean useTryLock);
+  ElderState getElderState(boolean force, boolean useTryLock);
 
   /**
    * Returns the id of the underlying distribution channel used for communication.
    *
    * @since GemFire 3.0
    */
-  public long getChannelId();
+  long getChannelId();
 
   /**
    * Adds a message to the outgoing queue. Note that <code>message</code> should not be modified
@@ -187,7 +188,7 @@ public interface DM extends ReplySender {
    * @throws NotSerializableException If <code>message</code> cannot be serialized
    * @see #putOutgoing(DistributionMessage)
    */
-  public Set putOutgoingUserData(DistributionMessage message) throws NotSerializableException;
+  Set putOutgoingUserData(DistributionMessage message) throws NotSerializableException;
 
   /**
    * Sends a message, guaranteed to be serialized
@@ -196,24 +197,24 @@ public interface DM extends ReplySender {
    * @param msg
    * @return recipients who did not receive the message
    */
-  public Set putOutgoing(DistributionMessage msg);
+  Set putOutgoing(DistributionMessage msg);
 
   /**
    * Returns the distributed system to which this distribution manager is connected.
    */
-  public InternalDistributedSystem getSystem();
+  InternalDistributedSystem getSystem();
 
   /**
    * Adds a <code>MembershipListener</code> to this distribution manager.
    */
-  public void addMembershipListener(MembershipListener l);
+  void addMembershipListener(MembershipListener l);
 
   /**
    * Removes a <code>MembershipListener</code> from this distribution manager.
    *
    * @throws IllegalArgumentException <code>l</code> was not registered on this distribution manager
    */
-  public void removeMembershipListener(MembershipListener l);
+  void removeMembershipListener(MembershipListener l);
 
   /**
    * Removes a <code>MembershipListener</code> listening for all members from this distribution
@@ -222,11 +223,11 @@ public interface DM extends ReplySender {
    * @throws IllegalArgumentException <code>l</code> was not registered on this distribution manager
    * @since GemFire 5.7
    */
-  public void removeAllMembershipListener(MembershipListener l);
+  void removeAllMembershipListener(MembershipListener l);
 
-  public void addAdminConsole(InternalDistributedMember id);
+  void addAdminConsole(InternalDistributedMember id);
 
-  public DMStats getStats();
+  DMStats getStats();
 
   /**
    * Used to get the DistributionConfig so that Connection can figure out if it is configured for
@@ -234,7 +235,7 @@ public interface DM extends ReplySender {
    *
    * @since GemFire 4.2.1
    */
-  public DistributionConfig getConfig();
+  DistributionConfig getConfig();
 
   /**
    * Makes note of a distribution manager that has shut down. Invokes the appropriate listeners.
@@ -243,28 +244,27 @@ public interface DM extends ReplySender {
    *
    * @see ShutdownMessage#process
    */
-  public void handleManagerDeparture(InternalDistributedMember theId, boolean crashed,
-      String reason);
+  void handleManagerDeparture(InternalDistributedMember theId, boolean crashed, String reason);
 
   /**
    * getThreadPool gets this distribution manager's message-processing thread pool
    */
-  public ExecutorService getThreadPool();
+  ExecutorService getThreadPool();
 
   /**
    * Return the high-priority message-processing executor
    */
-  public ExecutorService getHighPriorityThreadPool();
+  ExecutorService getHighPriorityThreadPool();
 
   /**
    * Return the waiting message-processing executor
    */
-  public ExecutorService getWaitingThreadPool();
+  ExecutorService getWaitingThreadPool();
 
   /**
    * Return the special waiting message-processing executor
    */
-  public ExecutorService getPrMetaDataCleanupThreadPool();
+  ExecutorService getPrMetaDataCleanupThreadPool();
 
   /**
    * gets this distribution manager's message-processing executor for ordered (i.e. serialized)
@@ -272,13 +272,13 @@ public interface DM extends ReplySender {
    */
   // public Executor getSerialExecutor();
 
-  public void close();
+  void close();
 
   /**
    * Returns the ordered list of current DistributionManagers in oldest-to-youngest order. Added for
    * DLockGrantor
    */
-  public List<InternalDistributedMember> getViewMembers();
+  List<InternalDistributedMember> getViewMembers();
 
   /**
    * Returns the oldest member in the given set of distribution managers. The current implementation
@@ -288,27 +288,27 @@ public interface DM extends ReplySender {
    * @throws NoSuchElementException when none of the given members is actually a member of the
    *         distributed system.
    */
-  public DistributedMember getOldestMember(Collection members) throws NoSuchElementException;
+  DistributedMember getOldestMember(Collection members) throws NoSuchElementException;
 
   /**
    * @return Set of Admin VM nodes
    */
-  public Set getAdminMemberSet();
+  Set getAdminMemberSet();
 
   /** Throws ShutdownException if closeInProgress returns true. */
-  public void throwIfDistributionStopped();
+  void throwIfDistributionStopped();
 
   /** Returns count of members filling the specified role */
-  public int getRoleCount(Role role);
+  int getRoleCount(Role role);
 
   /** Returns true if at least one member is filling the specified role */
-  public boolean isRolePresent(Role role);
+  boolean isRolePresent(Role role);
 
   /** Returns a set of all roles currently in the distributed system. */
-  public Set getAllRoles();
+  Set getAllRoles();
 
   /** Returns true if id is a current member of the distributed system */
-  public boolean isCurrentMember(InternalDistributedMember id);
+  boolean isCurrentMember(InternalDistributedMember id);
 
   /**
    * Remove given member from list of members who are pending a startup reply
@@ -316,37 +316,37 @@ public interface DM extends ReplySender {
    * @param m the member
    * @param departed true if we're removing them due to membership
    */
-  public void removeUnfinishedStartup(InternalDistributedMember m, boolean departed);
+  void removeUnfinishedStartup(InternalDistributedMember m, boolean departed);
 
-  public void setUnfinishedStartups(Collection s);
+  void setUnfinishedStartups(Collection s);
 
   /**
    * Return the CancelCriterion for this DM.
    *
    * @return CancelCriterion for this DM
    */
-  public CancelCriterion getCancelCriterion();
+  CancelCriterion getCancelCriterion();
 
   /**
    * Return the membership manager for this DM
    *
    * @return the membership manager
    */
-  public MembershipManager getMembershipManager();
+  MembershipManager getMembershipManager();
 
   /**
    * Set the root cause for DM failure
    *
    * @param t the underlying failure
    */
-  public void setRootCause(Throwable t);
+  void setRootCause(Throwable t);
 
   /**
    * Return the underlying root cause for DM failure, possibly null
    *
    * @return the underlying root cause
    */
-  public Throwable getRootCause();
+  Throwable getRootCause();
 
   /**
    * Return all members that are on the the this host
@@ -354,27 +354,25 @@ public interface DM extends ReplySender {
    * @return set of {@link InternalDistributedMember} including this VM
    * @since GemFire 5.9
    */
-  public Set<InternalDistributedMember> getMembersInThisZone();
+  Set<InternalDistributedMember> getMembersInThisZone();
 
   /**
    * Acquire a permit to request a GII from another member
    */
-  public void acquireGIIPermitUninterruptibly();
+  void acquireGIIPermitUninterruptibly();
 
   /**
    * Release a permit to request a GII from another member.
    */
-  public void releaseGIIPermit();
+  void releaseGIIPermit();
 
-  public int getDistributedSystemId();
+  int getDistributedSystemId();
 
-  public boolean enforceUniqueZone();
+  boolean enforceUniqueZone();
 
-  public Set<InternalDistributedMember> getMembersInSameZone(
-      InternalDistributedMember acceptedMember);
+  Set<InternalDistributedMember> getMembersInSameZone(InternalDistributedMember acceptedMember);
 
-  public boolean areInSameZone(InternalDistributedMember member1,
-      InternalDistributedMember member2);
+  boolean areInSameZone(InternalDistributedMember member1, InternalDistributedMember member2);
 
   /**
    * Returns true is the two members are on the same equivalent host machine based on overlapping IP
@@ -383,12 +381,11 @@ public interface DM extends ReplySender {
    * @param member1 First member
    * @param member2 Second member
    */
-  public boolean areOnEquivalentHost(InternalDistributedMember member1,
-      InternalDistributedMember member2);
+  boolean areOnEquivalentHost(InternalDistributedMember member1, InternalDistributedMember member2);
 
-  public Set<InetAddress> getEquivalents(InetAddress in);
+  Set<InetAddress> getEquivalents(InetAddress in);
 
-  public Set<DistributedMember> getGroupMembers(String group);
+  Set<DistributedMember> getGroupMembers(String group);
 
   /**
    * Adds the entry in hostedLocators for a member with one or more hosted locators. The value is a
@@ -402,7 +399,7 @@ public interface DM extends ReplySender {
    *
    * @since GemFire 6.6.3
    */
-  public void addHostedLocators(InternalDistributedMember member, Collection<String> locators,
+  void addHostedLocators(InternalDistributedMember member, Collection<String> locators,
       boolean isSharedConfigurationEnabled);
 
 
@@ -415,7 +412,7 @@ public interface DM extends ReplySender {
    *
    * @since GemFire 6.6.3
    */
-  public Collection<String> getHostedLocators(InternalDistributedMember member);
+  Collection<String> getHostedLocators(InternalDistributedMember member);
 
   /**
    * Gets the map of all members hosting locators. The key is the member, and the value is a
@@ -428,7 +425,7 @@ public interface DM extends ReplySender {
    *
    * @since GemFire 6.6.3
    */
-  public Map<InternalDistributedMember, Collection<String>> getAllHostedLocators();
+  Map<InternalDistributedMember, Collection<String>> getAllHostedLocators();
 
   /**
    * Gets the map of all members hosting locators with shared configuration. The key is the member,
@@ -439,7 +436,7 @@ public interface DM extends ReplySender {
    *
    * @since GemFire 8.0
    */
-  public Map<InternalDistributedMember, Collection<String>> getAllHostedLocatorsWithSharedConfiguration();
+  Map<InternalDistributedMember, Collection<String>> getAllHostedLocatorsWithSharedConfiguration();
 
   /****
    * Determines if the distributed system has the shared configuration service enabled or not.
@@ -447,24 +444,30 @@ public interface DM extends ReplySender {
    * @return true if the distributed system was started or had a locator with
    *         enable-cluster-configuration = true
    */
-  public boolean isSharedConfigurationServiceEnabledForDS();
+  boolean isSharedConfigurationServiceEnabledForDS();
 
   /**
    * Forces use of UDP for communications in the current thread. UDP is connectionless, so no tcp/ip
    * connections will be created or used for messaging until this setting is released with
    * releaseUDPMessagingForCurrentThread.
    */
-  public void forceUDPMessagingForCurrentThread();
+  void forceUDPMessagingForCurrentThread();
 
   /**
    * Releases use of UDP for all communications in the current thread, as established by
    * forceUDPMessagingForCurrentThread.
    */
-  public void releaseUDPMessagingForCurrentThread();
+  void releaseUDPMessagingForCurrentThread();
 
   int getDMType();
 
   InternalCache getCache();
 
   void setCache(InternalCache instance);
+
+  HealthMonitor getHealthMonitor(InternalDistributedMember owner);
+
+  void removeHealthMonitor(InternalDistributedMember owner, int theId);
+
+  void createHealthMonitor(InternalDistributedMember owner, GemFireHealthConfig cfg);
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/LonerDistributionManager.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/LonerDistributionManager.java
@@ -22,6 +22,7 @@ import java.util.concurrent.*;
 
 import org.apache.geode.CancelCriterion;
 import org.apache.geode.InternalGemFireError;
+import org.apache.geode.admin.GemFireHealthConfig;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.DurableClientAttributes;
 import org.apache.geode.distributed.Role;
@@ -1386,5 +1387,23 @@ public class LonerDistributionManager implements DM {
   @Override
   public void setCache(InternalCache instance) {
     this.cache = instance;
+  }
+
+  @Override
+  public HealthMonitor getHealthMonitor(InternalDistributedMember owner) {
+    throw new UnsupportedOperationException(
+        "getHealthMonitor is not supported by " + getClass().getSimpleName());
+  }
+
+  @Override
+  public void removeHealthMonitor(InternalDistributedMember owner, int theId) {
+    throw new UnsupportedOperationException(
+        "removeHealthMonitor is not supported by " + getClass().getSimpleName());
+  }
+
+  @Override
+  public void createHealthMonitor(InternalDistributedMember owner, GemFireHealthConfig cfg) {
+    throw new UnsupportedOperationException(
+        "createHealthMonitor is not supported by " + getClass().getSimpleName());
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/AddHealthListenerRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/AddHealthListenerRequest.java
@@ -57,7 +57,7 @@ public class AddHealthListenerRequest extends AdminRequest {
    * Must return a proper response to this request.
    */
   @Override
-  protected AdminResponse createResponse(DistributionManager dm) {
+  protected AdminResponse createResponse(DM dm) {
     return AddHealthListenerResponse.create(dm, this.getSender(), this.cfg);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/AddHealthListenerResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/AddHealthListenerResponse.java
@@ -35,8 +35,8 @@ public class AddHealthListenerResponse extends AdminResponse {
    * Returns a <code>AddHealthListenerResponse</code> that will be returned to the specified
    * recipient.
    */
-  public static AddHealthListenerResponse create(DistributionManager dm,
-      InternalDistributedMember recipient, GemFireHealthConfig cfg) {
+  public static AddHealthListenerResponse create(DM dm, InternalDistributedMember recipient,
+      GemFireHealthConfig cfg) {
     AddHealthListenerResponse m = new AddHealthListenerResponse();
     m.setRecipient(recipient);
     dm.createHealthMonitor(recipient, cfg);

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/AddStatListenerRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/AddStatListenerRequest.java
@@ -47,9 +47,11 @@ public class AddStatListenerRequest extends AdminRequest {
 
   /**
    * Must return a proper response to this request.
+   *
+   * @param dm
    */
   @Override
-  protected AdminResponse createResponse(DistributionManager dm) {
+  protected AdminResponse createResponse(DM dm) {
     return AddStatListenerResponse.create(dm, this.getSender(), this.resourceId, this.statName);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/AddStatListenerResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/AddStatListenerResponse.java
@@ -34,8 +34,8 @@ public class AddStatListenerResponse extends AdminResponse {
    * Returns a <code>AddStatListenerResponse</code> that will be returned to the specified
    * recipient. The message will contains a copy of the local manager's system config.
    */
-  public static AddStatListenerResponse create(DistributionManager dm,
-      InternalDistributedMember recipient, long resourceId, String statName) {
+  public static AddStatListenerResponse create(DM dm, InternalDistributedMember recipient,
+      long resourceId, String statName) {
     AddStatListenerResponse m = new AddStatListenerResponse();
     m.setRecipient(recipient);
     GemFireStatSampler sampler = null;

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/AdminFailureResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/AdminFailureResponse.java
@@ -12,40 +12,38 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
-
 package org.apache.geode.internal.admin.remote;
 
-import java.io.*;
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
 
-import org.apache.geode.*;
-import org.apache.geode.distributed.internal.*;
-import org.apache.geode.distributed.internal.membership.*;
+import org.apache.geode.DataSerializer;
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 
 /**
  * A response to a failed request.
  */
 public class AdminFailureResponse extends AdminResponse {
-  // instance variables
-  Exception cause;
+
+  private Exception cause;
 
   /**
-   * Returns a <code>AdminFailureResponse</code> that will be returned to the specified recipient.
-   * The message will contains a copy of the local manager's system config.
+   * Returns a {@code AdminFailureResponse} that will be returned to the specified recipient. The
+   * message will contains a copy of the local manager's system config.
    */
-  public static AdminFailureResponse create(DistributionManager dm,
-      InternalDistributedMember recipient, Exception cause) {
-    AdminFailureResponse m = new AdminFailureResponse();
-    m.setRecipient(recipient);
-    m.cause = cause;
-    return m;
+  public static AdminFailureResponse create(InternalDistributedMember recipient, Exception cause) {
+    AdminFailureResponse message = new AdminFailureResponse();
+    message.setRecipient(recipient);
+    message.cause = cause;
+    return message;
   }
 
-  // instance methods
   public Exception getCause() {
     return this.cause;
   }
 
+  @Override
   public int getDSFID() {
     return ADMIN_FAILURE_RESPONSE;
   }
@@ -59,11 +57,11 @@ public class AdminFailureResponse extends AdminResponse {
   @Override
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
     super.fromData(in);
-    this.cause = (Exception) DataSerializer.readObject(in);
+    this.cause = DataSerializer.readObject(in);
   }
 
   @Override
   public String toString() {
-    return "AdminFailureResponse from " + this.getRecipient() + " cause=" + this.cause;
+    return "AdminFailureResponse from " + getRecipient() + " cause=" + this.cause;
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/AdminMultipleReplyProcessor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/AdminMultipleReplyProcessor.java
@@ -16,21 +16,15 @@ package org.apache.geode.internal.admin.remote;
 
 import java.util.Collection;
 
-import org.apache.geode.CancelCriterion;
 import org.apache.geode.distributed.internal.DM;
 import org.apache.geode.distributed.internal.DistributionMessage;
-import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.ReplyException;
-import org.apache.geode.distributed.internal.ReplyMessage;
 import org.apache.geode.distributed.internal.ReplyProcessor21;
-import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
-
 
 /**
  * TODO prpersist. This code really needs to be merged with the AdminReplyProcessor. However, we're
  * getting close to the release and I don't want to mess with all of the admin code right now. We
  * need this class to handle failures from admin messages that expect replies from multiple members.
- *
  */
 public class AdminMultipleReplyProcessor extends ReplyProcessor21 {
 
@@ -38,47 +32,16 @@ public class AdminMultipleReplyProcessor extends ReplyProcessor21 {
     super(dm, initMembers);
   }
 
-  public AdminMultipleReplyProcessor(DM dm, InternalDistributedMember member) {
-    super(dm, member);
-  }
-
-  public AdminMultipleReplyProcessor(DM dm, InternalDistributedSystem system,
-      Collection initMembers, CancelCriterion cancelCriterion, boolean register) {
-    super(dm, system, initMembers, cancelCriterion, register);
-  }
-
-  public AdminMultipleReplyProcessor(InternalDistributedSystem system, Collection initMembers,
-      CancelCriterion cancelCriterion) {
-    super(system, initMembers, cancelCriterion);
-  }
-
-  public AdminMultipleReplyProcessor(InternalDistributedSystem system, Collection initMembers) {
-    super(system, initMembers);
-  }
-
-  public AdminMultipleReplyProcessor(InternalDistributedSystem system,
-      InternalDistributedMember member, CancelCriterion cancelCriterion) {
-    super(system, member, cancelCriterion);
-  }
-
-  public AdminMultipleReplyProcessor(InternalDistributedSystem system,
-      InternalDistributedMember member) {
-    super(system, member);
-  }
-
   @Override
-  protected void process(DistributionMessage msg, boolean warn) {
-    if (msg instanceof AdminFailureResponse) {
-      Exception ex = ((AdminFailureResponse) msg).getCause();
+  protected void process(DistributionMessage message, boolean warn) {
+    if (message instanceof AdminFailureResponse) {
+      Exception ex = ((AdminFailureResponse) message).getCause();
       if (ex != null) {
-        ReplyException rex = new ReplyException(ex);
-        rex.setSenderIfNull(msg.getSender());
-        processException(msg, rex);
+        ReplyException replyException = new ReplyException(ex);
+        replyException.setSenderIfNull(message.getSender());
+        processException(message, replyException);
       }
     }
-    super.process(msg, warn);
+    super.process(message, warn);
   }
-
-
-
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/AdminRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/AdminRequest.java
@@ -24,6 +24,7 @@ import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.DataSerializer;
 import org.apache.geode.admin.RuntimeAdminException;
+import org.apache.geode.distributed.internal.DM;
 import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.distributed.internal.PooledDistributionMessage;
 import org.apache.geode.distributed.internal.ReplyException;
@@ -134,7 +135,7 @@ public abstract class AdminRequest extends PooledDistributionMessage {
       cpMgr.jumpToModifiedClassLoader(modifiedClasspath);
       response = createResponse(dm);
     } catch (Exception ex) {
-      response = AdminFailureResponse.create(dm, this.getSender(), ex);
+      response = AdminFailureResponse.create(this.getSender(), ex);
     } finally {
       cpMgr.revertToOldClassLoader();
     }
@@ -150,7 +151,7 @@ public abstract class AdminRequest extends PooledDistributionMessage {
   /**
    * Must return a proper response to this request.
    */
-  protected abstract AdminResponse createResponse(DistributionManager dm);
+  protected abstract AdminResponse createResponse(DM dm);
 
   @Override
   public void toData(DataOutput out) throws IOException {

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/BridgeServerRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/BridgeServerRequest.java
@@ -17,7 +17,7 @@ package org.apache.geode.internal.admin.remote;
 import java.io.*;
 
 import org.apache.geode.DataSerializer;
-import org.apache.geode.distributed.internal.DistributionManager;
+import org.apache.geode.distributed.internal.DM;
 import org.apache.geode.internal.admin.CacheInfo;
 import org.apache.geode.internal.i18n.LocalizedStrings;
 
@@ -132,7 +132,7 @@ public class BridgeServerRequest extends AdminRequest {
    * Creates a <Code>BridgeServerResponse</code> to this request
    */
   @Override
-  protected AdminResponse createResponse(DistributionManager dm) {
+  protected AdminResponse createResponse(DM dm) {
     return BridgeServerResponse.create(dm, this);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/BridgeServerResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/BridgeServerResponse.java
@@ -22,7 +22,7 @@ import org.apache.geode.CancelException;
 import org.apache.geode.DataSerializer;
 import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.server.CacheServer;
-import org.apache.geode.distributed.internal.DistributionManager;
+import org.apache.geode.distributed.internal.DM;
 import org.apache.geode.internal.Assert;
 import org.apache.geode.internal.cache.CacheServerImpl;
 import org.apache.geode.internal.cache.InternalCache;
@@ -44,7 +44,7 @@ public class BridgeServerResponse extends AdminResponse {
   /**
    * Creates a {@code BridgeServerResponse} in response to the given request.
    */
-  static BridgeServerResponse create(DistributionManager dm, BridgeServerRequest request) {
+  static BridgeServerResponse create(DM dm, BridgeServerRequest request) {
     BridgeServerResponse m = new BridgeServerResponse();
     m.setRecipient(request.getSender());
 

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/CacheConfigRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/CacheConfigRequest.java
@@ -53,7 +53,7 @@ public class CacheConfigRequest extends AdminRequest {
    * Must return a proper response to this request.
    */
   @Override
-  protected AdminResponse createResponse(DistributionManager dm) {
+  protected AdminResponse createResponse(DM dm) {
     return CacheConfigResponse.create(dm, this.getSender(), this.cacheId, this.attributeCode,
         this.newValue);
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/CacheConfigResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/CacheConfigResponse.java
@@ -21,7 +21,7 @@ import java.io.IOException;
 import org.apache.geode.CancelException;
 import org.apache.geode.DataSerializer;
 import org.apache.geode.cache.CacheFactory;
-import org.apache.geode.distributed.internal.DistributionManager;
+import org.apache.geode.distributed.internal.DM;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.Assert;
 import org.apache.geode.internal.cache.InternalCache;
@@ -45,8 +45,8 @@ public class CacheConfigResponse extends AdminResponse {
   /**
    * Returns a {@code CacheConfigResponse} that will be returned to the specified recipient.
    */
-  public static CacheConfigResponse create(DistributionManager dm,
-      InternalDistributedMember recipient, int cacheId, byte attributeCode, int newValue) {
+  public static CacheConfigResponse create(DM dm, InternalDistributedMember recipient, int cacheId,
+      byte attributeCode, int newValue) {
     CacheConfigResponse m = new CacheConfigResponse();
     m.setRecipient(recipient);
     try {

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/CacheInfoRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/CacheInfoRequest.java
@@ -42,9 +42,11 @@ public class CacheInfoRequest extends AdminRequest {
 
   /**
    * Must return a proper response to this request.
+   *
+   * @param dm
    */
   @Override
-  protected AdminResponse createResponse(DistributionManager dm) {
+  protected AdminResponse createResponse(DM dm) {
     return CacheInfoResponse.create(dm, this.getSender());
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/CacheInfoResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/CacheInfoResponse.java
@@ -21,7 +21,7 @@ import java.io.IOException;
 import org.apache.geode.CancelException;
 import org.apache.geode.DataSerializer;
 import org.apache.geode.cache.CacheFactory;
-import org.apache.geode.distributed.internal.DistributionManager;
+import org.apache.geode.distributed.internal.DM;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.InternalCache;
 
@@ -37,8 +37,7 @@ public class CacheInfoResponse extends AdminResponse {
   /**
    * Returns a {@code CacheInfoResponse} that will be returned to the specified recipient.
    */
-  public static CacheInfoResponse create(DistributionManager dm,
-      InternalDistributedMember recipient) {
+  public static CacheInfoResponse create(DM dm, InternalDistributedMember recipient) {
     CacheInfoResponse m = new CacheInfoResponse();
     m.setRecipient(recipient);
     try {

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/CancelStatListenerRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/CancelStatListenerRequest.java
@@ -47,7 +47,7 @@ public class CancelStatListenerRequest extends AdminRequest {
    * Must return a proper response to this request.
    */
   @Override
-  protected AdminResponse createResponse(DistributionManager dm) {
+  protected AdminResponse createResponse(DM dm) {
     return CancelStatListenerResponse.create(dm, this.getSender(), this.listenerId);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/CancelStatListenerResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/CancelStatListenerResponse.java
@@ -34,8 +34,8 @@ public class CancelStatListenerResponse extends AdminResponse {
    * Returns a <code>CancelStatListenerResponse</code> that will be returned to the specified
    * recipient. The message will contains a copy of the local manager's system config.
    */
-  public static CancelStatListenerResponse create(DistributionManager dm,
-      InternalDistributedMember recipient, int listenerId) {
+  public static CancelStatListenerResponse create(DM dm, InternalDistributedMember recipient,
+      int listenerId) {
     CancelStatListenerResponse m = new CancelStatListenerResponse();
     m.setRecipient(recipient);
     GemFireStatSampler sampler = null;

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/CliLegacyMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/CliLegacyMessage.java
@@ -40,7 +40,7 @@ public abstract class CliLegacyMessage extends AdminRequest {
     } catch (Exception ex) {
       logger.error(
           LocalizedMessage.create(LocalizedStrings.CliLegacyMessage_ERROR, this.getClass()), ex);
-      response = AdminFailureResponse.create(dm, this.getSender(), ex);
+      response = AdminFailureResponse.create(this.getSender(), ex);
 
     }
     if (response != null) { // cancellations result in null response

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/CompactRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/CompactRequest.java
@@ -35,7 +35,6 @@ import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.distributed.internal.DistributionMessage;
 import org.apache.geode.distributed.internal.ReplyException;
 import org.apache.geode.internal.cache.DiskStoreImpl;
-import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.util.ArrayUtils;
@@ -81,7 +80,7 @@ public class CompactRequest extends CliLegacyMessage {
   }
 
   @Override
-  protected AdminResponse createResponse(DistributionManager dm) {
+  protected AdminResponse createResponse(DM dm) {
     InternalCache cache = dm.getCache();
     HashSet<PersistentID> compactedStores = new HashSet<>();
     if (cache != null && !cache.isClosed()) {
@@ -135,14 +134,14 @@ public class CompactRequest extends CliLegacyMessage {
     }
 
     @Override
-    protected void process(DistributionMessage msg, boolean warn) {
-      if (msg instanceof CompactResponse) {
-        final Set<PersistentID> persistentIds = ((CompactResponse) msg).getPersistentIds();
+    protected void process(DistributionMessage message, boolean warn) {
+      if (message instanceof CompactResponse) {
+        final Set<PersistentID> persistentIds = ((CompactResponse) message).getPersistentIds();
         if (persistentIds != null && !persistentIds.isEmpty()) {
-          this.results.put(msg.getSender(), persistentIds);
+          this.results.put(message.getSender(), persistentIds);
         }
       }
-      super.process(msg, warn);
+      super.process(message, warn);
     }
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/DurableClientInfoRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/DurableClientInfoRequest.java
@@ -55,8 +55,10 @@ public class DurableClientInfoRequest extends AdminRequest {
 
   /**
    * Must return a proper response to this request.
+   *
+   * @param dm
    */
-  protected AdminResponse createResponse(DistributionManager dm) {
+  protected AdminResponse createResponse(DM dm) {
     return DurableClientInfoResponse.create(dm, this.getSender(), this);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/DurableClientInfoResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/DurableClientInfoResponse.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 
 import org.apache.geode.cache.CacheClosedException;
 import org.apache.geode.cache.CacheFactory;
-import org.apache.geode.distributed.internal.DistributionManager;
+import org.apache.geode.distributed.internal.DM;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.CacheServerImpl;
 import org.apache.geode.internal.cache.InternalCache;
@@ -40,8 +40,8 @@ public class DurableClientInfoResponse extends AdminResponse {
   /**
    * Returns a {@code DurableClientInfoResponse} that will be returned to the specified recipient.
    */
-  public static DurableClientInfoResponse create(DistributionManager dm,
-      InternalDistributedMember recipient, DurableClientInfoRequest request) {
+  public static DurableClientInfoResponse create(DM dm, InternalDistributedMember recipient,
+      DurableClientInfoRequest request) {
     DurableClientInfoResponse m = new DurableClientInfoResponse();
     m.setRecipient(recipient);
     try {

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/FetchDistLockInfoRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/FetchDistLockInfoRequest.java
@@ -37,9 +37,11 @@ public class FetchDistLockInfoRequest extends AdminRequest {
 
   /**
    * Must return a proper response to this request.
+   *
+   * @param dm
    */
   @Override
-  protected AdminResponse createResponse(DistributionManager dm) {
+  protected AdminResponse createResponse(DM dm) {
     return FetchDistLockInfoResponse.create(dm, this.getSender());
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/FetchDistLockInfoResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/FetchDistLockInfoResponse.java
@@ -35,8 +35,7 @@ public class FetchDistLockInfoResponse extends AdminResponse {
    * recipient. The message will contains a copy of the local manager's distributed lock service
    * information.
    */
-  public static FetchDistLockInfoResponse create(DistributionManager dm,
-      InternalDistributedMember recipient) {
+  public static FetchDistLockInfoResponse create(DM dm, InternalDistributedMember recipient) {
     FetchDistLockInfoResponse m = new FetchDistLockInfoResponse();
     InternalDistributedMember id = dm.getDistributionManagerId();
     Set entries = DLockService.snapshotAllServices().entrySet();

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/FetchHealthDiagnosisRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/FetchHealthDiagnosisRequest.java
@@ -51,7 +51,7 @@ public class FetchHealthDiagnosisRequest extends AdminRequest {
    * Must return a proper response to this request.
    */
   @Override
-  protected AdminResponse createResponse(DistributionManager dm) {
+  protected AdminResponse createResponse(DM dm) {
     return FetchHealthDiagnosisResponse.create(dm, this.getSender(), this.id, this.healthCode);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/FetchHealthDiagnosisResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/FetchHealthDiagnosisResponse.java
@@ -36,8 +36,8 @@ public class FetchHealthDiagnosisResponse extends AdminResponse {
    * Returns a <code>FetchHealthDiagnosisResponse</code> that will be returned to the specified
    * recipient.
    */
-  public static FetchHealthDiagnosisResponse create(DistributionManager dm,
-      InternalDistributedMember recipient, int id, GemFireHealth.Health healthCode) {
+  public static FetchHealthDiagnosisResponse create(DM dm, InternalDistributedMember recipient,
+      int id, GemFireHealth.Health healthCode) {
     FetchHealthDiagnosisResponse m = new FetchHealthDiagnosisResponse();
     m.setRecipient(recipient);
     {

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/FetchHostRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/FetchHostRequest.java
@@ -41,7 +41,7 @@ public class FetchHostRequest extends AdminRequest {
    * Must return a proper response to this request.
    */
   @Override
-  protected AdminResponse createResponse(DistributionManager dm) {
+  protected AdminResponse createResponse(DM dm) {
     return FetchHostResponse.create(dm, this.getSender());
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/FetchHostResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/FetchHostResponse.java
@@ -27,8 +27,8 @@ import java.net.UnknownHostException;
 import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.DataSerializer;
+import org.apache.geode.distributed.internal.DM;
 import org.apache.geode.distributed.internal.DistributionConfig;
-import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.GemFireVersion;
 import org.apache.geode.internal.cache.CacheServerLauncher;
@@ -59,8 +59,7 @@ public class FetchHostResponse extends AdminResponse {
    * Returns a <code>FetchHostResponse</code> that will be returned to the specified recipient. The
    * message will contains a copy of this vm's local host.
    */
-  public static FetchHostResponse create(DistributionManager dm,
-      InternalDistributedMember recipient) {
+  public static FetchHostResponse create(DM dm, InternalDistributedMember recipient) {
     FetchHostResponse m = new FetchHostResponse();
     m.setRecipient(recipient);
     try {

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/FetchResourceAttributesRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/FetchResourceAttributesRequest.java
@@ -38,7 +38,7 @@ public class FetchResourceAttributesRequest extends AdminRequest {
   }
 
   @Override
-  public AdminResponse createResponse(DistributionManager dm) {
+  public AdminResponse createResponse(DM dm) {
     return FetchResourceAttributesResponse.create(dm, this.getSender(), resourceUniqueId);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/FetchResourceAttributesResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/FetchResourceAttributesResponse.java
@@ -12,23 +12,26 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
-
 package org.apache.geode.internal.admin.remote;
 
-import java.io.*;
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
 
-import org.apache.geode.*;
-import org.apache.geode.distributed.internal.*;
-import org.apache.geode.distributed.internal.membership.*;
+import org.apache.geode.DataSerializer;
+import org.apache.geode.StatisticDescriptor;
+import org.apache.geode.Statistics;
+import org.apache.geode.StatisticsType;
+import org.apache.geode.distributed.internal.DM;
+import org.apache.geode.distributed.internal.InternalDistributedSystem;
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 
 public class FetchResourceAttributesResponse extends AdminResponse {
 
-  // instance variables
   private RemoteStat[] stats;
 
-  public static FetchResourceAttributesResponse create(DistributionManager dm,
-      InternalDistributedMember recipient, long rsrcUniqueId) {
+  public static FetchResourceAttributesResponse create(DM dm, InternalDistributedMember recipient,
+      long rsrcUniqueId) {
     FetchResourceAttributesResponse m = new FetchResourceAttributesResponse();
     m.setRecipient(recipient);
     Statistics s = null;
@@ -53,9 +56,11 @@ public class FetchResourceAttributesResponse extends AdminResponse {
   }
 
   /**
-   * Constructor required by <code>DataSerializable</code>
+   * Constructor required by {@code DataSerializable}
    */
-  public FetchResourceAttributesResponse() {}
+  public FetchResourceAttributesResponse() {
+    // nothing
+  }
 
   public int getDSFID() {
     return FETCH_RESOURCE_ATTRIBUTES_RESPONSE;
@@ -75,6 +80,6 @@ public class FetchResourceAttributesResponse extends AdminResponse {
 
   @Override
   public String toString() {
-    return "FetchResourceAttributesResponse from " + this.getRecipient();
+    return "FetchResourceAttributesResponse from " + getRecipient();
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/FetchStatsRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/FetchStatsRequest.java
@@ -40,7 +40,7 @@ public class FetchStatsRequest extends AdminRequest {
   }
 
   @Override
-  public AdminResponse createResponse(DistributionManager dm) {
+  public AdminResponse createResponse(DM dm) {
     return FetchStatsResponse.create(dm, this.getSender(), this.statisticsTypeName);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/FetchStatsResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/FetchStatsResponse.java
@@ -18,23 +18,19 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.ConcurrentModificationException;
-import java.util.Iterator;
 import java.util.List;
 
 import org.apache.geode.DataSerializer;
 import org.apache.geode.Statistics;
-import org.apache.geode.distributed.internal.DistributionManager;
+import org.apache.geode.distributed.internal.DM;
 import org.apache.geode.distributed.internal.InternalDistributedSystem.StatisticsVisitor;
-import org.apache.geode.distributed.internal.membership.*;
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 
 /**
- * Provides a response of remote statistic resources for a <code>FetchStatsRequest</code>
- *
+ * Provides a response of remote statistic resources for a {@code FetchStatsRequest}
  */
 public class FetchStatsResponse extends AdminResponse {
 
-  // instance variables
   private RemoteStatResource[] stats;
 
   /**
@@ -44,12 +40,11 @@ public class FetchStatsResponse extends AdminResponse {
    * @param recipient the recipient who made the original request
    * @return response containing all remote stat resources
    */
-  public static FetchStatsResponse create(DistributionManager dm,
-      InternalDistributedMember recipient, final String statisticsTypeName) {
-    // LogWriterI18n log = dm.getLogger();
+  public static FetchStatsResponse create(DM dm, InternalDistributedMember recipient,
+      final String statisticsTypeName) {
     FetchStatsResponse m = new FetchStatsResponse();
     m.setRecipient(recipient);
-    final List<RemoteStatResource> statList = new ArrayList<RemoteStatResource>();
+    List<RemoteStatResource> statList = new ArrayList<RemoteStatResource>();
     // get vm-local stats
     // call visitStatistics to fix for bug 40358
     if (statisticsTypeName == null) {
@@ -71,7 +66,6 @@ public class FetchStatsResponse extends AdminResponse {
     m.stats = (RemoteStatResource[]) statList.toArray(m.stats);
     return m;
   }
-
 
   @Override
   public boolean sendViaUDP() {
@@ -130,7 +124,7 @@ public class FetchStatsResponse extends AdminResponse {
    */
   @Override
   public String toString() {
-    return "FetchStatsResponse from " + this.getRecipient() + " stats.length=" + stats.length;
+    return "FetchStatsResponse from " + getRecipient() + " stats.length=" + stats.length;
   }
 
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/FetchSysCfgRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/FetchSysCfgRequest.java
@@ -48,7 +48,7 @@ public class FetchSysCfgRequest extends AdminRequest {
    * Must return a proper response to this request.
    */
   @Override
-  protected AdminResponse createResponse(DistributionManager dm) {
+  protected AdminResponse createResponse(DM dm) {
     return FetchSysCfgResponse.create(dm, this.getSender());
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/FetchSysCfgResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/FetchSysCfgResponse.java
@@ -34,8 +34,7 @@ public class FetchSysCfgResponse extends AdminResponse {
    * Returns a <code>FetchSysCfgResponse</code> that will be returned to the specified recipient.
    * The message will contains a copy of the local manager's config.
    */
-  public static FetchSysCfgResponse create(DistributionManager dm,
-      InternalDistributedMember recipient) {
+  public static FetchSysCfgResponse create(DM dm, InternalDistributedMember recipient) {
     FetchSysCfgResponse m = new FetchSysCfgResponse();
     m.setRecipient(recipient);
     Config conf = dm.getSystem().getConfig();

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/LicenseInfoRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/LicenseInfoRequest.java
@@ -40,9 +40,11 @@ public class LicenseInfoRequest extends AdminRequest {
 
   /**
    * Must return a proper response to this request.
+   *
+   * @param dm
    */
   @Override
-  protected AdminResponse createResponse(DistributionManager dm) {
+  protected AdminResponse createResponse(DM dm) {
     return LicenseInfoResponse.create(dm, this.getSender());
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/LicenseInfoResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/LicenseInfoResponse.java
@@ -22,10 +22,10 @@ import java.util.Properties;
 import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.DataSerializer;
+import org.apache.geode.distributed.internal.DM;
 import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.logging.LogService;
-
 
 /**
  * A message that is sent in response to a {@link LicenseInfoRequest}.
@@ -33,15 +33,12 @@ import org.apache.geode.internal.logging.LogService;
 public class LicenseInfoResponse extends AdminResponse {
   private static final Logger logger = LogService.getLogger();
 
-  // instance variables
   private Properties p;
 
-
   /**
-   * Returns a <code>LicenseInfoResponse</code> that will be returned to the specified recipient.
+   * Returns a {@code LicenseInfoResponse} that will be returned to the specified recipient.
    */
-  public static LicenseInfoResponse create(DistributionManager dm,
-      InternalDistributedMember recipient) {
+  public static LicenseInfoResponse create(DM dm, InternalDistributedMember recipient) {
     LicenseInfoResponse m = new LicenseInfoResponse();
     m.setRecipient(recipient);
     m.p = new Properties();

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/MissingPersistentIDsRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/MissingPersistentIDsRequest.java
@@ -30,7 +30,6 @@ import org.apache.geode.distributed.internal.DM;
 import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.distributed.internal.DistributionMessage;
 import org.apache.geode.distributed.internal.ReplyException;
-import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.persistence.PersistentMemberID;
 import org.apache.geode.internal.cache.persistence.PersistentMemberManager;
@@ -78,7 +77,7 @@ public class MissingPersistentIDsRequest extends CliLegacyMessage {
   }
 
   @Override
-  protected AdminResponse createResponse(DistributionManager dm) {
+  protected AdminResponse createResponse(DM dm) {
     Set<PersistentID> missingIds = new HashSet<>();
     Set<PersistentID> localPatterns = new HashSet<>();
     InternalCache cache = dm.getCache();
@@ -124,12 +123,12 @@ public class MissingPersistentIDsRequest extends CliLegacyMessage {
     }
 
     @Override
-    protected void process(DistributionMessage msg, boolean warn) {
-      if (msg instanceof MissingPersistentIDsResponse) {
-        this.missing.addAll(((MissingPersistentIDsResponse) msg).getMissingIds());
-        this.existing.addAll(((MissingPersistentIDsResponse) msg).getLocalIds());
+    protected void process(DistributionMessage message, boolean warn) {
+      if (message instanceof MissingPersistentIDsResponse) {
+        this.missing.addAll(((MissingPersistentIDsResponse) message).getMissingIds());
+        this.existing.addAll(((MissingPersistentIDsResponse) message).getLocalIds());
       }
-      super.process(msg, warn);
+      super.process(message, warn);
     }
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/ObjectDetailsRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/ObjectDetailsRequest.java
@@ -56,9 +56,11 @@ public class ObjectDetailsRequest extends RegionAdminRequest implements Cancella
 
   /**
    * Must return a proper response to this request.
+   *
+   * @param dm
    */
   @Override
-  protected AdminResponse createResponse(DistributionManager dm) {
+  protected AdminResponse createResponse(DM dm) {
     CancellationRegistry.getInstance().registerMessage(this);
     resp = ObjectDetailsResponse.create(dm, this.getSender());
     if (cancelled) {

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/ObjectDetailsResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/ObjectDetailsResponse.java
@@ -38,8 +38,7 @@ public class ObjectDetailsResponse extends AdminResponse implements Cancellable 
    * Returns a <code>ObjectValueResponse</code> that will be returned to the specified recipient.
    * The message will contains a copy of the local manager's system config.
    */
-  public static ObjectDetailsResponse create(DistributionManager dm,
-      InternalDistributedMember recipient) {
+  public static ObjectDetailsResponse create(DM dm, InternalDistributedMember recipient) {
     ObjectDetailsResponse m = new ObjectDetailsResponse();
     m.setRecipient(recipient);
     return m;

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/ObjectNamesRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/ObjectNamesRequest.java
@@ -44,9 +44,11 @@ public class ObjectNamesRequest extends RegionAdminRequest implements Cancellabl
 
   /**
    * Must return a proper response to this request.
+   *
+   * @param dm
    */
   @Override
-  protected AdminResponse createResponse(DistributionManager dm) {
+  protected AdminResponse createResponse(DM dm) {
     CancellationRegistry.getInstance().registerMessage(this);
     resp = ObjectNamesResponse.create(dm, this.getSender());
     if (cancelled) {

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/ObjectNamesResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/ObjectNamesResponse.java
@@ -36,8 +36,7 @@ public class ObjectNamesResponse extends AdminResponse implements Cancellable {
    * Returns a <code>ObjectNamesResponse</code> that will be returned to the specified recipient.
    * The message will contains a copy of the local manager's system config.
    */
-  public static ObjectNamesResponse create(DistributionManager dm,
-      InternalDistributedMember recipient) {
+  public static ObjectNamesResponse create(DM dm, InternalDistributedMember recipient) {
     ObjectNamesResponse m = new ObjectNamesResponse();
     m.setRecipient(recipient);
     return m;

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/PrepareRevokePersistentIDRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/PrepareRevokePersistentIDRequest.java
@@ -27,7 +27,6 @@ import org.apache.geode.distributed.internal.DM;
 import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.distributed.internal.ReplyException;
 import org.apache.geode.internal.InternalDataSerializer;
-import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.persistence.PersistentMemberManager;
 import org.apache.geode.internal.cache.persistence.PersistentMemberPattern;
@@ -90,7 +89,7 @@ public class PrepareRevokePersistentIDRequest extends CliLegacyMessage {
   }
 
   @Override
-  protected AdminResponse createResponse(DistributionManager dm) {
+  protected AdminResponse createResponse(DM dm) {
     InternalCache cache = dm.getCache();
     if (cache != null && !cache.isClosed()) {
       PersistentMemberManager mm = cache.getPersistentMemberManager();

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RefreshMemberSnapshotRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RefreshMemberSnapshotRequest.java
@@ -41,7 +41,7 @@ public class RefreshMemberSnapshotRequest extends AdminRequest {
    * Must return a proper response to this request.
    */
   @Override
-  protected AdminResponse createResponse(DistributionManager dm) {
+  protected AdminResponse createResponse(DM dm) {
     return RefreshMemberSnapshotResponse.create(dm, this.getSender());
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RefreshMemberSnapshotResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RefreshMemberSnapshotResponse.java
@@ -22,7 +22,7 @@ import org.apache.geode.DataSerializer;
 import org.apache.geode.admin.GemFireMemberStatus;
 import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.distributed.DistributedSystem;
-import org.apache.geode.distributed.internal.DistributionManager;
+import org.apache.geode.distributed.internal.DM;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.InternalCache;
 
@@ -38,8 +38,7 @@ public class RefreshMemberSnapshotResponse extends AdminResponse {
    * Returns a {@code FetchSysCfgResponse} that will be returned to the specified recipient. The
    * message will contains a copy of the local manager's config.
    */
-  public static RefreshMemberSnapshotResponse create(DistributionManager dm,
-      InternalDistributedMember recipient) {
+  public static RefreshMemberSnapshotResponse create(DM dm, InternalDistributedMember recipient) {
     RefreshMemberSnapshotResponse m = new RefreshMemberSnapshotResponse();
     m.setRecipient(recipient);
 

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RegionAttributesRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RegionAttributesRequest.java
@@ -42,9 +42,11 @@ public class RegionAttributesRequest extends RegionAdminRequest {
 
   /**
    * Must return a proper response to this request.
+   *
+   * @param dm
    */
   @Override
-  protected AdminResponse createResponse(DistributionManager dm) {
+  protected AdminResponse createResponse(DM dm) {
     return RegionAttributesResponse.create(dm, this.getSender(), this.getRegion(dm.getSystem()));
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RegionAttributesResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RegionAttributesResponse.java
@@ -34,8 +34,8 @@ public class RegionAttributesResponse extends AdminResponse {
    * Returns a <code>RegionAttributesResponse</code> that will be returned to the specified
    * recipient. The message will contains a copy of the local manager's system config.
    */
-  public static RegionAttributesResponse create(DistributionManager dm,
-      InternalDistributedMember recipient, Region r) {
+  public static RegionAttributesResponse create(DM dm, InternalDistributedMember recipient,
+      Region r) {
     RegionAttributesResponse m = new RegionAttributesResponse();
     m.setRecipient(recipient);
     m.attributes = new RemoteRegionAttributes(r.getAttributes());

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RegionRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RegionRequest.java
@@ -111,9 +111,11 @@ public class RegionRequest extends AdminRequest {
 
   /**
    * Must return a proper response to this request.
+   *
+   * @param dm
    */
   @Override
-  protected AdminResponse createResponse(DistributionManager dm) {
+  protected AdminResponse createResponse(DM dm) {
     // nothing needs to be done. If we got this far then a cache must exist.
     return RegionResponse.create(dm, this.getSender(), this);
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RegionResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RegionResponse.java
@@ -48,7 +48,7 @@ public class RegionResponse extends AdminResponse {
    * Returns a <code>RegionResponse</code> that will be returned to the specified recipient. The
    * message will contains a copy of the local manager's system config.
    */
-  public static RegionResponse create(DistributionManager dm, InternalDistributedMember recipient,
+  public static RegionResponse create(DM dm, InternalDistributedMember recipient,
       RegionRequest request) {
     RegionResponse m = new RegionResponse();
 

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RegionSizeRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RegionSizeRequest.java
@@ -40,9 +40,11 @@ public class RegionSizeRequest extends RegionAdminRequest implements Cancellable
 
   /**
    * Must return a proper response to this request.
+   *
+   * @param dm
    */
   @Override
-  protected AdminResponse createResponse(DistributionManager dm) {
+  protected AdminResponse createResponse(DM dm) {
     Assert.assertTrue(this.getSender() != null);
     CancellationRegistry.getInstance().registerMessage(this);
     resp = RegionSizeResponse.create(dm, this.getSender());

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RegionSizeResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RegionSizeResponse.java
@@ -35,8 +35,7 @@ public class RegionSizeResponse extends AdminResponse implements Cancellable {
   /**
    * Returns a <code>RegionSizeResponse</code> that will be returned to the specified recipient.
    */
-  public static RegionSizeResponse create(DistributionManager dm,
-      InternalDistributedMember recipient) {
+  public static RegionSizeResponse create(DM dm, InternalDistributedMember recipient) {
     RegionSizeResponse m = new RegionSizeResponse();
     m.setRecipient(recipient);
     return m;

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RegionStatisticsRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RegionStatisticsRequest.java
@@ -44,7 +44,7 @@ public class RegionStatisticsRequest extends RegionAdminRequest {
    * Must return a proper response to this request.
    */
   @Override
-  protected AdminResponse createResponse(DistributionManager dm) {
+  protected AdminResponse createResponse(DM dm) {
     return RegionStatisticsResponse.create(dm, this.getSender(), this.getRegion(dm.getSystem()));
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RegionStatisticsResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RegionStatisticsResponse.java
@@ -34,8 +34,8 @@ public class RegionStatisticsResponse extends AdminResponse {
    * Returns a <code>RegionStatisticsResponse</code> that will be returned to the specified
    * recipient. The message will contains a copy of the local manager's system config.
    */
-  public static RegionStatisticsResponse create(DistributionManager dm,
-      InternalDistributedMember recipient, Region r) {
+  public static RegionStatisticsResponse create(DM dm, InternalDistributedMember recipient,
+      Region r) {
     RegionStatisticsResponse m = new RegionStatisticsResponse();
     m.setRecipient(recipient);
     m.regionStatistics = new RemoteCacheStatistics(r.getStatistics());

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RegionSubRegionSizeRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RegionSubRegionSizeRequest.java
@@ -18,7 +18,7 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 
-import org.apache.geode.distributed.internal.DistributionManager;
+import org.apache.geode.distributed.internal.DM;
 
 /**
  * Admin request to transfer region info for a member
@@ -38,7 +38,7 @@ public class RegionSubRegionSizeRequest extends AdminRequest implements Cancella
   }
 
   @Override
-  protected AdminResponse createResponse(DistributionManager dm) {
+  protected AdminResponse createResponse(DM dm) {
     CancellationRegistry.getInstance().registerMessage(this);
 
     resp = RegionSubRegionsSizeResponse.create(dm, this.getSender());

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RegionSubRegionsSizeResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RegionSubRegionsSizeResponse.java
@@ -26,7 +26,7 @@ import org.apache.geode.admin.RegionSubRegionSnapshot;
 import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.Region;
 import org.apache.geode.distributed.DistributedSystem;
-import org.apache.geode.distributed.internal.DistributionManager;
+import org.apache.geode.distributed.internal.DM;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.logging.LogService;
@@ -54,8 +54,7 @@ public class RegionSubRegionsSizeResponse extends AdminResponse implements Cance
    * Returns a {@code RegionSubRegionsSizeResponse} that will be returned to the specified
    * recipient. The message will contains a copy of the region snapshot
    */
-  public static RegionSubRegionsSizeResponse create(DistributionManager dm,
-      InternalDistributedMember recipient) {
+  public static RegionSubRegionsSizeResponse create(DM dm, InternalDistributedMember recipient) {
     RegionSubRegionsSizeResponse m = new RegionSubRegionsSizeResponse();
     m.setRecipient(recipient);
     m.snapshot = null;
@@ -64,7 +63,7 @@ public class RegionSubRegionsSizeResponse extends AdminResponse implements Cance
     return m;
   }
 
-  void populateSnapshot(DistributionManager dm) {
+  void populateSnapshot(DM dm) {
     if (this.cancelled) {
       return;
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RemoveHealthListenerRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RemoveHealthListenerRequest.java
@@ -48,7 +48,7 @@ public class RemoveHealthListenerRequest extends AdminRequest {
    * Must return a proper response to this request.
    */
   @Override
-  protected AdminResponse createResponse(DistributionManager dm) {
+  protected AdminResponse createResponse(DM dm) {
     return RemoveHealthListenerResponse.create(dm, this.getSender(), this.id);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RemoveHealthListenerResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RemoveHealthListenerResponse.java
@@ -33,8 +33,8 @@ public class RemoveHealthListenerResponse extends AdminResponse {
    * Returns a <code>RemoveHealthListenerResponse</code> that will be returned to the specified
    * recipient.
    */
-  public static RemoveHealthListenerResponse create(DistributionManager dm,
-      InternalDistributedMember recipient, int id) {
+  public static RemoveHealthListenerResponse create(DM dm, InternalDistributedMember recipient,
+      int id) {
     RemoveHealthListenerResponse m = new RemoveHealthListenerResponse();
     m.setRecipient(recipient);
     dm.removeHealthMonitor(recipient, id);

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/ResetHealthStatusRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/ResetHealthStatusRequest.java
@@ -46,9 +46,11 @@ public class ResetHealthStatusRequest extends AdminRequest {
 
   /**
    * Must return a proper response to this request.
+   *
+   * @param dm
    */
   @Override
-  protected AdminResponse createResponse(DistributionManager dm) {
+  protected AdminResponse createResponse(DM dm) {
     return ResetHealthStatusResponse.create(dm, this.getSender(), this.id);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/ResetHealthStatusResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/ResetHealthStatusResponse.java
@@ -33,8 +33,8 @@ public class ResetHealthStatusResponse extends AdminResponse {
    * Returns a <code>ResetHealthStatusResponse</code> that will be returned to the specified
    * recipient.
    */
-  public static ResetHealthStatusResponse create(DistributionManager dm,
-      InternalDistributedMember recipient, int id) {
+  public static ResetHealthStatusResponse create(DM dm, InternalDistributedMember recipient,
+      int id) {
     ResetHealthStatusResponse m = new ResetHealthStatusResponse();
     m.setRecipient(recipient);
     {

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RevokePersistentIDRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RevokePersistentIDRequest.java
@@ -26,7 +26,6 @@ import org.apache.geode.distributed.internal.DM;
 import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.distributed.internal.ReplyException;
 import org.apache.geode.internal.InternalDataSerializer;
-import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.persistence.PersistentMemberManager;
 import org.apache.geode.internal.cache.persistence.PersistentMemberPattern;
@@ -74,7 +73,7 @@ public class RevokePersistentIDRequest extends CliLegacyMessage {
   }
 
   @Override
-  protected AdminResponse createResponse(DistributionManager dm) {
+  protected AdminResponse createResponse(DM dm) {
     InternalCache cache = dm.getCache();
     if (cache != null && !cache.isClosed()) {
       PersistentMemberManager mm = cache.getPersistentMemberManager();

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RootRegionRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RootRegionRequest.java
@@ -45,7 +45,7 @@ public class RootRegionRequest extends AdminRequest {
    * Must return a proper response to this request.
    */
   @Override
-  protected AdminResponse createResponse(DistributionManager dm) {
+  protected AdminResponse createResponse(DM dm) {
     // nothing needs to be done. If we got this far then a cache must exist.
     return RootRegionResponse.create(dm, this.getSender());
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RootRegionResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RootRegionResponse.java
@@ -25,8 +25,8 @@ import org.apache.geode.CancelException;
 import org.apache.geode.DataSerializer;
 import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.Region;
+import org.apache.geode.distributed.internal.DM;
 import org.apache.geode.distributed.internal.DistributionConfig;
-import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.admin.GemFireVM;
 import org.apache.geode.internal.cache.InternalCache;
@@ -43,8 +43,7 @@ public class RootRegionResponse extends AdminResponse {
    * Returns a {@code RootRegionResponse} that will be returned to the specified recipient. The
    * message will contains a copy of the local manager's system config.
    */
-  public static RootRegionResponse create(DistributionManager dm,
-      InternalDistributedMember recipient) {
+  public static RootRegionResponse create(DM dm, InternalDistributedMember recipient) {
     RootRegionResponse m = new RootRegionResponse();
     try {
       InternalCache cache = (InternalCache) CacheFactory.getInstance(dm.getSystem());

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/ShutdownAllRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/ShutdownAllRequest.java
@@ -87,7 +87,7 @@ public class ShutdownAllRequest extends AdminRequest {
           if (logger.isDebugEnabled()) {
             logger.debug("caught exception while processing shutdownAll locally", ex);
           }
-          response = AdminFailureResponse.create(dism, myId, ex);
+          response = AdminFailureResponse.create(myId, ex);
         }
         response.setSender(myId);
         replyProcessor.process(response);
@@ -173,7 +173,7 @@ public class ShutdownAllRequest extends AdminRequest {
   }
 
   @Override
-  protected AdminResponse createResponse(DistributionManager dm) {
+  protected AdminResponse createResponse(DM dm) {
     boolean isToShutdown = hasCache();
     if (isToShutdown) {
       boolean isSuccess = false;

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/StoreSysCfgRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/StoreSysCfgRequest.java
@@ -50,7 +50,7 @@ public class StoreSysCfgRequest extends AdminRequest {
    * Must return a proper response to this request.
    */
   @Override
-  protected AdminResponse createResponse(DistributionManager dm) {
+  protected AdminResponse createResponse(DM dm) {
     return StoreSysCfgResponse.create(dm, this.getSender(), this.sc);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/StoreSysCfgResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/StoreSysCfgResponse.java
@@ -35,8 +35,7 @@ public class StoreSysCfgResponse extends AdminResponse {
    * Returns a <code>StoreSysCfgResponse</code> that states that a given set of distribution
    * managers are known by <code>dm</code> to be started.
    */
-  public static StoreSysCfgResponse create(DistributionManager dm,
-      InternalDistributedMember recipient, Config sc) {
+  public static StoreSysCfgResponse create(DM dm, InternalDistributedMember recipient, Config sc) {
     StoreSysCfgResponse m = new StoreSysCfgResponse();
     m.setRecipient(recipient);
     InternalDistributedSystem sys = dm.getSystem();

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/SubRegionRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/SubRegionRequest.java
@@ -42,9 +42,11 @@ public class SubRegionRequest extends RegionAdminRequest {
 
   /**
    * Must return a proper response to this request.
+   *
+   * @param dm
    */
   @Override
-  protected AdminResponse createResponse(DistributionManager dm) {
+  protected AdminResponse createResponse(DM dm) {
     return SubRegionResponse.create(dm, this.getSender(), this.getRegion(dm.getSystem()));
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/SubRegionResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/SubRegionResponse.java
@@ -37,8 +37,7 @@ public class SubRegionResponse extends AdminResponse {
    * Returns a <code>SubRegionResponse</code> that will be returned to the specified recipient. The
    * message will contains a copy of the local manager's system config.
    */
-  public static SubRegionResponse create(DistributionManager dm,
-      InternalDistributedMember recipient, Region r) {
+  public static SubRegionResponse create(DM dm, InternalDistributedMember recipient, Region r) {
     SubRegionResponse m = new SubRegionResponse();
     m.setRecipient(recipient);
 

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/TailLogRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/TailLogRequest.java
@@ -28,7 +28,7 @@ public class TailLogRequest extends AdminRequest {
   }
 
   @Override
-  public AdminResponse createResponse(DistributionManager dm) {
+  public AdminResponse createResponse(DM dm) {
     return TailLogResponse.create(dm, this.getSender());
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/TailLogResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/TailLogResponse.java
@@ -21,8 +21,8 @@ import java.io.*;
 import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.DataSerializer;
+import org.apache.geode.distributed.internal.DM;
 import org.apache.geode.distributed.internal.DistributionConfig;
-import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.i18n.LocalizedStrings;
@@ -38,8 +38,7 @@ public class TailLogResponse extends AdminResponse {
   private String tail;
   private String childTail;
 
-  public static TailLogResponse create(DistributionManager dm,
-      InternalDistributedMember recipient) {
+  public static TailLogResponse create(DM dm, InternalDistributedMember recipient) {
     TailLogResponse m = new TailLogResponse();
     m.setRecipient(recipient);
     try {

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/VersionInfoRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/VersionInfoRequest.java
@@ -42,9 +42,11 @@ public class VersionInfoRequest extends AdminRequest {
 
   /**
    * Must return a proper response to this request.
+   *
+   * @param dm
    */
   @Override
-  protected AdminResponse createResponse(DistributionManager dm) {
+  protected AdminResponse createResponse(DM dm) {
     return VersionInfoResponse.create(dm, this.getSender());
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/VersionInfoResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/VersionInfoResponse.java
@@ -36,8 +36,7 @@ public class VersionInfoResponse extends AdminResponse {
   /**
    * Returns a <code>VersionInfoResponse</code> that will be returned to the specified recipient.
    */
-  public static VersionInfoResponse create(DistributionManager dm,
-      InternalDistributedMember recipient) {
+  public static VersionInfoResponse create(DM dm, InternalDistributedMember recipient) {
     VersionInfoResponse m = new VersionInfoResponse();
     m.setRecipient(recipient);
     m.verInfo = GemFireVersion.asString();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/BackupManager.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/BackupManager.java
@@ -354,18 +354,16 @@ public class BackupManager implements MembershipListener {
           diskStore.getPersistentOplogSet().forceRoll(null);
 
           if (logger.isDebugEnabled()) {
-            logger.debug("done snaphotting for disk store {}", diskStore.getName());
+            logger.debug("done backing up disk store {}", diskStore.getName());
           }
           break;
         }
       }
       done = true;
     } finally {
-      if (!done) {
-        if (backup != null) {
-          backupByDiskStore.remove(diskStore);
-          backup.cleanup();
-        }
+      if (!done && backup != null) {
+        backupByDiskStore.remove(diskStore);
+        backup.cleanup();
       }
     }
     return backup;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/BackupManager.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/BackupManager.java
@@ -18,6 +18,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -266,7 +267,7 @@ public class BackupManager implements MembershipListener {
         File backupDir = getBackupDir(backup.getTargetDir(), index);
         // TODO prpersist - We could probably optimize this to *move* the files
         // that we know are supposed to be deleted.
-        oplog.copyTo(backupDir);
+        backupOplog(backupDir, oplog);
 
         // Allow the oplog to be deleted, and process any pending delete
         backup.backupFinished(oplog);
@@ -567,6 +568,28 @@ public class BackupManager implements MembershipListener {
     } finally {
       fos.close();
     }
+  }
+
+  private void backupOplog(File targetDir, Oplog oplog) throws IOException {
+    File crfFile = oplog.getCrfFile();
+    backupFile(targetDir, crfFile);
+
+    File drfFile = oplog.getDrfFile();
+    backupFile(targetDir, drfFile);
+
+    oplog.finishKrf();
+    File krfFile = oplog.getKrfFile();
+    backupFile(targetDir, krfFile);
+  }
+
+  private void backupFile(File targetDir, File file) throws IOException {
+    if (file != null && file.exists())
+      try {
+        Files.createLink(targetDir.toPath().resolve(file.getName()), file.toPath());
+      } catch (IOException | UnsupportedOperationException e) {
+        logger.warn("Unable to create hard link for + {}. Reverting to file copy", targetDir);
+        FileUtils.copyFileToDirectory(file, targetDir);
+      }
   }
 
   private String cleanSpecialCharacters(String string) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalRegion.java
@@ -45,6 +45,10 @@ import org.apache.geode.internal.cache.versions.VersionTag;
 public interface InternalRegion<K, V>
     extends Region<K, V>, HasCachePerfStats, RegionEntryContext, RegionAttributes, HasDiskRegion {
 
+  CachePerfStats getCachePerfStats();
+
+  DiskRegion getDiskRegion();
+
   RegionEntry getRegionEntry(K key);
 
   RegionVersionVector getVersionVector();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
@@ -2051,6 +2051,7 @@ public class LocalRegion extends AbstractRegion implements InternalRegion, Loade
    *
    * @since GemFire 3.2
    */
+  @Override
   public DiskRegion getDiskRegion() {
     return this.diskRegion;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/Oplog.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/Oplog.java
@@ -30,6 +30,7 @@ import java.io.InterruptedIOException;
 import java.io.SyncFailedException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -1160,7 +1161,7 @@ public class Oplog implements CompactableOplog, Flushable {
    * Otherwise, for windows the actual file length does not match with the File size obtained from
    * the File object
    */
-  File getOplogFile() throws SyncFailedException, IOException {
+  File getOplogFileForTest() throws IOException {
     // @todo check callers for drf
     // No need to get the backup lock prior to synchronizing (correct lock order) since the
     // synchronized block does not attempt to get the backup lock (incorrect lock order)
@@ -1170,6 +1171,14 @@ public class Oplog implements CompactableOplog, Flushable {
       }
       return this.crf.f;
     }
+  }
+
+  File getCrfFile() {
+    return this.crf.f;
+  }
+
+  File getDrfFile() {
+    return this.drf.f;
   }
 
   /**
@@ -4224,7 +4233,7 @@ public class Oplog implements CompactableOplog, Flushable {
     }
   }
 
-  private File getKrfFile() {
+  File getKrfFile() {
     return new File(this.diskFile.getPath() + KRF_FILE_EXT);
   }
 
@@ -5749,23 +5758,6 @@ public class Oplog implements CompactableOplog, Flushable {
 
   public void deleteDRFFileOnly() {
     deleteFile(this.drf);
-  }
-
-  public void copyTo(File targetDir) throws IOException {
-    if (this.crf.f != null && this.crf.f.exists()) {
-      FileUtils.copyFileToDirectory(this.crf.f, targetDir);
-    }
-    if (this.drf.f.exists()) {
-      FileUtils.copyFileToDirectory(this.drf.f, targetDir);
-    }
-
-    // this krf existence check fixes 45089
-    // TODO: should we wait for the async KRF creation to finish by calling this.finishKrf?
-    if (getParent().getDiskInitFile().hasKrf(this.oplogId)) {
-      if (this.getKrfFile().exists()) {
-        FileUtils.copyFileToDirectory(this.getKrfFile(), targetDir);
-      }
-    }
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/PersistentMemberManager.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/PersistentMemberManager.java
@@ -24,7 +24,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.cache.persistence.RevokedPersistentDataException;
-import org.apache.geode.distributed.internal.DistributionManager;
+import org.apache.geode.distributed.internal.DM;
 import org.apache.geode.distributed.internal.MembershipListener;
 import org.apache.geode.distributed.internal.ProfileListener;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -164,7 +164,7 @@ public class PersistentMemberManager {
    * @return true if this member is not currently running the chosen disk store. false if the revoke
    *         should be aborted because the disk store is already running.
    */
-  public boolean prepareRevoke(PersistentMemberPattern pattern, DistributionManager dm,
+  public boolean prepareRevoke(PersistentMemberPattern pattern, DM dm,
       InternalDistributedMember sender) {
     if (logger.isDebugEnabled()) {
       logger.debug("Preparing revoke if pattern {}", pattern);
@@ -232,10 +232,10 @@ public class PersistentMemberManager {
   public class PendingRevokeListener implements MembershipListener {
     InternalDistributedMember sender;
     private PersistentMemberPattern pattern;
-    private DistributionManager dm;
+    private DM dm;
 
     public PendingRevokeListener(PersistentMemberPattern pattern, InternalDistributedMember sender,
-        DistributionManager dm) {
+        DM dm) {
       this.dm = dm;
       this.pattern = pattern;
       this.sender = sender;

--- a/geode-core/src/main/java/org/apache/geode/management/BackupStatus.java
+++ b/geode-core/src/main/java/org/apache/geode/management/BackupStatus.java
@@ -19,14 +19,11 @@ import java.util.Set;
 
 import org.apache.geode.cache.persistence.PersistentID;
 import org.apache.geode.distributed.DistributedMember;
-import org.apache.geode.distributed.internal.DM;
-import org.apache.geode.internal.cache.BackupUtil;
 
 /**
- * The status of a backup operation, returned by
- * {@link BackupUtil#backupAllMembers(DM, java.io.File,java.io.File)}.
+ * The status of a backup operation.
  *
- * @since GemFire 6.5
+ * @since Geode 1.4
  */
 public interface BackupStatus {
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/messages/CompactRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/messages/CompactRequest.java
@@ -95,7 +95,7 @@ public class CompactRequest extends AdminRequest {
   }
 
   @Override
-  protected AdminResponse createResponse(DistributionManager dm) {
+  protected AdminResponse createResponse(DM dm) {
     PersistentID compactedDiskStore = compactDiskStore(this.diskStoreName);
 
     return new CompactResponse(this.getSender(), compactedDiskStore);
@@ -159,14 +159,14 @@ public class CompactRequest extends AdminRequest {
     }
 
     @Override
-    protected void process(DistributionMessage msg, boolean warn) {
-      if (msg instanceof CompactResponse) {
-        final PersistentID persistentId = ((CompactResponse) msg).getPersistentId();
+    protected void process(DistributionMessage message, boolean warn) {
+      if (message instanceof CompactResponse) {
+        final PersistentID persistentId = ((CompactResponse) message).getPersistentId();
         if (persistentId != null) {
-          results.put(msg.getSender(), persistentId);
+          results.put(message.getSender(), persistentId);
         }
       }
-      super.process(msg, warn);
+      super.process(message, warn);
     }
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/admin/internal/FinishBackupRequestTest.java
+++ b/geode-core/src/test/java/org/apache/geode/admin/internal/FinishBackupRequestTest.java
@@ -17,6 +17,7 @@ package org.apache.geode.admin.internal;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -145,7 +146,7 @@ public class FinishBackupRequestTest {
   public void sendShouldInvokeProcessLocally() throws Exception {
     finishBackupRequest.send();
 
-    verify(replyProcessor, times(1)).process(any(AdminResponse.class));
+    verify(replyProcessor, times(1)).process(any(AdminResponse.class), eq(false));
   }
 
   @Test
@@ -173,7 +174,7 @@ public class FinishBackupRequestTest {
   public void repliesWithFinishBackupResponse() throws Exception {
     finishBackupRequest.send();
 
-    verify(replyProcessor, times(1)).process(any(FinishBackupResponse.class));
+    verify(replyProcessor, times(1)).process(any(FinishBackupResponse.class), eq(false));
   }
 
   @Test
@@ -182,7 +183,7 @@ public class FinishBackupRequestTest {
 
     finishBackupRequest.send();
 
-    verify(replyProcessor, times(1)).process(any(AdminFailureResponse.class));
+    verify(replyProcessor, times(1)).process(any(AdminFailureResponse.class), eq(false));
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/admin/internal/FinishBackupRequestTest.java
+++ b/geode-core/src/test/java/org/apache/geode/admin/internal/FinishBackupRequestTest.java
@@ -1,0 +1,212 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.admin.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.InOrder;
+
+import org.apache.geode.admin.internal.FinishBackupRequest.FinishBackupReplyProcessor;
+import org.apache.geode.cache.CacheClosedException;
+import org.apache.geode.cache.persistence.PersistentID;
+import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.distributed.internal.DM;
+import org.apache.geode.distributed.internal.ReplyException;
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
+import org.apache.geode.internal.admin.remote.AdminFailureResponse;
+import org.apache.geode.internal.admin.remote.AdminResponse;
+import org.apache.geode.internal.cache.BackupManager;
+import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.test.junit.categories.UnitTest;
+
+@Category(UnitTest.class)
+public class FinishBackupRequestTest {
+
+  private FinishBackupRequest finishBackupRequest;
+
+  private FinishBackupReplyProcessor replyProcessor;
+  private DM dm;
+  private InternalCache cache;
+  private BackupManager backupManager;
+  private File targetDir;
+  private File baselineDir;
+
+  private InternalDistributedMember localMember;
+  private InternalDistributedMember member1;
+  private InternalDistributedMember member2;
+
+  private Set<InternalDistributedMember> recipients;
+
+  @Before
+  public void setUp() throws Exception {
+    // mocks here
+    replyProcessor = mock(FinishBackupReplyProcessor.class);
+    dm = mock(DM.class);
+    cache = mock(InternalCache.class);
+    backupManager = mock(BackupManager.class);
+    targetDir = mock(File.class);
+    baselineDir = mock(File.class);
+
+    when(dm.getCache()).thenReturn(cache);
+    when(dm.getDistributionManagerId()).thenReturn(localMember);
+    when(cache.getBackupManager()).thenReturn(backupManager);
+    when(replyProcessor.getResults()).thenReturn(Collections.emptyMap());
+
+    localMember = mock(InternalDistributedMember.class);
+    member1 = mock(InternalDistributedMember.class);
+    member2 = mock(InternalDistributedMember.class);
+
+    recipients = new HashSet<>();
+    recipients.add(member1);
+    recipients.add(member2);
+
+    finishBackupRequest =
+        new FinishBackupRequest(dm, recipients, replyProcessor, targetDir, baselineDir, false);
+  }
+
+  @Test
+  public void getRecipientsReturnsRecipientMembers() throws Exception {
+    assertThat(finishBackupRequest.getRecipients()).hasSize(2).contains(member1, member2);
+  }
+
+  @Test
+  public void getRecipientsDoesNotIncludeNull() throws Exception {
+    InternalDistributedMember nullMember = null;
+
+    assertThat(finishBackupRequest.getRecipients()).doesNotContain(nullMember);
+  }
+
+  @Test
+  public void sendShouldUseDMToSendMessage() throws Exception {
+    finishBackupRequest.send();
+
+    verify(dm, times(1)).putOutgoing(finishBackupRequest);
+  }
+
+  @Test
+  public void sendShouldWaitForRepliesFromRecipients() throws Exception {
+    finishBackupRequest.send();
+
+    verify(replyProcessor, times(1)).waitForReplies();
+  }
+
+  @Test
+  public void sendShouldReturnResultsContainingRecipientsAndLocalMember() throws Exception {
+    Set<PersistentID> localMember_PersistentIdSet = new HashSet<>();
+    localMember_PersistentIdSet.add(mock(PersistentID.class));
+    Set<PersistentID> member1_PersistentIdSet = new HashSet<>();
+    member1_PersistentIdSet.add(mock(PersistentID.class));
+    Set<PersistentID> member2_PersistentIdSet = new HashSet<>();
+    member2_PersistentIdSet.add(mock(PersistentID.class));
+    member2_PersistentIdSet.add(mock(PersistentID.class));
+    Map<DistributedMember, Set<PersistentID>> expectedResults = new HashMap<>();
+    expectedResults.put(localMember, localMember_PersistentIdSet);
+    expectedResults.put(member1, member1_PersistentIdSet);
+    expectedResults.put(member2, member2_PersistentIdSet);
+    when(replyProcessor.getResults()).thenReturn(expectedResults);
+
+    Map<DistributedMember, Set<PersistentID>> results = finishBackupRequest.send();
+
+    assertThat(results).isEqualTo(expectedResults);
+  }
+
+  @Test
+  public void sendShouldInvokeProcessLocally() throws Exception {
+    finishBackupRequest.send();
+
+    verify(replyProcessor, times(1)).process(any(AdminResponse.class));
+  }
+
+  @Test
+  public void sendShouldInvokeDoBackupLocally() throws Exception {
+    finishBackupRequest.send();
+
+    verify(backupManager, times(1)).doBackup(targetDir, baselineDir, false);
+  }
+
+  /**
+   * Confirms fix for GEODE-3940: Backup can hang while trying to get a lock
+   */
+  @Test
+  public void sendShouldDoBackupInLocalMemberBeforeWaitingForReplies() throws Exception {
+    InOrder inOrder = inOrder(backupManager, replyProcessor);
+
+    finishBackupRequest.send();
+
+    // assert that doBackup which releases BackupLock is invoked before invoking waitForReplies
+    inOrder.verify(backupManager, times(1)).doBackup(targetDir, baselineDir, false);
+    inOrder.verify(replyProcessor, times(1)).waitForReplies();
+  }
+
+  @Test
+  public void repliesWithFinishBackupResponse() throws Exception {
+    finishBackupRequest.send();
+
+    verify(replyProcessor, times(1)).process(any(FinishBackupResponse.class));
+  }
+
+  @Test
+  public void repliesWithAdminFailureResponseWhenDoBackupThrowsIOException() throws Exception {
+    when(backupManager.doBackup(targetDir, baselineDir, false)).thenThrow(new IOException());
+
+    finishBackupRequest.send();
+
+    verify(replyProcessor, times(1)).process(any(AdminFailureResponse.class));
+  }
+
+  @Test
+  public void sendShouldCompleteIfWaitForRepliesThrowsReplyExceptionCausedByCacheClosedException()
+      throws Exception {
+    doThrow(new ReplyException(new CacheClosedException())).when(replyProcessor).waitForReplies();
+
+    finishBackupRequest.send();
+  }
+
+  @Test
+  public void sendShouldThrowIfWaitForRepliesThrowsReplyExceptionNotCausedByCacheClosedException()
+      throws Exception {
+    doThrow(new ReplyException(new NullPointerException())).when(replyProcessor).waitForReplies();
+
+    assertThatThrownBy(() -> finishBackupRequest.send()).isInstanceOf(ReplyException.class)
+        .hasCauseInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void sendCompletesWhenWaitForRepliesThrowsInterruptedException() throws Exception {
+    doThrow(new InterruptedException()).when(replyProcessor).waitForReplies();
+
+    finishBackupRequest.send();
+  }
+
+}

--- a/geode-core/src/test/java/org/apache/geode/admin/internal/FlushToDiskRequestTest.java
+++ b/geode-core/src/test/java/org/apache/geode/admin/internal/FlushToDiskRequestTest.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.admin.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.InOrder;
+
+import org.apache.geode.admin.internal.FlushToDiskRequest.FlushToDiskProcessor;
+import org.apache.geode.cache.CacheClosedException;
+import org.apache.geode.cache.DiskStore;
+import org.apache.geode.distributed.internal.DM;
+import org.apache.geode.distributed.internal.ReplyException;
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
+import org.apache.geode.internal.admin.remote.AdminResponse;
+import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.test.junit.categories.UnitTest;
+
+@Category(UnitTest.class)
+public class FlushToDiskRequestTest {
+
+  private FlushToDiskRequest flushToDiskRequest;
+
+  private FlushToDiskProcessor replyProcessor;
+  private DM dm;
+  private InternalCache cache;
+
+  private DiskStore diskStore1;
+  private DiskStore diskStore2;
+  private Collection<DiskStore> diskStoreCollection;
+
+  private InternalDistributedMember localMember;
+  private InternalDistributedMember member1;
+  private InternalDistributedMember member2;
+
+  private Set<InternalDistributedMember> recipients;
+
+  @Before
+  public void setUp() throws Exception {
+    // mocks here
+    replyProcessor = mock(FlushToDiskProcessor.class);
+    dm = mock(DM.class);
+    cache = mock(InternalCache.class);
+    diskStore1 = mock(DiskStore.class);
+    diskStore2 = mock(DiskStore.class);
+
+    diskStoreCollection = new ArrayList<>();
+    diskStoreCollection.add(diskStore1);
+    diskStoreCollection.add(diskStore2);
+
+    when(dm.getCache()).thenReturn(cache);
+    when(dm.getDistributionManagerId()).thenReturn(localMember);
+    when(cache.listDiskStoresIncludingRegionOwned()).thenReturn(diskStoreCollection);
+
+    localMember = mock(InternalDistributedMember.class);
+    member1 = mock(InternalDistributedMember.class);
+    member2 = mock(InternalDistributedMember.class);
+
+    recipients = new HashSet<>();
+    recipients.add(member1);
+    recipients.add(member2);
+
+    flushToDiskRequest = new FlushToDiskRequest(dm, recipients, replyProcessor);
+  }
+
+  @Test
+  public void getRecipientsReturnsRecipientMembers() throws Exception {
+    assertThat(flushToDiskRequest.getRecipients()).hasSize(2).contains(member1, member2);
+  }
+
+  @Test
+  public void getRecipientsDoesNotIncludeNull() throws Exception {
+    InternalDistributedMember nullMember = null;
+
+    assertThat(flushToDiskRequest.getRecipients()).doesNotContain(nullMember);
+  }
+
+  @Test
+  public void sendShouldUseDMToSendMessage() throws Exception {
+    flushToDiskRequest.send();
+
+    verify(dm, times(1)).putOutgoing(flushToDiskRequest);
+  }
+
+  @Test
+  public void sendShouldWaitForRepliesFromRecipients() throws Exception {
+    flushToDiskRequest.send();
+
+    verify(replyProcessor, times(1)).waitForReplies();
+  }
+
+  @Test
+  public void sendShouldInvokeProcessLocally() throws Exception {
+    flushToDiskRequest.send();
+
+    verify(replyProcessor, times(1)).process(any(AdminResponse.class));
+  }
+
+  @Test
+  public void sendShouldFlushDiskStores() throws Exception {
+    flushToDiskRequest.send();
+
+    verify(diskStore1, times(1)).flush();
+    verify(diskStore2, times(1)).flush();
+  }
+
+  @Test
+  public void sendShouldFlushDiskStoresInLocalMemberBeforeWaitingForReplies() throws Exception {
+    InOrder inOrder = inOrder(diskStore1, diskStore2, replyProcessor);
+
+    flushToDiskRequest.send();
+
+    // assert that prepareForBackup is invoked before invoking waitForReplies
+    inOrder.verify(diskStore1, times(1)).flush();
+    inOrder.verify(diskStore2, times(1)).flush();
+    inOrder.verify(replyProcessor, times(1)).waitForReplies();
+  }
+
+  @Test
+  public void repliesWithFinishBackupResponse() throws Exception {
+    flushToDiskRequest.send();
+
+    verify(replyProcessor, times(1)).process(any(FlushToDiskResponse.class));
+  }
+
+  @Test
+  public void sendShouldCompleteIfWaitForRepliesThrowsReplyExceptionCausedByCacheClosedException()
+      throws Exception {
+    doThrow(new ReplyException(new CacheClosedException())).when(replyProcessor).waitForReplies();
+
+    flushToDiskRequest.send();
+  }
+
+  @Test
+  public void sendShouldThrowIfWaitForRepliesThrowsReplyExceptionNotCausedByCancelException()
+      throws Exception {
+    doThrow(new ReplyException(new NullPointerException())).when(replyProcessor).waitForReplies();
+
+    assertThatThrownBy(() -> flushToDiskRequest.send()).isInstanceOf(ReplyException.class)
+        .hasCauseInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void sendCompletesWhenWaitForRepliesThrowsInterruptedException() throws Exception {
+    doThrow(new InterruptedException()).when(replyProcessor).waitForReplies();
+
+    flushToDiskRequest.send();
+  }
+
+}

--- a/geode-core/src/test/java/org/apache/geode/admin/internal/FlushToDiskRequestTest.java
+++ b/geode-core/src/test/java/org/apache/geode/admin/internal/FlushToDiskRequestTest.java
@@ -17,6 +17,7 @@ package org.apache.geode.admin.internal;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -121,7 +122,7 @@ public class FlushToDiskRequestTest {
   public void sendShouldInvokeProcessLocally() throws Exception {
     flushToDiskRequest.send();
 
-    verify(replyProcessor, times(1)).process(any(AdminResponse.class));
+    verify(replyProcessor, times(1)).process(any(AdminResponse.class), eq(false));
   }
 
   @Test
@@ -148,7 +149,7 @@ public class FlushToDiskRequestTest {
   public void repliesWithFinishBackupResponse() throws Exception {
     flushToDiskRequest.send();
 
-    verify(replyProcessor, times(1)).process(any(FlushToDiskResponse.class));
+    verify(replyProcessor, times(1)).process(any(FlushToDiskResponse.class), eq(false));
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/admin/internal/PrepareBackupRequestTest.java
+++ b/geode-core/src/test/java/org/apache/geode/admin/internal/PrepareBackupRequestTest.java
@@ -17,6 +17,7 @@ package org.apache.geode.admin.internal;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -140,7 +141,7 @@ public class PrepareBackupRequestTest {
   public void sendShouldInvokeProcessLocally() throws Exception {
     prepareBackupRequest.send();
 
-    verify(replyProcessor, times(1)).process(any(AdminResponse.class));
+    verify(replyProcessor, times(1)).process(any(AdminResponse.class), eq(false));
   }
 
   @Test
@@ -165,7 +166,7 @@ public class PrepareBackupRequestTest {
   public void repliesWithFinishBackupResponse() throws Exception {
     prepareBackupRequest.send();
 
-    verify(replyProcessor, times(1)).process(any(PrepareBackupResponse.class));
+    verify(replyProcessor, times(1)).process(any(PrepareBackupResponse.class), eq(false));
   }
 
   @Test
@@ -176,7 +177,7 @@ public class PrepareBackupRequestTest {
 
     prepareBackupRequest.send();
 
-    verify(replyProcessor, times(1)).process(any(AdminFailureResponse.class));
+    verify(replyProcessor, times(1)).process(any(AdminFailureResponse.class), eq(false));
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/admin/internal/PrepareBackupRequestTest.java
+++ b/geode-core/src/test/java/org/apache/geode/admin/internal/PrepareBackupRequestTest.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.admin.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.InOrder;
+
+import org.apache.geode.admin.internal.PrepareBackupRequest.PrepareBackupReplyProcessor;
+import org.apache.geode.cache.CacheClosedException;
+import org.apache.geode.cache.persistence.PersistentID;
+import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.distributed.internal.DM;
+import org.apache.geode.distributed.internal.ReplyException;
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
+import org.apache.geode.internal.admin.remote.AdminFailureResponse;
+import org.apache.geode.internal.admin.remote.AdminResponse;
+import org.apache.geode.internal.cache.BackupManager;
+import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.test.junit.categories.UnitTest;
+
+@Category(UnitTest.class)
+public class PrepareBackupRequestTest {
+
+  private PrepareBackupRequest prepareBackupRequest;
+
+  private PrepareBackupReplyProcessor replyProcessor;
+  private DM dm;
+  private InternalCache cache;
+  private BackupManager backupManager;
+
+  private InternalDistributedMember localMember;
+  private InternalDistributedMember member1;
+  private InternalDistributedMember member2;
+
+  private Set<InternalDistributedMember> recipients;
+
+  @Before
+  public void setUp() throws Exception {
+    // mocks here
+    replyProcessor = mock(PrepareBackupReplyProcessor.class);
+    dm = mock(DM.class);
+    cache = mock(InternalCache.class);
+    backupManager = mock(BackupManager.class);
+
+    when(dm.getCache()).thenReturn(cache);
+    when(dm.getDistributionManagerId()).thenReturn(localMember);
+    when(cache.startBackup(any())).thenReturn(backupManager);
+    when(replyProcessor.getResults()).thenReturn(Collections.emptyMap());
+
+    localMember = mock(InternalDistributedMember.class);
+    member1 = mock(InternalDistributedMember.class);
+    member2 = mock(InternalDistributedMember.class);
+
+    recipients = new HashSet<>();
+    recipients.add(member1);
+    recipients.add(member2);
+
+    prepareBackupRequest = new PrepareBackupRequest(dm, recipients, replyProcessor);
+  }
+
+  @Test
+  public void getRecipientsReturnsRecipientMembers() throws Exception {
+    assertThat(prepareBackupRequest.getRecipients()).hasSize(2).contains(member1, member2);
+  }
+
+  @Test
+  public void getRecipientsDoesNotIncludeNull() throws Exception {
+    InternalDistributedMember nullMember = null;
+
+    assertThat(prepareBackupRequest.getRecipients()).doesNotContain(nullMember);
+  }
+
+  @Test
+  public void sendShouldUseDMToSendMessage() throws Exception {
+    prepareBackupRequest.send();
+
+    verify(dm, times(1)).putOutgoing(prepareBackupRequest);
+  }
+
+  @Test
+  public void sendShouldWaitForRepliesFromRecipients() throws Exception {
+    prepareBackupRequest.send();
+
+    verify(replyProcessor, times(1)).waitForReplies();
+  }
+
+  @Test
+  public void sendShouldReturnResultsContainingRecipientsAndLocalMember() throws Exception {
+    Set<PersistentID> localMember_PersistentIdSet = new HashSet<>();
+    localMember_PersistentIdSet.add(mock(PersistentID.class));
+    Set<PersistentID> member1_PersistentIdSet = new HashSet<>();
+    member1_PersistentIdSet.add(mock(PersistentID.class));
+    Set<PersistentID> member2_PersistentIdSet = new HashSet<>();
+    member2_PersistentIdSet.add(mock(PersistentID.class));
+    member2_PersistentIdSet.add(mock(PersistentID.class));
+    Map<DistributedMember, Set<PersistentID>> expectedResults = new HashMap<>();
+    expectedResults.put(localMember, localMember_PersistentIdSet);
+    expectedResults.put(member1, member1_PersistentIdSet);
+    expectedResults.put(member2, member2_PersistentIdSet);
+    when(replyProcessor.getResults()).thenReturn(expectedResults);
+
+    Map<DistributedMember, Set<PersistentID>> results = prepareBackupRequest.send();
+
+    assertThat(results).isEqualTo(expectedResults);
+  }
+
+  @Test
+  public void sendShouldInvokeProcessLocally() throws Exception {
+    prepareBackupRequest.send();
+
+    verify(replyProcessor, times(1)).process(any(AdminResponse.class));
+  }
+
+  @Test
+  public void sendShouldInvokePrepareForBackup() throws Exception {
+    prepareBackupRequest.send();
+
+    verify(backupManager, times(1)).prepareForBackup();
+  }
+
+  @Test
+  public void sendShouldPrepareForBackupInLocalMemberBeforeWaitingForReplies() throws Exception {
+    InOrder inOrder = inOrder(backupManager, replyProcessor);
+
+    prepareBackupRequest.send();
+
+    // assert that prepareForBackup is invoked before invoking waitForReplies
+    inOrder.verify(backupManager, times(1)).prepareForBackup();
+    inOrder.verify(replyProcessor, times(1)).waitForReplies();
+  }
+
+  @Test
+  public void repliesWithFinishBackupResponse() throws Exception {
+    prepareBackupRequest.send();
+
+    verify(replyProcessor, times(1)).process(any(PrepareBackupResponse.class));
+  }
+
+  @Test
+  public void repliesWithAdminFailureResponseWhenPrepareForBackupThrowsIOException()
+      throws Exception {
+    prepareBackupRequest = spy(prepareBackupRequest);
+    doThrow(new IOException()).when(prepareBackupRequest).prepareForBackup(dm);
+
+    prepareBackupRequest.send();
+
+    verify(replyProcessor, times(1)).process(any(AdminFailureResponse.class));
+  }
+
+  @Test
+  public void sendShouldCompleteIfWaitForRepliesThrowsReplyExceptionCausedByCacheClosedException()
+      throws Exception {
+    doThrow(new ReplyException(new CacheClosedException())).when(replyProcessor).waitForReplies();
+
+    prepareBackupRequest.send();
+  }
+
+  @Test
+  public void sendShouldThrowIfWaitForRepliesThrowsReplyExceptionNotCausedByCacheClosedException()
+      throws Exception {
+    doThrow(new ReplyException(new NullPointerException())).when(replyProcessor).waitForReplies();
+
+    assertThatThrownBy(() -> prepareBackupRequest.send()).isInstanceOf(ReplyException.class)
+        .hasCauseInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void sendCompletesWhenWaitForRepliesThrowsInterruptedException() throws Exception {
+    doThrow(new InterruptedException()).when(replyProcessor).waitForReplies();
+
+    prepareBackupRequest.send();
+  }
+
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/BackupDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/BackupDUnitTest.java
@@ -341,7 +341,7 @@ public class BackupDUnitTest extends PersistentPartitionedRegionTestBase {
           DistributionMessageObserver.setInstance(null);
           IOException exception = new IOException("Backup in progess");
           AdminFailureResponse response =
-              AdminFailureResponse.create(dm, message.getSender(), exception);
+              AdminFailureResponse.create(message.getSender(), exception);
           response.setMsgId(((PrepareBackupRequest) message).getMsgId());
           dm.putOutgoing(response);
           throw new RuntimeException("Stop processing");

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/BackupLockTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/BackupLockTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.test.junit.categories.UnitTest;
+
+@Category(UnitTest.class)
+public class BackupLockTest {
+
+  private BackupLock backupLock;
+  private ExecutorService executor;
+
+  @Before
+  public void setUp() throws Exception {
+    backupLock = new BackupLock();
+    executor = Executors.newSingleThreadExecutor();
+  }
+
+  @Test
+  public void lockShouldBlockUntilLockForBackup() throws Exception {
+    backupLock.lockForBackup();
+    backupLock.setBackupThread();
+
+    AtomicBoolean beforeLock = new AtomicBoolean();
+    AtomicBoolean afterLock = new AtomicBoolean();
+
+    backupLock.setBackupLockTestHook(() -> beforeLock.set(true));
+
+    executor.submit(() -> {
+      backupLock.lock(); // beforeLock is set inside lock() method
+      afterLock.set(true);
+    });
+
+    await().atMost(10, SECONDS).until(() -> assertThat(beforeLock).isTrue());
+    assertThat(afterLock).isFalse();
+
+    backupLock.unlockForBackup();
+    await().atMost(10, SECONDS).until(() -> assertThat(afterLock).isTrue());
+  }
+
+  @Test
+  public void otherThreadShouldBeAbleToUnlockForBackup() throws Exception {
+    backupLock.lockForBackup();
+    backupLock.setBackupThread();
+
+    await().atMost(10, SECONDS).until(() -> assertThat(backupLock.isBackingUp()).isTrue());
+    assertThat(backupLock.isCurrentThreadDoingBackup()).isTrue();
+
+    executor.submit(() -> {
+      assertThat(backupLock.isCurrentThreadDoingBackup()).isFalse();
+      backupLock.unlockForBackup();
+    });
+
+    await().atMost(10, SECONDS).until(() -> assertThat(backupLock.isBackingUp()).isFalse());
+  }
+
+  @Test
+  public void isCurrentThreadDoingBackupShouldBeSetAndUnset() throws Exception {
+    backupLock.lockForBackup();
+    backupLock.setBackupThread();
+
+    assertThat(backupLock.isCurrentThreadDoingBackup()).isTrue();
+
+    backupLock.unlockForBackup();
+
+    assertThat(backupLock.isCurrentThreadDoingBackup()).isFalse();
+  }
+
+  @Test
+  public void threadLocalShouldNotLeak() throws Exception {
+    backupLock.lockForBackup();
+    backupLock.setBackupThread();
+
+    assertThat(backupLock.hasThreadLocal()).isTrue();
+
+    backupLock.unlockForBackup();
+
+    assertThat(backupLock.hasThreadLocal()).isFalse();
+  }
+
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/Bug34179TooManyFilesOpenJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/Bug34179TooManyFilesOpenJUnitTest.java
@@ -84,7 +84,7 @@ public class Bug34179TooManyFilesOpenJUnitTest extends DiskRegionTestingBase {
   /**
    * cleans all the directory of all the files present in them
    */
-  protected static void deleteFiles() {
+  protected void deleteFiles() {
     for (int i = 0; i < dirs.length; i++) {
       File[] files = dirs[i].listFiles();
       for (int j = 0; j < files.length; j++) {

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/DiskRegRecoveryJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/DiskRegRecoveryJUnitTest.java
@@ -662,7 +662,7 @@ public class DiskRegRecoveryJUnitTest extends DiskRegionTestingBase {
     region.put("3", value);
     File oplogFile = null;
     try {
-      oplogFile = ((LocalRegion) region).getDiskRegion().testHook_getChild().getOplogFile();
+      oplogFile = ((LocalRegion) region).getDiskRegion().testHook_getChild().getOplogFileForTest();
     } catch (Exception e) {
       logWriter.error(
           "Exception in synching data present in the buffers of RandomAccessFile of Oplog, to the disk",

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/DiskRegionAsyncRecoveryJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/DiskRegionAsyncRecoveryJUnitTest.java
@@ -192,7 +192,7 @@ public class DiskRegionAsyncRecoveryJUnitTest extends DiskRegionTestingBase {
     putEntries(region, 10, 15, "A");
 
     PersistentOplogSet set = store.getPersistentOplogSet(region.getDiskRegion());
-    String currentChild = set.getChild().getOplogFile().getName();
+    String currentChild = set.getChild().getOplogFileForTest().getName();
     // Wait for the krfs to be created
     Set<String> crfs;
     Set<String> krfs;

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/DiskRegionHelperFactory.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/DiskRegionHelperFactory.java
@@ -27,8 +27,8 @@ import org.apache.geode.cache.util.ObjectSizer;
  */
 public class DiskRegionHelperFactory {
 
-  public static Region getRegion(Cache cache, DiskRegionProperties diskProps, Scope regionScope) {
-    Region region = null;
+  private static Region<Object, Object> getRegion(Cache cache, DiskRegionProperties diskProps,
+      Scope regionScope) {
     DiskStoreFactory dsf = cache.createDiskStoreFactory();
     AttributesFactory factory = new AttributesFactory();
     if (diskProps.getDiskDirs() == null) {
@@ -46,7 +46,6 @@ public class DiskRegionHelperFactory {
     } else {
       dsf.setDiskDirsAndSizes(diskProps.getDiskDirs(), diskProps.getDiskDirSizes());
     }
-    // Properties props = new Properties();
     ((DiskStoreFactoryImpl) dsf).setMaxOplogSizeInBytes(diskProps.getMaxOplogSize());
     dsf.setAutoCompact(diskProps.isRolling());
     dsf.setAllowForceCompaction(diskProps.getAllowForceCompaction());
@@ -87,6 +86,7 @@ public class DiskRegionHelperFactory {
     factory.setLoadFactor(diskProps.getLoadFactor());
     factory.setStatisticsEnabled(diskProps.getStatisticsEnabled());
 
+    Region<Object, Object> region = null;
     try {
       region = cache.createVMRegion(diskProps.getRegionName(), factory.createRegionAttributes());
     } catch (TimeoutException e) {
@@ -97,7 +97,7 @@ public class DiskRegionHelperFactory {
     return region;
   }
 
-  public static Region getSyncPersistOnlyRegion(Cache cache,
+  public static Region<Object, Object> getSyncPersistOnlyRegion(Cache cache,
       DiskRegionProperties diskRegionProperties, Scope regionScope) {
     if (diskRegionProperties == null) {
       diskRegionProperties = new DiskRegionProperties();
@@ -108,7 +108,7 @@ public class DiskRegionHelperFactory {
 
   }
 
-  public static Region getAsyncPersistOnlyRegion(Cache cache,
+  public static Region<Object, Object> getAsyncPersistOnlyRegion(Cache cache,
       DiskRegionProperties diskRegionProperties) {
     if (diskRegionProperties == null) {
       diskRegionProperties = new DiskRegionProperties();
@@ -118,7 +118,7 @@ public class DiskRegionHelperFactory {
     return getRegion(cache, diskRegionProperties, Scope.LOCAL);
   }
 
-  public static Region getSyncOverFlowOnlyRegion(Cache cache,
+  public static Region<Object, Object> getSyncOverFlowOnlyRegion(Cache cache,
       DiskRegionProperties diskRegionProperties) {
     if (diskRegionProperties == null) {
       diskRegionProperties = new DiskRegionProperties();
@@ -129,7 +129,7 @@ public class DiskRegionHelperFactory {
     return getRegion(cache, diskRegionProperties, Scope.LOCAL);
   }
 
-  public static Region getAsyncOverFlowOnlyRegion(Cache cache,
+  public static Region<Object, Object> getAsyncOverFlowOnlyRegion(Cache cache,
       DiskRegionProperties diskRegionProperties) {
     if (diskRegionProperties == null) {
       diskRegionProperties = new DiskRegionProperties();
@@ -140,7 +140,7 @@ public class DiskRegionHelperFactory {
     return getRegion(cache, diskRegionProperties, Scope.LOCAL);
   }
 
-  public static Region getSyncOverFlowAndPersistRegion(Cache cache,
+  public static Region<Object, Object> getSyncOverFlowAndPersistRegion(Cache cache,
       DiskRegionProperties diskRegionProperties) {
     if (diskRegionProperties == null) {
       diskRegionProperties = new DiskRegionProperties();
@@ -151,7 +151,7 @@ public class DiskRegionHelperFactory {
     return getRegion(cache, diskRegionProperties, Scope.LOCAL);
   }
 
-  public static Region getAsyncOverFlowAndPersistRegion(Cache cache,
+  public static Region<Object, Object> getAsyncOverFlowAndPersistRegion(Cache cache,
       DiskRegionProperties diskRegionProperties) {
     if (diskRegionProperties == null) {
       diskRegionProperties = new DiskRegionProperties();
@@ -162,7 +162,7 @@ public class DiskRegionHelperFactory {
     return getRegion(cache, diskRegionProperties, Scope.LOCAL);
   }
 
-  public static Region getSyncHeapLruAndPersistRegion(Cache cache,
+  public static Region<Object, Object> getSyncHeapLruAndPersistRegion(Cache cache,
       DiskRegionProperties diskRegionProperties) {
     if (diskRegionProperties == null) {
       diskRegionProperties = new DiskRegionProperties();
@@ -172,93 +172,4 @@ public class DiskRegionHelperFactory {
     diskRegionProperties.setHeapEviction(true);
     return getRegion(cache, diskRegionProperties, Scope.LOCAL);
   }
-
-  public static Region getAsyncHeapLruAndPersistRegion(Cache cache,
-      DiskRegionProperties diskRegionProperties) {
-    if (diskRegionProperties == null) {
-      diskRegionProperties = new DiskRegionProperties();
-    }
-    diskRegionProperties.setPersistBackup(true);
-    diskRegionProperties.setSynchronous(false);
-    diskRegionProperties.setHeapEviction(true);
-    return getRegion(cache, diskRegionProperties, Scope.LOCAL);
-  }
-
-  public static Region getSyncPersistOnlyRegionInfiniteOplog(Cache cache,
-      DiskRegionProperties diskRegionProperties, String regionName) {
-    if (diskRegionProperties == null) {
-      diskRegionProperties = new DiskRegionProperties();
-    }
-    diskRegionProperties.setMaxOplogSize(0);
-    diskRegionProperties.setRolling(false);
-    diskRegionProperties.setPersistBackup(true);
-    diskRegionProperties.setSynchronous(true);
-    return getRegion(cache, diskRegionProperties, Scope.LOCAL);
-
-  }
-
-  public static Region getAsyncPersistOnlyRegionInfiniteOplog(Cache cache,
-      DiskRegionProperties diskRegionProperties) {
-    if (diskRegionProperties == null) {
-      diskRegionProperties = new DiskRegionProperties();
-    }
-    diskRegionProperties.setMaxOplogSize(0);
-    diskRegionProperties.setRolling(false);
-    diskRegionProperties.setPersistBackup(true);
-    diskRegionProperties.setSynchronous(false);
-    return getRegion(cache, diskRegionProperties, Scope.LOCAL);
-  }
-
-  public static Region getSyncOverFlowOnlyRegionInfiniteOplog(Cache cache,
-      DiskRegionProperties diskRegionProperties) {
-    if (diskRegionProperties == null) {
-      diskRegionProperties = new DiskRegionProperties();
-    }
-    diskRegionProperties.setMaxOplogSize(0);
-    diskRegionProperties.setRolling(false);
-    diskRegionProperties.setPersistBackup(false);
-    diskRegionProperties.setSynchronous(true);
-    diskRegionProperties.setOverflow(true);
-    return getRegion(cache, diskRegionProperties, Scope.LOCAL);
-  }
-
-  public static Region getAsyncOverFlowOnlyRegionInfiniteOplog(Cache cache,
-      DiskRegionProperties diskRegionProperties) {
-    if (diskRegionProperties == null) {
-      diskRegionProperties = new DiskRegionProperties();
-    }
-    diskRegionProperties.setMaxOplogSize(0);
-    diskRegionProperties.setRolling(false);
-    diskRegionProperties.setPersistBackup(false);
-    diskRegionProperties.setSynchronous(false);
-    diskRegionProperties.setOverflow(true);
-    return getRegion(cache, diskRegionProperties, Scope.LOCAL);
-  }
-
-  public static Region getSyncOverFlowAndPersistRegionInfiniteOplog(Cache cache,
-      DiskRegionProperties diskRegionProperties) {
-    if (diskRegionProperties == null) {
-      diskRegionProperties = new DiskRegionProperties();
-    }
-    diskRegionProperties.setMaxOplogSize(0);
-    diskRegionProperties.setRolling(false);
-    diskRegionProperties.setPersistBackup(true);
-    diskRegionProperties.setSynchronous(true);
-    diskRegionProperties.setOverflow(true);
-    return getRegion(cache, diskRegionProperties, Scope.LOCAL);
-  }
-
-  public static Region getAsyncOverFlowAndPersistRegionInfiniteOplog(Cache cache,
-      DiskRegionProperties diskRegionProperties) {
-    if (diskRegionProperties == null) {
-      diskRegionProperties = new DiskRegionProperties();
-    }
-    diskRegionProperties.setMaxOplogSize(0);
-    diskRegionProperties.setRolling(false);
-    diskRegionProperties.setPersistBackup(true);
-    diskRegionProperties.setSynchronous(false);
-    diskRegionProperties.setOverflow(true);
-    return getRegion(cache, diskRegionProperties, Scope.LOCAL);
-  }
-
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/DiskRegionJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/DiskRegionJUnitTest.java
@@ -1415,7 +1415,7 @@ public class DiskRegionJUnitTest extends DiskRegionTestingBase {
 
     for (int i = 0; i < dirs.length; i++) {
       File[] files = dirs[i].listFiles();
-      assertTrue("Files already exists", files.length == 0);
+      assertTrue("Files already exists", files == null || files.length == 0);
     }
     region = DiskRegionHelperFactory.getAsyncOverFlowOnlyRegion(cache, diskProps);
 
@@ -1460,7 +1460,7 @@ public class DiskRegionJUnitTest extends DiskRegionTestingBase {
 
     for (int i = 0; i < dirs.length; i++) {
       File[] files = dirs[i].listFiles();
-      assertTrue("Files already exists", files.length == 0);
+      assertTrue("Files already exists", files == null || files.length == 0);
     }
     region = DiskRegionHelperFactory.getSyncPersistOnlyRegion(cache, diskProps, Scope.LOCAL);
 
@@ -2354,7 +2354,7 @@ public class DiskRegionJUnitTest extends DiskRegionTestingBase {
         }
       }
       assertTrue(i > 1);
-      assertTrue(switchedOplog[0].getOplogFile().delete());
+      assertTrue(switchedOplog[0].getOplogFileForTest().delete());
       region.close();
       // We don't validate the oplogs until we recreate the disk store.
       DiskStoreImpl store = ((LocalRegion) region).getDiskStore();

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/OplogJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/OplogJUnitTest.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.IntStream;
@@ -37,23 +36,20 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import org.apache.geode.StatisticsFactory;
-import org.apache.geode.cache.AttributesFactory;
 import org.apache.geode.cache.CacheWriterException;
-import org.apache.geode.cache.CommitConflictException;
-import org.apache.geode.cache.DataPolicy;
 import org.apache.geode.cache.DiskAccessException;
 import org.apache.geode.cache.DiskStore;
 import org.apache.geode.cache.DiskStoreFactory;
 import org.apache.geode.cache.EntryEvent;
 import org.apache.geode.cache.EntryNotFoundException;
+import org.apache.geode.cache.RegionFactory;
+import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.cache.Scope;
 import org.apache.geode.cache.util.CacheWriterAdapter;
 import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.internal.cache.Oplog.OPLOG_TYPE;
 import org.apache.geode.internal.cache.entries.DiskEntry;
 import org.apache.geode.test.dunit.ThreadUtils;
-import org.apache.geode.test.dunit.Wait;
-import org.apache.geode.test.dunit.WaitCriterion;
 import org.apache.geode.test.junit.categories.FlakyTest;
 import org.apache.geode.test.junit.categories.IntegrationTest;
 
@@ -63,52 +59,15 @@ import org.apache.geode.test.junit.categories.IntegrationTest;
 @Category(IntegrationTest.class)
 public class OplogJUnitTest extends DiskRegionTestingBase {
 
-  boolean proceed = false;
+  private boolean proceed = false;
 
   private final DiskRegionProperties diskProps = new DiskRegionProperties();
 
-  static final int OP_CREATE = 1;
+  private long delta;
 
-  static final int OP_MODIFY = 2;
+  private volatile boolean assertDone = false;
 
-  static final int OP_DEL = 3;
-
-  protected static volatile Random random = new Random();
-
-  protected long expectedOplogSize = Oplog.OPLOG_NEW_ENTRY_BASE_REC_SIZE;
-
-  volatile int totalSuccessfulOperations = 0;
-
-  protected int numCreate = 0;
-
-  protected int numModify = 0;
-
-  protected int numDel = 0;
-
-  protected long delta;
-
-  protected boolean flushOccurredAtleastOnce = false;
-
-  protected volatile boolean assertDone = false;
-
-  boolean failure = false;
-
-  /** The key for entry */
-  static final String KEY = "KEY1";
-
-  /** The initial value for key */
-  static final String OLD_VALUE = "VAL1";
-
-  /** The updated value for key */
-  static final String NEW_VALUE = "VAL2";
-
-  /** The value read from cache using LocalRegion.getValueOnDiskOrBuffer API */
-  static volatile String valueRead = null;
-
-  /** Boolean to indicate test to proceed for validation */
-  static volatile boolean proceedForValidation = false;
-
-  protected volatile Thread rollerThread = null;
+  private boolean failure = false;
 
   @Override
   protected final void postSetUp() throws Exception {
@@ -127,169 +86,65 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
   @Test
   public void testIsBackup() {
 
-    region = DiskRegionHelperFactory.getSyncOverFlowAndPersistRegion(cache, diskProps);
-    if (!((LocalRegion) region).getDiskRegion().isBackup()) {
-      fail("Test persist backup not being correctly set for overflow and persist");
-    }
-    closeDown();
+    InternalRegion overFlowAndPersistRegionRegion =
+        (InternalRegion) DiskRegionHelperFactory.getSyncOverFlowAndPersistRegion(cache, diskProps);
+    assertTrue("Not correctly setup for overflow and persist",
+        overFlowAndPersistRegionRegion.getDiskRegion().isBackup());
+    closeDown(overFlowAndPersistRegionRegion);
 
-    region = DiskRegionHelperFactory.getSyncOverFlowOnlyRegion(cache, diskProps);
-    if (((LocalRegion) region).getDiskRegion().isBackup()) {
-      fail("Test persist backup not being correctly set for overflow only mode");
-    }
-    closeDown();
+    InternalRegion overFlowOnlyRegion =
+        (InternalRegion) DiskRegionHelperFactory.getSyncOverFlowOnlyRegion(cache, diskProps);
+    assertFalse("Not correctly setup for overflow only mode",
+        overFlowOnlyRegion.getDiskRegion().isBackup());
+    closeDown(overFlowOnlyRegion);
 
-    region = DiskRegionHelperFactory.getSyncPersistOnlyRegion(cache, diskProps, Scope.LOCAL);
-    if (!((LocalRegion) region).getDiskRegion().isBackup()) {
-      fail("Test persist backup not being correctly set for persist only");
-    }
-    closeDown();
+    InternalRegion persistOnlyRegion = (InternalRegion) DiskRegionHelperFactory
+        .getSyncPersistOnlyRegion(cache, diskProps, Scope.LOCAL);
+    assertTrue("Not correctly setup for  persist only mode",
+        persistOnlyRegion.getDiskRegion().isBackup());
+    closeDown(persistOnlyRegion);
   }
 
   /*
    * Test method for 'org.apache.geode.internal.cache.Oplog.useSyncWrites()'
    */
   @Test
-  public void testUseSyncWrites() {
-    boolean result;
+  public void testUseSyncWritesWhenSet() {
     diskProps.setSynchronous(true);
-    region = DiskRegionHelperFactory.getSyncOverFlowAndPersistRegion(cache, diskProps);
-    result = ((LocalRegion) region).getAttributes().isDiskSynchronous();
-    if (!result) {
-      fail("Synchronous is false when it is supposed to be true");
-    }
-    closeDown();
+    InternalRegion syncOverFlowAndPersistRegion =
+        (InternalRegion) DiskRegionHelperFactory.getSyncOverFlowAndPersistRegion(cache, diskProps);
+    assertTrue(syncOverFlowAndPersistRegion.getAttributes().isDiskSynchronous());
+    closeDown(syncOverFlowAndPersistRegion);
 
-    region = DiskRegionHelperFactory.getSyncOverFlowOnlyRegion(cache, diskProps);
+    InternalRegion syncOverFlowOnlyRegion =
+        (InternalRegion) DiskRegionHelperFactory.getSyncOverFlowOnlyRegion(cache, diskProps);
+    assertTrue(syncOverFlowOnlyRegion.getAttributes().isDiskSynchronous());
+    closeDown(syncOverFlowOnlyRegion);
 
-    result = ((LocalRegion) region).getAttributes().isDiskSynchronous();
-    if (!result) {
-      fail("Synchronous is false when it is supposed to be true");
-    }
-    closeDown();
-
-    region = DiskRegionHelperFactory.getSyncPersistOnlyRegion(cache, diskProps, Scope.LOCAL);
-
-    result = ((LocalRegion) region).getAttributes().isDiskSynchronous();
-    if (!result) {
-      fail("Synchronous is false when it is supposed to be true");
-    }
-    closeDown();
-
-    diskProps.setSynchronous(false);
-    region = DiskRegionHelperFactory.getAsyncOverFlowAndPersistRegion(cache, diskProps);
-
-    result = ((LocalRegion) region).getAttributes().isDiskSynchronous();
-    if (result) {
-      fail("Synchronous is true when it is supposed to be false");
-    }
-
-    closeDown();
-    region = DiskRegionHelperFactory.getAsyncOverFlowOnlyRegion(cache, diskProps);
-
-    result = ((LocalRegion) region).getAttributes().isDiskSynchronous();
-    if (result) {
-      fail("Synchronous is true when it is supposed to be false");
-    }
-    closeDown();
-
-    region = DiskRegionHelperFactory.getAsyncPersistOnlyRegion(cache, diskProps);
-
-    result = ((LocalRegion) region).getAttributes().isDiskSynchronous();
-    if (result) {
-      fail("Synchronous is true when it is supposed to be false");
-    }
-    closeDown();
+    InternalRegion syncPersistOnlyRegion = (InternalRegion) DiskRegionHelperFactory
+        .getSyncPersistOnlyRegion(cache, diskProps, Scope.LOCAL);
+    assertTrue(syncPersistOnlyRegion.getAttributes().isDiskSynchronous());
+    closeDown(syncPersistOnlyRegion);
   }
 
-  // @todo port testBufferOperations
-  /**
-   * Asif: Tests the correct behaviour of attributes like byte-threshhold, asynch thread wait
-   * time,etc. 'org.apache.geode.internal.cache.Oplog.bufferOperations()'
-   */
-  // @Test
-  // public void testBufferOperations()
-  // {
-  // boolean result;
+  @Test
+  public void testNotUseSyncWritesWhenNotSet() {
+    diskProps.setSynchronous(false);
+    InternalRegion asyncOverFlowAndPersistRegion =
+        (InternalRegion) DiskRegionHelperFactory.getAsyncOverFlowAndPersistRegion(cache, diskProps);
+    assertFalse(asyncOverFlowAndPersistRegion.getAttributes().isDiskSynchronous());
+    closeDown(asyncOverFlowAndPersistRegion);
 
-  // diskProps.setBytesThreshold(0);
-  // region = DiskRegionHelperFactory.getAsyncOverFlowAndPersistRegion(cache,
-  // diskProps);
-  // Oplog.WriterThread writer = ((LocalRegion)region).getDiskRegion()
-  // .getChild().getAsynchWriter();
-  // long waitTime = writer.getAsynchThreadWaitTime();
-  // long buffSize = writer.getBufferSize();
-  // result = waitTime == writer.getDefaultAsynchThreadWaitTime()
-  // && buffSize == 0;
+    InternalRegion asyncOverFlowOnlyRegion =
+        (InternalRegion) DiskRegionHelperFactory.getAsyncOverFlowOnlyRegion(cache, diskProps);
+    assertFalse(asyncOverFlowOnlyRegion.getAttributes().isDiskSynchronous());
+    closeDown(asyncOverFlowOnlyRegion);
 
-  // assertTrue("buffer operations is true when it is supposed to be false",
-  // result);
-
-  // closeDown();
-
-  // region = DiskRegionHelperFactory.getAsyncOverFlowOnlyRegion(cache,
-  // diskProps);
-  // writer = ((LocalRegion)region).getDiskRegion().getChild().getAsynchWriter();
-  // waitTime = writer.getAsynchThreadWaitTime();
-  // buffSize = writer.getBufferSize();
-  // result = waitTime == writer.getDefaultAsynchThreadWaitTime()
-  // && buffSize == 0;
-
-  // assertTrue("buffer operations is true when it is supposed to be false",
-  // result);
-  // closeDown();
-
-  // region = DiskRegionHelperFactory
-  // .getAsyncPersistOnlyRegion(cache, diskProps);
-  // writer = ((LocalRegion)region).getDiskRegion().getChild().getAsynchWriter();
-  // waitTime = writer.getAsynchThreadWaitTime();
-  // buffSize = writer.getBufferSize();
-  // result = waitTime == writer.getDefaultAsynchThreadWaitTime()
-  // && buffSize == 0;
-
-  // assertTrue("buffer operations is true when it is supposed to be false",
-  // result);
-
-  // closeDown();
-
-  // diskProps.setBytesThreshold(100);
-
-  // region = DiskRegionHelperFactory.getAsyncOverFlowAndPersistRegion(cache,
-  // diskProps);
-
-  // writer = ((LocalRegion)region).getDiskRegion().getChild().getAsynchWriter();
-  // waitTime = writer.getAsynchThreadWaitTime();
-  // buffSize = writer.getBufferSize();
-  // result = waitTime <= 0 && buffSize > 0;
-  // assertTrue("bufferoperations is false when it is supposed to be true",
-  // result);
-
-  // closeDown();
-
-  // region = DiskRegionHelperFactory.getAsyncOverFlowOnlyRegion(cache,
-  // diskProps);
-
-  // writer = ((LocalRegion)region).getDiskRegion().getChild().getAsynchWriter();
-  // waitTime = writer.getAsynchThreadWaitTime();
-  // buffSize = writer.getBufferSize();
-  // result = waitTime <= 0 && buffSize > 0;
-  // assertTrue("baufferoperations is false when it is supposed to be true",
-  // result);
-
-  // closeDown();
-
-  // region = DiskRegionHelperFactory
-  // .getAsyncPersistOnlyRegion(cache, diskProps);
-
-  // writer = ((LocalRegion)region).getDiskRegion().getChild().getAsynchWriter();
-  // waitTime = writer.getAsynchThreadWaitTime();
-  // buffSize = writer.getBufferSize();
-  // result = waitTime <= 0 && buffSize > 0;
-  // assertTrue("baufferoperations is false when it is supposed to be true",
-  // result);
-
-  // closeDown();
-  // }
+    InternalRegion asyncPersistOnlyRegion =
+        (InternalRegion) DiskRegionHelperFactory.getAsyncPersistOnlyRegion(cache, diskProps);
+    assertFalse(asyncPersistOnlyRegion.getAttributes().isDiskSynchronous());
+    closeDown(asyncPersistOnlyRegion);
+  }
 
   /**
    * Test method for 'org.apache.geode.internal.cache.Oplog.clear(File)'
@@ -301,7 +156,7 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
     region.clear();
     region.close();
     region = DiskRegionHelperFactory.getSyncOverFlowAndPersistRegion(cache, diskProps);
-    assertTrue(" failed in get OverflowAndPersist ", region.get(new Integer(0)) == null);
+    assertTrue(" failed in get OverflowAndPersist ", region.get(0) == null);
     closeDown();
 
     region = DiskRegionHelperFactory.getSyncOverFlowOnlyRegion(cache, diskProps);
@@ -309,7 +164,7 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
     region.clear();
     region.close();
     region = DiskRegionHelperFactory.getSyncOverFlowOnlyRegion(cache, diskProps);
-    assertTrue(" failed in get OverflowOnly ", region.get(new Integer(0)) == null);
+    assertTrue(" failed in get OverflowOnly ", region.get(0) == null);
     closeDown();
 
     region = DiskRegionHelperFactory.getSyncPersistOnlyRegion(cache, diskProps, Scope.LOCAL);
@@ -317,7 +172,7 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
     region.clear();
     region.close();
     region = DiskRegionHelperFactory.getSyncPersistOnlyRegion(cache, diskProps, Scope.LOCAL);
-    assertTrue(" failed in get PersistOnly ", region.get(new Integer(0)) == null);
+    assertTrue(" failed in get PersistOnly ", region.get(0) == null);
     closeDown();
   }
 
@@ -333,10 +188,8 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
       Oplog oplog = dr.testHook_getChild();
       long id = oplog.getOplogId();
       oplog.close();
-      // lk should still exist since it locks DiskStore not just one oplog
-      // checkIfContainsFile(".lk");
 
-      StatisticsFactory factory = region.getCache().getDistributedSystem();
+      StatisticsFactory factory = cache.getDistributedSystem();
       Oplog newOplog =
           new Oplog(id, dr.getOplogSet(), new DirectoryHolder(factory, dirs[0], 1000, 0));
       dr.getOplogSet().setChild(newOplog);
@@ -347,8 +200,6 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
       region = DiskRegionHelperFactory.getSyncOverFlowOnlyRegion(cache, diskProps);
       DiskRegion dr = ((LocalRegion) region).getDiskRegion();
       dr.testHookCloseAllOverflowOplogs();
-      // lk should still exist since it locks DiskStore not just one oplog
-      // checkIfContainsFile(".lk");
       checkIfContainsFile("OVERFLOW");
       closeDown();
     }
@@ -359,15 +210,22 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
       Oplog oplog = dr.testHook_getChild();
       long id = oplog.getOplogId();
       oplog.close();
-      // lk should still exist since it locks DiskStore not just one oplog
-      // checkIfContainsFile(".lk");
-      StatisticsFactory factory = region.getCache().getDistributedSystem();
+      StatisticsFactory factory = cache.getDistributedSystem();
       Oplog newOplog =
           new Oplog(id, dr.getOplogSet(), new DirectoryHolder(factory, dirs[0], 1000, 2));
       dr.setChild(newOplog);
       closeDown();
     }
 
+  }
+
+  private void closeDown(InternalRegion region) {
+    super.closeDown(region);
+    DiskRegion diskRegion = region != null ? region.getDiskRegion() : null;
+    if (diskRegion != null) {
+      diskRegion.getDiskStore().close();
+      ((InternalCache) cache).removeDiskStore(diskRegion.getDiskStore());
+    }
   }
 
   @Override
@@ -383,14 +241,12 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
     }
   }
 
-
-
-  void checkIfContainsFile(String fileExtension) {
-    for (int i = 0; i < 4; i++) {
-      File[] files = dirs[i].listFiles();
-      for (int j = 0; j < files.length; j++) {
-        if (files[j].getAbsolutePath().endsWith(fileExtension)) {
-          fail("file " + files[j] + " still exists after oplog.close()");
+  private void checkIfContainsFile(String fileExtension) {
+    for (File dir : dirs) {
+      File[] files = dir.listFiles();
+      for (File file : files) {
+        if (file.getAbsolutePath().endsWith(fileExtension)) {
+          fail("file " + file + " still exists after oplog.close()");
         }
       }
     }
@@ -405,42 +261,42 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
     put100Int();
     putTillOverFlow(region);
     try {
-      region.destroy(new Integer(0));
+      region.destroy(0);
     } catch (EntryNotFoundException e1) {
       logWriter.error("Exception occurred", e1);
       fail(" Entry not found when it was expected to be there");
     }
     region.close();
     region = DiskRegionHelperFactory.getSyncOverFlowAndPersistRegion(cache, diskProps);
-    assertTrue(" failed in get OverflowAndPersist ", region.get(new Integer(0)) == null);
+    assertTrue(" failed in get OverflowAndPersist ", region.get(0) == null);
     closeDown();
 
     region = DiskRegionHelperFactory.getSyncOverFlowOnlyRegion(cache, diskProps);
     put100Int();
     putTillOverFlow(region);
     try {
-      region.destroy(new Integer(0));
+      region.destroy(0);
     } catch (EntryNotFoundException e1) {
       logWriter.error("Exception occurred", e1);
       fail(" Entry not found when it was expected to be there");
     }
     region.close();
     region = DiskRegionHelperFactory.getSyncOverFlowOnlyRegion(cache, diskProps);
-    assertTrue(" failed in get OverflowOnly ", region.get(new Integer(0)) == null);
+    assertTrue(" failed in get OverflowOnly ", region.get(0) == null);
 
     closeDown();
 
     region = DiskRegionHelperFactory.getSyncPersistOnlyRegion(cache, diskProps, Scope.LOCAL);
     put100Int();
     try {
-      region.destroy(new Integer(0));
+      region.destroy(0);
     } catch (EntryNotFoundException e1) {
       logWriter.error("Exception occurred", e1);
       fail(" Entry not found when it was expected to be there");
     }
     region.close();
     region = DiskRegionHelperFactory.getSyncPersistOnlyRegion(cache, diskProps, Scope.LOCAL);
-    assertTrue(" failed in get PersistOnly ", region.get(new Integer(0)) == null);
+    assertTrue(" failed in get PersistOnly ", region.get(0) == null);
     closeDown();
 
   }
@@ -452,118 +308,29 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
   public void testRemove() {
     region = DiskRegionHelperFactory.getSyncOverFlowAndPersistRegion(cache, diskProps);
     putTillOverFlow(region);
-    region.remove(new Integer(0));
+    region.remove(0);
     region.close();
     region = DiskRegionHelperFactory.getSyncOverFlowAndPersistRegion(cache, diskProps);
-    assertTrue(" failed in get OverflowAndPersist ", region.get(new Integer(0)) == null);
+    assertTrue(" failed in get OverflowAndPersist ", region.get(0) == null);
     closeDown();
 
     region = DiskRegionHelperFactory.getSyncOverFlowOnlyRegion(cache, diskProps);
     putTillOverFlow(region);
-    region.remove(new Integer(0));
-    assertTrue(" failed in get OverflowOnly ", region.get(new Integer(0)) == null);
+    region.remove(0);
+    assertTrue(" failed in get OverflowOnly ", region.get(0) == null);
     region.close();
     region = DiskRegionHelperFactory.getSyncOverFlowOnlyRegion(cache, diskProps);
     closeDown();
 
     region = DiskRegionHelperFactory.getSyncPersistOnlyRegion(cache, diskProps, Scope.LOCAL);
     put100Int();
-    region.remove(new Integer(0));
-    assertTrue(" failed in get PersistOnly ", region.get(new Integer(0)) == null);
+    region.remove(0);
+    assertTrue(" failed in get PersistOnly ", region.get(0) == null);
     region.close();
     region = DiskRegionHelperFactory.getSyncPersistOnlyRegion(cache, diskProps, Scope.LOCAL);
     closeDown();
 
   }
-
-  // @todo: port testByteBufferCreationForCreateModifyAndDeleteOperation
-  /**
-   * This tests the final ByteBuffer object that gets created for synch/Asynch operation for a
-   * create / modify & Delete operation
-   *
-   */
-  // @Test
-  // public void testByteBufferCreationForCreateModifyAndDeleteOperation()
-  // {
-  // // Asif First create a persist only disk region which is of aysnch
-  // // & switch of OplOg type
-  // diskProps.setMaxOplogSize(1000);
-  // diskProps.setBytesThreshold(500);
-  // diskProps.setPersistBackup(true);
-  // diskProps.setRolling(false);
-  // diskProps.setSynchronous(false);
-  // diskProps.setTimeInterval(-1);
-  // diskProps.setOverflow(false);
-
-  // region = DiskRegionHelperFactory
-  // .getAsyncPersistOnlyRegion(cache, diskProps);
-  // byte[] val = new byte[10];
-  // for (int i = 0; i < 10; ++i) {
-  // val[i] = (byte)i;
-  // }
-  // region.put(new Integer(1), val);
-  // DiskEntry entry = ((DiskEntry)((LocalRegion)region)
-  // .basicGetEntry(new Integer(1)));
-  // long opKey = entry.getDiskId().getKeyId();
-  // // The final position in the Byte Buffer created in Asynch Op should be
-  // int createPos = 2 + 4 + val.length;
-  // if (opKey > Integer.MAX_VALUE) {
-  // createPos += 8;
-  // }
-  // else if (opKey > Short.MAX_VALUE) {
-  // createPos += 4;
-  // }
-  // else {
-  // createPos += 2;
-  // }
-  // createPos += 4;
-  // createPos += EntryEventImpl.serialize(new Integer(1)).length;
-  // DiskRegion dr = ((LocalRegion)region).getDiskRegion();
-  // Oplog.WriterThread writer = dr.getChild().getAsynchWriter();
-  // Oplog.AsyncOp asynchOp = writer
-  // .getAsynchOpForEntryFromPendingFlushMap(entry.getDiskId());
-  // ByteBuffer bb = asynchOp.getByteBuffer();
-  // assertTrue(createPos == bb.position());
-  // assertTrue(bb.limit() == bb.capacity());
-  // byte val1[] = new byte[20];
-  // for (int i = 0; i < 20; ++i) {
-  // val1[i] = (byte)i;
-  // }
-  // region.put(new Integer(1), val1);
-  // bb = writer.getAsynchOpForEntryFromPendingFlushMap(entry.getDiskId())
-  // .getByteBuffer();
-  // createPos += 10;
-  // assertTrue(createPos == bb.position());
-  // assertTrue(bb.limit() == bb.capacity());
-  // byte val2[] = new byte[30];
-  // for (int i = 0; i < 30; ++i) {
-  // val2[i] = (byte)i;
-  // }
-  // region.put(new Integer(1), val2);
-  // bb = writer.getAsynchOpForEntryFromPendingFlushMap(entry.getDiskId())
-  // .getByteBuffer();
-  // createPos += 10;
-  // assertTrue(createPos == bb.position());
-  // assertTrue(bb.limit() == bb.capacity());
-  // long opSizeBeforeCreateRemove = dr.getChild().getOplogSize();
-  // long pendingFlushSize = dr.getChild().getAsynchWriter()
-  // .getCurrentBufferedBytesSize();
-  // region.put(new Integer(2), val2);
-  // DiskEntry entry2 = ((DiskEntry)((LocalRegion)region)
-  // .basicGetEntry(new Integer(2)));
-  // bb = writer.getAsynchOpForEntryFromPendingFlushMap(entry2.getDiskId())
-  // .getByteBuffer();
-  // assertNotNull(bb);
-  // region.remove(new Integer(2));
-  // assertNull(writer
-  // .getAsynchOpForEntryFromPendingFlushMap(entry2.getDiskId()));
-  // assertIndexDetailsEquals(opSizeBeforeCreateRemove, dr.getChild().getOplogSize());
-  // assertIndexDetailsEquals(pendingFlushSize, dr.getChild().getAsynchWriter()
-  // .getCurrentBufferedBytesSize());
-
-  // closeDown();
-
-  // }
 
   /**
    * Tests whether the data is written in the right format on the disk
@@ -584,28 +351,28 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
 
       region = DiskRegionHelperFactory.getSyncPersistOnlyRegion(cache, diskProps, Scope.LOCAL);
       byte[] val = new byte[10];
-      for (int i = 0; i < 10; ++i) {
+      for (int i = 0; i < val.length; ++i) {
         val[i] = (byte) i;
       }
-      region.put(new Integer(1), val);
+      region.put(1, val);
 
-      DiskEntry entry = ((DiskEntry) ((LocalRegion) region).basicGetEntry(new Integer(1)));
+      DiskEntry entry = ((DiskEntry) ((LocalRegion) region).basicGetEntry(1));
       DiskRegion dr = ((LocalRegion) region).getDiskRegion();
 
       val = (byte[]) dr.getNoBuffer(entry.getDiskId());
-      for (int i = 0; i < 10; ++i) {
+      for (int i = 0; i < val.length; ++i) {
         if (val[i] != (byte) i) {
           fail("Test for fault in from disk failed");
         }
       }
       val = (byte[]) DiskStoreImpl.convertBytesAndBitsIntoObject(
           dr.getBytesAndBitsWithoutLock(entry.getDiskId(), true, false));
-      for (int i = 0; i < 10; ++i) {
+      for (int i = 0; i < val.length; ++i) {
         if (val[i] != (byte) i) {
           fail("Test for fault in from disk failed");
         }
       }
-      region.invalidate(new Integer(1));
+      region.invalidate(1);
       assertTrue(dr.getNoBuffer(entry.getDiskId()) == Token.INVALID);
 
     } catch (Exception e) {
@@ -614,60 +381,6 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
     }
     closeDown();
   }
-
-  // @todo port testAsynchWriterTerminationOnSwitch
-  /**
-   * Tests the termination of asynch writer for an Oplog after the switch has been made
-   *
-   */
-  // @Test
-  // public void testAsynchWriterTerminationOnSwitch()
-  // {
-  // // & switch of OplOg type
-  // diskProps.setMaxOplogSize(23);
-  // diskProps.setBytesThreshold(0);
-  // diskProps.setPersistBackup(true);
-  // diskProps.setRolling(false);
-  // diskProps.setSynchronous(false);
-  // diskProps.setTimeInterval(10000);
-  // diskProps.setOverflow(false);
-  // // diskProps.setDiskDirs(new File[]{new File("test1"), new
-  // // File("test2"),
-  // // new File("test3")});
-
-  // region = DiskRegionHelperFactory
-  // .getAsyncPersistOnlyRegion(cache, diskProps);
-  // DiskRegion dr = ((LocalRegion)region).getDiskRegion();
-  // Oplog.WriterThread writer = dr.getChild().getAsynchWriter();
-  // // Populate data just below the switch over threshhold
-  // byte[] val = new byte[5];
-  // for (int i = 0; i < 5; ++i) {
-  // val[i] = (byte)i;
-  // }
-
-  // region.put(new Integer(1), val);
-
-  // DiskEntry entry = ((DiskEntry)((LocalRegion)region)
-  // .basicGetEntry(new Integer(1)));
-  // long opKey = entry.getDiskId().getKeyId();
-  // // The final position in the Byte Buffer created in Asynch Op should be
-  // int createPos = 2 + 4 + val.length;
-  // if (opKey > Integer.MAX_VALUE) {
-  // createPos += 8;
-  // }
-  // else if (opKey > Short.MAX_VALUE) {
-  // createPos += 4;
-  // }
-  // else {
-  // createPos += 2;
-  // }
-  // createPos += 4;
-  // createPos += EntryEventImpl.serialize(new Integer(1)).length;
-  // assertTrue(createPos == 22);
-  // region.put(new Integer(2), val);
-  // DistributedTestCase.join(writer.getThread(), 10 * 1000, null);
-  // closeDown();
-  // }
 
   /**
    * Tests the original ByteBufferPool gets transferred to the new Oplog for synch mode
@@ -682,26 +395,22 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
     diskProps.setSynchronous(true);
     diskProps.setTimeInterval(10000);
     diskProps.setOverflow(false);
-    // diskProps.setDiskDirs(new File[]{new File("test1"), new
-    // File("test2"),
-    // new File("test3")});
 
     region = DiskRegionHelperFactory.getSyncPersistOnlyRegion(cache, diskProps, Scope.LOCAL);
     DiskRegion dr = ((LocalRegion) region).getDiskRegion();
-    // assertNull(dr.getChild().getAsynchWriter());
     // Populate data just below the switch over threshhold
     byte[] val = new byte[5];
-    for (int i = 0; i < 5; ++i) {
+    for (int i = 0; i < val.length; ++i) {
       val[i] = (byte) i;
     }
 
-    region.put(new Integer(1), val);
+    region.put(1, val);
 
-    ((LocalRegion) region).basicGetEntry(new Integer(1));
+    ((LocalRegion) region).basicGetEntry(1);
     Oplog old = dr.testHook_getChild();
     ByteBuffer oldWriteBuf = old.getWriteBuf();
-    region.forceRolling(); // start a new oplog
-    region.put(new Integer(2), val);
+    dr.forceRolling();
+    region.put(2, val);
     Oplog switched = dr.testHook_getChild();
     assertTrue(old != switched);
     assertEquals(dr.getDiskStore().persistentOplogs.getChild(2), switched);
@@ -710,872 +419,6 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
     closeDown();
 
   }
-
-  // @todo port this test if needed. ByteBufferPool code is going to change
-  /**
-   * Tests the ByteBufferPool usage during asynch mode operation & ensuring that GetOperation does
-   * not get corrupted data due to returing of ByetBuffer to the pool. There are 5 pre created pools
-   * in Oplog . Each pool has size of 1. Out of 5 pools , only one pool is used by the test. Thus
-   * there are 4 bytebuffers which will always be free. Thus if the asynch writer had initially 8
-   * byte buffers only 4 will be released
-   *
-   */
-  // @Test
-  // public void testByteBufferPoolUsageForAsynchMode()
-  // {
-  // final int PRCREATED_POOL_NUM = 5;
-  // try {
-  // // Asif First create a persist only disk region which is of aysnch
-  // // & switch of OplOg type
-  // diskProps.setMaxOplogSize(1000);
-  // diskProps.setPersistBackup(true);
-  // diskProps.setRolling(false);
-  // diskProps.setSynchronous(false);
-  // diskProps.setTimeInterval(-1);
-  // diskProps.setOverflow(false);
-  // final int byte_threshold = 500;
-  // diskProps.setBytesThreshold(byte_threshold);
-  // byte[] val = new byte[50];
-  // region = DiskRegionHelperFactory.getAsyncPersistOnlyRegion(cache,
-  // diskProps);
-  // for (int i = 0; i < 50; ++i) {
-  // val[i] = (byte)i;
-  // }
-  // region.put(new Integer(1), val);
-  // final int singleOpSize = evaluateSizeOfOperationForPersist(
-  // new Integer(1), val, ((DiskEntry)((LocalRegion)region)
-  // .basicGetEntry(new Integer(1))).getDiskId(), OP_CREATE);
-
-  // final int loopCount = byte_threshold / singleOpSize + 1;
-  // LocalRegion.ISSUE_CALLBACKS_TO_CACHE_OBSERVER = true;
-
-  // final Thread th = new Thread(new Runnable() {
-  // public void run()
-  // {
-  // takeRecursiveLockOnAllEntries(1);
-  // DiskRegion dr = ((LocalRegion)region).getDiskRegion();
-  // // Asif : Sleep for somemore time
-  // try {
-  // Thread.yield();
-  // Thread.sleep(4000);
-  // }
-  // catch (InterruptedException ie) {
-  // logWriter.error("Exception occurred", ie);
-  // failureCause = "No guarantee of vaildity of result hence failing. Exception = "
-  // + ie;
-  // testFailed = true;
-  // fail("No guarantee of vaildity of result hence failing. Exception = "
-  // + ie);
-  // }
-
-  // // There shoudl beatleast one Pool which has active counts
-  // // as two
-  // Oplog.ByteBufferPool bbp = null;
-  // List pools = dr.getChild().getByteBufferPoolList();
-  // Iterator itr = pools.iterator();
-  // boolean found = false;
-  // while (itr.hasNext()) {
-  // bbp = (Oplog.ByteBufferPool)itr.next();
-  // int len = bbp.getByteBufferHolderList().size();
-  // if (len == (loopCount - (PRCREATED_POOL_NUM - 1))) {
-  // found = true;
-  // break;
-  // }
-  // }
-
-  // if (!found) {
-  // testFailed = true;
-  // failureCause = "Test failed as the Asynch writer did not release ByetBuffer after get
-  // operation";
-  // fail("Test failed as the Asynch writer did not release ByetBuffer after get operation");
-
-  // }
-
-  // }
-
-  // private void takeRecursiveLockOnAllEntries(int key)
-  // {
-  // // Get the DisKID
-  // DiskRegion dr = ((LocalRegion)region).getDiskRegion();
-  // if (key > loopCount) {
-  // // Interrupt the writer thread so as to start releasing
-  // // bytebuffer to pool
-  // //dr.getChild().getAsynchWriter().interrupt();
-  // // Sleep for a while & check the active ByteBuffer
-  // // count.
-  // // It should be two
-  // try {
-  // Thread.yield();
-  // Thread.sleep(5000);
-  // }
-  // catch (InterruptedException ie) {
-  // logWriter.error("Exception occurred", ie);
-  // failureCause = "No guarantee of vaildity of result hence failing. Exception = "
-  // + ie;
-  // testFailed = true;
-  // fail("No guarantee of vaildity of result hence failing. Exception = "
-  // + ie);
-  // }
-  // // Check the number of ByteBuffers in the pool.
-  // List pools = dr.getChild().getByteBufferPoolList();
-  // // There shoudl beatleast one Pool which has active
-  // // counts as two
-  // Oplog.ByteBufferPool bbp = null;
-  // Iterator itr = pools.iterator();
-  // boolean found = true;
-  // int len = -1;
-  // while (itr.hasNext()) {
-  // bbp = (Oplog.ByteBufferPool)itr.next();
-  // len = bbp.getByteBufferHolderList().size();
-  // if (len > 1) {
-  // found = false;
-  // break;
-  // }
-  // }
-  // if (!found) {
-  // failureCause = "Test failed as the Asynch writer released ByteBuffer before get operation. The
-  // length of byte buffer pool is found to be greater than 0. the length is"
-  // + len;
-  // testFailed = true;
-  // fail("Test failed as the Asynch writer released ByteBuffer before get operation");
-  // }
-  // }
-  // else {
-  // DiskEntry entry = ((DiskEntry)((LocalRegion)region)
-  // .basicGetEntry(new Integer(key)));
-  // DiskId id = entry.getDiskId();
-
-  // synchronized (id) {
-  // takeRecursiveLockOnAllEntries(++key);
-
-  // }
-  // }
-  // }
-
-  // });
-
-  // CacheObserver old = CacheObserverHolder
-  // .setInstance(new CacheObserverAdapter() {
-  // public void afterWritingBytes()
-  // {
-  // // Asif Start a Thread & do a get in the thread without
-  // // releasing the
-  // // lock on dik ID
-  // th.start();
-  // synchronized (OplogJUnitTest.this) {
-  // OplogJUnitTest.this.proceed = true;
-  // OplogJUnitTest.this.notify();
-  // }
-  // try {
-  // th.join(30 * 1000); // Yes, really use Thread#join here
-  // fail("never interrupted");
-  // }
-  // catch (InterruptedException ie) {
-  // // OK. Expected the interrupted Exception
-  // if (debug)
-  // System.out.println("Got the right exception");
-  // }
-
-  // }
-  // });
-
-  // int totalOpSize = singleOpSize;
-  // for (int j = 1; j < loopCount; ++j) {
-  // region.put(new Integer(j + 1), val);
-  // totalOpSize += evaluateSizeOfOperationForPersist(new Integer(j + 1),
-  // val, ((DiskEntry)((LocalRegion)region).basicGetEntry(new Integer(
-  // j + 1))).getDiskId(), OP_CREATE);
-  // }
-  // assertTrue(totalOpSize - byte_threshold <= singleOpSize);
-
-  // if (!proceed) {
-  // synchronized (this) {
-  // if (!proceed) {
-  // this.wait(25000);
-  // if (!proceed) {
-  // fail("Test failed as no callback recieved from asynch writer");
-  // }
-  // }
-  // }
-  // }
-  // DistributedTestCase.join(th, 30 * 1000, null);
-  // CacheObserverHolder.setInstance(old);
-  // }
-  // catch (Exception e) {
-  // logWriter.error("Exception occurred", e);
-  // fail(e.toString());
-  // }
-  // assertFalse(failureCause, testFailed);
-  // LocalRegion.ISSUE_CALLBACKS_TO_CACHE_OBSERVER = false;
-  // closeDown();
-  // }
-
-  // give the new oplog record format it is too hard for the test to calculate
-  // the expected size
-  // /**
-  // */
-  // @Test
-  // public void testSynchModeConcurrentOperations()
-  // {
-  // final Map map = new HashMap();
-  // diskProps.setMaxOplogSize(1024 * 1024 * 20);
-  // diskProps.setPersistBackup(true);
-  // diskProps.setRolling(false);
-  // diskProps.setSynchronous(true);
-  // diskProps.setOverflow(false);
-  // final int THREAD_COUNT = 90;
-
-  // final byte[] val = new byte[50];
-  // region = DiskRegionHelperFactory.getSyncPersistOnlyRegion(cache, diskProps);
-  // for (int i = 1; i < 101; ++i) {
-  // map.put(new Integer(i), new Integer(i));
-  // }
-  // Thread[] threads = new Thread[THREAD_COUNT];
-  // for (int i = 0; i < THREAD_COUNT; ++i) {
-  // threads[i] = new Thread(new Runnable() {
-
-  // public void run()
-  // {
-  // int sizeOfOp = 0;
-  // DiskId id = null;
-  // for (int j = 0; j < 50; ++j) {
-  // int keyNum = random.nextInt(10) + 1;
-  // Integer key = new Integer(keyNum);
-  // Integer intgr = (Integer)map.get(key);
-  // try {
-  // synchronized (intgr) {
-
-  // region.create(key, val);
-  // DiskEntry entry = ((DiskEntry)((LocalRegion)region)
-  // .basicGetEntry(key));
-  // id = entry.getDiskId();
-
-  // }
-  // sizeOfOp = OplogJUnitTest.evaluateSizeOfOperationForPersist(key,
-  // val, id, OP_CREATE);
-  // synchronized (OplogJUnitTest.this) {
-  // OplogJUnitTest.this.expectedOplogSize += sizeOfOp;
-  // ++OplogJUnitTest.this.totalSuccessfulOperations;
-  // ++OplogJUnitTest.this.numCreate;
-  // }
-  // }
-  // catch (EntryExistsException eee) {
-  // if (OplogJUnitTest.this.logWriter.finerEnabled()) {
-  // OplogJUnitTest.this.logWriter
-  // .finer("The entry already exists so this operation will not increase the size of oplog");
-  // }
-  // }
-  // try {
-  // boolean isUpdate = false;
-  // synchronized (intgr) {
-  // isUpdate = region.containsKey(key);
-  // region.put(key, val);
-  // DiskEntry entry = ((DiskEntry)((LocalRegion)region)
-  // .basicGetEntry(key));
-  // id = entry.getDiskId();
-  // }
-  // sizeOfOp = OplogJUnitTest.evaluateSizeOfOperationForPersist(key,
-  // val, id, (isUpdate ? OP_MODIFY : OP_CREATE));
-  // synchronized (OplogJUnitTest.this) {
-  // OplogJUnitTest.this.expectedOplogSize += sizeOfOp;
-  // ++OplogJUnitTest.this.totalSuccessfulOperations;
-  // if (!isUpdate) {
-  // ++OplogJUnitTest.this.numCreate;
-  // }
-  // else {
-  // ++OplogJUnitTest.this.numModify;
-  // }
-  // }
-  // }
-  // catch (EntryDestroyedException ede) {
-  // if (OplogJUnitTest.this.logWriter.finerEnabled()) {
-  // OplogJUnitTest.this.logWriter
-  // .finer("The entry already exists so this operation will not increase the size of oplog");
-  // }
-  // }
-
-  // boolean deleted = false;
-  // synchronized (intgr) {
-  // if (region.containsKey(key)) {
-  // DiskEntry entry = ((DiskEntry)((LocalRegion)region)
-  // .basicGetEntry(key));
-  // id = entry.getDiskId();
-  // region.remove(key);
-  // deleted = true;
-  // }
-
-  // }
-  // if (deleted) {
-  // sizeOfOp = OplogJUnitTest.evaluateSizeOfOperationForPersist(key,
-  // null, id, OP_DEL);
-  // synchronized (OplogJUnitTest.this) {
-  // OplogJUnitTest.this.expectedOplogSize += sizeOfOp;
-  // ++OplogJUnitTest.this.totalSuccessfulOperations;
-  // ++OplogJUnitTest.this.numDel;
-
-  // }
-  // }
-
-  // }
-
-  // }
-
-  // });
-  // threads[i].start();
-  // }
-
-  // for (int i = 0; i < THREAD_COUNT; ++i) {
-  // DistributedTestCase.join(threads[i], 30 * 1000, null);
-  // }
-  // long inMemOplogSize = 0;
-  // File opFile = null;
-  // try {
-  // opFile = ((LocalRegion)region).getDiskRegion().getChild().getOplogFile();
-  // }
-  // catch (Exception e) {
-  // logWriter
-  // .error(
-  // "Exception in synching data present in the buffers of RandomAccessFile of Oplog, to the disk",
-  // e);
-  // fail("Test failed because synching of data present in buffer of RandomAccesFile ");
-  // }
-  // synchronized (opFile) {
-  // inMemOplogSize = ((LocalRegion)region).getDiskRegion().getChild().getOplogSize();
-  // }
-
-  // long actFileSize = 0;
-  // try {
-
-  // actFileSize = ((LocalRegion)region).getDiskRegion().getChild().testGetOplogFileLength();
-  // }
-  // catch (IOException e) {
-
-  // fail("exception not expected" + e);
-  // fail("The test failed as the oplog could not eb synched to disk");
-  // }
-  // assertIndexDetailsEquals((this.numCreate + this.numDel + this.numModify),
-  // this.totalSuccessfulOperations);
-  // assertTrue(" The expected oplog size =" + inMemOplogSize
-  // + " Actual Oplog file size =" + actFileSize,
-  // inMemOplogSize == actFileSize);
-  // assertTrue(" The expected oplog size =" + this.expectedOplogSize
-  // + " In memeory Oplog size =" + inMemOplogSize,
-  // this.expectedOplogSize == inMemOplogSize);
-  // closeDown();
-
-  // }
-
-  static int evaluateSizeOfOperationForPersist(Object key, byte[] val, DiskId id,
-      int OperationType) {
-    int size = 1;
-    long opKey = id.getKeyId();
-    switch (OperationType) {
-      case OP_CREATE:
-        size += 4 + EntryEventImpl.serialize(key).length + 1 + 4 + val.length;
-        break;
-
-      case OP_MODIFY:
-        // @todo how do a know if the key needed to be serialized?
-        size += 1 + 4 + val.length + Oplog.bytesNeeded(opKey);
-        break;
-      case OP_DEL:
-        size += Oplog.bytesNeeded(opKey);
-        break;
-    }
-    return size;
-
-  }
-
-  // give the new oplog record format it is too hard for the test to calculate
-  // the expected size
-  // /**
-  // * Tests whether the switching of Oplog happens correctly without size
-  // * violation in case of concurrent region operations for synch mode.
-  // */
-  // @Test
-  // public void testSwitchingForConcurrentSynchedOperations()
-  // {
-  // final Map map = new HashMap();
-  // final int MAX_OPLOG_SIZE = 500;
-  // diskProps.setMaxOplogSize(MAX_OPLOG_SIZE);
-  // diskProps.setPersistBackup(true);
-  // diskProps.setRolling(false);
-  // diskProps.setSynchronous(true);
-  // diskProps.setOverflow(false);
-  // final int THREAD_COUNT = 5;
-  // final byte[] val = new byte[50];
-  // final byte[] uval = new byte[1];
-  // region = DiskRegionHelperFactory.getSyncPersistOnlyRegion(cache, diskProps);
-  // for (int i = 1; i < 101; ++i) {
-  // map.put(new Integer(i), new Integer(i));
-  // }
-  // final AI uniqueCtr = CFactory.createAI();
-  // Thread[] threads = new Thread[THREAD_COUNT];
-  // for (int i = 0; i < THREAD_COUNT; ++i) {
-  // threads[i] = new Thread(new Runnable() {
-  // public void run()
-  // {
-  // int sizeOfOp = 0;
-  // DiskId id = null;
-  // for (int j = 0; j < 50; ++j) {
-  // int keyNum = random.nextInt(10) + 1;
-  // Integer key = new Integer(keyNum);
-  // Integer intgr = (Integer)map.get(key);
-  // try {
-  // String uniqueKey = "UK" + uniqueCtr.incrementAndGet();
-  // // since the files for "empty" oplogs now get cleaned up early
-  // // create a unique key to keep this oplog alive.
-  // region.create(uniqueKey, uval);
-  // DiskEntry uentry = ((DiskEntry)((LocalRegion)region)
-  // .basicGetEntry(uniqueKey));
-  // sizeOfOp = OplogJUnitTest.evaluateSizeOfOperationForPersist(uniqueKey, uval,
-  // uentry.getDiskId(), OP_CREATE);
-  // synchronized (OplogJUnitTest.this) {
-  // OplogJUnitTest.this.expectedOplogSize += sizeOfOp;
-  // ++OplogJUnitTest.this.totalSuccessfulOperations;
-  // ++OplogJUnitTest.this.numCreate;
-  // }
-
-  // synchronized (intgr) {
-
-  // region.create(key, val);
-  // DiskEntry entry = ((DiskEntry)((LocalRegion)region)
-  // .basicGetEntry(key));
-  // id = entry.getDiskId();
-
-  // }
-  // sizeOfOp = OplogJUnitTest.evaluateSizeOfOperationForPersist(key,
-  // val, id, OP_CREATE);
-
-  // synchronized (OplogJUnitTest.this) {
-  // OplogJUnitTest.this.expectedOplogSize += sizeOfOp;
-  // ++OplogJUnitTest.this.totalSuccessfulOperations;
-  // ++OplogJUnitTest.this.numCreate;
-  // }
-  // }
-  // catch (EntryExistsException eee) {
-  // if (logWriter.finerEnabled()) {
-  // logWriter
-  // .finer("The entry already exists so this operation will not increase the size of oplog");
-  // }
-  // }
-  // try {
-  // boolean isUpdate = false;
-  // synchronized (intgr) {
-  // isUpdate = region.containsKey(key) && region.get(key) != null
-  // && region.get(key) != Token.DESTROYED;
-  // region.put(key, val);
-  // DiskEntry entry = ((DiskEntry)((LocalRegion)region)
-  // .basicGetEntry(key));
-  // id = entry.getDiskId();
-  // }
-  // sizeOfOp = OplogJUnitTest.evaluateSizeOfOperationForPersist(key,
-  // val, id, (isUpdate ? OP_MODIFY : OP_CREATE));
-  // synchronized (OplogJUnitTest.this) {
-  // OplogJUnitTest.this.expectedOplogSize += sizeOfOp;
-  // ++OplogJUnitTest.this.totalSuccessfulOperations;
-  // if (!isUpdate) {
-  // ++OplogJUnitTest.this.numCreate;
-  // }
-  // else {
-  // ++OplogJUnitTest.this.numModify;
-  // }
-  // }
-  // }
-  // catch (EntryDestroyedException ede) {
-  // if (logWriter.finerEnabled()) {
-  // logWriter
-  // .finer("The entry already exists so this operation will not increase the size of oplog");
-  // }
-  // }
-
-  // boolean deleted = false;
-  // synchronized (intgr) {
-
-  // if (region.containsKey(key) && region.get(key) != null
-  // && region.get(key) != Token.DESTROYED) {
-  // DiskEntry entry = ((DiskEntry)((LocalRegion)region)
-  // .basicGetEntry(key));
-  // id = entry.getDiskId();
-  // region.remove(key);
-  // deleted = true;
-  // }
-
-  // }
-  // if (deleted) {
-  // sizeOfOp = OplogJUnitTest.evaluateSizeOfOperationForPersist(key,
-  // null, id, OP_DEL);
-  // synchronized (OplogJUnitTest.this) {
-  // OplogJUnitTest.this.expectedOplogSize += sizeOfOp;
-  // ++OplogJUnitTest.this.totalSuccessfulOperations;
-  // ++OplogJUnitTest.this.numDel;
-
-  // }
-  // }
-
-  // }
-
-  // }
-
-  // });
-  // threads[i].start();
-  // }
-
-  // for (int i = 0; i < THREAD_COUNT; ++i) {
-  // DistributedTestCase.join(threads[i], 30 * 1000, null);
-  // }
-
-  // long currentOplogID = ((LocalRegion)region).getDiskRegion().getChild()
-  // .getOplogId();
-  // assertTrue(
-  // " Switching did not happen, increase the iterations to insert more data ",
-  // currentOplogID > 1);
-  // long inMemOplogSize = 0;
-
-  // for (int j = 1; j <= currentOplogID; ++j) {
-
-  // Oplog oplog = ((LocalRegion)region).getDiskRegion().getChild(j);
-  // // if (j < currentOplogID) {
-  // // // oplogs are now closed to save memory and file descriptors
-  // // // once they are no longer needed
-  // // assertIndexDetailsEquals(null, oplog);
-  // // } else {
-  // inMemOplogSize += oplog.getOplogSize();
-  // logWriter.info(" Oplog size="+ oplog.getOplogSize() + " Max Oplog size
-  // acceptable="+MAX_OPLOG_SIZE );
-  // assertTrue(
-  // " The max Oplog Size limit is violated when taken the inmemory oplog size",
-  // oplog.getOplogSize() <= MAX_OPLOG_SIZE);
-
-  // // File opFile = null;
-  // try {
-  // oplog.getOplogFile();
-  // }
-  // catch (Exception e) {
-  // logWriter
-  // .error(
-  // "Exception in synching data present in the buffers of RandomAccessFile of Oplog, to the disk",
-  // e);
-  // fail("Test failed because synching of data present in buffer of RandomAccesFile ");
-  // }
-
-  // assertTrue(
-  // " The max Oplog Size limit is violated when taken the actual file size",
-  // oplog.getActualFileLength() <= MAX_OPLOG_SIZE);
-  // assertIndexDetailsEquals(oplog.getOplogSize(), oplog.getActualFileLength());
-  // // }
-  // }
-
-  // inMemOplogSize +=
-  // ((LocalRegion)region).getDiskRegion().getDiskStore().undeletedOplogSize.get();
-
-  // assertTrue(" The sum of all oplogs size as expected ="
-  // + this.expectedOplogSize + " Actual sizes of all oplogs ="
-  // + inMemOplogSize, this.expectedOplogSize == inMemOplogSize);
-
-  // assertIndexDetailsEquals((this.numCreate + this.numDel + this.numModify),
-  // this.totalSuccessfulOperations);
-  // closeDown();
-
-  // }
-
-  // give the new oplog record format it is too hard for the test to calculate
-  // the expected size
-  // /**
-  // * Tests whether the switching of Oplog happens correctly without size
-  // * violation in case of concurrent region operations for asynch mode.
-  // *
-  // */
-  // @Test
-  // public void testSwitchingForConcurrentASynchedOperations()
-  // {
-  // final int MAX_OPLOG_SIZE = 500;
-  // diskProps.setMaxOplogSize(MAX_OPLOG_SIZE);
-  // diskProps.setPersistBackup(true);
-  // diskProps.setRolling(false);
-  // diskProps.setSynchronous(false);
-  // diskProps.setOverflow(false);
-  // diskProps.setBytesThreshold(100);
-  // final int THREAD_COUNT = 40;
-  // final byte[] val = new byte[50];
-  // region = DiskRegionHelperFactory
-  // .getAsyncPersistOnlyRegion(cache, diskProps);
-
-  // Thread[] threads = new Thread[THREAD_COUNT];
-  // for (int i = 0; i < THREAD_COUNT; ++i) {
-  // final int threadNum = (i + 1);
-  // threads[i] = new Thread(new Runnable() {
-  // public void run()
-  // {
-  // int sizeOfOp = 0;
-  // DiskId id = null;
-  // try {
-  // region.create(new Integer(threadNum), val);
-  // }
-
-  // catch (EntryExistsException e) {
-  // e.printStackTrace();
-  // testFailed = true;
-  // failureCause = "Entry existed with key =" + threadNum;
-  // fail("Entry existed with key =" + threadNum);
-  // }
-  // DiskEntry entry = ((DiskEntry)((LocalRegion)region)
-  // .basicGetEntry(new Integer(threadNum)));
-  // id = entry.getDiskId();
-
-  // sizeOfOp = OplogJUnitTest.evaluateSizeOfOperationForPersist(
-  // new Integer(threadNum), val, id, OP_CREATE);
-  // synchronized (OplogJUnitTest.this) {
-  // OplogJUnitTest.this.expectedOplogSize += sizeOfOp;
-  // ++OplogJUnitTest.this.totalSuccessfulOperations;
-  // ++OplogJUnitTest.this.numCreate;
-  // }
-
-  // }
-
-  // });
-
-  // threads[i].start();
-  // }
-
-  // for (int i = 0; i < THREAD_COUNT; ++i) {
-  // DistributedTestCase.join(threads[i], 30 * 1000, null);
-  // }
-
-  // long currentOplogID = ((LocalRegion)region).getDiskRegion().getChild()
-  // .getOplogId();
-  // assertTrue(
-  // " Switching did not happen, increase the iterations to insert more data ",
-  // currentOplogID > 1);
-  // if (debug)
-  // System.out.print("Total number of oplogs created = " + currentOplogID);
-  // long inMemOplogSize = 0;
-
-  // for (int j = 1; j <= currentOplogID; ++j) {
-  // Oplog oplog = ((LocalRegion)region).getDiskRegion().getChild(j);
-  // // if (j < currentOplogID) {
-  // // // oplogs are now closed to save memory and file descriptors
-  // // // once they are no longer needed
-  // // assertIndexDetailsEquals(null, oplog);
-  // // } else {
-  // inMemOplogSize += oplog.getOplogSize();
-  // //oplog.forceFlush();
-  // assertTrue(
-  // " The max Oplog Size limit is violated when taken the inmemory oplog size",
-  // oplog.getOplogSize() <= MAX_OPLOG_SIZE);
-  // // File opFile = null;
-  // try {
-  // oplog.getOplogFile();
-  // }
-  // catch (Exception e) {
-  // logWriter
-  // .error(
-  // "Exception in synching data present in the buffers of RandomAccessFile of Oplog, to the disk",
-  // e);
-  // fail("Test failed because synching of data present in buffer of RandomAccesFile ");
-  // }
-  // assertTrue(
-  // " The max Oplog Size limit is violated when taken the actual file size",
-  // oplog.getActualFileLength() <= MAX_OPLOG_SIZE);
-  // assertIndexDetailsEquals(oplog.getOplogSize(), oplog.getActualFileLength());
-  // // }
-  // }
-
-  // inMemOplogSize +=
-  // ((LocalRegion)region).getDiskRegion().getDiskStore().undeletedOplogSize.get();
-
-  // assertTrue(" The sum of all oplogs size as expected ="
-  // + this.expectedOplogSize + " Actual sizes of all oplogs ="
-  // + inMemOplogSize, this.expectedOplogSize == inMemOplogSize);
-  // assertIndexDetailsEquals((this.numCreate + this.numDel + this.numModify),
-  // this.totalSuccessfulOperations);
-  // assertFalse(failureCause, testFailed);
-  // closeDown();
-
-  // }
-
-  // /**
-  // */
-  // @Test
-  // public void testAsyncWriterTerminationAfterSwitch()
-  // {
-  // final int MAX_OPLOG_SIZE = 500;
-  // diskProps.setMaxOplogSize(MAX_OPLOG_SIZE);
-  // diskProps.setPersistBackup(true);
-  // diskProps.setRolling(false);
-  // diskProps.setSynchronous(false);
-  // diskProps.setOverflow(false);
-  // diskProps.setBytesThreshold(100);
-  // final int THREAD_COUNT = 40;
-  // final byte[] val = new byte[50];
-  // region = DiskRegionHelperFactory
-  // .getAsyncPersistOnlyRegion(cache, diskProps);
-
-  // Thread[] threads = new Thread[THREAD_COUNT];
-  // for (int i = 0; i < THREAD_COUNT; ++i) {
-  // final int threadNum = (i + 1);
-  // threads[i] = new Thread(new Runnable() {
-  // public void run()
-  // {
-  // int sizeOfOp = 0;
-  // DiskId id = null;
-  // try {
-  // region.create(new Integer(threadNum), val);
-  // }
-
-  // catch (EntryExistsException e) {
-  // testFailed = true;
-  // failureCause = "Entry existed with key =" + threadNum;
-  // fail("Entry existed with key =" + threadNum);
-  // }
-  // DiskEntry entry = ((DiskEntry)((LocalRegion)region)
-  // .basicGetEntry(new Integer(threadNum)));
-  // id = entry.getDiskId();
-
-  // sizeOfOp = OplogJUnitTest.evaluateSizeOfOperationForPersist(
-  // new Integer(threadNum), val, id, OP_CREATE);
-  // synchronized (OplogJUnitTest.this) {
-  // OplogJUnitTest.this.expectedOplogSize += sizeOfOp;
-  // ++OplogJUnitTest.this.totalSuccessfulOperations;
-  // ++OplogJUnitTest.this.numCreate;
-  // }
-
-  // }
-
-  // });
-
-  // threads[i].start();
-  // }
-
-  // for (int i = 0; i < THREAD_COUNT; ++i) {
-  // DistributedTestCase.join(threads[i], 30 * 1000, null);
-  // }
-
-  // long currentOplogID = ((LocalRegion)region).getDiskRegion().getChild()
-  // .getOplogId();
-  // assertTrue(
-  // " Switching did not happen, increase the iterations to insert more data ",
-  // currentOplogID > 1);
-
-  // for (int j = 1; j < currentOplogID; ++j) {
-  // Oplog oplog = ((LocalRegion)region).getDiskRegion().getChild(j);
-  // // if (oplog != null) {
-  // // DistributedTestCase.join(oplog.getAsynchWriter().getThread(), 10 * 1000, null);
-  // // }
-  // }
-  // assertFalse(failureCause, testFailed);
-  // closeDown();
-
-  // }
-
-  // /**
-  // */
-  // @Test
-  // public void testMultipleByteBuffersASynchOperations()
-  // {
-  // final int MAX_OPLOG_SIZE = 100000;
-  // diskProps.setMaxOplogSize(MAX_OPLOG_SIZE);
-  // diskProps.setPersistBackup(true);
-  // diskProps.setRolling(false);
-  // diskProps.setSynchronous(false);
-  // diskProps.setOverflow(false);
-  // diskProps.setBytesThreshold(1000);
-  // Oplog.testSetMaxByteBufferSize(100);
-  // LocalRegion.ISSUE_CALLBACKS_TO_CACHE_OBSERVER = true;
-  // final int OP_COUNT = 40;
-  // final byte[] val = new byte[50];
-  // region = DiskRegionHelperFactory
-  // .getAsyncPersistOnlyRegion(cache, diskProps);
-  // CacheObserver old = CacheObserverHolder
-  // .setInstance(new CacheObserverAdapter() {
-  // public void afterWritingBytes()
-  // {
-
-  // synchronized (OplogJUnitTest.this) {
-  // flushOccurredAtleastOnce = true;
-  // OplogJUnitTest.this.notify();
-  // }
-
-  // }
-  // });
-
-  // int sizeOfOp = 0;
-  // DiskId id = null;
-  // for (int i = 0; i < OP_COUNT; ++i) {
-  // try {
-  // region.create(new Integer(i), val);
-  // DiskEntry entry = ((DiskEntry)((LocalRegion)region)
-  // .basicGetEntry(new Integer(i)));
-  // id = entry.getDiskId();
-  // sizeOfOp += evaluateSizeOfOperationForPersist(new Integer(i), val, id,
-  // OP_CREATE);
-
-  // }
-
-  // catch (EntryExistsException e) {
-  // fail("Entry existed with key =" + i);
-  // }
-  // }
-  // Oplog currOplog = ((LocalRegion)region).getDiskRegion().getChild();
-  // long currentOplogID = currOplog.getOplogId();
-  // long expectedSize = currOplog.getOplogSize();
-  // // Ensure that now switching has happned during the operations
-  // assertIndexDetailsEquals(1, currentOplogID);
-  // assertTrue(
-  // "The number of operations did not cause asynch writer to run atleast once , the expected file
-  // size = "
-  // + expectedSize, expectedSize > 1000);
-  // if (!flushOccurredAtleastOnce) {
-  // synchronized (this) {
-  // if (!flushOccurredAtleastOnce) {
-  // try {
-  // this.wait(20000);
-  // }
-  // catch (InterruptedException e) {
-  // fail("No guarantee as flushed occure deven once.Exception=" + e);
-  // }
-  // }
-  // }
-  // }
-  // if (!flushOccurredAtleastOnce) {
-  // fail("In the wait duration , flush did not occur even once. Try increasing the wait time");
-  // }
-  // long actualFileSize = 0L;
-
-  // try {
-  // actualFileSize = currOplog.getFileChannel().position();
-  // }
-  // catch (IOException e) {
-  // fail(e.toString());
-  // }
-
-  // assertTrue(
-  // "The number of operations did not cause asynch writer to run atleast once as the actual file
-  // size = "
-  // + actualFileSize, actualFileSize >= 1000);
-  // //currOplog.forceFlush();
-  // // File opFile = null;
-  // try {
-  // currOplog.getOplogFile();
-  // }
-  // catch (Exception e) {
-  // logWriter
-  // .error(
-  // "Exception in synching data present in the buffers of RandomAccessFile of Oplog, to the disk",
-  // e);
-  // fail("Test failed because synching of data present in buffer of RandomAccesFile ");
-  // }
-  // actualFileSize = currOplog.getActualFileLength();
-  // assertTrue(
-  // " The expected Oplog Size not equal to the actual file size. Expected size="
-  // + expectedSize + " actual size = " + actualFileSize,
-  // expectedSize == actualFileSize);
-  // Oplog.testSetMaxByteBufferSize(Integer.MAX_VALUE);
-  // LocalRegion.ISSUE_CALLBACKS_TO_CACHE_OBSERVER = false;
-  // CacheObserverHolder.setInstance(old);
-  // closeDown();
-
-  // }
 
   /**
    * Tests the bug which arises in case of asynch mode during oplog switching caused by conflation
@@ -1599,11 +442,7 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
     final CacheObserver old = CacheObserverHolder.setInstance(new CacheObserverAdapter() {
       @Override
       public void afterConflation(ByteBuffer orig, ByteBuffer conflated) {
-        Thread th = new Thread(new Runnable() {
-          public void run() {
-            region.put("2", new byte[75]);
-          }
-        });
+        Thread th = new Thread(() -> region.put("2", new byte[75]));
         assertNull(conflated);
         th.start();
         ThreadUtils.join(th, 30 * 1000);
@@ -1695,10 +534,6 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
       Object val_11 = ((LocalRegion) region).getValueOnDisk("11");
       assertEquals(val_11, Token.LOCAL_INVALID);
 
-    } catch (Exception e) {
-      logWriter.error("Exception occurred", e);
-      // fail("The test failed due to exception = " + e);
-      throw e;
     } finally {
       closeDown();
     }
@@ -1907,7 +742,6 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
       final int MAX_OPLOG_SIZE = 2000;
       diskProps.setMaxOplogSize(MAX_OPLOG_SIZE);
       diskProps.setPersistBackup(true);
-      // diskProps.setRolling(true);
       diskProps.setSynchronous(true);
       diskProps.setOverflow(false);
       diskProps.setDiskDirsAndSizes(new File[] {dirs[0]}, new int[] {1400});
@@ -1969,11 +803,7 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
       region.put("key1", val);
       region.put("key2", val);
       region.put("key3", val);
-      final Thread th = new Thread(new Runnable() {
-        public void run() {
-          region.remove("key1");
-        }
-      });
+      final Thread th = new Thread(() -> region.remove("key1"));
       // main thread acquires the write lock
       ((LocalRegion) region).getDiskRegion().acquireWriteLock();
       try {
@@ -1997,146 +827,12 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
   }
 
   /**
-   * Tests the various configurable parameters used by the ByteBufferPool . The behaviour of
-   * parameters is based on the mode of DiskRegion ( synch or asynch) . Pls refer to the class
-   * documentation ( Oplog.ByteBufferPool) for the exact behaviour of the class
-   *
-   */
-  // @Test
-  // public void testByteBufferPoolParameters()
-  // {
-  // // If the mode is asynch , the ByteBuffer obtained should e non direct else
-  // // direct
-  // final int MAX_OPLOG_SIZE = 500;
-  // diskProps.setMaxOplogSize(MAX_OPLOG_SIZE);
-  // diskProps.setPersistBackup(true);
-  // diskProps.setRolling(false);
-  // diskProps.setSynchronous(true);
-  // diskProps.setOverflow(false);
-  // region = DiskRegionHelperFactory.getSyncPersistOnlyRegion(cache, diskProps);
-  // List bbPools = ((LocalRegion)region).getDiskRegion().getChild()
-  // .getByteBufferPoolList();
-  // ByteBuffer bb = ((Oplog.ByteBufferPool)bbPools.get(1)).getBufferFromPool();
-  // assertTrue(" ByteBuffer is not of type direct", bb.isDirect());
-  // region.destroyRegion();
-  // diskProps.setMaxOplogSize(MAX_OPLOG_SIZE);
-  // diskProps.setPersistBackup(true);
-  // diskProps.setRolling(false);
-  // diskProps.setSynchronous(false);
-  // diskProps.setOverflow(false);
-  // region = DiskRegionHelperFactory
-  // .getAsyncPersistOnlyRegion(cache, diskProps);
-  // bbPools = ((LocalRegion)region).getDiskRegion().getChild()
-  // .getByteBufferPoolList();
-  // bb = ((Oplog.ByteBufferPool)bbPools.get(1)).getBufferFromPool();
-  // assertTrue(" ByteBuffer is not of type direct", bb.isDirect());
-  // region.close();
-  // // Test max pool limit & wait time ( valid only in synch mode).
-  // diskProps.setSynchronous(true);
-  // diskProps.setRegionName("testRegion");
-  // System.setProperty("/testRegion_MAX_POOL_SIZE", "1");
-
-  // System.setProperty("/testRegion_WAIT_TIME", "4000");
-  // region = DiskRegionHelperFactory.getSyncPersistOnlyRegion(cache, diskProps);
-  // bbPools = ((LocalRegion)region).getDiskRegion().getChild()
-  // .getByteBufferPoolList();
-  // bb = ((Oplog.ByteBufferPool)bbPools.get(1)).getBufferFromPool();
-  // assertTrue("Since the Pool has one Entry , it should be direct", bb
-  // .isDirect());
-
-  // long t1 = System.currentTimeMillis();
-  // bb = ((Oplog.ByteBufferPool)bbPools.get(1)).getBufferFromPool();
-  // long t2 = System.currentTimeMillis();
-  // assertTrue(
-  // "Since the Pool should have been exhausted hence non direct byte buffer should have been
-  // returned",
-  // !bb.isDirect());
-  // assertTrue("The wait time for ByteBuffer pool was not respected ",
-  // (t2 - t1) > 3000);
-  // region.close();
-  // // // In case of asynch mode , the upper limit should not have been imposed
-  // // System.setProperty("/testRegion_MAX_POOL_SIZE", "1");
-  // // System.setProperty("/testRegion_WAIT_TIME", "5000");
-  // // diskProps.setSynchronous(false);
-  // // diskProps.setRegionName("testRegion");
-  // // region = DiskRegionHelperFactory
-  // // .getAsyncPersistOnlyRegion(cache, diskProps);
-  // // bbPools = ((LocalRegion)region).getDiskRegion().getChild()
-  // // .getByteBufferPoolList();
-  // // bb = ((Oplog.ByteBufferPool)bbPools.get(1)).getBufferFromPool();
-  // // t1 = System.currentTimeMillis();
-  // // bb = ((Oplog.ByteBufferPool)bbPools.get(1)).getBufferFromPool();
-  // // t2 = System.currentTimeMillis();
-  // // assertTrue(
-  // // "There should not have been any wait time " + (t2-t1) + " for ByteBuffer pool ",
-  // // (t2 - t1) / 1000 < 3);
-  // // region.close();
-  // System.setProperty("/testRegion_MAX_POOL_SIZE", "2");
-  // System.setProperty("/testRegion_WAIT_TIME", "5000");
-  // diskProps.setSynchronous(true);
-  // diskProps.setRegionName("testRegion");
-  // region = DiskRegionHelperFactory.getSyncPersistOnlyRegion(cache, diskProps);
-  // bbPools = ((LocalRegion)region).getDiskRegion().getChild()
-  // .getByteBufferPoolList();
-  // Oplog.ByteBufferPool pool = (Oplog.ByteBufferPool)bbPools.get(1);
-  // ByteBuffer bb1 = pool.getBufferFromPool();
-  // ByteBuffer bb2 = pool.getBufferFromPool();
-  // assertIndexDetailsEquals(2, pool.getTotalBuffers());
-  // assertIndexDetailsEquals(2, pool.getBuffersInUse());
-  // ((LocalRegion)region).getDiskRegion().getChild().releaseBuffer(bb1);
-  // ((LocalRegion)region).getDiskRegion().getChild().releaseBuffer(bb2);
-  // assertIndexDetailsEquals(0, pool.getBuffersInUse());
-  // region.close();
-
-  // System.setProperty("/testRegion_MAX_POOL_SIZE", "1");
-  // System.setProperty("/testRegion_WAIT_TIME", "1000");
-  // diskProps.setSynchronous(true);
-  // diskProps.setRegionName("testRegion");
-  // region = DiskRegionHelperFactory.getSyncPersistOnlyRegion(cache, diskProps);
-  // bbPools = ((LocalRegion)region).getDiskRegion().getChild()
-  // .getByteBufferPoolList();
-  // pool = (Oplog.ByteBufferPool)bbPools.get(1);
-  // bb1 = pool.getBufferFromPool();
-  // bb2 = pool.getBufferFromPool();
-  // assertIndexDetailsEquals(1, pool.getTotalBuffers());
-  // assertIndexDetailsEquals(1, pool.getBuffersInUse());
-  // ((LocalRegion)region).getDiskRegion().getChild().releaseBuffer(bb1);
-  // ((LocalRegion)region).getDiskRegion().getChild().releaseBuffer(bb2);
-  // assertIndexDetailsEquals(0, pool.getBuffersInUse());
-  // closeDown();
-
-  // }
-
-  /**
-   * Tests the ByteBuffer Pool operations for release of ByteBuffers in case the objects being put
-   * vary in size & hence use ByteBuffer Pools present at different indexes
-   *
-   */
-  // @Test
-  // public void testByteBufferPoolReleaseBugTest()
-  // {
-
-  // diskProps.setPersistBackup(true);
-  // diskProps.setRolling(false);
-  // diskProps.setSynchronous(true);
-  // diskProps.setOverflow(false);
-  // System.setProperty("/testRegion_UNIT_BUFF_SIZE", "100");
-  // System.setProperty("/testRegion_UNIT_BUFF_SIZE", "100");
-  // System.setProperty("gemfire.log-level", getGemFireLogLevel());
-  // region = DiskRegionHelperFactory.getSyncPersistOnlyRegion(cache, diskProps);
-  // region.put("key1", new byte[900]);
-  // region.put("key1", new byte[700]);
-  // closeDown();
-
-  // }
-
-  /**
    * Tests if buffer size & time are not set , the asynch writer gets awakened on time basis of
    * default 1 second
    *
    */
   @Test
-  public void testAsynchWriterAttribBehaviour1() {
+  public void testAsynchWriterAttribBehaviour1() throws Exception {
     DiskStoreFactory dsf = cache.createDiskStoreFactory();
     ((DiskStoreFactoryImpl) dsf).setMaxOplogSizeInBytes(10000);
     File dir = new File("testingDirectoryDefault");
@@ -2144,20 +840,14 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
     dir.deleteOnExit();
     File[] dirs = {dir};
     dsf.setDiskDirs(dirs);
-    AttributesFactory factory = new AttributesFactory();
+    RegionFactory<Object, Object> factory =
+        cache.createRegionFactory(RegionShortcut.REPLICATE_PERSISTENT);
     final long t1 = System.currentTimeMillis();
     DiskStore ds = dsf.create("test");
     factory.setDiskSynchronous(false);
     factory.setDiskStoreName(ds.getName());
-    factory.setDataPolicy(DataPolicy.PERSISTENT_REPLICATE);
     factory.setScope(Scope.LOCAL);
-    try {
-      region = cache.createVMRegion("test", factory.createRegionAttributes());
-    } catch (Exception e1) {
-      logWriter.error("Test failed due to exception", e1);
-      fail("Test failed due to exception " + e1);
-
-    }
+    region = factory.create("test");
 
     LocalRegion.ISSUE_CALLBACKS_TO_CACHE_OBSERVER = true;
     CacheObserver old = CacheObserverHolder.setInstance(
@@ -2179,13 +869,7 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
     region.put("key1", "111111111111");
     synchronized (this) {
       if (LocalRegion.ISSUE_CALLBACKS_TO_CACHE_OBSERVER) {
-        try {
-          this.wait(10000);
-        } catch (InterruptedException e) {
-          logWriter.error("Test failed due to exception", e);
-          fail("Test failed due to exception " + e);
-
-        }
+        this.wait(10000);
         assertFalse(LocalRegion.ISSUE_CALLBACKS_TO_CACHE_OBSERVER);
       }
     }
@@ -2201,7 +885,7 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
    */
   @Ignore("TODO:DARREL_DISABLE: test is disabled")
   @Test
-  public void testAsynchWriterAttribBehaviour2() {
+  public void testAsynchWriterAttribBehaviour2() throws Exception {
     DiskStoreFactory dsf = cache.createDiskStoreFactory();
     ((DiskStoreFactoryImpl) dsf).setMaxOplogSizeInBytes(10000);
     dsf.setQueueSize(2);
@@ -2210,19 +894,13 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
     dir.deleteOnExit();
     File[] dirs = {dir};
     dsf.setDiskDirs(dirs);
-    AttributesFactory factory = new AttributesFactory();
+    RegionFactory<Object, Object> factory =
+        cache.createRegionFactory(RegionShortcut.REPLICATE_PERSISTENT);
     DiskStore ds = dsf.create("test");
     factory.setDiskSynchronous(false);
     factory.setDiskStoreName(ds.getName());
-    factory.setDataPolicy(DataPolicy.PERSISTENT_REPLICATE);
     factory.setScope(Scope.LOCAL);
-    try {
-      region = cache.createVMRegion("test", factory.createRegionAttributes());
-    } catch (Exception e1) {
-      logWriter.error("Test failed due to exception", e1);
-      fail("Test failed due to exception " + e1);
-
-    }
+    region = factory.create("test");
 
     LocalRegion.ISSUE_CALLBACKS_TO_CACHE_OBSERVER = true;
     CacheObserver old = CacheObserverHolder.setInstance(
@@ -2239,23 +917,13 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
         });
 
     region.put("key1", new byte[25]);
-    try {
-      Thread.sleep(1000);
-    } catch (InterruptedException e) {
-      logWriter.error("Test failed due to exception", e);
-      fail("Test failed due to exception " + e);
-    }
+    Thread.sleep(1000);
     assertTrue(LocalRegion.ISSUE_CALLBACKS_TO_CACHE_OBSERVER);
     region.put("key2", new byte[25]);
     synchronized (this) {
       if (LocalRegion.ISSUE_CALLBACKS_TO_CACHE_OBSERVER) {
-        try {
-          OplogJUnitTest.this.wait(10000);
-          assertFalse(LocalRegion.ISSUE_CALLBACKS_TO_CACHE_OBSERVER);
-        } catch (InterruptedException e2) {
-          logWriter.error("Test failed due to exception", e2);
-          fail("Test failed due to exception " + e2);
-        }
+        OplogJUnitTest.this.wait(10000);
+        assertFalse(LocalRegion.ISSUE_CALLBACKS_TO_CACHE_OBSERVER);
       }
     }
     CacheObserverHolder.setInstance(old);
@@ -2268,7 +936,7 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
    *
    */
   @Test
-  public void testAsynchWriterAttribBehaviour3() {
+  public void testAsynchWriterAttribBehaviour3() throws Exception {
     DiskStoreFactory dsf = cache.createDiskStoreFactory();
     ((DiskStoreFactoryImpl) dsf).setMaxOplogSizeInBytes(500);
     dsf.setQueueSize(0);
@@ -2278,19 +946,13 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
     dir.deleteOnExit();
     File[] dirs = {dir};
     dsf.setDiskDirs(dirs);
-    AttributesFactory factory = new AttributesFactory();
+    RegionFactory<Object, Object> factory =
+        cache.createRegionFactory(RegionShortcut.REPLICATE_PERSISTENT);
     DiskStore ds = dsf.create("test");
     factory.setDiskSynchronous(false);
     factory.setDiskStoreName(ds.getName());
-    factory.setDataPolicy(DataPolicy.PERSISTENT_REPLICATE);
     factory.setScope(Scope.LOCAL);
-    try {
-      region = cache.createVMRegion("test", factory.createRegionAttributes());
-    } catch (Exception e1) {
-      logWriter.error("Test failed due to exception", e1);
-      fail("Test failed due to exception " + e1);
-
-    }
+    region = factory.create("test");
 
     LocalRegion.ISSUE_CALLBACKS_TO_CACHE_OBSERVER = true;
     CacheObserver old = CacheObserverHolder.setInstance(
@@ -2305,27 +967,19 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
             }
           }
         });
-    try {
-      region.put("key1", new byte[100]);
-      region.put("key2", new byte[100]);
-      region.put("key3", new byte[100]);
-      region.put("key4", new byte[100]);
-      region.put("key5", new byte[100]);
-      Thread.sleep(1000);
-      assertTrue(LocalRegion.ISSUE_CALLBACKS_TO_CACHE_OBSERVER);
-    } catch (Exception e) {
-      logWriter.error("Test failed due to exception", e);
-      fail("Test failed due to exception " + e);
-    }
-    region.forceRolling();
+    region.put("key1", new byte[100]);
+    region.put("key2", new byte[100]);
+    region.put("key3", new byte[100]);
+    region.put("key4", new byte[100]);
+    region.put("key5", new byte[100]);
+    Thread.sleep(1000);
+    assertTrue(LocalRegion.ISSUE_CALLBACKS_TO_CACHE_OBSERVER);
+
+
+    ((LocalRegion) region).getDiskRegion().forceRolling();
     synchronized (this) {
       if (LocalRegion.ISSUE_CALLBACKS_TO_CACHE_OBSERVER) {
-        try {
-          OplogJUnitTest.this.wait(10000);
-        } catch (InterruptedException e2) {
-          logWriter.error("Test failed due to exception", e2);
-          fail("Test failed due to exception " + e2);
-        }
+        OplogJUnitTest.this.wait(10000);
       }
     }
     assertFalse(LocalRegion.ISSUE_CALLBACKS_TO_CACHE_OBSERVER);
@@ -2334,62 +988,11 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
   }
 
   /**
-   * Tests if the preblowing of a file with size greater than the disk space available so that
-   * preblowing results in IOException , is able to recover without problem
-   *
-   */
-  // Now we preallocate spaces for if files and also crfs and drfs. So the below test is not valid
-  // any more. See revision: r42359 and r42320. So disabling this test.
-  @Ignore("TODO: test is disabled")
-  @Test
-  public void testPreblowErrorCondition() {
-    DiskStoreFactory dsf = cache.createDiskStoreFactory();
-    ((DiskStoreFactoryImpl) dsf).setMaxOplogSizeInBytes(100000000L * 1024L * 1024L * 1024L);
-    dsf.setAutoCompact(false);
-    File dir = new File("testingDirectoryDefault");
-    dir.mkdir();
-    dir.deleteOnExit();
-    File[] dirs = {dir};
-    int size[] = new int[] {Integer.MAX_VALUE};
-    dsf.setDiskDirsAndSizes(dirs, size);
-    AttributesFactory factory = new AttributesFactory();
-    logWriter.info("<ExpectedException action=add>" + "Could not pregrow" + "</ExpectedException>");
-    try {
-      DiskStore ds = dsf.create("test");
-      factory.setDiskStoreName(ds.getName());
-      factory.setDiskSynchronous(true);
-      factory.setDataPolicy(DataPolicy.PERSISTENT_REPLICATE);
-      factory.setScope(Scope.LOCAL);
-      try {
-        region = cache.createVMRegion("test", factory.createRegionAttributes());
-      } catch (Exception e1) {
-        logWriter.error("Test failed due to exception", e1);
-        fail("Test failed due to exception " + e1);
-
-      }
-      region.put("key1", new byte[900]);
-      byte[] val = null;
-      try {
-        val = (byte[]) ((LocalRegion) region).getValueOnDisk("key1");
-      } catch (Exception e) {
-        // TODO Auto-generated catch block
-        e.printStackTrace();
-        fail(e.toString());
-      }
-      assertTrue(val.length == 900);
-    } finally {
-      logWriter
-          .info("<ExpectedException action=remove>" + "Could not pregrow" + "</ExpectedException>");
-    }
-    closeDown();
-  }
-
-  /**
    * Tests if the byte buffer pool in asynch mode tries to contain the pool size
    *
    */
   @Test
-  public void testByteBufferPoolContainment() {
+  public void testByteBufferPoolContainment() throws Exception {
 
     diskProps.setPersistBackup(true);
     diskProps.setRolling(false);
@@ -2421,104 +1024,13 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
     for (int i = 0; i < 10; ++i) {
       region.put("" + i, val);
     }
-    try {
-      synchronized (OplogJUnitTest.this) {
-        if (LocalRegion.ISSUE_CALLBACKS_TO_CACHE_OBSERVER) {
-          OplogJUnitTest.this.wait(9000);
-          assertEquals(false, LocalRegion.ISSUE_CALLBACKS_TO_CACHE_OBSERVER);
-        }
+    synchronized (OplogJUnitTest.this) {
+      if (LocalRegion.ISSUE_CALLBACKS_TO_CACHE_OBSERVER) {
+        OplogJUnitTest.this.wait(9000);
+        assertEquals(false, LocalRegion.ISSUE_CALLBACKS_TO_CACHE_OBSERVER);
       }
-
-    } catch (InterruptedException ie) {
-      fail("interrupted");
     }
-    // ((LocalRegion)region).getDiskRegion().getChild().forceFlush();
-    // int x = ((LocalRegion)region).getDiskRegion().getChild().getAsynchWriter()
-    // .getApproxFreeBuffers();
-    // assertIndexDetailsEquals(10, x);
   }
-
-  // we no longer have a pendingFlushMap
-  // /**
-  // * This test does the following: <br>
-  // * 1)Create a diskRegion with async mode and byte-threshold as 25 bytes. <br>
-  // * 2)Put an entry into the region such that the async-buffer is just over 25
-  // * bytes and the writer-thread is invoked. <br>
-  // * 3)Using CacheObserver.afterSwitchingWriteAndFlushMaps callback, perform a
-  // * put on the same key just after the async writer thread swaps the
-  // * pendingFlushMap and pendingWriteMap for flushing. <br>
-  // * 4)Using CacheObserver.afterWritingBytes, read the value for key
-  // * (LocalRegion.getValueOnDiskOrBuffer) just after the async writer thread has
-  // * flushed to the disk. <br>
-  // * 5) Verify that the value read in step3 is same as the latest value. This
-  // * will ensure that the flushBufferToggle flag is functioning as expected ( It
-  // * prevents the writer thread from setting the oplog-offset in diskId if that
-  // * particular entry has been updated by a put-thread while the
-  // * async-writer-thread is flushing that entry.)
-  // *
-  // * @throws Exception
-  // */
-  // @Test
-  // public void testFlushBufferToggleFlag() throws Exception
-  // {
-  // final int MAX_OPLOG_SIZE = 100000;
-  // diskProps.setMaxOplogSize(MAX_OPLOG_SIZE);
-  // diskProps.setPersistBackup(true);
-  // diskProps.setRolling(false);
-  // diskProps.setSynchronous(false);
-  // diskProps.setOverflow(false);
-  // diskProps.setBytesThreshold(25);
-  // LocalRegion.ISSUE_CALLBACKS_TO_CACHE_OBSERVER = true;
-
-  // region = DiskRegionHelperFactory
-  // .getAsyncPersistOnlyRegion(cache, diskProps);
-  // CacheObserver old = CacheObserverHolder
-  // .setInstance(new CacheObserverAdapter() {
-  // public void afterWritingBytes()
-  // {
-  // LocalRegion localregion = (LocalRegion)region;
-  // try {
-  // valueRead = (String)localregion.getValueOnDiskOrBuffer(KEY);
-  // synchronized (OplogJUnitTest.class) {
-  // proceedForValidation = true;
-  // OplogJUnitTest.class.notify();
-  // }
-  // }
-  // catch (EntryNotFoundException e) {
-  // e.printStackTrace();
-  // }
-  // }
-
-  // public void afterSwitchingWriteAndFlushMaps()
-  // {
-  // region.put(KEY, NEW_VALUE);
-  // }
-
-  // });
-
-  // region.put(KEY, OLD_VALUE);
-
-  // if (!proceedForValidation) {
-  // synchronized (OplogJUnitTest.class) {
-  // if (!proceedForValidation) {
-  // try {
-  // OplogJUnitTest.class.wait(9000);
-  // assertIndexDetailsEquals(true, proceedForValidation);
-  // }
-  // catch (InterruptedException e) {
-  // fail("interrupted");
-  // }
-  // }
-  // }
-  // }
-
-  // cache.getLogger().info("valueRead : " + valueRead);
-  // assertIndexDetailsEquals("valueRead is stale, doesnt match with latest PUT", NEW_VALUE,
-  // valueRead);
-  // LocalRegion.ISSUE_CALLBACKS_TO_CACHE_OBSERVER = false;
-  // CacheObserverHolder.setInstance(old);
-  // closeDown();
-  // }
 
   /**
    * tests async stats are correctly updated
@@ -2536,7 +1048,9 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
         .timeout(10, TimeUnit.SECONDS).until(() -> assertEquals(100, dss.getQueueSize()));
 
     assertEquals(0, dss.getFlushes());
-    region.writeToDisk();
+
+    DiskRegion diskRegion = ((LocalRegion) region).getDiskRegion();
+    diskRegion.getDiskStore().flush();
     Awaitility.await().pollInterval(10, TimeUnit.MILLISECONDS).pollDelay(10, TimeUnit.MILLISECONDS)
         .timeout(10, TimeUnit.SECONDS).until(() -> assertEquals(0, dss.getQueueSize()));
     Awaitility.await().pollInterval(10, TimeUnit.MILLISECONDS).pollDelay(10, TimeUnit.MILLISECONDS)
@@ -2544,7 +1058,7 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
     put100Int();
     Awaitility.await().pollInterval(10, TimeUnit.MILLISECONDS).pollDelay(10, TimeUnit.MILLISECONDS)
         .timeout(10, TimeUnit.SECONDS).until(() -> assertEquals(100, dss.getQueueSize()));
-    region.writeToDisk();
+    diskRegion.getDiskStore().flush();
     Awaitility.await().pollInterval(10, TimeUnit.MILLISECONDS).pollDelay(10, TimeUnit.MILLISECONDS)
         .timeout(10, TimeUnit.SECONDS).until(() -> assertEquals(0, dss.getQueueSize()));
     Awaitility.await().pollInterval(10, TimeUnit.MILLISECONDS).pollDelay(10, TimeUnit.MILLISECONDS)
@@ -2612,62 +1126,58 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
    */
   @Test
   public void testEntryAlreadyWrittenIsCorrectlyUnmarkedForOverflowOnly() throws Exception {
-    try {
-      diskProps.setPersistBackup(false);
-      diskProps.setRolling(false);
-      diskProps.setMaxOplogSize(1024 * 1024);
-      diskProps.setSynchronous(true);
-      diskProps.setOverflow(true);
-      diskProps.setBytesThreshold(10000);
-      diskProps.setTimeInterval(0);
-      diskProps.setOverFlowCapacity(1);
-      region = DiskRegionHelperFactory.getSyncOverFlowOnlyRegion(cache, diskProps);
-      final byte[] val = new byte[1000];
-      region.put("1", val);
-      region.put("2", val);
-      // "1" should now be on disk
-      region.get("1");
-      // "2" should now be on disk
-      DiskEntry entry1 = (DiskEntry) ((LocalRegion) region).basicGetEntry("1");
-      DiskId did1 = entry1.getDiskId();
-      DiskId.isInstanceofOverflowIntOplogOffsetDiskId(did1);
-      assertTrue(!did1.needsToBeWritten());
-      region.put("1", "3");
-      assertTrue(did1.needsToBeWritten());
-      region.put("2", val);
-      DiskEntry entry2 = (DiskEntry) ((LocalRegion) region).basicGetEntry("2");
-      DiskId did2 = entry2.getDiskId();
-      assertTrue(!did2.needsToBeWritten() || !did1.needsToBeWritten());
-      tearDown();
-      setUp();
-      diskProps.setPersistBackup(false);
-      diskProps.setRolling(false);
-      long opsize = Integer.MAX_VALUE;
-      opsize += 100L;
-      diskProps.setMaxOplogSize(opsize);
-      diskProps.setSynchronous(true);
-      diskProps.setOverflow(true);
-      diskProps.setBytesThreshold(10000);
-      diskProps.setTimeInterval(0);
-      diskProps.setOverFlowCapacity(1);
-      region = DiskRegionHelperFactory.getSyncOverFlowOnlyRegion(cache, diskProps);
-      region.put("1", val);
-      region.put("2", val);
-      region.get("1");
-      entry1 = (DiskEntry) ((LocalRegion) region).basicGetEntry("1");
-      did1 = entry1.getDiskId();
-      DiskId.isInstanceofOverflowOnlyWithLongOffset(did1);
-      assertTrue(!did1.needsToBeWritten());
-      region.put("1", "3");
-      assertTrue(did1.needsToBeWritten());
-      region.put("2", "3");
-      did2 = entry2.getDiskId();
-      assertTrue(!did2.needsToBeWritten() || !did1.needsToBeWritten());
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail(e.toString());
-    }
+    diskProps.setPersistBackup(false);
+    diskProps.setRolling(false);
+    diskProps.setMaxOplogSize(1024 * 1024);
+    diskProps.setSynchronous(true);
+    diskProps.setOverflow(true);
+    diskProps.setBytesThreshold(10000);
+    diskProps.setTimeInterval(0);
+    diskProps.setOverFlowCapacity(1);
+    region = DiskRegionHelperFactory.getSyncOverFlowOnlyRegion(cache, diskProps);
+    final byte[] val = new byte[1000];
+    region.put("1", val);
+    region.put("2", val);
+    // "1" should now be on disk
+    region.get("1");
+    // "2" should now be on disk
+    DiskEntry entry1 = (DiskEntry) ((LocalRegion) region).basicGetEntry("1");
+    DiskId did1 = entry1.getDiskId();
+    DiskId.isInstanceofOverflowIntOplogOffsetDiskId(did1);
+    assertTrue(!did1.needsToBeWritten());
+    region.put("1", "3");
+    assertTrue(did1.needsToBeWritten());
+    region.put("2", val);
+    DiskEntry entry2 = (DiskEntry) ((LocalRegion) region).basicGetEntry("2");
+    DiskId did2 = entry2.getDiskId();
+    assertTrue(!did2.needsToBeWritten() || !did1.needsToBeWritten());
+    tearDown();
+    setUp();
+    diskProps.setPersistBackup(false);
+    diskProps.setRolling(false);
+    long opsize = Integer.MAX_VALUE;
+    opsize += 100L;
+    diskProps.setMaxOplogSize(opsize);
+    diskProps.setSynchronous(true);
+    diskProps.setOverflow(true);
+    diskProps.setBytesThreshold(10000);
+    diskProps.setTimeInterval(0);
+    diskProps.setOverFlowCapacity(1);
+    region = DiskRegionHelperFactory.getSyncOverFlowOnlyRegion(cache, diskProps);
+    region.put("1", val);
+    region.put("2", val);
+    region.get("1");
+    entry1 = (DiskEntry) ((LocalRegion) region).basicGetEntry("1");
+    did1 = entry1.getDiskId();
+    DiskId.isInstanceofOverflowOnlyWithLongOffset(did1);
+    assertTrue(!did1.needsToBeWritten());
+    region.put("1", "3");
+    assertTrue(did1.needsToBeWritten());
+    region.put("2", "3");
+    did2 = entry2.getDiskId();
+    assertTrue(!did2.needsToBeWritten() || !did1.needsToBeWritten());
   }
+
 
   /**
    * An persistent or overflow with persistence entry which is evicted to disk, will have the flag
@@ -2713,17 +1223,11 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
     final byte[] val = new byte[1000];
     DiskRegion dr = ((LocalRegion) region).getDiskRegion();
     region.put("1", val);
-    // region.get("1");
     region.put("2", val);
-    // region.get("2");
     region.put("3", val);
-    // region.get("3");
     DiskEntry entry1 = (DiskEntry) ((LocalRegion) region).basicGetEntry("1");
-    // DiskId did1 = entry1.getDiskId();
     DiskEntry entry2 = (DiskEntry) ((LocalRegion) region).basicGetEntry("2");
-    // DiskId did2 = entry2.getDiskId();
     DiskEntry entry3 = (DiskEntry) ((LocalRegion) region).basicGetEntry("3");
-    // DiskId did3 = entry3.getDiskId();
     assertNull(entry2.getDiskId());
     assertNull(entry3.getDiskId());
     assertNotNull(entry1.getDiskId());
@@ -2778,17 +1282,11 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
     final byte[] val = new byte[1000];
     DiskRegion dr = ((LocalRegion) region).getDiskRegion();
     region.put("1", val);
-    // region.get("1");
     region.put("2", val);
-    // region.get("2");
     region.put("3", val);
-    // region.get("3");
     DiskEntry entry1 = (DiskEntry) ((LocalRegion) region).basicGetEntry("1");
-    // DiskId did1 = entry1.getDiskId();
     DiskEntry entry2 = (DiskEntry) ((LocalRegion) region).basicGetEntry("2");
-    // DiskId did2 = entry2.getDiskId();
     DiskEntry entry3 = (DiskEntry) ((LocalRegion) region).basicGetEntry("3");
-    // DiskId did3 = entry3.getDiskId();
     assertNotNull(entry2.getDiskId());
     assertNotNull(entry3.getDiskId());
     assertNotNull(entry1.getDiskId());
@@ -2804,11 +1302,8 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
     region = DiskRegionHelperFactory.getSyncOverFlowAndPersistRegion(cache, diskProps);
     dr = ((LocalRegion) region).getDiskRegion();
     entry1 = (DiskEntry) ((LocalRegion) region).basicGetEntry("1");
-    // did1 = entry1.getDiskId();
     entry2 = (DiskEntry) ((LocalRegion) region).basicGetEntry("2");
-    // did2 = entry2.getDiskId();
     entry3 = (DiskEntry) ((LocalRegion) region).basicGetEntry("3");
-    // did3 = entry3.getDiskId();
 
     assertNotNull(entry2.getDiskId());
     assertNotNull(entry3.getDiskId());
@@ -2821,111 +1316,7 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
     assertNotNull(DiskEntry.Helper.getValueOnDiskOrBuffer(entry3, dr, (LocalRegion) region));
     assertNotNull(DiskEntry.Helper.getValueOnDiskOrBuffer(entry2, dr, (LocalRegion) region));
     assertNotNull(DiskEntry.Helper.getValueOnDiskOrBuffer(entry1, dr, (LocalRegion) region));
-
   }
-
-  // @todo this test is failing for some reason. Does it need to be fixed?
-  /**
-   * Bug test to reproduce the bug 37261. The scenario which this test depicts is not actually the
-   * cause of Bug 37261. This test validates the case where a synch persist only entry1 is created
-   * in Oplog1. A put operation on entry2 causes the switch , but before Oplog1 is rolled , the
-   * entry1 is modified so that it references Oplog2. Thus in effect roller will skip rolling entry1
-   * when rolling Oplog1.Now entry1 is deleted in Oplog2 and then a rolling happens. There should
-   * not be any error
-   */
-  // @Test
-  // public void testBug37261_1()
-  // {
-  // CacheObserver old = CacheObserverHolder.getInstance();
-  // try {
-  // // Create a persist only region with rolling true
-  // diskProps.setPersistBackup(true);
-  // diskProps.setRolling(true);
-  // diskProps.setCompactionThreshold(100);
-  // diskProps.setMaxOplogSize(1024);
-  // diskProps.setSynchronous(true);
-  // this.proceed = false;
-  // region = DiskRegionHelperFactory.getSyncPersistOnlyRegion(cache,
-  // diskProps);
-  // // create an entry 1 in oplog1,
-  // region.put("key1", new byte[800]);
-
-  // // Asif the second put will cause a switch to oplog 2 & also cause the
-  // // oplog1
-  // // to be submitted to the roller
-  // LocalRegion.ISSUE_CALLBACKS_TO_CACHE_OBSERVER = true;
-  // CacheObserverHolder.setInstance(new CacheObserverAdapter() {
-  // public void beforeGoingToCompact()
-  // {
-  // // modify entry 1 so that it points to the new switched oplog
-  // Thread th = new Thread(new Runnable() {
-  // public void run()
-  // {
-  // region.put("key1", new byte[400]);
-  // }
-  // });
-  // th.start();
-  // try {
-  // DistributedTestCase.join(th, 30 * 1000, null);
-  // }
-  // catch (Exception e) {
-  // e.printStackTrace();
-  // failureCause = e.toString();
-  // failure = true;
-  // }
-  // }
-
-  // public void afterHavingCompacted()
-  // {
-  // synchronized (OplogJUnitTest.this) {
-  // rollerThread = Thread.currentThread();
-  // OplogJUnitTest.this.notify();
-  // OplogJUnitTest.this.proceed = true;
-  // }
-  // }
-  // });
-  // region.put("key2", new byte[300]);
-  // synchronized (this) {
-  // if (!this.proceed) {
-  // this.wait(15000);
-  // assertTrue(this.proceed);
-  // }
-  // }
-  // this.proceed = false;
-  // // Asif Delete the 1st entry
-  // region.destroy("key1");
-
-  // CacheObserverHolder.setInstance(new CacheObserverAdapter() {
-  // public void afterHavingCompacted()
-  // {
-  // synchronized (OplogJUnitTest.this) {
-  // OplogJUnitTest.this.notify();
-  // OplogJUnitTest.this.proceed = true;
-  // }
-  // }
-  // });
-  // // Coz another switch and wait till rolling done
-  // region.put("key2", new byte[900]);
-
-  // synchronized (this) {
-  // if (!this.proceed) {
-  // this.wait(15000);
-  // assertFalse(this.proceed);
-  // }
-  // }
-  // // Check if the roller is stil alive
-  // assertTrue(rollerThread.isAlive());
-  // }
-  // catch (Exception e) {
-  // e.printStackTrace();
-  // fail("Test failed du toe xception" + e);
-  // }
-  // finally {
-  // CacheObserverHolder.setInstance(old);
-  // LocalRegion.ISSUE_CALLBACKS_TO_CACHE_OBSERVER = false;
-  // }
-
-  // }
 
   /**
    * Tests the condition when a 'put' is in progress and concurrent 'clear' and 'put'(on the same
@@ -2935,7 +1326,7 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
    * This put should not proceed. Also, Region creation after closing should not give an exception.
    */
   @Test
-  public void testPutClearPut() {
+  public void testPutClearPut() throws Exception {
     try {
       // Create a persist only region with rolling true
       diskProps.setPersistBackup(true);
@@ -2944,16 +1335,14 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
       diskProps.setSynchronous(true);
       this.proceed = false;
       region = DiskRegionHelperFactory.getSyncPersistOnlyRegion(cache, diskProps, Scope.LOCAL);
-      final Thread clearOp = new Thread(new Runnable() {
-        public void run() {
-          try {
-            LocalRegion.ISSUE_CALLBACKS_TO_CACHE_OBSERVER = false;
-            region.clear();
-            region.put("key1", "value3");
-          } catch (Exception e) {
-            testFailed = true;
-            failureCause = "Encountered Exception=" + e;
-          }
+      final Thread clearOp = new Thread(() -> {
+        try {
+          LocalRegion.ISSUE_CALLBACKS_TO_CACHE_OBSERVER = false;
+          region.clear();
+          region.put("key1", "value3");
+        } catch (Exception e) {
+          testFailed = true;
+          failureCause = "Encountered Exception=" + e;
         }
       });
       region.getAttributesMutator().setCacheWriter(new CacheWriterAdapter() {
@@ -2978,9 +1367,6 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
       } else {
         fail(failureCause);
       }
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Test failed due to exception" + e);
     } finally {
       testFailed = false;
       proceed = false;
@@ -2997,7 +1383,7 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
    *
    */
   @Test
-  public void testPutClearCreate() {
+  public void testPutClearCreate() throws Exception {
     failure = false;
     try {
       // Create a persist only region with rolling true
@@ -3013,11 +1399,7 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
       CacheObserverHolder.setInstance(new CacheObserverAdapter() {
         @Override
         public void afterSettingDiskRef() {
-          Thread clearTh = new Thread(new Runnable() {
-            public void run() {
-              region.clear();
-            }
-          });
+          Thread clearTh = new Thread(() -> region.clear());
           clearTh.start();
           try {
             ThreadUtils.join(clearTh, 120 * 1000);
@@ -3036,10 +1418,7 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
       region.close();
       region = DiskRegionHelperFactory.getSyncPersistOnlyRegion(cache, diskProps, Scope.LOCAL);
       assertEquals(1, region.size());
-      assertEquals("value2", (String) region.get("key1"));
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Test failed due to exception" + e);
+      assertEquals("value2", region.get("key1"));
     } finally {
       testFailed = false;
       proceed = false;
@@ -3061,45 +1440,28 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
     assertNotNull(region);
     region.put("key", "createValue");
     region.put("key1", "createValue1");
-    try {
-      cache.getCacheTransactionManager().begin();
-      region.destroy("key");
-      cache.getCacheTransactionManager().commit();
-      assertNull("The deleted entry should have been null",
-          ((LocalRegion) region).entries.getEntry("key"));
-    } catch (CommitConflictException e) {
-      testFailed = true;
-      fail("CommitConflitException encountered");
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Test failed due to exception" + e);
-    }
+    cache.getCacheTransactionManager().begin();
+    region.destroy("key");
+    cache.getCacheTransactionManager().commit();
+    assertNull("The deleted entry should have been null",
+        ((LocalRegion) region).entries.getEntry("key"));
   }
 
   /**
    * Test to force a recovery to follow the path of switchOutFilesForRecovery and ensuring that
    * IOExceptions do not come as a result. This is also a bug test for bug 37682
-   *
-   * @throws Exception
    */
   @Test
   public void testSwitchFilesForRecovery() throws Exception {
     region = DiskRegionHelperFactory.getSyncPersistOnlyRegion(cache, null, Scope.LOCAL);
     put100Int();
-    region.forceRolling();
+    ((LocalRegion) region).getDiskRegion().forceRolling();
     Thread.sleep(2000);
     put100Int();
     int sizeOfRegion = region.size();
     region.close();
-    // this variable will set to false in the src code itself
-    // NewLBHTreeDiskRegion.setJdbmexceptionOccurredToTrueForTesting = true;
-    try {
-      region = DiskRegionHelperFactory.getSyncPersistOnlyRegion(cache, null, Scope.LOCAL);
-    } catch (Exception e) {
-      fail("failed in recreating region due to" + e);
-    } finally {
-      // NewLBHTreeDiskRegion.setJdbmexceptionOccurredToTrueForTesting = false;
-    }
+    region = DiskRegionHelperFactory.getSyncPersistOnlyRegion(cache, null, Scope.LOCAL);
+
     if (sizeOfRegion != region.size()) {
       fail(" Expected region size to be " + sizeOfRegion + " after recovery but it is "
           + region.size());
@@ -3138,9 +1500,6 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
         if (this.didBeforeCall) {
           this.didBeforeCall = false;
           LocalRegion.ISSUE_CALLBACKS_TO_CACHE_OBSERVER = false;
-          // assertTrue("Assert failure for DSpaceUsage in afterHavingCompacted ",
-          // diskSpaceUsageStats() == calculatedDiskSpaceUsageStats());
-          // what is the point of this assert?
           checkDiskStats();
         }
       }
@@ -3157,20 +1516,12 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
       region = DiskRegionHelperFactory.getSyncPersistOnlyRegion(cache, diskProps, Scope.LOCAL);
       LocalRegion.ISSUE_CALLBACKS_TO_CACHE_OBSERVER = true;
       region.put("key1", val);
-      // Disk space should have changed due to 1 put
-      // assertTrue("stats did not increase after put 1 ", diskSpaceUsageStats() ==
-      // calculatedDiskSpaceUsageStats());
       checkDiskStats();
       region.put("key2", val);
-      // assertTrue("stats did not increase after put 2", diskSpaceUsageStats() ==
-      // calculatedDiskSpaceUsageStats());
       checkDiskStats();
       // This put will cause a switch as max-oplog size (500) will be exceeded (600)
       region.put("key3", val);
       synchronized (freezeRoller) {
-        // assertTrue("current disk space usage with Roller thread in wait and put key3 done is
-        // incorrect " + diskSpaceUsageStats() + " " + calculatedDiskSpaceUsageStats(),
-        // diskSpaceUsageStats()== calculatedDiskSpaceUsageStats());
         checkDiskStats();
         assertDone = true;
         freezeRoller.set(true);
@@ -3188,20 +1539,14 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
       // "Disk space usage zero when region recreated"
       checkDiskStats();
       region.put("key4", val);
-      // assertTrue("stats did not increase after put 4", diskSpaceUsageStats() ==
-      // calculatedDiskSpaceUsageStats());
       checkDiskStats();
       region.put("key5", val);
-      // assertTrue("stats did not increase after put 5", diskSpaceUsageStats() ==
-      // calculatedDiskSpaceUsageStats());
       checkDiskStats();
       assertDone = false;
       LocalRegion.ISSUE_CALLBACKS_TO_CACHE_OBSERVER = true;
       region.put("key6", val);
       // again we expect a switch in oplog here
       synchronized (freezeRoller) {
-        // assertTrue("current disk space usage with Roller thread in wait and put key6 done is
-        // incorrect", diskSpaceUsageStats()== calculatedDiskSpaceUsageStats());
         checkDiskStats();
         assertDone = true;
         freezeRoller.set(true);
@@ -3317,14 +1662,9 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
       LocalRegion.ISSUE_CALLBACKS_TO_CACHE_OBSERVER = true;
       cache.getLogger().info("putting key1");
       region.put("key1", val);
-      // Disk space should have changed due to 1 put
-      // assertTrue("stats did not increase after put 1 ", diskSpaceUsageStats() ==
-      // calculatedDiskSpaceUsageStats());
       checkDiskStats();
       cache.getLogger().info("putting key2");
       region.put("key2", val);
-      // assertTrue("stats did not increase after put 2", diskSpaceUsageStats() ==
-      // calculatedDiskSpaceUsageStats());
       checkDiskStats();
 
       cache.getLogger().info("removing key1");
@@ -3349,145 +1689,6 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
     } finally {
       LocalRegion.ISSUE_CALLBACKS_TO_CACHE_OBSERVER = false;
       CacheObserverHolder.setInstance(old);
-    }
-  }
-
-  // @todo this test is broken; size1 can keep changing since the roller will
-  // keep copying forward forever. Need to change it so copy forward oplogs
-  // will not be compacted so that size1 reaches a steady state
-  /**
-   * Tests stats verification with rolling enabled
-   */
-  // @Test
-  // public void testSizeStatsAfterRecreationWithRollingEnabled() throws Exception
-  // {
-  // final int MAX_OPLOG_SIZE = 500;
-  // diskProps.setMaxOplogSize(MAX_OPLOG_SIZE);
-  // diskProps.setPersistBackup(true);
-  // diskProps.setRolling(true);
-  // diskProps.setCompactionThreshold(100);
-  // diskProps.setSynchronous(true);
-  // diskProps.setOverflow(false);
-  // diskProps.setDiskDirsAndSizes(new File[] { dirs[0] }, new int[] { 4000 });
-  // final byte[] val = new byte[200];
-  // region = DiskRegionHelperFactory.getSyncPersistOnlyRegion(cache,
-  // diskProps);
-  // final DiskRegion dr = ((LocalRegion)region).getDiskRegion();
-  // final Object lock = new Object();
-  // final boolean [] exceptionOccurred = new boolean[] {true};
-  // final boolean [] okToExit = new boolean[] {false};
-
-  // CacheObserver old = CacheObserverHolder
-  // .setInstance(new CacheObserverAdapter() {
-  // private long before = -1;
-  // public void beforeDeletingCompactedOplog(Oplog rolledOplog)
-  // {
-  // if (before == -1) {
-  // // only want to call this once; before the 1st oplog destroy
-  // before = dr.getNextDir().getDirStatsDiskSpaceUsage();
-  // }
-  // }
-  // public void afterHavingCompacted() {
-  // if(before > -1) {
-  // synchronized(lock) {
-  // okToExit[0] = true;
-  // long after = dr.getNextDir().getDirStatsDiskSpaceUsage();;
-  // exceptionOccurred[0] = false;
-  // LocalRegion.ISSUE_CALLBACKS_TO_CACHE_OBSERVER = false;
-  // lock.notify();
-  // }
-  // }
-  // }
-  // });
-  // try {
-
-  // LocalRegion.ISSUE_CALLBACKS_TO_CACHE_OBSERVER = true;
-  // region.put("key1", val);
-  // region.put("key2", val);
-  // // This put will cause a switch as max-oplog size (500) will be exceeded (600)
-  // region.put("key3", val);
-  // synchronized(lock) {
-  // if (!okToExit[0]) {
-  // lock.wait(9000);
-  // assertTrue(okToExit[0]);
-  // }
-  // assertFalse(exceptionOccurred[0]);
-  // }
-  // while (region.forceCompaction() != null) {
-  // // wait until no more oplogs to compact
-  // Thread.sleep(50);
-  // }
-  // long size1 =0;
-  // for(DirectoryHolder dh:dr.getDirectories()) {
-  // cache.getLogger().info(" dir=" + dh.getDir()
-  // + " size1=" + dh.getDirStatsDiskSpaceUsage());
-  // size1 += dh.getDirStatsDiskSpaceUsage();
-  // }
-  // System.out.println("Size before closing= "+ size1);
-  // region.close();
-  // diskProps.setRolling(false);
-  // region = DiskRegionHelperFactory.getSyncPersistOnlyRegion(cache,
-  // diskProps);
-
-  // long size2 =0;
-  // for(DirectoryHolder dh:((LocalRegion)region).getDiskRegion().getDirectories()) {
-  // cache.getLogger().info(" dir=" + dh.getDir()
-  // + " size2=" + dh.getDirStatsDiskSpaceUsage());
-  // size2 += dh.getDirStatsDiskSpaceUsage();
-  // }
-  // System.out.println("Size after recreation= "+ size2);
-  // assertIndexDetailsEquals(size1, size2);
-  // region.close();
-
-  // }
-  // finally {
-  // LocalRegion.ISSUE_CALLBACKS_TO_CACHE_OBSERVER = false;
-  // CacheObserverHolder.setInstance(old);
-  // }
-  // }
-
-  // This test is not valid. When listenForDataSerializeChanges is called
-  // it ALWAYS does vrecman writes and a commit. Look at saveInstantiators
-  // and saveDataSerializers to see these commit calls.
-  // These calls can cause the size of the files to change.
-  /**
-   * Tests if without rolling the region size before close is same as after recreation
-   */
-  @Test
-  public void testSizeStatsAfterRecreation() throws Exception {
-    final int MAX_OPLOG_SIZE = 500;
-    diskProps.setMaxOplogSize(MAX_OPLOG_SIZE);
-    diskProps.setPersistBackup(true);
-    diskProps.setRolling(false);
-    diskProps.setSynchronous(true);
-    diskProps.setOverflow(false);
-    diskProps.setDiskDirsAndSizes(new File[] {dirs[0], dirs[1]}, new int[] {4000, 4000});
-    final byte[] val = new byte[200];
-    region = DiskRegionHelperFactory.getSyncPersistOnlyRegion(cache, diskProps, Scope.LOCAL);
-    DiskRegion dr = ((LocalRegion) region).getDiskRegion();
-
-    try {
-      LocalRegion.ISSUE_CALLBACKS_TO_CACHE_OBSERVER = true;
-      for (int i = 0; i < 8; ++i) {
-        region.put("key" + i, val);
-      }
-      long size1 = 0;
-      for (DirectoryHolder dh : dr.getDirectories()) {
-        size1 += dh.getDirStatsDiskSpaceUsage();
-      }
-      System.out.println("Size before close = " + size1);
-      region.close();
-      region = DiskRegionHelperFactory.getSyncPersistOnlyRegion(cache, diskProps, Scope.LOCAL);
-      dr = ((LocalRegion) region).getDiskRegion();
-      long size2 = 0;
-      for (DirectoryHolder dh : dr.getDirectories()) {
-        size2 += dh.getDirStatsDiskSpaceUsage();
-      }
-      System.out.println("Size after recreation= " + size2);
-      assertEquals(size1, size2);
-      region.close();
-    } finally {
-      LocalRegion.ISSUE_CALLBACKS_TO_CACHE_OBSERVER = false;
     }
   }
 
@@ -3618,7 +1819,7 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
     });
 
     File[] files = dir.listFiles();
-    HashSet<String> verified = new HashSet<String>();
+    HashSet<String> verified = new HashSet<>();
     for (File file : files) {
       String name = file.getName();
       byte[] expect = new byte[Oplog.OPLOG_MAGIC_SEQ_REC_SIZE];
@@ -3704,8 +1905,6 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
     }
   }
 
-
-
   @Test
   public void testAsynchModeStatsBehaviour() throws Exception {
     final int MAX_OPLOG_SIZE = 1000;
@@ -3753,15 +1952,12 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
     }
   }
 
-  protected long diskSpaceUsageStats() {
+  private long diskSpaceUsageStats() {
     return ((LocalRegion) region).getDiskRegion().getInfoFileDir().getDirStatsDiskSpaceUsage();
   }
 
-  protected long calculatedDiskSpaceUsageStats() {
-    long oplogSize = oplogSize();
-    // cache.getLogger().info(" oplogSize=" + oplogSize
-    // + " statSize=" + diskSpaceUsageStats());
-    return oplogSize;
+  private long calculatedDiskSpaceUsageStats() {
+    return oplogSize();
   }
 
   private void checkDiskStats() {
@@ -3782,14 +1978,11 @@ public class OplogJUnitTest extends DiskRegionTestingBase {
 
   private long oplogSize() {
     long size = ((LocalRegion) region).getDiskRegion().getDiskStore().undeletedOplogSize.get();
-    // cache.getLogger().info("undeletedOplogSize=" + size);
     Oplog[] opArray =
         ((LocalRegion) region).getDiskRegion().getDiskStore().persistentOplogs.getAllOplogs();
-    if ((opArray != null) && (opArray.length != 0)) {
-      for (int j = 0; j < opArray.length; ++j) {
-        size += opArray[j].getOplogSize();
-        // cache.getLogger().info("oplog#" + opArray[j].getOplogId()
-        // + ".size=" + opArray[j].getOplogSize());
+    if (opArray != null) {
+      for (Oplog log : opArray) {
+        size += log.getOplogSize();
       }
     }
     return size;

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/SimpleDiskRegionJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/SimpleDiskRegionJUnitTest.java
@@ -214,7 +214,7 @@ public class SimpleDiskRegionJUnitTest extends DiskRegionTestingBase {
   // newOplog = dr.getChild();
   // assertIndexDetailsEquals(null, region.get(new Integer(1)));
   // try {
-  // dr.addToOplogSet(id, new File(oplog.getOplogFile()
+  // dr.addToOplogSet(id, new File(oplog.getOplogFileForTest()
   // .getPath()), dr.getNextDir());
   // }
   // catch (Exception e) {

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/diskPerf/DiskRegionOverflowAsyncRollingOpLogJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/diskPerf/DiskRegionOverflowAsyncRollingOpLogJUnitTest.java
@@ -114,7 +114,7 @@ public class DiskRegionOverflowAsyncRollingOpLogJUnitTest extends DiskRegionTest
 
   private void populateSecond10kto20kwrites() {
     afterHavingCompacted = false;
-    DiskRegionTestingBase.setCacheObserverCallBack();
+    setCacheObserverCallBack();
     CacheObserverHolder.setInstance(new CacheObserverAdapter() {
       public void afterHavingCompacted() {
         afterHavingCompacted = true;
@@ -185,7 +185,7 @@ public class DiskRegionOverflowAsyncRollingOpLogJUnitTest extends DiskRegionTest
     log.info(statsGet2);
     if (debug)
       System.out.println("Perf Stats of get which is fauting in from Second OpLog  :" + statsGet2);
-    DiskRegionTestingBase.unSetCacheObserverCallBack();
+    unSetCacheObserverCallBack();
   }
 
   /**

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/diskPerf/DiskRegionOverflowSyncRollingOpLogJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/diskPerf/DiskRegionOverflowSyncRollingOpLogJUnitTest.java
@@ -106,7 +106,7 @@ public class DiskRegionOverflowSyncRollingOpLogJUnitTest extends DiskRegionTesti
 
     // LRUStatistics lruStats = getLRUStats(region);
 
-    DiskRegionTestingBase.setCacheObserverCallBack();
+    setCacheObserverCallBack();
 
     CacheObserverHolder.setInstance(new CacheObserverAdapter() {
       public void afterHavingCompacted() {
@@ -175,7 +175,7 @@ public class DiskRegionOverflowSyncRollingOpLogJUnitTest extends DiskRegionTesti
     log.info(statsGet2);
     System.out.println("Perf Stats of get which is fauting in from Second OpLog  :" + statsGet2);
 
-    DiskRegionTestingBase.unSetCacheObserverCallBack();
+    unSetCacheObserverCallBack();
 
   }
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/diskPerf/DiskRegionPerfJUnitPerformanceTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/diskPerf/DiskRegionPerfJUnitPerformanceTest.java
@@ -494,7 +494,7 @@ public class DiskRegionPerfJUnitPerformanceTest extends DiskRegionTestingBase {
     log.info(stats_ForSameKeyputs);
   }
 
-  protected static void deleteFiles() {
+  protected void deleteFiles() {
     for (int i = 0; i < 4; i++) {
       File[] files = dirs[i].listFiles();
       for (int j = 0; j < files.length; j++) {

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/diskPerf/DiskRegionRollOpLogJUnitPerformanceTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/diskPerf/DiskRegionRollOpLogJUnitPerformanceTest.java
@@ -558,7 +558,7 @@ public class DiskRegionRollOpLogJUnitPerformanceTest extends DiskRegionTestingBa
     log.info(stats_ForSameKeyputs);
   }
 
-  protected static void deleteFiles() {
+  protected void deleteFiles() {
     for (int i = 0; i < 4; i++) {
       File[] files = dirs[i].listFiles();
       for (int j = 0; j < files.length; j++) {


### PR DESCRIPTION
There are 3 separate commits in this PR. 1) reintroduce Nick's commit for GEODE-3801, 2) Lynn's fix for deadlock in backup messages, 3) prevent logger warnings when sender processes the backup messages.

commit d55e6d6cae348fedb9f1341a9abde2096be3bead (HEAD -> feature/GEODE-3940, origin/feature/GEODE-3940, kirklund-fork/feature/GEODE-3940)
Author: Kirk Lund <klund@apache.org>
Date:   Wed Nov 8 10:25:07 2017 -0800

    GEODE-3940: prevent warning when processing message by sender
    
    Prevents logging warning when processing these message types by sender:
    
    * FinishBackupRequest, FlushToDiskRequest, PrepareBackupRequest

commit 81ff81da9fc121607b35aca15d99e24cf0783e7f
Author: Lynn Gallinat <lgallinat@pivotal.io>
Date:   Fri Nov 3 17:09:42 2017 -0700

    GEODE-3940: fix deadlock in backup messages
    
    * introduce unit tests for backup messages
    * add unit test for BackupLock

commit 080730b2df5c7ec0a17acd195a5b953dfc6a0d5c
Author: Nick Reich <nreich@pivotal.io>
Date:   Tue Oct 24 08:24:42 2017 -0700

    GEODE-3801: Use hardlinks for backup oplog files (#963)
    
    * Oplog files that are backed up are read-only. For this reason,
      they can be transfered to the backup location through hard links,
      instead of copying the file. This change improves speed of backups.
      If the creation of a hard link fails, we revert to the existing copy
      behavior.
    * During backups, the copying of the oplog's krf file was being done while
      that file could still be in the process of writing. This change ensures
      that if a krf is to be written, that it is finished and included in the
      backup
    * cleanup existing oplog tests