### PR TITLE
GEODE-4049: refactor CreateRegionCommand and DestoryRegionCommand status

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/execute/FunctionContext.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/execute/FunctionContext.java
@@ -14,7 +14,10 @@
  */
 package org.apache.geode.cache.execute;
 
+import org.apache.logging.log4j.util.Strings;
+
 import org.apache.geode.cache.Cache;
+import org.apache.geode.distributed.DistributedMember;
 
 /**
  * Defines the execution context of a {@link Function}. It is required by the
@@ -77,4 +80,22 @@ public interface FunctionContext<T1> {
   public boolean isPossibleDuplicate();
 
   public Cache getCache();
+
+  /**
+   * a convenience method to get the name of the member this function executes on. call this
+   * function once in your function execution to avoid performance issues.
+   *
+   * @return member name or id if name is blank
+   */
+  public default String getMemberName() {
+    DistributedMember member = getCache().getDistributedSystem().getDistributedMember();
+
+    // if this member has name, use it, otherwise, use the id
+    String memberName = member.getName();
+    if (!Strings.isBlank(memberName)) {
+      return memberName;
+    }
+
+    return member.getId();
+  }
 }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateAsyncEventQueueCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateAsyncEventQueueCommand.java
@@ -24,8 +24,6 @@ import org.springframework.shell.core.annotation.CliCommand;
 import org.springframework.shell.core.annotation.CliOption;
 
 import org.apache.geode.cache.asyncqueue.internal.AsyncEventQueueFactoryImpl;
-import org.apache.geode.cache.execute.Function;
-import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
@@ -119,7 +117,7 @@ public class CreateAsyncEventQueueCommand implements GfshCommand {
         gatewaySubstitutionListener, listener, listenerProperties, forwardExpirationDestroy);
 
     CreateAsyncEventQueueFunction function = new CreateAsyncEventQueueFunction();
-    List<CliFunctionResult> results = execute(function, aeqArgs, targetMembers);
+    List<CliFunctionResult> results = executeAndGetFunctionResult(function, aeqArgs, targetMembers);
 
     if (results.size() == 0) {
       throw new RuntimeException("No results received.");
@@ -149,9 +147,4 @@ public class CreateAsyncEventQueueCommand implements GfshCommand {
     return commandResult;
   }
 
-  List<CliFunctionResult> execute(Function function, Object args,
-      Set<DistributedMember> targetMembers) {
-    ResultCollector rc = executeFunction(function, args, targetMembers);
-    return CliFunctionResult.cleanResults((List<?>) rc.getResult());
-  }
 }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyDiskStoreCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyDiskStoreCommand.java
@@ -22,12 +22,10 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.springframework.shell.core.annotation.CliCommand;
 import org.springframework.shell.core.annotation.CliOption;
 
-import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.functions.CliFunctionResult;
 import org.apache.geode.management.internal.cli.functions.DestroyDiskStoreFunction;
 import org.apache.geode.management.internal.cli.functions.DestroyDiskStoreFunctionArgs;
