### PR TITLE
GEODE-4079: Deprecated Hash Index

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/query/IndexType.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/IndexType.java
@@ -50,7 +50,11 @@ public enum IndexType {
    * <code>long int short byte char float double</code>
    *
    * @see QueryService#createIndex(String, IndexType, String, String)
+   * @deprecated Due to the overhead caused by rehashing while expanding the backing array, hash
+   *             index has been deprecated since Apache Geode 1.4.0. Use
+   *             {@link IndexType#FUNCTIONAL} instead.
    */
+  @Deprecated
   HASH("HASH"),
 
 

--- a/geode-core/src/main/java/org/apache/geode/cache/query/QueryService.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/QueryService.java
@@ -14,9 +14,11 @@
  */
 package org.apache.geode.cache.query;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.List;
 
-import org.apache.geode.cache.*;
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.Region;
 import org.apache.geode.cache.query.internal.Undefined;
 
 /**
@@ -76,7 +78,11 @@ public interface QueryService {
    * @throws UnsupportedOperationException If Index is being created on a region which does not
    *         support indexes.
    *
+   * @deprecated Due to the overhead caused by rehashing while expanding the backing array, hash
+   *             index has been deprecated since Apache Geode 1.4.0. Use method
+   *             {@link QueryService#createIndex(String, String, String)} instead.
    */
+  @Deprecated
   public Index createHashIndex(String indexName, String indexedExpression, String regionPath)
       throws IndexInvalidException, IndexNameConflictException, IndexExistsException,
       RegionNotFoundException, UnsupportedOperationException;
@@ -120,7 +126,11 @@ public interface QueryService {
    *
    * @throws RegionNotFoundException if the region referred to in the fromClause doesn't exist
    *
+   * @deprecated Due to the overhead caused by rehashing while expanding the backing array, hash
+   *             index has been deprecated since Apache Geode 1.4.0. Use method
+   *             {@link QueryService#defineIndex(String, String, String)} instead.
    */
+  @Deprecated
   public void defineHashIndex(String indexName, String indexedExpression, String regionPath)
       throws RegionNotFoundException;
 
@@ -146,7 +156,12 @@ public interface QueryService {
    *        mktValue field: indexExpression: "p.mktValue" regionPath: "/portfolio p"
    *
    * @throws RegionNotFoundException if the region referred to in the fromClause doesn't exist
+   *
+   * @deprecated Due to the overhead caused by rehashing while expanding the backing array, hash
+   *             index has been deprecated since Apache Geode 1.4.0. Use method
+   *             {@link QueryService#defineIndex(String, String, String, String)} instead.
    */
+  @Deprecated
   public void defineHashIndex(String indexName, String indexedExpression, String regionPath,
       String imports) throws RegionNotFoundException;
 
@@ -232,7 +247,12 @@ public interface QueryService {
    * @throws RegionNotFoundException if the region referred to in the fromClause doesn't exist
    * @throws UnsupportedOperationException If Index is being created on a region which overflows to
    *         disk
+   *
+   * @deprecated Due to the overhead caused by rehashing while expanding the backing array, hash
+   *             index has been deprecated since Apache Geode 1.4.0. Use method
+   *             {@link QueryService#createIndex(String, String, String, String)} instead
    */
+  @Deprecated
   public Index createHashIndex(String indexName, String indexedExpression, String regionPath,
       String imports) throws IndexInvalidException, IndexNameConflictException,
       IndexExistsException, RegionNotFoundException, UnsupportedOperationException;

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/HashIndex.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/HashIndex.java
@@ -86,7 +86,12 @@ import org.apache.geode.internal.offheap.StoredObject;
  * This index does not support the storage of projection attributes.
  * <p>
  * Currently this implementation only supports an index on a region path.
+ *
+ * @deprecated Due to the overhead caused by rehashing while expanding the backing array, Hash Index
+ *             has been deprecated since Apache Geode 1.4.0. Instead the use of
+ *             {@link CompactRangeIndex} is recommended
  */
+@Deprecated
 public class HashIndex extends AbstractIndex {
   private static final Logger logger = LogService.getLogger();
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheXml.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheXml.java
@@ -543,6 +543,11 @@ public abstract class CacheXml implements EntityResolver2, ErrorHandler {
   /** The name of the index type attribute */
   protected static final String INDEX_TYPE = "type";
   /** The name of the <code>hash-index</code> index type attribute */
+  /**
+   * @deprecated Due to the overhead caused by rehashing while expanding the backing array, Hash
+   *             Index has been deprecated since Apache Geode 1.4.0. Use {@link CacheXml#FUNCTIONAL}
+   */
+  @Deprecated
   protected static final String HASH_INDEX_TYPE = "hash";
   /** The name of the <code>range-index</code> index type attribute */
   protected static final String RANGE_INDEX_TYPE = "range";

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/i18n/CliStrings.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/i18n/CliStrings.java
@@ -734,11 +734,11 @@ public class CliStrings {
       "Name/Id of the member in which the index will be created.";
   public static final String CREATE_INDEX__TYPE = "type";
   public static final String CREATE_INDEX__TYPE__HELP =
-      "Type of the index. Valid values are: range, key and hash.";
+      "Type of the index. Valid values are: range and key. Deprecated : hash has been deprecated since Apache Geode 1.4.0";
   public static final String CREATE_INDEX__GROUP__HELP =
       "Group of members in which the index will be created.";
   public static final String CREATE_INDEX__INVALID__INDEX__TYPE__MESSAGE =
-      "Invalid index type,value must be one of the following: range, key or hash.";
+      "Invalid index type,value must be one of the following: range, key and hash. Deprecated : hash has been deprecated since Apache Geode 1.4.0";
   public static final String CREATE_INDEX__SUCCESS__MSG =
       "Index successfully created with following details";
   public static final String CREATE_INDEX__FAILURE__MSG =


### PR DESCRIPTION
	* Added deprecated tags on HashIndex class
	* Deprecated createHashIndex calls in QueryService
	* Deprecated HASH type in IndexType
	* Added to the help text in gfsh create index mentioning hash index being deprecated since Apache Geode 1.4.0

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
