### PR TITLE
GEODE-3869: Fix early eviction.

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/eviction/AbstractEvictionList.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/eviction/AbstractEvictionList.java
@@ -116,8 +116,6 @@ abstract class AbstractEvictionList implements EvictionList {
       return;
     }
 
-    evictionNode.unsetRecentlyUsed();
-
     if (logger.isTraceEnabled(LogMarker.LRU_CLOCK)) {
       logger.trace(LogMarker.LRU_CLOCK, LocalizedMessage
           .create(LocalizedStrings.NewLRUClockHand_ADDING_ANODE_TO_LRU_LIST, evictionNode));

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/eviction/LRUListWithAsyncSorting.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/eviction/LRUListWithAsyncSorting.java
@@ -127,6 +127,7 @@ public class LRUListWithAsyncSorting extends AbstractEvictionList {
 
       if (evictionNode.isRecentlyUsed() && evictionAttempts < MAX_EVICTION_ATTEMPTS) {
         evictionAttempts++;
+        evictionNode.unsetRecentlyUsed();
         appendEntry(evictionNode);
         continue;
       }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/eviction/LRUListWithSyncSorting.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/eviction/LRUListWithSyncSorting.java
@@ -88,6 +88,7 @@ public class LRUListWithSyncSorting extends AbstractEvictionList {
           logger.trace(LogMarker.LRU_CLOCK, LocalizedMessage
               .create(LocalizedStrings.NewLRUClockHand_SKIPPING_RECENTLY_USED_ENTRY, aNode));
         }
+        aNode.unsetRecentlyUsed();
         appendEntry(aNode);
         continue; // keep looking
       } else {

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/eviction/AbstractEvictionListTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/eviction/AbstractEvictionListTest.java
@@ -161,7 +161,6 @@ public class AbstractEvictionListTest {
     EvictionNode node = mock(EvictionNode.class);
     evictionList.appendEntry(node);
 
-    verify(node).unsetRecentlyUsed();
     verify(node).setNext(evictionList.tail);
     verify(node).setPrevious(evictionList.head);
     assertThat(evictionList.tail.previous()).isSameAs(node);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/eviction/LRUListWithAsyncSortingTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/eviction/LRUListWithAsyncSortingTest.java
@@ -177,9 +177,9 @@ public class LRUListWithAsyncSortingTest {
     when(recentlyUsedNode.next()).thenReturn(list.tail);
     list.incrementRecentlyUsed();
 
-    // unsetRecentlyUsed() is called once on appendEntry(...) and once during scan
+    // unsetRecentlyUsed() is called once during scan
     await().atMost(10, TimeUnit.SECONDS)
-        .until(() -> verify(recentlyUsedNode, times(2)).unsetRecentlyUsed());
+        .until(() -> verify(recentlyUsedNode, times(1)).unsetRecentlyUsed());
     realExecutor.shutdown();
   }
 
@@ -196,9 +196,9 @@ public class LRUListWithAsyncSortingTest {
     when(recentlyUsedNode.next()).thenReturn(recentlyUsedNode);
     list.incrementRecentlyUsed();
 
-    // unsetRecentlyUsed() is called once on appendEntry(...) and once during scan
+    // unsetRecentlyUsed() is called once during scan
     await().atMost(10, TimeUnit.SECONDS)
-        .until(() -> verify(recentlyUsedNode, times(2)).unsetRecentlyUsed());
+        .until(() -> verify(recentlyUsedNode, times(1)).unsetRecentlyUsed());
     realExecutor.shutdown();
   }
 
@@ -226,9 +226,9 @@ public class LRUListWithAsyncSortingTest {
     when(recentlyUsedNode.isRecentlyUsed()).thenReturn(true);
     list.incrementRecentlyUsed();
 
-    // unsetRecentlyUsed() is called once on appendEntry(...) and once during scan
+    // unsetRecentlyUsed() is called once during scan
     await().atMost(10, TimeUnit.SECONDS)
-        .until(() -> verify(recentlyUsedNode, times(2)).unsetRecentlyUsed());
+        .until(() -> verify(recentlyUsedNode, times(1)).unsetRecentlyUsed());
     assertThat(list.tail.previous()).isEqualTo(recentlyUsedNode);
     realExecutor.shutdown();
   }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/eviction/LRUListWithSyncSortingIntegrationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/eviction/LRUListWithSyncSortingIntegrationTest.java
@@ -149,7 +149,8 @@ public class LRUListWithSyncSortingIntegrationTest {
   }
 
   @Test
-  public void evictsRecentlyUsedNodeIfOverLimit() throws Exception {
+  public void getEvictableEntryReturnsRecentlyUsedNodeAfterSearchMaxEntriesExceeded()
+      throws Exception {
     IntStream.range(10, 16).forEach(i -> {
       EvictionNode node = new LRUTestEntry(i);
       nodes.add(node);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/eviction/RegionEntryEvictionIntegrationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/eviction/RegionEntryEvictionIntegrationTest.java
@@ -16,13 +16,10 @@ package org.apache.geode.internal.cache.eviction;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.IntStream;
-
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TestName;
 
 import org.apache.geode.cache.Cache;
@@ -30,8 +27,9 @@ import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.EvictionAttributes;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionShortcut;
-import org.apache.geode.internal.cache.InternalRegion;
+import org.apache.geode.test.junit.categories.IntegrationTest;
 
+@Category(IntegrationTest.class)
 public class RegionEntryEvictionIntegrationTest {
   private Region<String, String> region;
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/eviction/RegionEntryEvictionIntegrationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/eviction/RegionEntryEvictionIntegrationTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.eviction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.CacheFactory;
+import org.apache.geode.cache.EvictionAttributes;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.internal.cache.InternalRegion;
+
+public class RegionEntryEvictionIntegrationTest {
+  private Region<String, String> region;
+
+  @Rule
+  public TestName testName = new TestName();
+
+  @Before
+  public void setUp() throws Exception {
+    region = createRegion();
+  }
+
+  @Test
+  public void verifyMostRecentEntryIsNotEvicted() {
+    region.create("one", "one");
+    region.create("twoo", "twoo");
+    region.put("one", "one");
+    region.put("twoo", "twoo");
+
+    region.create("threee", "threee");
+    assertThat(region.size()).isEqualTo(2);
+    assertThat(region.containsKey("threee")).isTrue();
+  }
+
+  private Region<String, String> createRegion() throws Exception {
+    Cache cache = new CacheFactory().set("locators", "").set("mcast-port", "0").create();
+    return cache.<String, String>createRegionFactory(RegionShortcut.REPLICATE)
+        .setEvictionAttributes(EvictionAttributes.createLRUEntryAttributes(2))
+        .create(testName.getMethodName());
+  }
+
+}


### PR DESCRIPTION
While code review found that the refactoring moved "evictionNode.unsetRecentlyUsed()" to
"appendEntry()" which gets call by other places (adding entry into the list); this causes
the recently used entry to be evicted early.

