### PR TITLE
GEODE-4091: add ThreadFactory for evictor

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/eviction/LRUListWithAsyncSorting.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/eviction/LRUListWithAsyncSorting.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.logging.log4j.Logger;
@@ -29,6 +30,7 @@ import org.apache.geode.internal.cache.versions.RegionVersionVector;
 import org.apache.geode.internal.i18n.LocalizedStrings;
 import org.apache.geode.internal.lang.SystemPropertyHelper;
 import org.apache.geode.internal.logging.LogService;
+import org.apache.geode.internal.logging.LoggingThreadGroup;
 import org.apache.geode.internal.logging.log4j.LocalizedMessage;
 import org.apache.geode.internal.logging.log4j.LogMarker;
 
@@ -68,9 +70,19 @@ public class LRUListWithAsyncSorting extends AbstractEvictionList {
     if (threads < 1) {
       threads = Math.max((Runtime.getRuntime().availableProcessors() / 4), 1);
     }
-    // TODO need ThreadGroup that handles thread naming and
-    // unhandled exception logging
-    return Executors.newFixedThreadPool(threads);
+    final LoggingThreadGroup group =
+        LoggingThreadGroup.createThreadGroup("LRUListWithAsyncSorting Threads", logger);
+    ThreadFactory threadFactory = new ThreadFactory() {
+      private final AtomicInteger threadId = new AtomicInteger();
+
+      public Thread newThread(final Runnable command) {
+        Thread thread = new Thread(group, command,
+            "LRUListWithAsyncSortingThread" + this.threadId.incrementAndGet());
+        thread.setDaemon(true);
+        return thread;
+      }
+    };
+    return Executors.newFixedThreadPool(threads, threadFactory);
   }
 
   LRUListWithAsyncSorting(InternalEvictionStatistics stats, BucketRegion region) {


### PR DESCRIPTION
The threads created to do background eviction scanning
will now be named "LRUListWithAsyncSortingThreadNNN".
The will now be daemon threads.
They now have an unhandled exception handler.
Their group is named "LRUListWithAsyncSorting Threads".

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
