### PR TITLE
GEODE-3982: MemoryIndexStoreIterator should not call GemFireCacheImpl

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/MemoryIndexStore.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/MemoryIndexStore.java
@@ -612,7 +612,7 @@ public class MemoryIndexStore implements IndexStore {
     MemoryIndexStoreEntry currentEntry;
 
     MemoryIndexStoreIterator(Map submap, Object indexKey, Collection keysToRemove) {
-      this(submap, indexKey, keysToRemove, GemFireCacheImpl.getInstance().cacheTimeMillis());
+      this(submap, indexKey, keysToRemove, cache.cacheTimeMillis());
     }
 
     private MemoryIndexStoreIterator(Map submap, Object indexKey, Collection keysToRemove,

--- a/geode-core/src/test/java/org/apache/geode/cache/query/internal/index/MemoryIndexStoreJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/internal/index/MemoryIndexStoreJUnitTest.java
@@ -75,6 +75,12 @@ public class MemoryIndexStoreJUnitTest {
   }
 
   @Test
+  public void createIteratorWhenCacheNulledWhenShuttingDownShouldNotThrowNPE() {
+    GemFireCacheImpl.setInstanceForTests(null);
+    store.get("T");
+  }
+
+  @Test
   public void testSizeOfStoreReturnsNumberOfKeysAndNotActualNumberOfValues() {
     IntStream.range(0, 150).forEach(i -> {
       try {


### PR DESCRIPTION
Setting the cache from the memory index store instead of GemFireCacheImpl.getInstance().