### PR TITLE
GEODE-4058: Always delete disk files after every test runs

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/internal/cache/backup/BackupDistributedTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/backup/BackupDistributedTest.java
@@ -300,11 +300,7 @@ public class BackupDistributedTest extends PersistentPartitionedRegionTestBase {
 
     // Destroy the current data
     invokeInEveryVM("Clean disk dirs", () -> {
-      try {
-        cleanDiskDirs();
-      } catch (IOException e) {
-        throw new RuntimeException(e);
-      }
+      cleanDiskDirs();
     });
 
     restoreBackup(2);
@@ -433,11 +429,7 @@ public class BackupDistributedTest extends PersistentPartitionedRegionTestBase {
 
   private void cleanDiskDirsInEveryVM() {
     invokeInEveryVM("cleanDiskDirsInEveryVM", () -> {
-      try {
-        cleanDiskDirs();
-      } catch (IOException e) {
-        throw new UncheckedIOException(e);
-      }
+      cleanDiskDirs();
     });
   }
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/PersistentColocatedPartitionedRegionDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/PersistentColocatedPartitionedRegionDUnitTest.java
@@ -2228,11 +2228,7 @@ public class PersistentColocatedPartitionedRegionDUnitTest
     // Runnable to clean up disk dirs on a members
     SerializableRunnable cleanDiskDirs = new SerializableRunnable("Clean disk dirs") {
       public void run() {
-        try {
-          cleanDiskDirs();
-        } catch (IOException e) {
-          throw new RuntimeException(e);
-        }
+        cleanDiskDirs();
       }
     };
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/fixed/FixedPartitioningTestBase.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/fixed/FixedPartitioningTestBase.java
@@ -1286,13 +1286,13 @@ public class FixedPartitioningTestBase extends JUnit4DistributedTestCase {
     }
 
     try {
-      cleanDiskDirs();
+      cleanDisk();
     } catch (IOException e) {
       LogWriterUtils.getLogWriter().error("Error cleaning disk dirs", e);
     }
   }
 
-  public static void cleanDiskDirs() throws IOException {
+  public static void cleanDisk() throws IOException {
     FileUtils.deleteDirectory(getDiskDir());
   }
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/wan/AsyncEventQueueTestBase.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/wan/AsyncEventQueueTestBase.java
@@ -99,7 +99,6 @@ import org.apache.geode.test.dunit.LogWriterUtils;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.Wait;
 import org.apache.geode.test.dunit.WaitCriterion;
-import org.apache.geode.test.dunit.cache.internal.JUnit4CacheTestCase;
 import org.apache.geode.test.dunit.internal.JUnit4DistributedTestCase;
 import org.apache.geode.test.junit.categories.DistributedTest;
 
@@ -1558,7 +1557,7 @@ public class AsyncEventQueueTestBase extends JUnit4DistributedTestCase {
 
   public static void cleanupVM() throws IOException {
     closeCache();
-    JUnit4CacheTestCase.cleanDiskDirs();
+    JUnit4DistributedTestCase.cleanDiskDirs();
   }
 
   public static void closeCache() throws IOException {

--- a/geode-core/src/test/java/org/apache/geode/test/dunit/cache/internal/JUnit4CacheTestCase.java
+++ b/geode-core/src/test/java/org/apache/geode/test/dunit/cache/internal/JUnit4CacheTestCase.java
@@ -15,19 +15,16 @@
 package org.apache.geode.test.dunit.cache.internal;
 
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
-import static org.apache.geode.distributed.ConfigurationProperties.SERIALIZABLE_OBJECT_FILTER;
 import static org.apache.geode.distributed.internal.DistributionConfig.GEMFIRE_PREFIX;
 
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.util.Arrays;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.Logger;
 import org.awaitility.Awaitility;
 
@@ -52,7 +49,6 @@ import org.apache.geode.internal.cache.LocalRegion;
 import org.apache.geode.internal.cache.xmlcache.CacheCreation;
 import org.apache.geode.internal.cache.xmlcache.CacheXmlGenerator;
 import org.apache.geode.internal.logging.LogService;
-import org.apache.geode.test.dunit.Assert;
 import org.apache.geode.test.dunit.IgnoredException;
 import org.apache.geode.test.dunit.Invoke;
 import org.apache.geode.test.dunit.VM;
@@ -490,17 +486,6 @@ public abstract class JUnit4CacheTestCase extends JUnit4DistributedTestCase
    */
   public static final File[] getDiskDirs() {
     return new File[] {getDiskDir()};
-  }
-
-  public static final void cleanDiskDirs() throws IOException {
-    FileUtils.deleteQuietly(getDiskDir());
-    Arrays.stream(new File(".").listFiles()).forEach(file -> deleteBACKUPDiskStoreFile(file));
-  }
-
-  private static void deleteBACKUPDiskStoreFile(final File file) {
-    if (file.getName().startsWith("BACKUPDiskStore-")) {
-      FileUtils.deleteQuietly(file);
-    }
   }
 
   /**

--- a/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/WANTestBase.java
+++ b/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/WANTestBase.java
@@ -3674,7 +3674,7 @@ public class WANTestBase extends JUnit4DistributedTestCase {
       Locator.getLocator().stop();
     }
     closeCache();
-    CacheTestCase.cleanDiskDirs();
+    JUnit4DistributedTestCase.cleanDiskDirs();
   }
 
   public static void closeCache() {


### PR DESCRIPTION
Avoid hangs due to leftover disk files by making sure that all tests
that use JUnit4DistributedCase have their disk files cleaned up after
the test, including a locators ConfigDiskDir_

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
