### PR TITLE
GEODE-3539: Add missing test coverage for 'list regions' and 'describe region' commands

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListRegionCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListRegionCommand.java
@@ -16,9 +16,12 @@
 package org.apache.geode.management.internal.cli.commands;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashSet;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 import org.springframework.shell.core.annotation.CliCommand;
 import org.springframework.shell.core.annotation.CliOption;
@@ -29,7 +32,9 @@ import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
+import org.apache.geode.management.internal.cli.AbstractCliAroundInterceptor;
 import org.apache.geode.management.internal.cli.CliUtil;
+import org.apache.geode.management.internal.cli.GfshParseResult;
 import org.apache.geode.management.internal.cli.domain.RegionInformation;
 import org.apache.geode.management.internal.cli.functions.GetRegionsFunction;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
@@ -67,19 +72,11 @@ public class ListRegionCommand implements GfshCommand {
       ArrayList<?> resultList = (ArrayList<?>) rc.getResult();
 
       if (resultList != null) {
-
-        for (Object resultObj : resultList) {
-          if (resultObj != null) {
-            if (resultObj instanceof Object[]) {
-              Object[] resultObjectArray = (Object[]) resultObj;
-              for (Object regionInfo : resultObjectArray) {
-                if (regionInfo instanceof RegionInformation) {
-                  regionInfoSet.add((RegionInformation) regionInfo);
-                }
-              }
-            }
-          }
-        }
+        // Gather all RegionInformation into a flat set.
+        regionInfoSet.addAll(resultList.stream().filter(Objects::nonNull)
+            .filter(Object[].class::isInstance).map(Object[].class::cast).flatMap(Arrays::stream)
+            .filter(RegionInformation.class::isInstance).map(RegionInformation.class::cast)
+            .collect(Collectors.toSet()));
 
         Set<String> regionNames = new TreeSet<>();
 

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/HeadlessGfsh.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/HeadlessGfsh.java
@@ -121,7 +121,7 @@ public class HeadlessGfsh implements ResultHandler {
   }
 
   public Object getResult() throws InterruptedException {
-    // Dont wait for when some command calls gfsh.stop();
+    // Don't wait for when some command calls gfsh.stop();
     if (shell.stopCalledThroughAPI)
       return null;
     try {
@@ -144,6 +144,10 @@ public class HeadlessGfsh implements ResultHandler {
   public void clear() {
     queue.clear();
     outputString = null;
+  }
+
+  public void setTimeout(long timeout) {
+    this.timeout = timeout;
   }
 
   public void clearEvents() {

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DescribeRegionIntegrationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DescribeRegionIntegrationTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.management.internal.cli.commands;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.test.junit.categories.IntegrationTest;
+import org.apache.geode.test.junit.rules.GfshCommandRule;
+import org.apache.geode.test.junit.rules.GfshCommandRule.PortType;
+import org.apache.geode.test.junit.rules.ServerStarterRule;
+
+@Category(IntegrationTest.class)
+public class DescribeRegionIntegrationTest {
+  private static String MEMBER_NAME = "test-server";
+  private static String REGION_NAME = "test-region";
+  private static String GROUP_NAME = "test-group";
+
+  @ClassRule
+  public static ServerStarterRule server = new ServerStarterRule()
+      .withRegion(RegionShortcut.REPLICATE, REGION_NAME).withName(MEMBER_NAME)
+      .withProperty("groups", GROUP_NAME).withJMXManager().withEmbeddedLocator().withAutoStart();
+
+  @Rule
+  public GfshCommandRule gfsh = new GfshCommandRule();
+
+  @Test
+  public void commandFailsWhenNotConnected() throws Exception {
+    gfsh.executeAndAssertThat("describe region").statusIsError()
+        .containsOutput("was found but is not currently available");
+  }
+
+  @Test
+  public void commandFailsWithoutNameOption() throws Exception {
+    String cmd = "describe region";
+    gfsh.connectAndVerify(server.getEmbeddedLocatorPort(), PortType.locator);
+    gfsh.executeAndAssertThat(cmd).statusIsError().containsOutput("You should specify option");
+  }
+
+  @Test
+  public void commandFailsWithBadNameOption() throws Exception {
+    String cmd = "describe region --name=invalid-region-name";
+    gfsh.connectAndVerify(server.getEmbeddedLocatorPort(), PortType.locator);
+    gfsh.executeAndAssertThat(cmd).statusIsError().containsOutput("invalid-region-name not found");
+  }
+
+  @Test
+  public void commandSucceedsWithGoodNameOption() throws Exception {
+    String cmd = "describe region --name=" + REGION_NAME;
+    gfsh.connectAndVerify(server.getEmbeddedLocatorPort(), PortType.locator);
+    gfsh.executeAndAssertThat(cmd).statusIsSuccess().containsOutput("Name", "Data Policy",
+        "Hosting Members");
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ListRegionDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ListRegionDUnitTest.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.management.internal.cli.commands;
+
+import static org.apache.geode.distributed.ConfigurationProperties.ENABLE_TIME_STATISTICS;
+import static org.apache.geode.distributed.ConfigurationProperties.GROUPS;
+import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
+import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
+import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
+import static org.apache.geode.distributed.ConfigurationProperties.NAME;
+import static org.apache.geode.distributed.ConfigurationProperties.STATISTIC_SAMPLING_ENABLED;
+import static org.apache.geode.management.internal.cli.i18n.CliStrings.GROUP;
+import static org.apache.geode.management.internal.cli.i18n.CliStrings.LIST_REGION;
+import static org.apache.geode.management.internal.cli.i18n.CliStrings.MEMBER;
+
+import java.util.Properties;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.CacheFactory;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionFactory;
+import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.management.internal.cli.util.CommandStringBuilder;
+import org.apache.geode.test.dunit.rules.LocatorServerStartupRule;
+import org.apache.geode.test.dunit.rules.MemberVM;
+import org.apache.geode.test.junit.categories.DistributedTest;
+import org.apache.geode.test.junit.rules.GfshCommandRule;
+
+@Category(DistributedTest.class)
+public class ListRegionDUnitTest {
+  private static final String REGION1 = "region1";
+  private static final String REGION2 = "region2";
+  private static final String REGION3 = "region3";
+  private static final String SUBREGION1A = "subregion1A";
+  private static final String SUBREGION1B = "subregion1B";
+  private static final String SUBREGION1C = "subregion1C";
+  private static final String PR1 = "PR1";
+  private static final String LOCALREGIONONSERVER1 = "LocalRegionOnServer1";
+
+  private static final String SERVER1_NAME = "Server-1";
+  private static final String SERVER2_NAME = "Server-2";
+  private static final String LOCATOR_NAME = "Locator";
+  private static final String GROUP1_NAME = "G1";
+  private static final String GROUP2_NAME = "G2";
+  private static final String GROUP3_NAME = "G3";
+
+  @ClassRule
+  public static LocatorServerStartupRule lsRule = new LocatorServerStartupRule();
+
+  @ClassRule
+  public static GfshCommandRule gfshShellConnectionRule = new GfshCommandRule();
+
+  @BeforeClass
+  public static void setupSystem() throws Exception {
+    final Properties locatorProps = createProperties(LOCATOR_NAME, GROUP3_NAME);
+    MemberVM locator = lsRule.startLocatorVM(0, locatorProps);
+
+    final Properties server1Props = createProperties(SERVER1_NAME, GROUP1_NAME);
+    server1Props.setProperty(LOCATORS, "localhost[" + locator.getPort() + "]");
+    MemberVM server1 = lsRule.startServerVM(1, server1Props, locator.getPort());
+
+    final Properties server2Props = createProperties(SERVER2_NAME, GROUP2_NAME);
+    MemberVM server = lsRule.startServerVM(2, server2Props, locator.getPort());
+
+    server1.invoke(() -> {
+      final Cache cache = CacheFactory.getAnyInstance();
+      RegionFactory<String, Integer> dataRegionFactory =
+          cache.createRegionFactory(RegionShortcut.PARTITION);
+      dataRegionFactory.create(PR1);
+      createLocalRegion(LOCALREGIONONSERVER1);
+    });
+
+    server.invoke(() -> {
+      final Cache cache = CacheFactory.getAnyInstance();
+      RegionFactory<String, Integer> dataRegionFactory =
+          cache.createRegionFactory(RegionShortcut.PARTITION);
+      dataRegionFactory.create(PR1);
+      createRegionsWithSubRegions();
+    });
+
+    gfshShellConnectionRule.connectAndVerify(locator);
+  }
+
+  @Test
+  public void listAllRegions() throws Exception {
+    String listRegions = new CommandStringBuilder(LIST_REGION).toString();
+    gfshShellConnectionRule.executeAndAssertThat(listRegions).statusIsSuccess().containsOutput(PR1,
+        LOCALREGIONONSERVER1, REGION1, REGION2, REGION3);
+  }
+
+  @Test
+  public void listRegionsOnManager() throws Exception {
+    String listRegions =
+        new CommandStringBuilder(LIST_REGION).addOption(MEMBER, SERVER1_NAME).toString();
+    gfshShellConnectionRule.executeAndAssertThat(listRegions).statusIsSuccess().containsOutput(PR1,
+        LOCALREGIONONSERVER1);
+  }
+
+  @Test
+  public void listRegionsOnServer() throws Exception {
+    CommandStringBuilder csb = new CommandStringBuilder(LIST_REGION);
+    csb.addOption(MEMBER, SERVER2_NAME);
+    gfshShellConnectionRule.executeAndAssertThat(csb.toString()).statusIsSuccess()
+        .containsOutput(PR1, REGION1, REGION2, REGION3, SUBREGION1A);
+  }
+
+  @Test
+  public void listRegionsInGroup1() throws Exception {
+    CommandStringBuilder csb = new CommandStringBuilder(LIST_REGION);
+    csb.addOption(GROUP, GROUP1_NAME);
+    gfshShellConnectionRule.executeAndAssertThat(csb.toString()).statusIsSuccess()
+        .containsOutput(PR1, LOCALREGIONONSERVER1);
+  }
+
+  @Test
+  public void listRegionsInGroup2() throws Exception {
+    CommandStringBuilder csb = new CommandStringBuilder(LIST_REGION);
+    csb.addOption(GROUP, GROUP2_NAME);
+    gfshShellConnectionRule.executeAndAssertThat(csb.toString()).statusIsSuccess()
+        .containsOutput(PR1, REGION1, REGION2, REGION3, SUBREGION1A);
+  }
+
+
+  private static Properties createProperties(String name, String groups) {
+    Properties props = new Properties();
+    props.setProperty(MCAST_PORT, "0");
+    props.setProperty(LOG_LEVEL, "info");
+    props.setProperty(STATISTIC_SAMPLING_ENABLED, "true");
+    props.setProperty(ENABLE_TIME_STATISTICS, "true");
+    props.setProperty(NAME, name);
+    props.setProperty(GROUPS, groups);
+    return props;
+  }
+
+  private static void createLocalRegion(final String regionName) {
+    final Cache cache = CacheFactory.getAnyInstance();
+    // Create the data region
+    RegionFactory<String, Integer> dataRegionFactory =
+        cache.createRegionFactory(RegionShortcut.LOCAL);
+    dataRegionFactory.create(regionName);
+  }
+
+  private static void createRegionsWithSubRegions() {
+    final Cache cache = CacheFactory.getAnyInstance();
+
+    RegionFactory<String, Integer> dataRegionFactory =
+        cache.createRegionFactory(RegionShortcut.REPLICATE);
+    dataRegionFactory.setConcurrencyLevel(3);
+    Region<String, Integer> region1 = dataRegionFactory.create(REGION1);
+    region1.createSubregion(SUBREGION1C, region1.getAttributes());
+    Region<String, Integer> subregion2 =
+        region1.createSubregion(SUBREGION1A, region1.getAttributes());
+
+    subregion2.createSubregion(SUBREGION1B, subregion2.getAttributes());
+    dataRegionFactory.create(REGION2);
+    dataRegionFactory.create(REGION3);
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ListRegionIntegrationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ListRegionIntegrationTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.management.internal.cli.commands;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.test.junit.categories.IntegrationTest;
+import org.apache.geode.test.junit.rules.GfshCommandRule;
+import org.apache.geode.test.junit.rules.GfshCommandRule.PortType;
+import org.apache.geode.test.junit.rules.ServerStarterRule;
+
+@Category(IntegrationTest.class)
+public class ListRegionIntegrationTest {
+  private static String MEMBER_NAME = "test-server";
+  private static String REGION_NAME = "test-region";
+  private static String GROUP_NAME = "test-group";
+  private static String OUTPUT_HEADER = "List of regions";
+
+  @ClassRule
+  public static ServerStarterRule server = new ServerStarterRule()
+      .withRegion(RegionShortcut.REPLICATE, REGION_NAME).withName(MEMBER_NAME)
+      .withProperty("groups", GROUP_NAME).withJMXManager().withAutoStart();
+
+  @Rule
+  public GfshCommandRule gfsh = new GfshCommandRule(server::getJmxPort, PortType.jmxManager);
+
+  @Before
+  public void setup() {
+    gfsh.setTimeout(2);
+  }
+
+  @Test
+  public void commandFailsWhenNotConnected() throws Exception {
+    gfsh.disconnect();
+    gfsh.executeAndAssertThat("list regions").statusIsError()
+        .containsOutput("was found but is not currently available");
+  }
+
+  @Test
+  public void memberAndGroupAreMutuallyExclusive() throws Exception {
+    String cmd = "list regions --member=" + MEMBER_NAME + " --group=" + GROUP_NAME;
+    gfsh.executeAndAssertThat(cmd).statusIsError()
+        .containsOutput("Please provide either \"member\" or \"group\" option.");
+  }
+
+  @Test
+  public void commandWithNoOptionsSucceeds() throws Exception {
+    String cmd = "list regions";
+    gfsh.executeAndAssertThat(cmd).statusIsSuccess()
+        .tableHasColumnWithValuesContaining(OUTPUT_HEADER, REGION_NAME);
+  }
+
+  @Test
+  public void commandWithMemberSucceeds() throws Exception {
+    String cmd = "list regions --member=" + MEMBER_NAME;
+    gfsh.executeAndAssertThat(cmd).statusIsSuccess()
+        .tableHasColumnWithValuesContaining(OUTPUT_HEADER, REGION_NAME);
+  }
+
+  @Test
+  public void commandWithGroupSucceeds() throws Exception {
+    String cmd = "list regions --group=" + GROUP_NAME;
+    gfsh.executeAndAssertThat(cmd).statusIsSuccess()
+        .tableHasColumnWithValuesContaining(OUTPUT_HEADER, REGION_NAME);
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/test/junit/rules/GfshCommandRule.java
+++ b/geode-core/src/test/java/org/apache/geode/test/junit/rules/GfshCommandRule.java
@@ -215,7 +215,7 @@ public class GfshCommandRule extends DescribedExternalResource {
 
   public CommandResult executeCommand(String command) {
     gfsh.executeCommand(command);
-    CommandResult result = null;
+    CommandResult result;
     try {
       result = (CommandResult) gfsh.getResult();
     } catch (InterruptedException e) {
@@ -260,6 +260,10 @@ public class GfshCommandRule extends DescribedExternalResource {
 
   public File getWorkingDir() {
     return workingDir;
+  }
+
+  public void setTimeout(long timeoutInSeconds) {
+    gfsh.setTimeout(timeoutInSeconds);
   }
 
   public enum PortType {


### PR DESCRIPTION
* Mutually exclusive options --group and --member checked in interceptor instead of failing server-side
* Command logic flattened to stream.
* Testing of 'list region' and 'describe region' separated into distinct DUnit and Integration tests
* Removed @Flaky annotation from 'describe region' DUnit test.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
