### PR TITLE
GEODE-3980: Remove unneeded additional findAvailablePids calls

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/internal/process/lang/AvailablePidTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/process/lang/AvailablePidTest.java
@@ -97,7 +97,6 @@ public class AvailablePidTest {
     assertThat(availablePid.findAvailablePids(2)).hasSize(2);
     assertThat(availablePid.findAvailablePids(3)).hasSize(3);
     assertThat(availablePid.findAvailablePids(5)).hasSize(5);
-    assertThat(availablePid.findAvailablePids(8)).hasSize(8);
   }
 
   @Test
@@ -106,7 +105,6 @@ public class AvailablePidTest {
     assertThatNoPidIsDuplicated(availablePid.findAvailablePids(2));
     assertThatNoPidIsDuplicated(availablePid.findAvailablePids(3));
     assertThatNoPidIsDuplicated(availablePid.findAvailablePids(5));
-    assertThatNoPidIsDuplicated(availablePid.findAvailablePids(8));
   }
 
   @Test


### PR DESCRIPTION
The extra findAvailablePids calls result in flaky results on
Windows.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
