### PR TITLE
GEODE-3539: enhance GfshCommandRule. Rename method for consistency.

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DescribeDiskStoreCommandIntegrationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DescribeDiskStoreCommandIntegrationTest.java
@@ -54,7 +54,7 @@ public class DescribeDiskStoreCommandIntegrationTest {
   }
 
   @ClassRule
-  public static GfshCommandRule gfsh = new GfshCommandRule().setTimeout(1);
+  public static GfshCommandRule gfsh = new GfshCommandRule().withTimeout(1);
 
   @Test
   public void commandFailsWithoutOptions() throws Exception {

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ListDiskStoreCommandIntegrationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ListDiskStoreCommandIntegrationTest.java
@@ -40,7 +40,7 @@ public class ListDiskStoreCommandIntegrationTest {
           .withName(MEMBER_NAME).withJMXManager().withAutoStart();
 
   @Rule
-  public GfshCommandRule gfsh = new GfshCommandRule().setTimeout(1);
+  public GfshCommandRule gfsh = new GfshCommandRule().withTimeout(1);
 
   @Test
   public void commandSucceedsWhenConnected() throws Exception {

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ListRegionIntegrationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ListRegionIntegrationTest.java
@@ -42,11 +42,6 @@ public class ListRegionIntegrationTest {
   @Rule
   public GfshCommandRule gfsh = new GfshCommandRule(server::getJmxPort, PortType.jmxManager);
 
-  @Before
-  public void setup() {
-    gfsh.setTimeout(2);
-  }
-
   @Test
   public void commandFailsWhenNotConnected() throws Exception {
     gfsh.disconnect();

--- a/geode-core/src/test/java/org/apache/geode/test/junit/rules/GfshCommandRule.java
+++ b/geode-core/src/test/java/org/apache/geode/test/junit/rules/GfshCommandRule.java
@@ -268,11 +268,8 @@ public class GfshCommandRule extends DescribedExternalResource {
     return workingDir;
   }
 
-  public GfshCommandRule setTimeout(int timeoutInSeconds) {
+  public GfshCommandRule withTimeout(int timeoutInSeconds) {
     this.gfshTimeout = timeoutInSeconds;
-    if (gfsh != null) {
-      gfsh.setTimeout(timeoutInSeconds);
-    }
     return this;
   }
 


### PR DESCRIPTION
* reduce the default timeout
* add ability to configure the timeout at construction time.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
