### PR TITLE
GEODE-3539: Add test coverage to 'alter disk-store'.

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/AlterDiskStoreDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/AlterDiskStoreDUnitTest.java
@@ -19,7 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.Serializable;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -52,7 +51,7 @@ public class AlterDiskStoreDUnitTest {
   private static MemberVM server1;
 
   @Rule
-  public LocatorServerStartupRule startupRule = new LocatorServerStartupRule().withTempWorkingDir();
+  public LocatorServerStartupRule startupRule = new LocatorServerStartupRule();
 
   @Rule
   public GfshCommandRule gfsh = new GfshCommandRule();
@@ -132,8 +131,7 @@ public class AlterDiskStoreDUnitTest {
   }
 
   private String getDiskDirPathString() throws IOException {
-    return startupRule.getWorkingDirRoot().toPath().resolve(diskDirName).toFile()
-        .getCanonicalPath();
+    return gfsh.getWorkingDir().toPath().resolve(diskDirName).toFile().getCanonicalPath();
   }
 
   private String commandWithRemoveAndNoOtherOption() throws IOException {

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/AlterDiskStoreDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/AlterDiskStoreDUnitTest.java
@@ -42,7 +42,7 @@ import org.apache.geode.test.junit.rules.GfshCommandRule;
 import org.apache.geode.test.junit.rules.GfshCommandRule.PortType;
 
 @Category(DistributedTest.class)
-public class AlterDiskStoreDUnitTest implements Serializable {
+public class AlterDiskStoreDUnitTest {
   private static final String regionName = "region1";
   private static final String diskStoreName = "disk-store1";
   private static final String diskDirName = "diskStoreDir";

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/AlterDiskStoreDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/AlterDiskStoreDUnitTest.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.management.internal.cli.commands;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Serializable;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.DataPolicy;
+import org.apache.geode.cache.EvictionAction;
+import org.apache.geode.cache.EvictionAttributes;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionFactory;
+import org.apache.geode.cache.Scope;
+import org.apache.geode.management.internal.cli.i18n.CliStrings;
+import org.apache.geode.management.internal.cli.util.CommandStringBuilder;
+import org.apache.geode.test.dunit.rules.LocatorServerStartupRule;
+import org.apache.geode.test.dunit.rules.MemberVM;
+import org.apache.geode.test.junit.categories.DistributedTest;
+import org.apache.geode.test.junit.rules.GfshCommandRule;
+import org.apache.geode.test.junit.rules.GfshCommandRule.PortType;
+
+@Category(DistributedTest.class)
+public class AlterDiskStoreDUnitTest implements Serializable {
+  private static final String regionName = "region1";
+  private static final String diskStoreName = "disk-store1";
+  private static final String diskDirName = "diskStoreDir";
+  private static final String aKey = "key1";
+
+  private static MemberVM locator;
+  private static MemberVM server1;
+
+  @Rule
+  public LocatorServerStartupRule startupRule = new LocatorServerStartupRule().withTempWorkingDir();
+
+  @Rule
+  public GfshCommandRule gfsh = new GfshCommandRule();
+
+  @Before
+  public void setupCluster() throws Exception {
+
+    File diskStoreDirFile = new File(getDiskDirPathString());
+
+    if (!diskStoreDirFile.exists()) {
+      diskStoreDirFile.mkdirs();
+    }
+
+    locator = startupRule.startLocatorVM(0);
+    server1 = startupRule.startServerVM(1, locator.getPort());
+    String diskDirPathString = getDiskDirPathString();
+    server1.invoke(() -> {
+      Cache cache = LocatorServerStartupRule.getCache();
+      cache.createDiskStoreFactory().setDiskDirs(new File[] {new File(diskDirPathString)})
+          .setMaxOplogSize(1).setAllowForceCompaction(true).setAutoCompact(false)
+          .create(diskStoreName);
+
+      EvictionAttributes ea =
+          EvictionAttributes.createLRUEntryAttributes(1, EvictionAction.OVERFLOW_TO_DISK);
+
+      RegionFactory<String, String> regionFactory = cache.createRegionFactory();
+      Region<String, String> region = regionFactory.setDiskStoreName(diskStoreName)
+          .setDiskSynchronous(true).setDataPolicy(DataPolicy.PERSISTENT_REPLICATE)
+          .setScope(Scope.DISTRIBUTED_ACK).setEvictionAttributes(ea).create(regionName);
+      region.put(aKey, "value");
+    });
+  }
+
+  @Test
+  public void diskStoreIsLockedWhileMemberIsAlive() throws Exception {
+    gfsh.connectAndVerify(locator.getJmxPort(), PortType.jmxManager);
+    String commandString = commandToSetManyVariables();
+    gfsh.executeAndAssertThat(commandString).statusIsError().containsOutput("Could not lock",
+        "Other JVMs might have created diskstore with same name using the same directory");
+  }
+
+  @Test
+  public void alterDiskStoreUpdatesValues() throws Exception {
+    startupRule.stopVM(1);
+
+    gfsh.connectAndVerify(locator.getJmxPort(), PortType.jmxManager);
+    String commandOne = commandToSetManyVariables();
+    gfsh.executeAndAssertThat(commandOne).statusIsSuccess().containsOutput("concurrencyLevel=5",
+        "lruAction=local-destroy", "compressor=org.apache.geode.compression.SnappyCompressor",
+        "initialCapacity=6");
+
+    String commandTwo = commandToSetCompressorToNone();
+    gfsh.executeAndAssertThat(commandTwo).statusIsSuccess().containsOutput("-compressor=none");
+  }
+
+  @Test
+  public void alterDiskStoreWithRemoveDoesRemoveRegion() throws IOException {
+    // Verify to start that there exists the data in the region
+    server1.invoke(() -> {
+      Region region = LocatorServerStartupRule.getCache().getRegion(regionName);
+      assertThat(region).isNotNull();
+      assertThat(region.get(aKey)).isNotNull();
+    });
+
+    // Halt the member and "alter" the disk store with the --remove option
+    startupRule.stopVM(1);
+    String cmd = commandWithRemoveAndNoOtherOption();
+    gfsh.executeAndAssertThat(cmd).statusIsSuccess().containsOutput("The region " + regionName
+        + " was successfully removed from the disk store " + diskStoreName);
+
+    // Restart the member and see that the disk store / region is gone.
+    startupRule.startServerVM(1, locator.getPort());
+    server1.invoke(() -> {
+      Region region = LocatorServerStartupRule.getCache().getRegion(regionName);
+      assertThat(region).isNull();
+    });
+  }
+
+  private String getDiskDirPathString() throws IOException {
+    return startupRule.getWorkingDirRoot().toPath().resolve(diskDirName).toFile()
+        .getCanonicalPath();
+  }
+
+  private String commandWithRemoveAndNoOtherOption() throws IOException {
+    CommandStringBuilder csb = new CommandStringBuilder(CliStrings.ALTER_DISK_STORE);
+    csb.addOption(CliStrings.ALTER_DISK_STORE__DISKSTORENAME, diskStoreName);
+    csb.addOption(CliStrings.ALTER_DISK_STORE__REGIONNAME, regionName);
+    csb.addOption(CliStrings.ALTER_DISK_STORE__DISKDIRS, getDiskDirPathString());
+    csb.addOption(CliStrings.ALTER_DISK_STORE__REMOVE, "true");
+    return csb.toString();
+  }
+
+  private String commandToSetCompressorToNone() throws IOException {
+    CommandStringBuilder csb = new CommandStringBuilder(CliStrings.ALTER_DISK_STORE);
+    csb.addOption(CliStrings.ALTER_DISK_STORE__DISKSTORENAME, diskStoreName);
+    csb.addOption(CliStrings.ALTER_DISK_STORE__REGIONNAME, regionName);
+    csb.addOption(CliStrings.ALTER_DISK_STORE__DISKDIRS, getDiskDirPathString());
+    csb.addOption(CliStrings.ALTER_DISK_STORE__COMPRESSOR, "none");
+    return csb.toString();
+  }
+
+  private String commandToSetManyVariables() throws IOException {
+    CommandStringBuilder csb = new CommandStringBuilder(CliStrings.ALTER_DISK_STORE);
+    csb.addOption(CliStrings.ALTER_DISK_STORE__DISKSTORENAME, diskStoreName);
+    csb.addOption(CliStrings.ALTER_DISK_STORE__REGIONNAME, regionName);
+    csb.addOption(CliStrings.ALTER_DISK_STORE__DISKDIRS, getDiskDirPathString());
+    csb.addOption(CliStrings.ALTER_DISK_STORE__CONCURRENCY__LEVEL, "5");
+    csb.addOption(CliStrings.ALTER_DISK_STORE__INITIAL__CAPACITY, "6");
+    csb.addOption(CliStrings.ALTER_DISK_STORE__LRU__EVICTION__ACTION, "local-destroy");
+    csb.addOption(CliStrings.ALTER_DISK_STORE__COMPRESSOR,
+        "org.apache.geode.compression.SnappyCompressor");
+    csb.addOption(CliStrings.ALTER_DISK_STORE__STATISTICS__ENABLED, "true");
+    return csb.toString();
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/AlterDiskStoreIntegrationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/AlterDiskStoreIntegrationTest.java
@@ -15,46 +15,41 @@
 
 package org.apache.geode.management.internal.cli.commands;
 
-import java.io.IOException;
+import static org.mockito.Mockito.spy;
 
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.util.CommandStringBuilder;
-import org.apache.geode.test.junit.categories.IntegrationTest;
-import org.apache.geode.test.junit.rules.GfshCommandRule;
-import org.apache.geode.test.junit.rules.GfshCommandRule.PortType;
-import org.apache.geode.test.junit.rules.ServerStarterRule;
+import org.apache.geode.test.junit.categories.UnitTest;
+import org.apache.geode.test.junit.rules.GfshParserRule;
 
-@Category(IntegrationTest.class)
+@Category(UnitTest.class)
 public class AlterDiskStoreIntegrationTest {
-  private static final String regionName = "region1";
-  private static final String diskStoreName = "disk-store1";
-
   @Rule
-  public GfshCommandRule gfsh = new GfshCommandRule();
+  public GfshParserRule gfsh = new GfshParserRule();
+
+  private GfshCommand command;
+
+  @Before
+  public void before() {
+    command = spy(AlterOfflineDiskStoreCommand.class);
+  }
 
   @Test
   public void removeOptionMustBeUsedAlone() throws Exception {
-    String commandString = commandWithRemoveAndOtherOption();
-    gfsh.executeAndAssertThat(commandString).statusIsError()
-        .containsOutput("Cannot use the --remove=true parameter with any other parameters");
-  }
-
-  private String commandWithRemoveAndOtherOption() throws IOException {
     CommandStringBuilder csb = new CommandStringBuilder(CliStrings.ALTER_DISK_STORE);
-    csb.addOption(CliStrings.ALTER_DISK_STORE__DISKSTORENAME, diskStoreName);
-    csb.addOption(CliStrings.ALTER_DISK_STORE__REGIONNAME, regionName);
-    csb.addOption(CliStrings.ALTER_DISK_STORE__DISKDIRS, getDiskDirPathString());
+    csb.addOption(CliStrings.ALTER_DISK_STORE__DISKSTORENAME, "diskStoreName");
+    csb.addOption(CliStrings.ALTER_DISK_STORE__REGIONNAME, "regionName");
+    csb.addOption(CliStrings.ALTER_DISK_STORE__DISKDIRS, "./someDirectory");
     csb.addOption(CliStrings.ALTER_DISK_STORE__CONCURRENCY__LEVEL, "5");
     csb.addOption(CliStrings.ALTER_DISK_STORE__REMOVE, "true");
-    return csb.toString();
-  }
+    String commandString = csb.toString();
 
-  private String getDiskDirPathString() throws IOException {
-    return gfsh.getWorkingDir().getCanonicalPath();
+    gfsh.executeAndAssertThat(command, commandString).statusIsError()
+        .containsOutput("Cannot use the --remove=true parameter with any other parameters");
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/AlterDiskStoreIntegrationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/AlterDiskStoreIntegrationTest.java
@@ -32,16 +32,10 @@ import org.apache.geode.test.junit.rules.ServerStarterRule;
 @Category(IntegrationTest.class)
 public class AlterDiskStoreIntegrationTest {
   private static final String regionName = "region1";
-  private static final String memberName = "server";
   private static final String diskStoreName = "disk-store1";
 
   @Rule
-  public ServerStarterRule server =
-      new ServerStarterRule().withRegion(RegionShortcut.REPLICATE, regionName).withName(memberName)
-          .withWorkingDir().withJMXManager().withAutoStart();
-
-  @Rule
-  public GfshCommandRule gfsh = new GfshCommandRule(server::getJmxPort, PortType.jmxManager);
+  public GfshCommandRule gfsh = new GfshCommandRule();
 
   @Test
   public void removeOptionMustBeUsedAlone() throws Exception {
@@ -61,7 +55,6 @@ public class AlterDiskStoreIntegrationTest {
   }
 
   private String getDiskDirPathString() throws IOException {
-    return server.getWorkingDir().getCanonicalPath();
+    return gfsh.getWorkingDir().getCanonicalPath();
   }
-
 }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/AlterDiskStoreIntegrationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/AlterDiskStoreIntegrationTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.management.internal.cli.commands;
+
+import java.io.IOException;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.management.internal.cli.i18n.CliStrings;
+import org.apache.geode.management.internal.cli.util.CommandStringBuilder;
+import org.apache.geode.test.junit.categories.IntegrationTest;
+import org.apache.geode.test.junit.rules.GfshCommandRule;
+import org.apache.geode.test.junit.rules.GfshCommandRule.PortType;
+import org.apache.geode.test.junit.rules.ServerStarterRule;
+
+@Category(IntegrationTest.class)
+public class AlterDiskStoreIntegrationTest {
+  private static final String regionName = "region1";
+  private static final String memberName = "server";
+  private static final String diskStoreName = "disk-store1";
+
+  @Rule
+  public ServerStarterRule server =
+      new ServerStarterRule().withRegion(RegionShortcut.REPLICATE, regionName).withName(memberName)
+          .withWorkingDir().withJMXManager().withAutoStart();
+
+  @Rule
+  public GfshCommandRule gfsh = new GfshCommandRule(server::getJmxPort, PortType.jmxManager);
+
+  @Test
+  public void removeOptionMustBeUsedAlone() throws Exception {
+    String commandString = commandWithRemoveAndOtherOption();
+    gfsh.executeAndAssertThat(commandString).statusIsError()
+        .containsOutput("Cannot use the --remove=true parameter with any other parameters");
+  }
+
+  private String commandWithRemoveAndOtherOption() throws IOException {
+    CommandStringBuilder csb = new CommandStringBuilder(CliStrings.ALTER_DISK_STORE);
+    csb.addOption(CliStrings.ALTER_DISK_STORE__DISKSTORENAME, diskStoreName);
+    csb.addOption(CliStrings.ALTER_DISK_STORE__REGIONNAME, regionName);
+    csb.addOption(CliStrings.ALTER_DISK_STORE__DISKDIRS, getDiskDirPathString());
+    csb.addOption(CliStrings.ALTER_DISK_STORE__CONCURRENCY__LEVEL, "5");
+    csb.addOption(CliStrings.ALTER_DISK_STORE__REMOVE, "true");
+    return csb.toString();
+  }
+
+  private String getDiskDirPathString() throws IOException {
+    return server.getWorkingDir().getCanonicalPath();
+  }
+
+}

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/AlterDiskStoreJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/AlterDiskStoreJUnitTest.java
@@ -28,7 +28,7 @@ import org.apache.geode.test.junit.categories.UnitTest;
 import org.apache.geode.test.junit.rules.GfshParserRule;
 
 @Category(UnitTest.class)
-public class AlterDiskStoreIntegrationTest {
+public class AlterDiskStoreJUnitTest {
   @Rule
   public GfshParserRule gfsh = new GfshParserRule();
 

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DiskStoreCommandsDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DiskStoreCommandsDUnitTest.java
@@ -238,33 +238,6 @@ public class DiskStoreCommandsDUnitTest {
     assertThat(diskStoreExistsInClusterConfig(locator)).isFalse();
   }
 
-  @Test
-  public void testAlterDiskStore() throws Exception {
-    Properties props = new Properties();
-    props.setProperty("groups", GROUP);
-    MemberVM locator = rule.startLocatorVM(0);
-    MemberVM server1 = rule.startServerVM(1, props, locator.getPort());
-
-    gfsh.connectAndVerify(locator);
-
-    createDiskStoreAndRegion(locator, 1);
-
-    String diskDirs = new File(server1.getWorkingDir(), DISKSTORE).getAbsolutePath();
-    gfsh.executeAndAssertThat(
-        String.format("alter disk-store --name=%s --region=%s --disk-dirs=%s --concurrency-level=5",
-            DISKSTORE, REGION_1, diskDirs))
-        .statusIsError().containsOutput("Could not lock");
-
-    server1.invoke(LocatorServerStartupRule::stopMemberInThisVM);
-
-    gfsh.executeAndAssertThat(String.format(
-        "alter disk-store --name=%s --region=%s --disk-dirs=%s --concurrency-level=5 --initial-capacity=6 --lru-action=local-destroy --compressor=%s --enable-statistics=true",
-        DISKSTORE, REGION_1, diskDirs, SnappyCompressor.class.getName())).statusIsSuccess()
-        .containsOutput("concurrencyLevel=16", "concurrencyLevel=5", "initialCapacity=16",
-            "initialCapacity=6", "lruAction=overflow-to-disk", "lruAction=local-destroy",
-            "compressor=none", "compressor=" + SnappyCompressor.class.getName(),
-            "statisticsEnabled=false", "statisticsEnabled=true");
-  }
 
   @Test
   public void testBackupDiskStore() throws Exception {


### PR DESCRIPTION
* Remove flaky testing from DiskStoreCommandsDUnitTest, converted to AlterDiskStoreDUnitTest
* Added AlterDiskStoreIntegrationTest for testing of option conflict

---

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
