### PR TITLE
GEODE-3985: rolling upgrade tests is prone to accidentally roll the vms back to current version

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgrade2DUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgrade2DUnitTest.java
@@ -727,9 +727,9 @@ public class RollingUpgrade2DUnitTest extends JUnit4DistributedTestCase {
   public void doTestPutAndGetMixedServers(String objectType, boolean partitioned, String oldVersion)
       throws Exception {
     final Host host = Host.getHost(0);
-    VM currentServer1 = host.getVM(0);
+    VM currentServer1 = host.getVM(VersionManager.CURRENT_VERSION, 0);
     VM oldServerAndLocator = host.getVM(oldVersion, 1);
-    VM currentServer2 = host.getVM(2);
+    VM currentServer2 = host.getVM(VersionManager.CURRENT_VERSION, 2);
     VM oldServer2 = host.getVM(oldVersion, 3);
 
     String regionName = "aRegion";
@@ -796,9 +796,9 @@ public class RollingUpgrade2DUnitTest extends JUnit4DistributedTestCase {
 
   public void doTestQueryMixedServers(boolean partitioned, String oldVersion) throws Exception {
     final Host host = Host.getHost(0);
-    VM currentServer1 = host.getVM(0);
+    VM currentServer1 = host.getVM(VersionManager.CURRENT_VERSION, 0);
     VM oldServer = host.getVM(oldVersion, 1);
-    VM currentServer2 = host.getVM(2);
+    VM currentServer2 = host.getVM(VersionManager.CURRENT_VERSION, 2);
     VM oldServerAndLocator = host.getVM(oldVersion, 3);
 
     String regionName = "cqs";
@@ -846,9 +846,9 @@ public class RollingUpgrade2DUnitTest extends JUnit4DistributedTestCase {
 
   public void doTestTracePRQuery(boolean partitioned, String oldVersion) throws Exception {
     final Host host = Host.getHost(0);
-    VM currentServer1 = host.getVM(0);
+    VM currentServer1 = host.getVM(VersionManager.CURRENT_VERSION, 0);
     VM oldServer = host.getVM(oldVersion, 1);
-    VM currentServer2 = host.getVM(2);
+    VM currentServer2 = host.getVM(VersionManager.CURRENT_VERSION, 2);
     VM oldServerAndLocator = host.getVM(oldVersion, 3);
 
     String regionName = "cqs";
@@ -892,9 +892,9 @@ public class RollingUpgrade2DUnitTest extends JUnit4DistributedTestCase {
   public void doTestCreateIndexes(boolean createMultiIndexes, boolean partitioned,
       String oldVersion) throws Exception {
     final Host host = Host.getHost(0);
-    final VM currentServer1 = host.getVM(0);
+    final VM currentServer1 = host.getVM(VersionManager.CURRENT_VERSION, 0);
     final VM oldServer = host.getVM(oldVersion, 1);
-    final VM currentServer2 = host.getVM(2);
+    final VM currentServer2 = host.getVM(VersionManager.CURRENT_VERSION, 2);
     final VM oldServerAndLocator = host.getVM(oldVersion, 3);
 
     String regionName = "cqs";
@@ -1035,8 +1035,8 @@ public class RollingUpgrade2DUnitTest extends JUnit4DistributedTestCase {
     final Host host = Host.getHost(0);
     VM oldLocator = host.getVM(oldVersion, 0);
     VM oldServer = host.getVM(oldVersion, 1);
-    VM currentServer1 = host.getVM(2);
-    VM currentServer2 = host.getVM(3);
+    VM currentServer1 = host.getVM(VersionManager.CURRENT_VERSION, 2);
+    VM currentServer2 = host.getVM(VersionManager.CURRENT_VERSION, 3);
 
     int[] locatorPorts = AvailablePortHelper.getRandomAvailableTCPPorts(1);
     String hostName = NetworkUtils.getServerHostName(host);
@@ -1091,7 +1091,7 @@ public class RollingUpgrade2DUnitTest extends JUnit4DistributedTestCase {
     final Host host = Host.getHost(0);
     VM locator = host.getVM(oldVersion, 0);
     VM server1 = host.getVM(oldVersion, 1);
-    VM server2 = host.getVM(2);
+    VM server2 = host.getVM(VersionManager.CURRENT_VERSION, 2);
     VM client = host.getVM(oldVersion, 3);
 
     int[] ports = AvailablePortHelper.getRandomAvailableTCPPorts(3);
@@ -1266,7 +1266,7 @@ public class RollingUpgrade2DUnitTest extends JUnit4DistributedTestCase {
   private VM rollServerToCurrent(VM oldServer, int[] locatorPorts) throws Exception {
     // Roll the server
     oldServer.invoke(invokeCloseCache());
-    VM rollServer = Host.getHost(0).getVM(oldServer.getId());
+    VM rollServer = Host.getHost(0).getVM(VersionManager.CURRENT_VERSION, oldServer.getId());
     rollServer.invoke(invokeCreateCache(locatorPorts == null ? getSystemPropertiesPost71()
         : getSystemPropertiesPost71(locatorPorts)));
     rollServer.invoke(invokeAssertVersion(Version.CURRENT_ORDINAL));
@@ -1276,7 +1276,7 @@ public class RollingUpgrade2DUnitTest extends JUnit4DistributedTestCase {
   private VM rollClientToCurrent(VM oldClient, String[] hostNames, int[] locatorPorts,
       boolean subscriptionEnabled) throws Exception {
     oldClient.invoke(invokeCloseCache());
-    VM rollClient = Host.getHost(0).getVM(oldClient.getId());
+    VM rollClient = Host.getHost(0).getVM(VersionManager.CURRENT_VERSION, oldClient.getId());
     rollClient.invoke(invokeCreateClientCache(getClientSystemProperties(), hostNames, locatorPorts,
         subscriptionEnabled));
     rollClient.invoke(invokeAssertVersion(Version.CURRENT_ORDINAL));
@@ -1342,7 +1342,7 @@ public class RollingUpgrade2DUnitTest extends JUnit4DistributedTestCase {
       final String testName, final String locatorString) throws Exception {
     // Roll the locator
     rollLocator.invoke(invokeStopLocator());
-    VM newLocator = Host.getHost(0).getVM(rollLocator.getId());
+    VM newLocator = Host.getHost(0).getVM(VersionManager.CURRENT_VERSION, rollLocator.getId());
     newLocator.invoke(invokeStartLocator(serverHostName, port, testName,
         getLocatorProperties91AndAfter(locatorString)));
     return newLocator;

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeDUnitTest.java
@@ -356,7 +356,13 @@ public class RollingUpgradeDUnitTest extends JUnit4DistributedTestCase {
   private VM rollServerToCurrent(VM oldServer, int[] locatorPorts) throws Exception {
     // Roll the server
     oldServer.invoke(invokeCloseCache());
-    VM rollServer = Host.getHost(0).getVM(oldServer.getId()); // gets a vm with the current version
+    VM rollServer = Host.getHost(0).getVM(VersionManager.CURRENT_VERSION, oldServer.getId()); // gets
+                                                                                              // a
+                                                                                              // vm
+                                                                                              // with
+                                                                                              // the
+                                                                                              // current
+                                                                                              // version
     rollServer.invoke(invokeCreateCache(locatorPorts == null ? getSystemPropertiesPost71()
         : getSystemPropertiesPost71(locatorPorts)));
     rollServer.invoke(invokeAssertVersion(Version.CURRENT_ORDINAL));
@@ -401,7 +407,12 @@ public class RollingUpgradeDUnitTest extends JUnit4DistributedTestCase {
       final String testName, final String locatorString) throws Exception {
     // Roll the locator
     oldLocator.invoke(invokeStopLocator());
-    VM rollLocator = Host.getHost(0).getVM(oldLocator.getId()); // gets a VM with current version
+    VM rollLocator = Host.getHost(0).getVM(VersionManager.CURRENT_VERSION, oldLocator.getId()); // gets
+                                                                                                // a
+                                                                                                // VM
+                                                                                                // with
+                                                                                                // current
+                                                                                                // version
     final Properties props = new Properties();
     props.setProperty(DistributionConfig.ENABLE_CLUSTER_CONFIGURATION_NAME, "false");
     rollLocator.invoke(invokeStartLocator(serverHostName, port, testName, locatorString, props));

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ClientServerMiscDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ClientServerMiscDUnitTest.java
@@ -146,8 +146,8 @@ public class ClientServerMiscDUnitTest extends JUnit4CacheTestCase {
   @Override
   public final void postSetUp() throws Exception {
     host = Host.getHost(0);
-    server1 = host.getVM(2);
-    server2 = host.getVM(3);
+    server1 = host.getVM(VersionManager.CURRENT_VERSION, 2);
+    server2 = host.getVM(VersionManager.CURRENT_VERSION, 3);
   }
 
   int initServerCache(boolean notifyBySub) {
@@ -1409,7 +1409,7 @@ public class ClientServerMiscDUnitTest extends JUnit4CacheTestCase {
     }
     if (isHA) {
       // add another server for HA scenario
-      initServerCache(true, host.getVM(1), true);
+      initServerCache(true, host.getVM(VersionManager.CURRENT_VERSION, 1), true);
     }
     String rName = "/" + REGION_NAME1;
     String prName = "/" + PR_REGION_NAME;

--- a/geode-core/src/test/java/org/apache/geode/test/dunit/standalone/DUnitLauncher.java
+++ b/geode-core/src/test/java/org/apache/geode/test/dunit/standalone/DUnitLauncher.java
@@ -481,9 +481,18 @@ public class DUnitLauncher {
       addHost(this);
     }
 
+    /**
+     * this will not bounce VM to a different version. It will only get the current running VM or
+     * launch a new one if not already launched.
+     */
     @Override
     public VM getVM(int n) {
-      return getVM(VersionManager.CURRENT_VERSION, n);
+      if (n < getVMCount()) {
+        VM current = super.getVM(n);
+        return getVM(current.getVersion(), n);
+      } else {
+        return getVM(VersionManager.CURRENT_VERSION, n);
+      }
     }
 
     @Override

--- a/geode-core/src/test/java/org/apache/geode/test/dunit/standalone/ProcessManager.java
+++ b/geode-core/src/test/java/org/apache/geode/test/dunit/standalone/ProcessManager.java
@@ -25,8 +25,6 @@ import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.lang.management.ManagementFactory;
 import java.lang.management.RuntimeMXBean;
-import java.net.InetAddress;
-import java.nio.file.Files;
 import java.rmi.AccessException;
 import java.rmi.NotBoundException;
 import java.rmi.RemoteException;
@@ -40,7 +38,6 @@ import org.apache.commons.io.FileUtils;
 
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.InternalLocator;
-import org.apache.geode.test.dunit.Host;
 import org.apache.geode.test.dunit.VM;
 
 /**
@@ -192,6 +189,8 @@ public class ProcessManager {
 
       String mainClasses = buildDir + "classes" + separator + "main";
       dunitClasspath = removeFromPath(dunitClasspath, mainClasses);
+
+      dunitClasspath = removeFromPath(dunitClasspath, "geode-core/out/production");
 
       String mainResources = buildDir + "resources" + separator + "main";
       dunitClasspath = removeFromPath(dunitClasspath, mainResources);

--- a/geode-cq/src/test/java/org/apache/geode/internal/cache/tier/sockets/ClientServerMiscBCDUnitTest.java
+++ b/geode-cq/src/test/java/org/apache/geode/internal/cache/tier/sockets/ClientServerMiscBCDUnitTest.java
@@ -125,8 +125,8 @@ public class ClientServerMiscBCDUnitTest extends ClientServerMiscDUnitTest {
   private void doTestSubscriptionWithMixedServersAndPeerFeed(String version,
       boolean usePeerForFeed) {
     server1 = Host.getHost(0).getVM(testVersion, 2);
-    server2 = Host.getHost(0).getVM(3);
-    VM server3 = Host.getHost(0).getVM(4);
+    server2 = Host.getHost(0).getVM(VersionManager.CURRENT_VERSION, 3);
+    VM server3 = Host.getHost(0).getVM(VersionManager.CURRENT_VERSION, 4);
     VM interestClient = Host.getHost(0).getVM(testVersion, 0);
     VM feeder = Host.getHost(0).getVM(version, 1);
 
@@ -227,8 +227,7 @@ public class ClientServerMiscBCDUnitTest extends ClientServerMiscDUnitTest {
   public void giiEventQueueShouldSucceedWithMixedVersions(String server1Version,
       String server2Version) {
     VM interestClient = Host.getHost(0).getVM(testVersion, 0);
-    // VM interestClient = Host.getHost(0).getVM(0);
-    VM feeder = Host.getHost(0).getVM(1);
+    VM feeder = Host.getHost(0).getVM(VersionManager.CURRENT_VERSION, 1);
     server1 = Host.getHost(0).getVM(server1Version, 2);
     server2 = Host.getHost(0).getVM(server2Version, 3);
 

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/LuceneSearchWithRollingUpgradeDUnit.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/LuceneSearchWithRollingUpgradeDUnit.java
@@ -304,7 +304,7 @@ public class LuceneSearchWithRollingUpgradeDUnit extends JUnit4DistributedTestCa
   private VM rollClientToCurrent(VM oldClient, String[] hostNames, int[] locatorPorts,
       boolean subscriptionEnabled) throws Exception {
     oldClient.invoke(invokeCloseCache());
-    VM rollClient = Host.getHost(0).getVM(oldClient.getId());
+    VM rollClient = Host.getHost(0).getVM(VersionManager.CURRENT_VERSION, oldClient.getId());
     rollClient.invoke(invokeCreateClientCache(getClientSystemProperties(), hostNames, locatorPorts,
         subscriptionEnabled));
     rollClient.invoke(invokeAssertVersion(Version.CURRENT_ORDINAL));
@@ -672,7 +672,13 @@ public class LuceneSearchWithRollingUpgradeDUnit extends JUnit4DistributedTestCa
   private VM rollServerToCurrent(VM oldServer, int[] locatorPorts) throws Exception {
     // Roll the server
     oldServer.invoke(invokeCloseCache());
-    VM rollServer = Host.getHost(0).getVM(oldServer.getId()); // gets a vm with the current version
+    VM rollServer = Host.getHost(0).getVM(VersionManager.CURRENT_VERSION, oldServer.getId()); // gets
+                                                                                              // a
+                                                                                              // vm
+                                                                                              // with
+                                                                                              // the
+                                                                                              // current
+                                                                                              // version
     rollServer.invoke(invokeCreateCache(locatorPorts == null ? getSystemPropertiesPost71()
         : getSystemPropertiesPost71(locatorPorts)));
     rollServer.invoke(invokeAssertVersion(Version.CURRENT_ORDINAL));
@@ -699,7 +705,12 @@ public class LuceneSearchWithRollingUpgradeDUnit extends JUnit4DistributedTestCa
       final String testName, final String locatorString) throws Exception {
     // Roll the locator
     oldLocator.invoke(invokeStopLocator());
-    VM rollLocator = Host.getHost(0).getVM(oldLocator.getId()); // gets a VM with current version
+    VM rollLocator = Host.getHost(0).getVM(VersionManager.CURRENT_VERSION, oldLocator.getId()); // gets
+                                                                                                // a
+                                                                                                // VM
+                                                                                                // with
+                                                                                                // current
+                                                                                                // version
     final Properties props = new Properties();
     props.setProperty(DistributionConfig.ENABLE_CLUSTER_CONFIGURATION_NAME, "false");
     rollLocator.invoke(invokeStartLocator(serverHostName, port, testName, locatorString, props));

--- a/geode-wan/src/test/java/org/apache/geode/cache/wan/WANRollingUpgradeDUnitTest.java
+++ b/geode-wan/src/test/java/org/apache/geode/cache/wan/WANRollingUpgradeDUnitTest.java
@@ -89,7 +89,7 @@ public class WANRollingUpgradeDUnitTest extends JUnit4CacheTestCase {
     final Host host = Host.getHost(0);
     VM oldLocator = host.getVM(oldVersion, 0);
     VM oldServer = host.getVM(oldVersion, 1);
-    VM currentServer = host.getVM(2);
+    VM currentServer = host.getVM(VersionManager.CURRENT_VERSION, 2);
 
     // Start locator
     final int port = AvailablePort.getRandomAvailablePort(AvailablePort.SOCKET);
@@ -130,10 +130,10 @@ public class WANRollingUpgradeDUnitTest extends JUnit4CacheTestCase {
     VM site1Client = host.getVM(oldVersion, 3);
 
     // Get current site members
-    VM site2Locator = host.getVM(4);
-    VM site2Server1 = host.getVM(5);
-    VM site2Server2 = host.getVM(6);
-    VM site2Client = host.getVM(7);
+    VM site2Locator = host.getVM(VersionManager.CURRENT_VERSION, 4);
+    VM site2Server1 = host.getVM(VersionManager.CURRENT_VERSION, 5);
+    VM site2Server2 = host.getVM(VersionManager.CURRENT_VERSION, 6);
+    VM site2Client = host.getVM(VersionManager.CURRENT_VERSION, 7);
 
     // Get old site locator properties
     String hostName = NetworkUtils.getServerHostName(host);
@@ -193,9 +193,9 @@ public class WANRollingUpgradeDUnitTest extends JUnit4CacheTestCase {
     VM site1Client = host.getVM(oldVersion, 3);
 
     // Get current site members
-    VM site2Locator = host.getVM(4);
-    VM site2Server1 = host.getVM(5);
-    VM site2Server2 = host.getVM(6);
+    VM site2Locator = host.getVM(VersionManager.CURRENT_VERSION, 4);
+    VM site2Server1 = host.getVM(VersionManager.CURRENT_VERSION, 5);
+    VM site2Server2 = host.getVM(VersionManager.CURRENT_VERSION, 6);
 
     // Get old site locator properties
     String hostName = NetworkUtils.getServerHostName(host);
@@ -255,10 +255,10 @@ public class WANRollingUpgradeDUnitTest extends JUnit4CacheTestCase {
     VM site1Server2 = host.getVM(oldVersion, 2);
 
     // Get current site members
-    VM site2Locator = host.getVM(4);
-    VM site2Server1 = host.getVM(5);
-    VM site2Server2 = host.getVM(6);
-    VM site2Client = host.getVM(7);
+    VM site2Locator = host.getVM(VersionManager.CURRENT_VERSION, 4);
+    VM site2Server1 = host.getVM(VersionManager.CURRENT_VERSION, 5);
+    VM site2Server2 = host.getVM(VersionManager.CURRENT_VERSION, 6);
+    VM site2Client = host.getVM(VersionManager.CURRENT_VERSION, 7);
 
     // Get old site locator properties
     String hostName = NetworkUtils.getServerHostName(host);
@@ -319,9 +319,9 @@ public class WANRollingUpgradeDUnitTest extends JUnit4CacheTestCase {
     VM site1Client = host.getVM(oldVersion, 3);
 
     // Get current site members
-    VM site2Locator = host.getVM(4);
-    VM site2Server1 = host.getVM(5);
-    VM site2Server2 = host.getVM(6);
+    VM site2Locator = host.getVM(VersionManager.CURRENT_VERSION, 4);
+    VM site2Server1 = host.getVM(VersionManager.CURRENT_VERSION, 5);
+    VM site2Server2 = host.getVM(VersionManager.CURRENT_VERSION, 6);
 
     // Get old site locator properties
     String hostName = NetworkUtils.getServerHostName(host);
@@ -442,9 +442,9 @@ public class WANRollingUpgradeDUnitTest extends JUnit4CacheTestCase {
     VM site1Client = host.getVM(oldVersion, 3);
 
     // Get old site members
-    VM site2Locator = host.getVM(4);
-    VM site2Server1 = host.getVM(5);
-    VM site2Server2 = host.getVM(6);
+    VM site2Locator = host.getVM(VersionManager.CURRENT_VERSION, 4);
+    VM site2Server1 = host.getVM(VersionManager.CURRENT_VERSION, 5);
+    VM site2Server2 = host.getVM(VersionManager.CURRENT_VERSION, 6);
 
     // Get mixed site locator properties
     String hostName = NetworkUtils.getServerHostName(host);
@@ -512,7 +512,7 @@ public class WANRollingUpgradeDUnitTest extends JUnit4CacheTestCase {
   private VM rollLocatorToCurrent(VM rollLocator, int port, int distributedSystemId,
       String locators, String remoteLocators) throws Exception {
     rollLocator.invoke(() -> stopLocator());
-    VM newLocator = Host.getHost(0).getVM(rollLocator.getId());
+    VM newLocator = Host.getHost(0).getVM(VersionManager.CURRENT_VERSION, rollLocator.getId());
     newLocator.invoke(() -> startLocator(port, distributedSystemId, locators, remoteLocators));
     return newLocator;
   }
@@ -521,7 +521,7 @@ public class WANRollingUpgradeDUnitTest extends JUnit4CacheTestCase {
       int distributedSystem, String regionName, String senderId, int messageSyncInterval)
       throws Exception {
     oldServer.invoke(() -> closeCache());
-    VM rollServer = Host.getHost(0).getVM(oldServer.getId());
+    VM rollServer = Host.getHost(0).getVM(VersionManager.CURRENT_VERSION, oldServer.getId());
     startAndConfigureServers(rollServer, null, locators, distributedSystem, regionName, senderId,
         messageSyncInterval);
     return rollServer;


### PR DESCRIPTION


* getVM(int index) call will not roll the vm back to current version.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
