### PR TITLE
GEODE-3788: add utility methods to get the async event queues in the …

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/ManagementService.java
+++ b/geode-core/src/main/java/org/apache/geode/management/ManagementService.java
@@ -217,6 +217,11 @@ public abstract class ManagementService {
   public abstract Set<ObjectName> queryMBeanNames(DistributedMember member);
 
   /**
+   * Returns the ids of the async event queues on this member
+   */
+  public abstract Set<String> getAsyncEventQueueIds(DistributedMember member);
+
+  /**
    * Returns an instance of an MBean. This is a reference to the MBean instance and not a
    * {@link ObjectInstance}.
    *

--- a/geode-core/src/main/java/org/apache/geode/management/internal/SystemManagementService.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/SystemManagementService.java
@@ -18,6 +18,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
 
 import javax.management.Notification;
 import javax.management.ObjectName;
@@ -355,6 +356,13 @@ public class SystemManagementService extends BaseManagementService {
       }
       return federatingManager.findAllProxies(member);
     }
+  }
+
+  @Override
+  public Set<String> getAsyncEventQueueIds(DistributedMember member) {
+    Set<ObjectName> mBeanNames = this.queryMBeanNames(member);
+    return mBeanNames.stream().filter(x -> "AsyncEventQueue".equals(x.getKeyProperty("service")))
+        .map(x -> x.getKeyProperty("queue")).collect(Collectors.toSet());
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/CliUtil.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/CliUtil.java
@@ -60,6 +60,7 @@ import org.apache.geode.management.DistributedRegionMXBean;
 import org.apache.geode.management.ManagementService;
 import org.apache.geode.management.cli.Result;
 import org.apache.geode.management.internal.MBeanJMXAdapter;
+import org.apache.geode.management.internal.SystemManagementService;
 import org.apache.geode.management.internal.cli.exceptions.UserErrorException;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
@@ -404,6 +405,16 @@ public class CliUtil {
           CliStrings.format(CliStrings.COMMAND_FAILURE_MESSAGE, commandName));
     }
     return result;
+  }
+
+  public static Set<DistributedMember> getMembersWithAsyncEventQueue(InternalCache cache,
+      String queueId) {
+    SystemManagementService managementService =
+        (SystemManagementService) ManagementService.getExistingManagementService(cache);
+    Set<DistributedMember> members = findMembers(null, null);
+    return members.stream()
+        .filter(m -> managementService.getAsyncEventQueueIds(m).contains(queueId))
+        .collect(Collectors.toSet());
   }
 
   static class CustomFileFilter implements FileFilter {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/GfshCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/GfshCommand.java
@@ -183,4 +183,8 @@ public interface GfshCommand extends CommandMarker {
   default Set<DistributedMember> findAnyMembersForRegion(InternalCache cache, String regionPath) {
     return CliUtil.getRegionAssociatedMembers(regionPath, cache, false);
   }
+
+  default Set<DistributedMember> findMembersWithAsyncEventQueue(String queueId) {
+    return CliUtil.getMembersWithAsyncEventQueue(getCache(), queueId);
+  }
 }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/CliUtilDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/CliUtilDUnitTest.java
@@ -31,6 +31,7 @@ import org.junit.experimental.categories.Category;
 import org.apache.geode.distributed.ConfigurationProperties;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.wan.MyAsyncEventListener;
 import org.apache.geode.management.internal.cli.exceptions.UserErrorException;
 import org.apache.geode.test.dunit.rules.LocatorServerStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
@@ -183,6 +184,35 @@ public class CliUtilDUnitTest {
     });
   }
 
+
+  @Test
+  public void getMembersWithQueueId() throws Exception {
+    gfsh.executeAndAssertThat("create async-event-queue --id=queue1 --group=group1 --listener="
+        + MyAsyncEventListener.class.getName()).statusIsSuccess();
+    gfsh.executeAndAssertThat("create async-event-queue --id=queue2 --group=group2 --listener="
+        + MyAsyncEventListener.class.getName()).statusIsSuccess();
+    gfsh.executeAndAssertThat(
+        "create async-event-queue --id=queue --listener=" + MyAsyncEventListener.class.getName())
+        .statusIsSuccess();
+
+    locator.waitTillAsyncEventQueuesAreReadyOnServers("queue1", 2);
+    locator.waitTillAsyncEventQueuesAreReadyOnServers("queue2", 2);
+    locator.waitTillAsyncEventQueuesAreReadyOnServers("queue", 4);
+
+    locator.invoke(() -> {
+      members =
+          CliUtil.getMembersWithAsyncEventQueue(LocatorServerStartupRule.getCache(), "queue1");
+      assertThat(getNames(members)).containsExactlyInAnyOrder("member1", "member2");
+
+      members =
+          CliUtil.getMembersWithAsyncEventQueue(LocatorServerStartupRule.getCache(), "queue2");
+      assertThat(getNames(members)).containsExactlyInAnyOrder("member3", "member4");
+
+      members = CliUtil.getMembersWithAsyncEventQueue(LocatorServerStartupRule.getCache(), "queue");
+      assertThat(getNames(members)).containsExactlyInAnyOrder("member1", "member2", "member3",
+          "member4");
+    });
+  }
 
   private static Set<String> getNames(Set<DistributedMember> members) {
     return members.stream().map(DistributedMember::getName).collect(Collectors.toSet());

--- a/geode-core/src/test/java/org/apache/geode/test/dunit/rules/MemberVM.java
+++ b/geode-core/src/test/java/org/apache/geode/test/dunit/rules/MemberVM.java
@@ -137,4 +137,12 @@ public class MemberVM implements Member {
     vm.invoke(() -> LocatorServerStartupRule.memberStarter.waitTillDiskStoreIsReady(diskstoreName,
         serverCount));
   }
+
+  public void waitTillAsyncEventQueuesAreReadyOnServers(String queueId, int serverCount) {
+    vm.invoke(() -> {
+      LocatorServerStartupRule.memberStarter.waitTillAsyncEventQueuesAreReadyOnServers(queueId,
+          serverCount);
+    });
+  }
+
 }

--- a/geode-core/src/test/java/org/apache/geode/test/junit/rules/MemberStarterRule.java
+++ b/geode-core/src/test/java/org/apache/geode/test/junit/rules/MemberStarterRule.java
@@ -43,6 +43,7 @@ import org.apache.geode.internal.net.SocketCreatorFactory;
 import org.apache.geode.management.DistributedRegionMXBean;
 import org.apache.geode.management.DistributedSystemMXBean;
 import org.apache.geode.management.ManagementService;
+import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.security.SecurityManager;
 import org.apache.geode.test.junit.rules.serializable.SerializableExternalResource;
 
@@ -205,9 +206,9 @@ public abstract class MemberStarterRule<T> extends SerializableExternalResource 
       if (properties.containsKey(NAME)) {
         name = properties.getProperty(NAME);
       } else {
-        if (this instanceof ServerStarterRule)
+        if (this instanceof ServerStarterRule) {
           name = "server";
-        else {
+        } else {
           name = "locator";
         }
       }
@@ -261,6 +262,11 @@ public abstract class MemberStarterRule<T> extends SerializableExternalResource 
   public void waitTillDiskStoreIsReady(String diskstoreName, int serverCount) {
     await().atMost(30, TimeUnit.SECONDS)
         .until(() -> getDiskStoreCount(diskstoreName) == serverCount);
+  }
+
+  public void waitTillAsyncEventQueuesAreReadyOnServers(String queueId, int serverCount) {
+    await().atMost(2, TimeUnit.SECONDS).until(
+        () -> CliUtil.getMembersWithAsyncEventQueue(getCache(), queueId).size() == serverCount);
   }
 
   abstract void stopMember();


### PR DESCRIPTION
Utility methods added while doing the async-event-queue work. It's not needed by the "alter asyn-event-queue" command, but it would be useful for later.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
