### PR TITLE
GEODE-4079 Identify hash indexes as deprecated in docs

### DIFF
--- a/geode-docs/developing/query_index/create_multiple_indexes.html.md.erb
+++ b/geode-docs/developing/query_index/create_multiple_indexes.html.md.erb
@@ -34,8 +34,6 @@ gfsh> define index --name=myIndex1 --expression=exp1 --region=/exampleRegion
 
 gfsh> define index --name=myIndex2 --expression="c.exp2" --region="/exampleRegion e, e.collection1 c" 
 
-gfsh> define index --name=myIndex3 --expression=exp3 --region=/exampleRegion --type=hash 
-
 gfsh> create defined indexes
  
 ```
@@ -56,7 +54,6 @@ Message : Region ' /r3' not found: from  /r3Occurred on following members
     QueryService queryService = cache.getQueryService();
     queryService.defineIndex("name1", "indexExpr1", "regionPath1");
     queryService.defineIndex("name2", "indexExpr2", "regionPath2");
-    queryService.defineHashIndex("name3", "indexExpr3", "regionPath2");
     queryService.defineKeyIndex("name4", "indexExpr4", "regionPath2");
     List<Index> indexes = queryService.createDefinedIndexes();
 ```

--- a/geode-docs/developing/query_index/creating_an_index.html.md.erb
+++ b/geode-docs/developing/query_index/creating_an_index.html.md.erb
@@ -29,7 +29,7 @@ To create an index, use one of the following `QueryService` methods:
 
 -   `createIndex`. Creates the default type of index, a range index. Use this type of index if you will be writing queries that will be doing any kind of comparison operation besides an equality comparison.
 -   `createKeyIndex`. Creates a key index. See [Creating Key Indexes](creating_key_indexes.html#concept_09E29507AF0D42CF81D261B030D0B7C8) for more information.
--   `createHashIndex`. Creates a hash index. See [Creating Hash Indexes](creating_hash_indexes.html#concept_5C7614F71F394C62ACA1BDC5684A7AC4) for more information.
+-   **Deprecated.** `createHashIndex`. Creates a hash index. See [Creating Hash Indexes](creating_hash_indexes.html#concept_5C7614F71F394C62ACA1BDC5684A7AC4) for more information.
 -   `createDefinedIndexes`. Creates multiple indexes that were previously defined using `defineIndex`. See [Creating Multiple Indexes at Once](create_multiple_indexes.html) for more information.
 
 The following sections provide examples of index creation:
@@ -39,7 +39,6 @@ The following sections provide examples of index creation:
 ``` pre
 gfsh> create index --name=myIndex --expression=status --region=/exampleRegion
 gfsh> create index --name=myKeyIndex --type=key --expression=id --region=/exampleRegion
-gfsh> create index --name=myHashIndex --type=hash --expression=mktValue --region=/exampleRegion
 ```
 
 See [Index Commands](../../tools_modules/gfsh/quick_ref_commands_by_area.html#topic_688C66526B4649AFA51C0F72F34FA45E) for more examples.
@@ -50,7 +49,6 @@ See [Index Commands](../../tools_modules/gfsh/quick_ref_commands_by_area.html#to
 QueryService qs = cache.getQueryService();
  qs.createIndex("myIndex", "status", "/exampleRegion");
  qs.createKeyIndex("myKeyIndex", "id", "/exampleRegion");
- qs.createHashIndex("myHashIndex", "mktValue", "/exampleRegion");
 ```
 
 **Using cache.xml:**
@@ -61,7 +59,6 @@ QueryService qs = cache.getQueryService();
  </region-attributes>
  <index name="myIndex" from-clause="/exampleRegion" expression="status"/>
  <index name="myKeyIndex" from-clause="/exampleRegion" expression="id" key-index="true"/>
- <index name="myHashIndex" from-clause="/exampleRegion p" expression="p.mktValue" type="hash"/>
  ...
 </region>
 ```

--- a/geode-docs/developing/query_index/creating_hash_indexes.html.md.erb
+++ b/geode-docs/developing/query_index/creating_hash_indexes.html.md.erb
@@ -19,7 +19,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
+**Hash indexes are deprecated.**
 <%=vars.product_name%> supports the creation of hash indexes for the purpose of performing equality-based queries.
+
 
 ## <a id="concept_5C7614F71F394C62ACA1BDC5684A7AC4__section_8A927DFB29364DA7856E7FE122FC1654" class="no-quick-link"></a>Hash Index Performance
 
@@ -57,6 +59,8 @@ and recovery time substantially.
 If memory is not a concern, use a range index instead of a hash index.
 
 ## <a id="concept_5C7614F71F394C62ACA1BDC5684A7AC4__section_CA2476E015D14DE7B522377C931A8492" class="no-quick-link"></a>Examples of Creating a Hash Index
+
+**Hash indexes are deprecated.**
 
 **Using the Java API:**
 

--- a/geode-docs/developing/query_index/query_index.html.md.erb
+++ b/geode-docs/developing/query_index/query_index.html.md.erb
@@ -38,7 +38,7 @@ A query run without the aid of an index iterates through every object in the col
 
 -   **[Creating Hash Indexes](creating_hash_indexes.html)**
 
-    <%=vars.product_name%> supports the creation of hash indexes for the purposes of performing equality-based queries.
+    **Hash indexes are deprecated.** <%=vars.product_name%> supports the creation of hash indexes for the purposes of performing equality-based queries.
 
 -   **[Creating Indexes on Map Fields ("Map Indexes")](creating_map_indexes.html)**
 


### PR DESCRIPTION
I have marked all subsections on hash indexes as deprecated, and I have removed all examples (java code, XML, and gfsh commands) that demonstrated how to do things with hash indexes.