### PR TITLE
GEODE-3929: GFSH create lucene index command allowed on existing regi…

### DIFF
--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneServiceImpl.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneServiceImpl.java
@@ -32,7 +32,6 @@ import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.miscellaneous.PerFieldAnalyzerWrapper;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 
-import org.apache.geode.cache.AttributesFactory;
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.EvictionAlgorithm;
 import org.apache.geode.cache.EvictionAttributes;
@@ -62,11 +61,11 @@ import org.apache.geode.cache.lucene.internal.management.ManagementIndexListener
 import org.apache.geode.cache.lucene.internal.results.LuceneGetPageFunction;
 import org.apache.geode.cache.lucene.internal.results.PageResults;
 import org.apache.geode.cache.lucene.internal.xml.LuceneServiceXmlGenerator;
+import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.internal.DSFIDFactory;
 import org.apache.geode.internal.DataSerializableFixedID;
 import org.apache.geode.internal.cache.CacheService;
 import org.apache.geode.internal.cache.InternalCache;
-import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.internal.cache.RegionListener;
 import org.apache.geode.internal.cache.extension.Extensible;
@@ -89,6 +88,8 @@ public class LuceneServiceImpl implements InternalLuceneService {
   private final HashMap<String, LuceneIndex> indexMap = new HashMap<String, LuceneIndex>();
   private final HashMap<String, LuceneIndexCreationProfile> definedIndexMap = new HashMap<>();
   private IndexListener managementListener;
+  public static boolean LUCENE_REINDEX =
+      Boolean.getBoolean(DistributionConfig.GEMFIRE_PREFIX + "luceneReindex");
 
   public LuceneServiceImpl() {}
 

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexCommandsDUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexCommandsDUnitTest.java
@@ -78,7 +78,7 @@ public class LuceneIndexCommandsDUnitTest implements Serializable {
   @Rule
   public SerializableTestName testName = new SerializableTestName();
 
-  private MemberVM serverVM;
+  protected MemberVM serverVM;
 
   @Before
   public void before() throws Exception {
@@ -154,24 +154,26 @@ public class LuceneIndexCommandsDUnitTest implements Serializable {
 
 
   @Test
-  public void createIndexShouldCreateANewIndex() throws Exception {
+  public void createIndexShouldCreateANewIndex() {
     CommandStringBuilder csb = new CommandStringBuilder(LuceneCliStrings.LUCENE_CREATE_INDEX);
     csb.addOption(LuceneCliStrings.LUCENE__INDEX_NAME, INDEX_NAME);
     csb.addOption(LuceneCliStrings.LUCENE__REGION_PATH, REGION_NAME);
     csb.addOption(LuceneCliStrings.LUCENE_CREATE_INDEX__FIELD, "field1,field2,field3");
 
-    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess()
+        .containsOutput("Successfully created lucene index");
+
+    serverVM.invoke(() -> createRegion());
 
     serverVM.invoke(() -> {
       LuceneService luceneService = LuceneServiceProvider.get(getCache());
-      createRegion();
       final LuceneIndex index = luceneService.getIndex(INDEX_NAME, REGION_NAME);
       assertArrayEquals(new String[] {"field1", "field2", "field3"}, index.getFieldNames());
     });
   }
 
   @Test
-  public void createIndexWithAnalyzersShouldCreateANewIndex() throws Exception {
+  public void createIndexWithAnalyzersShouldCreateANewIndex() {
     List<String> analyzerNames = new ArrayList<>();
     analyzerNames.add(StandardAnalyzer.class.getCanonicalName());
     analyzerNames.add(KeywordAnalyzer.class.getCanonicalName());
@@ -183,11 +185,14 @@ public class LuceneIndexCommandsDUnitTest implements Serializable {
     csb.addOption(LuceneCliStrings.LUCENE_CREATE_INDEX__FIELD, "field1,field2,field3");
     csb.addOption(LuceneCliStrings.LUCENE_CREATE_INDEX__ANALYZER, String.join(",", analyzerNames));
 
-    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess()
+        .containsOutput("Successfully created lucene index");
+
+    serverVM.invoke(() -> createRegion());
+
 
     serverVM.invoke(() -> {
       LuceneService luceneService = LuceneServiceProvider.get(getCache());
-      createRegion();
       final LuceneIndex index = luceneService.getIndex(INDEX_NAME, REGION_NAME);
       final Map<String, Analyzer> fieldAnalyzers = index.getFieldAnalyzers();
       assertEquals(StandardAnalyzer.class, fieldAnalyzers.get("field1").getClass());
@@ -197,7 +202,7 @@ public class LuceneIndexCommandsDUnitTest implements Serializable {
   }
 
   @Test
-  public void createIndexWithALuceneSerializerShouldCreateANewIndex() throws Exception {
+  public void createIndexWithALuceneSerializerShouldCreateANewIndex() {
     CommandStringBuilder csb = new CommandStringBuilder(LuceneCliStrings.LUCENE_CREATE_INDEX);
     csb.addOption(LuceneCliStrings.LUCENE__INDEX_NAME, INDEX_NAME);
     csb.addOption(LuceneCliStrings.LUCENE__REGION_PATH, REGION_NAME);
@@ -205,11 +210,14 @@ public class LuceneIndexCommandsDUnitTest implements Serializable {
     csb.addOption(LuceneCliStrings.LUCENE_CREATE_INDEX__SERIALIZER,
         PrimitiveSerializer.class.getCanonicalName());
 
-    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess()
+        .containsOutput("Successfully created lucene index");
+
+    serverVM.invoke(() -> createRegion());
+
 
     serverVM.invoke(() -> {
       LuceneService luceneService = LuceneServiceProvider.get(getCache());
-      createRegion();
       final LuceneIndex index = luceneService.getIndex(INDEX_NAME, REGION_NAME);
       assertThat(index.getLuceneSerializer()).isInstanceOf(PrimitiveSerializer.class);
     });
@@ -217,7 +225,6 @@ public class LuceneIndexCommandsDUnitTest implements Serializable {
 
   @Test
   public void createIndexShouldNotAcceptBadIndexOrRegionNames() {
-    // CommandStringBuilder csb;
     CommandStringBuilder csb = new CommandStringBuilder(LuceneCliStrings.LUCENE_CREATE_INDEX);
     csb.addOption(LuceneCliStrings.LUCENE__INDEX_NAME, INDEX_NAME);
     csb.addOption(LuceneCliStrings.LUCENE__REGION_PATH, "\'__\'");
@@ -252,7 +259,7 @@ public class LuceneIndexCommandsDUnitTest implements Serializable {
   }
 
   @Test
-  public void createIndexShouldTrimAnalyzerNames() throws Exception {
+  public void createIndexShouldTrimAnalyzerNames() {
     List<String> analyzerNames = new ArrayList<>();
     analyzerNames.add(StandardAnalyzer.class.getCanonicalName());
     analyzerNames.add(KeywordAnalyzer.class.getCanonicalName());
@@ -265,11 +272,14 @@ public class LuceneIndexCommandsDUnitTest implements Serializable {
     csb.addOption(LuceneCliStrings.LUCENE_CREATE_INDEX__ANALYZER,
         "\"org.apache.lucene.analysis.standard.StandardAnalyzer, org.apache.lucene.analysis.core.KeywordAnalyzer, org.apache.lucene.analysis.standard.StandardAnalyzer\"");
 
-    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess()
+        .containsOutput("Successfully created lucene index");
+
+    serverVM.invoke(() -> createRegion());
+
 
     serverVM.invoke(() -> {
       LuceneService luceneService = LuceneServiceProvider.get(getCache());
-      createRegion();
       final LuceneIndex index = luceneService.getIndex(INDEX_NAME, REGION_NAME);
       final Map<String, Analyzer> fieldAnalyzers = index.getFieldAnalyzers();
       assertEquals(StandardAnalyzer.class, fieldAnalyzers.get("field1").getClass());
@@ -297,8 +307,7 @@ public class LuceneIndexCommandsDUnitTest implements Serializable {
   }
 
   @Test
-  public void createIndexWithWhitespaceOrDefaultKeywordAnalyzerShouldUseStandardAnalyzer()
-      throws Exception {
+  public void createIndexWithWhitespaceOrDefaultKeywordAnalyzerShouldUseStandardAnalyzer() {
     // Test whitespace analyzer name
     String analyzerList = StandardAnalyzer.class.getCanonicalName() + ",     ,"
         + KeywordAnalyzer.class.getCanonicalName();
@@ -308,7 +317,8 @@ public class LuceneIndexCommandsDUnitTest implements Serializable {
     csb.addOption(LuceneCliStrings.LUCENE_CREATE_INDEX__FIELD, "field1,field2,field3");
     csb.addOption(LuceneCliStrings.LUCENE_CREATE_INDEX__ANALYZER, "'" + analyzerList + "'");
 
-    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess()
+        .containsOutput("Successfully created lucene index");
 
     // Test empty analyzer name
     analyzerList =
@@ -319,7 +329,8 @@ public class LuceneIndexCommandsDUnitTest implements Serializable {
     csb.addOption(LuceneCliStrings.LUCENE_CREATE_INDEX__FIELD, "field1,field2,field3");
     csb.addOption(LuceneCliStrings.LUCENE_CREATE_INDEX__ANALYZER, analyzerList);
 
-    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess()
+        .containsOutput("Successfully created lucene index");
 
     // Test keyword analyzer name
     analyzerList = StandardAnalyzer.class.getCanonicalName() + ",DEFAULT,"
@@ -330,7 +341,8 @@ public class LuceneIndexCommandsDUnitTest implements Serializable {
     csb.addOption(LuceneCliStrings.LUCENE_CREATE_INDEX__FIELD, "field1,field2,field3");
     csb.addOption(LuceneCliStrings.LUCENE_CREATE_INDEX__ANALYZER, analyzerList);
 
-    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess()
+        .containsOutput("Successfully created lucene index");
 
     serverVM.invoke(() -> {
       LuceneService luceneService = LuceneServiceProvider.get(getCache());
@@ -655,7 +667,7 @@ public class LuceneIndexCommandsDUnitTest implements Serializable {
         .containsOutput(expectedOutput);
   }
 
-  private void createRegion() {
+  protected void createRegion() {
     getCache().createRegionFactory(RegionShortcut.PARTITION).create(REGION_NAME);
   }
 
@@ -715,7 +727,7 @@ public class LuceneIndexCommandsDUnitTest implements Serializable {
         new Object[] {regionPath});
   }
 
-  private static Cache getCache() {
+  protected static Cache getCache() {
     return LocatorServerStartupRule.getCache();
   }
 

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexCommandsWithReindexAllowedDUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexCommandsWithReindexAllowedDUnitTest.java
@@ -1,0 +1,228 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache.lucene.internal.cli;
+
+import static org.apache.geode.cache.lucene.test.LuceneTestUtilities.INDEX_NAME;
+import static org.apache.geode.cache.lucene.test.LuceneTestUtilities.REGION_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.core.KeywordAnalyzer;
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.geode.cache.lucene.LuceneIndex;
+import org.apache.geode.cache.lucene.LuceneService;
+import org.apache.geode.cache.lucene.LuceneServiceProvider;
+import org.apache.geode.cache.lucene.internal.LuceneServiceImpl;
+import org.apache.geode.cache.lucene.internal.repository.serializer.PrimitiveSerializer;
+import org.apache.geode.management.internal.cli.util.CommandStringBuilder;
+
+public class LuceneIndexCommandsWithReindexAllowedDUnitTest extends LuceneIndexCommandsDUnitTest {
+
+  @After
+  public void clearLuceneReindexFeatureFlag() {
+    serverVM.invoke(() -> LuceneServiceImpl.LUCENE_REINDEX = false);
+  }
+
+  @Before
+  public void setLuceneReindexFeatureFlag() {
+    serverVM.invoke(() -> LuceneServiceImpl.LUCENE_REINDEX = true);
+  }
+
+  @Test
+  public void whenLuceneReindexAllowedCreateIndexShouldCreateANewIndex() {
+    CommandStringBuilder csb = new CommandStringBuilder(LuceneCliStrings.LUCENE_CREATE_INDEX);
+    csb.addOption(LuceneCliStrings.LUCENE__INDEX_NAME, INDEX_NAME);
+    csb.addOption(LuceneCliStrings.LUCENE__REGION_PATH, REGION_NAME);
+    csb.addOption(LuceneCliStrings.LUCENE_CREATE_INDEX__FIELD, "field1,field2,field3");
+
+    serverVM.invoke(() -> createRegion());
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess()
+        .containsOutput("Successfully created lucene index");
+
+    serverVM.invoke(() -> {
+      LuceneService luceneService = LuceneServiceProvider.get(getCache());
+      final LuceneIndex index = luceneService.getIndex(INDEX_NAME, REGION_NAME);
+      assertArrayEquals(new String[] {"field1", "field2", "field3"}, index.getFieldNames());
+    });
+  }
+
+
+  @Test
+  public void whenLuceneReindexAllowedCreateIndexWithAnalyzersShouldCreateANewIndex() {
+    List<String> analyzerNames = new ArrayList<>();
+    analyzerNames.add(StandardAnalyzer.class.getCanonicalName());
+    analyzerNames.add(KeywordAnalyzer.class.getCanonicalName());
+    analyzerNames.add(StandardAnalyzer.class.getCanonicalName());
+
+    CommandStringBuilder csb = new CommandStringBuilder(LuceneCliStrings.LUCENE_CREATE_INDEX);
+    csb.addOption(LuceneCliStrings.LUCENE__INDEX_NAME, INDEX_NAME);
+    csb.addOption(LuceneCliStrings.LUCENE__REGION_PATH, REGION_NAME);
+    csb.addOption(LuceneCliStrings.LUCENE_CREATE_INDEX__FIELD, "field1,field2,field3");
+    csb.addOption(LuceneCliStrings.LUCENE_CREATE_INDEX__ANALYZER, String.join(",", analyzerNames));
+
+    serverVM.invoke(() -> createRegion());
+
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess()
+        .containsOutput("Successfully created lucene index");
+
+
+    serverVM.invoke(() -> {
+      LuceneService luceneService = LuceneServiceProvider.get(getCache());
+      final LuceneIndex index = luceneService.getIndex(INDEX_NAME, REGION_NAME);
+      final Map<String, Analyzer> fieldAnalyzers = index.getFieldAnalyzers();
+      assertEquals(StandardAnalyzer.class, fieldAnalyzers.get("field1").getClass());
+      assertEquals(KeywordAnalyzer.class, fieldAnalyzers.get("field2").getClass());
+      assertEquals(StandardAnalyzer.class, fieldAnalyzers.get("field3").getClass());
+    });
+  }
+
+  @Test
+  public void whenLuceneReindexAllowedCreateIndexWithALuceneSerializerShouldCreateANewIndex() {
+    CommandStringBuilder csb = new CommandStringBuilder(LuceneCliStrings.LUCENE_CREATE_INDEX);
+    csb.addOption(LuceneCliStrings.LUCENE__INDEX_NAME, INDEX_NAME);
+    csb.addOption(LuceneCliStrings.LUCENE__REGION_PATH, REGION_NAME);
+    csb.addOption(LuceneCliStrings.LUCENE_CREATE_INDEX__FIELD, "field1,field2,field3");
+    csb.addOption(LuceneCliStrings.LUCENE_CREATE_INDEX__SERIALIZER,
+        PrimitiveSerializer.class.getCanonicalName());
+
+    serverVM.invoke(() -> createRegion());
+
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess()
+        .containsOutput("Successfully created lucene index");
+
+    serverVM.invoke(() -> {
+      LuceneService luceneService = LuceneServiceProvider.get(getCache());
+      final LuceneIndex index = luceneService.getIndex(INDEX_NAME, REGION_NAME);
+      assertThat(index.getLuceneSerializer()).isInstanceOf(PrimitiveSerializer.class);
+    });
+  }
+
+  @Test
+  public void whenLuceneReindexAllowedCreateIndexShouldTrimAnalyzerNames() {
+    List<String> analyzerNames = new ArrayList<>();
+    analyzerNames.add(StandardAnalyzer.class.getCanonicalName());
+    analyzerNames.add(KeywordAnalyzer.class.getCanonicalName());
+    analyzerNames.add(StandardAnalyzer.class.getCanonicalName());
+
+    CommandStringBuilder csb = new CommandStringBuilder(LuceneCliStrings.LUCENE_CREATE_INDEX);
+    csb.addOption(LuceneCliStrings.LUCENE__INDEX_NAME, INDEX_NAME);
+    csb.addOption(LuceneCliStrings.LUCENE__REGION_PATH, REGION_NAME);
+    csb.addOption(LuceneCliStrings.LUCENE_CREATE_INDEX__FIELD, "field1,field2,field3");
+    csb.addOption(LuceneCliStrings.LUCENE_CREATE_INDEX__ANALYZER,
+        "\"org.apache.lucene.analysis.standard.StandardAnalyzer, org.apache.lucene.analysis.core.KeywordAnalyzer, org.apache.lucene.analysis.standard.StandardAnalyzer\"");
+
+    serverVM.invoke(() -> createRegion());
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess()
+        .containsOutput("Successfully created lucene index");
+
+    serverVM.invoke(() -> {
+      LuceneService luceneService = LuceneServiceProvider.get(getCache());
+      final LuceneIndex index = luceneService.getIndex(INDEX_NAME, REGION_NAME);
+      final Map<String, Analyzer> fieldAnalyzers = index.getFieldAnalyzers();
+      assertEquals(StandardAnalyzer.class, fieldAnalyzers.get("field1").getClass());
+      assertEquals(KeywordAnalyzer.class, fieldAnalyzers.get("field2").getClass());
+      assertEquals(StandardAnalyzer.class, fieldAnalyzers.get("field3").getClass());
+    });
+  }
+
+  @Test
+  public void whenLuceneReindexAllowedCreateIndexWithWhitespaceOrDefaultKeywordAnalyzerShouldUseStandardAnalyzer() {
+
+    serverVM.invoke(() -> createRegion());
+
+    // Test whitespace analyzer name
+    String analyzerList = StandardAnalyzer.class.getCanonicalName() + ",     ,"
+        + KeywordAnalyzer.class.getCanonicalName();
+    CommandStringBuilder csb = new CommandStringBuilder(LuceneCliStrings.LUCENE_CREATE_INDEX);
+    csb.addOption(LuceneCliStrings.LUCENE__INDEX_NAME, "space");
+    csb.addOption(LuceneCliStrings.LUCENE__REGION_PATH, REGION_NAME);
+    csb.addOption(LuceneCliStrings.LUCENE_CREATE_INDEX__FIELD, "field1,field2,field3");
+    csb.addOption(LuceneCliStrings.LUCENE_CREATE_INDEX__ANALYZER, "'" + analyzerList + "'");
+
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess()
+        .containsOutput("Successfully created lucene index");
+
+    // Test empty analyzer name
+    analyzerList =
+        StandardAnalyzer.class.getCanonicalName() + ",," + KeywordAnalyzer.class.getCanonicalName();
+    csb = new CommandStringBuilder(LuceneCliStrings.LUCENE_CREATE_INDEX);
+    csb.addOption(LuceneCliStrings.LUCENE__INDEX_NAME, "empty");
+    csb.addOption(LuceneCliStrings.LUCENE__REGION_PATH, REGION_NAME);
+    csb.addOption(LuceneCliStrings.LUCENE_CREATE_INDEX__FIELD, "field1,field2,field3");
+    csb.addOption(LuceneCliStrings.LUCENE_CREATE_INDEX__ANALYZER, analyzerList);
+
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess()
+        .containsOutput("Successfully created lucene index");
+
+    // Test keyword analyzer name
+    analyzerList = StandardAnalyzer.class.getCanonicalName() + ",DEFAULT,"
+        + KeywordAnalyzer.class.getCanonicalName();
+    csb = new CommandStringBuilder(LuceneCliStrings.LUCENE_CREATE_INDEX);
+    csb.addOption(LuceneCliStrings.LUCENE__INDEX_NAME, "keyword");
+    csb.addOption(LuceneCliStrings.LUCENE__REGION_PATH, REGION_NAME);
+    csb.addOption(LuceneCliStrings.LUCENE_CREATE_INDEX__FIELD, "field1,field2,field3");
+    csb.addOption(LuceneCliStrings.LUCENE_CREATE_INDEX__ANALYZER, analyzerList);
+
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess()
+        .containsOutput("Successfully created lucene index");
+
+    serverVM.invoke(() -> {
+      LuceneService luceneService = LuceneServiceProvider.get(getCache());
+      final LuceneIndex spaceIndex = luceneService.getIndex("space", REGION_NAME);
+      final Map<String, Analyzer> spaceFieldAnalyzers = spaceIndex.getFieldAnalyzers();
+
+      final LuceneIndex emptyIndex = luceneService.getIndex("empty", REGION_NAME);
+      final Map<String, Analyzer> emptyFieldAnalyzers2 = emptyIndex.getFieldAnalyzers();
+
+      final LuceneIndex keywordIndex = luceneService.getIndex("keyword", REGION_NAME);
+      final Map<String, Analyzer> keywordFieldAnalyzers = keywordIndex.getFieldAnalyzers();
+
+      // Test whitespace analyzers
+      assertEquals(StandardAnalyzer.class.getCanonicalName(),
+          spaceFieldAnalyzers.get("field1").getClass().getCanonicalName());
+      assertEquals(StandardAnalyzer.class.getCanonicalName(),
+          spaceFieldAnalyzers.get("field2").getClass().getCanonicalName());
+      assertEquals(KeywordAnalyzer.class.getCanonicalName(),
+          spaceFieldAnalyzers.get("field3").getClass().getCanonicalName());
+
+      // Test empty analyzers
+      assertEquals(StandardAnalyzer.class.getCanonicalName(),
+          emptyFieldAnalyzers2.get("field1").getClass().getCanonicalName());
+      assertEquals(StandardAnalyzer.class.getCanonicalName(),
+          emptyFieldAnalyzers2.get("field2").getClass().getCanonicalName());
+      assertEquals(KeywordAnalyzer.class.getCanonicalName(),
+          emptyFieldAnalyzers2.get("field3").getClass().getCanonicalName());
+
+      // Test keyword analyzers
+      assertEquals(StandardAnalyzer.class.getCanonicalName(),
+          keywordFieldAnalyzers.get("field1").getClass().getCanonicalName());
+      assertEquals(StandardAnalyzer.class.getCanonicalName(),
+          keywordFieldAnalyzers.get("field2").getClass().getCanonicalName());
+      assertEquals(KeywordAnalyzer.class.getCanonicalName(),
+          keywordFieldAnalyzers.get("field3").getClass().getCanonicalName());
+    });
+  }
+
+}

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/cli/functions/LuceneCreateIndexFunctionJUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/cli/functions/LuceneCreateIndexFunctionJUnitTest.java
@@ -14,8 +14,12 @@
  */
 package org.apache.geode.cache.lucene.internal.cli.functions;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,8 +35,8 @@ import org.mockito.ArgumentCaptor;
 
 import org.apache.geode.cache.execute.FunctionContext;
 import org.apache.geode.cache.execute.ResultSender;
-import org.apache.geode.cache.lucene.LuceneIndexFactory;
 import org.apache.geode.cache.lucene.internal.InternalLuceneService;
+import org.apache.geode.cache.lucene.internal.LuceneIndexFactoryImpl;
 import org.apache.geode.cache.lucene.internal.cli.LuceneIndexInfo;
 import org.apache.geode.cache.lucene.internal.repository.serializer.PrimitiveSerializer;
 import org.apache.geode.distributed.DistributedSystem;
@@ -52,7 +56,7 @@ public class LuceneCreateIndexFunctionJUnitTest {
   FunctionContext context;
   ResultSender resultSender;
   CliFunctionResult expectedResult;
-  private LuceneIndexFactory factory;
+  private LuceneIndexFactoryImpl factory;
 
   @Before
   public void prepare() {
@@ -61,7 +65,7 @@ public class LuceneCreateIndexFunctionJUnitTest {
     member = ds.getDistributedMember().getId();
     service = mock(InternalLuceneService.class);
     when(cache.getService(InternalLuceneService.class)).thenReturn(service);
-    factory = mock(LuceneIndexFactory.class);
+    factory = mock(LuceneIndexFactoryImpl.class);
     when(service.createIndexFactory()).thenReturn(factory);
 
     context = mock(FunctionContext.class);
@@ -94,7 +98,7 @@ public class LuceneCreateIndexFunctionJUnitTest {
     verify(factory).addField(eq("field1"), isA(StandardAnalyzer.class));
     verify(factory).addField(eq("field2"), isA(KeywordAnalyzer.class));
     verify(factory).addField(eq("field3"), isA(StandardAnalyzer.class));
-    verify(factory).create(eq("index1"), eq("/region1"));
+    verify(factory).create(eq("index1"), eq("/region1"), eq(false));
 
     ArgumentCaptor<Set> resultCaptor = ArgumentCaptor.forClass(Set.class);
     verify(resultSender).lastResult(resultCaptor.capture());
@@ -116,7 +120,7 @@ public class LuceneCreateIndexFunctionJUnitTest {
     verify(factory).addField(eq("field1"));
     verify(factory).addField(eq("field2"));
     verify(factory).addField(eq("field3"));
-    verify(factory).create(eq("index1"), eq("/region1"));
+    verify(factory).create(eq("index1"), eq("/region1"), eq(false));
 
     ArgumentCaptor<Set> resultCaptor = ArgumentCaptor.forClass(Set.class);
     verify(resultSender).lastResult(resultCaptor.capture());
@@ -140,7 +144,7 @@ public class LuceneCreateIndexFunctionJUnitTest {
     verify(factory).addField(eq("field2"));
     verify(factory).addField(eq("field3"));
     verify(factory).setLuceneSerializer(isA(PrimitiveSerializer.class));
-    verify(factory).create(eq("index1"), eq("/region1"));
+    verify(factory).create(eq("index1"), eq("/region1"), eq(false));
 
     ArgumentCaptor<Set> resultCaptor = ArgumentCaptor.forClass(Set.class);
     verify(resultSender).lastResult(resultCaptor.capture());


### PR DESCRIPTION
…ons.

	* create lucene index gfsh command can now be executed on pre-existing regions.
	* Tests modified to include the case where the index is created on an existing region.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
