### PR TITLE
GEODE-4117: use loopback instead of non-existent server host

### DIFF
--- a/geode-core/src/test/resources/org/apache/geode/internal/cache/xmlcache/CacheXmlParserJUnitTest.testSimpleClientCacheXml.cache.xml
+++ b/geode-core/src/test/resources/org/apache/geode/internal/cache/xmlcache/CacheXmlParserJUnitTest.testSimpleClientCacheXml.cache.xml
@@ -22,7 +22,7 @@
     version="1.0">
      
 	<pool name="sessions" subscription-enabled="true">   
-		<server host="1.2.3.4" port="11211" /> 
+		<server host="127.0.0.1" port="11211" />
 	</pool>
 </client-cache>
 


### PR DESCRIPTION
This change speeds up the test to run in just over 2 seconds instead of taking over 2 minutes to complete.