@@ -54,7 +52,7 @@ public class DestroyDiskStoreCommand implements GfshCommand {
 
     TabularResultData tabularData = ResultBuilder.createTabularResultData();
 
-    Set<DistributedMember> targetMembers = CliUtil.findMembers(groups, null);
+    Set<DistributedMember> targetMembers = findMembers(groups, null);
 
     if (targetMembers.isEmpty()) {
       return ResultBuilder.createUserErrorResult(CliStrings.NO_MEMBERS_FOUND_MESSAGE);
@@ -62,9 +60,8 @@ public class DestroyDiskStoreCommand implements GfshCommand {
 
     DestroyDiskStoreFunctionArgs functionArgs = new DestroyDiskStoreFunctionArgs(name, ifExist);
 
-    ResultCollector<?, ?> rc =
-        CliUtil.executeFunction(new DestroyDiskStoreFunction(), functionArgs, targetMembers);
-    List<CliFunctionResult> results = CliFunctionResult.cleanResults((List<?>) rc.getResult());
+    List<CliFunctionResult> results =
+        executeAndGetFunctionResult(new DestroyDiskStoreFunction(), functionArgs, targetMembers);
 
     AtomicReference<XmlEntity> xmlEntity = new AtomicReference<>();
     for (CliFunctionResult result : results) {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/GfshCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/GfshCommand.java
@@ -15,6 +15,7 @@
 package org.apache.geode.management.internal.cli.commands;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 import org.springframework.shell.core.CommandMarker;
@@ -33,6 +34,7 @@ import org.apache.geode.management.ManagementService;
 import org.apache.geode.management.cli.Result;
 import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.exceptions.EntityNotFoundException;
+import org.apache.geode.management.internal.cli.functions.CliFunctionResult;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.shell.Gfsh;
 
@@ -178,6 +180,12 @@ public interface GfshCommand extends CommandMarker {
   default ResultCollector<?, ?> executeFunction(Function function, Object args,
       final DistributedMember targetMember) {
     return executeFunction(function, args, Collections.singleton(targetMember));
+  }
+
+  default List<CliFunctionResult> executeAndGetFunctionResult(Function function, Object args,
+      Set<DistributedMember> targetMembers) {
+    ResultCollector rc = executeFunction(function, args, targetMembers);
+    return CliFunctionResult.cleanResults((List<?>) rc.getResult());
   }
 
   default Set<DistributedMember> findAnyMembersForRegion(InternalCache cache, String regionPath) {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/RegionCreateFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/RegionCreateFunction.java
@@ -74,8 +74,7 @@ public class RegionCreateFunction implements Function, InternalEntity {
     ResultSender<Object> resultSender = context.getResultSender();
 
     Cache cache = context.getCache();
-    String memberNameOrId =
-        CliUtil.getMemberNameOrId(cache.getDistributedSystem().getDistributedMember());
+    String memberNameOrId = context.getMemberName();
 
     RegionFunctionArgs regionCreateArgs = (RegionFunctionArgs) context.getArguments();
 

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateAsyncEventQueueCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateAsyncEventQueueCommandTest.java
@@ -128,8 +128,8 @@ public class CreateAsyncEventQueueCommandTest {
 
     // this is only to make the code pass that member check
     doReturn(Collections.emptySet()).when(command).getMembers(any(), any());
-    doReturn(functionResults).when(command).execute(isA(Function.class), isA(Object.class),
-        isA(Set.class));
+    doReturn(functionResults).when(command).executeAndGetFunctionResult(isA(Function.class),
+        isA(Object.class), isA(Set.class));
 
     gfsh.executeAndAssertThat(command, MINIUM_COMMAND).statusIsSuccess().persisted()
         .tableHasRowCount("Member", 2)
@@ -151,8 +151,8 @@ public class CreateAsyncEventQueueCommandTest {
 
     // this is only to make the code pass that member check
     doReturn(Collections.emptySet()).when(command).getMembers(any(), any());
-    doReturn(functionResults).when(command).execute(isA(Function.class), isA(Object.class),
-        isA(Set.class));
+    doReturn(functionResults).when(command).executeAndGetFunctionResult(isA(Function.class),
+        isA(Object.class), isA(Set.class));
 
     gfsh.executeAndAssertThat(command, MINIUM_COMMAND).statusIsSuccess().persisted() // need to make
                                                                                      // sure
@@ -182,8 +182,8 @@ public class CreateAsyncEventQueueCommandTest {
 
     // this is only to make the code pass that member check
     doReturn(Collections.emptySet()).when(command).getMembers(any(), any());
-    doReturn(functionResults).when(command).execute(isA(Function.class), isA(Object.class),
-        isA(Set.class));
+    doReturn(functionResults).when(command).executeAndGetFunctionResult(isA(Function.class),
+        isA(Object.class), isA(Set.class));
 
     gfsh.executeAndAssertThat(command, MINIUM_COMMAND).statusIsSuccess().persisted()
         .tableHasRowCount("Member", 2)
@@ -202,8 +202,8 @@ public class CreateAsyncEventQueueCommandTest {
     List<CliFunctionResult> functionResults = new ArrayList<>();
     XmlEntity xmlEntity = mock(XmlEntity.class);
     functionResults.add(new CliFunctionResult("member1", xmlEntity, "SUCCESS"));
-    doReturn(functionResults).when(command).execute(isA(Function.class), isA(Object.class),
-        isA(Set.class));
+    doReturn(functionResults).when(command).executeAndGetFunctionResult(isA(Function.class),
+        isA(Object.class), isA(Set.class));
 
     gfsh.executeAndAssertThat(command, MINIUM_COMMAND).statusIsSuccess().failToPersist();
 


### PR DESCRIPTION
* use tabular result display for destroy region command.
* status to reflect at least one region is created/deleted and cluser config is updated.


Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
