### PR TITLE
GEODE-4014: use getVMCount instead of hardcoding number of VMs

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/test/dunit/rules/tests/CacheRuleTest.java
+++ b/geode-core/src/test/java/org/apache/geode/test/dunit/rules/tests/CacheRuleTest.java
@@ -227,10 +227,14 @@ public class CacheRuleTest {
 
     @Test
     public void createCacheInAll_createsCluster() throws Exception {
-      assertThat(cacheRule.getCache().getDistributionManager().getViewMembers()).hasSize(6);
-      for (int i = 0; i < Host.getHost(0).getVMCount(); i++) {
+      int vmCount = Host.getHost(0).getVMCount();
+
+      assertThat(cacheRule.getCache().getDistributionManager().getViewMembers())
+          .hasSize(vmCount + 2);
+      for (int i = 0; i < vmCount; i++) {
         Host.getHost(0).getVM(i).invoke(() -> {
-          assertThat(cacheRule.getCache().getDistributionManager().getViewMembers()).hasSize(6);
+          assertThat(cacheRule.getCache().getDistributionManager().getViewMembers())
+              .hasSize(vmCount + 2);
         });
       }
     }


### PR DESCRIPTION
GEODE-4014 only occurs if one of the previously run dunit tests (within fork every 30) used more than the default four VMs. This change will keep CacheRuleTest passing no matter how many VMs are available to dunit.