### PR TITLE
GEODE-3999: Prevent prematurely running out of heap

### DIFF
--- a/geode-assembly/src/test/java/org/apache/geode/management/internal/cli/commands/LauncherLifecycleCommandsDUnitTest.java
+++ b/geode-assembly/src/test/java/org/apache/geode/management/internal/cli/commands/LauncherLifecycleCommandsDUnitTest.java
@@ -986,7 +986,7 @@ public class LauncherLifecycleCommandsDUnitTest extends CliCommandTestBase {
         pathname + TIMESTAMP.format(Calendar.getInstance().getTime()));
     command.addOption(CliStrings.START_SERVER__SERVER_PORT, String.valueOf(serverPort));
     command.addOption(CliStrings.START_SERVER__USE_CLUSTER_CONFIGURATION, Boolean.FALSE.toString());
-    command.addOption(CliStrings.START_SERVER__MAXHEAP, "10M");
+    command.addOption(CliStrings.START_SERVER__MAXHEAP, "12M");
     command.addOption(CliStrings.START_SERVER__LOG_LEVEL, "config");
     command.addOption(CliStrings.START_SERVER__DIR, workingDirectory.getCanonicalPath());
     command.addOption(CliStrings.START_SERVER__CACHE_XML_FILE,


### PR DESCRIPTION
The heap size for test014GemFireServerJvmProcessTerminatesOnOutOfMemoryError
is marginally increased from 10M to 12M. This should allow sufficient
memory to start the servers, but not so much that the test takes too long
to force the OutOfMemoryError.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
