### PR TITLE
GEODE-4114: Removed usage of GemFireCacheImpl.getInstance in geode-lu…

### DIFF
--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/LuceneIndexRecoveryHAIntegrationTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/LuceneIndexRecoveryHAIntegrationTest.java
@@ -63,7 +63,6 @@ public class LuceneIndexRecoveryHAIntegrationTest {
 
   @After
   public void tearDown() {
-    Cache cache = GemFireCacheImpl.getInstance();
     if (cache != null) {
       cache.close();
     }

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/management/LuceneManagementDUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/management/LuceneManagementDUnitTest.java
@@ -15,13 +15,12 @@
 package org.apache.geode.cache.lucene.internal.management;
 
 import static org.apache.geode.cache.lucene.test.LuceneTestUtilities.INDEX_NAME;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
-import java.io.Serializable;
-import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -39,9 +38,8 @@ import org.apache.geode.cache.lucene.LuceneService;
 import org.apache.geode.cache.lucene.LuceneServiceProvider;
 import org.apache.geode.cache.lucene.management.LuceneIndexMetrics;
 import org.apache.geode.cache.lucene.management.LuceneServiceMXBean;
-import org.apache.geode.distributed.ConfigurationProperties;
 import org.apache.geode.distributed.DistributedMember;
-import org.apache.geode.internal.cache.GemFireCacheImpl;
+import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.management.ManagementTestBase;
 import org.apache.geode.management.MemberMXBean;
 import org.apache.geode.management.internal.MBeanJMXAdapter;
@@ -62,7 +60,7 @@ public class LuceneManagementDUnitTest extends ManagementTestBase {
     }
 
     // Verify MBean proxies are created in the managing node
-    getManagingNode().invoke(() -> verifyMBeanProxies());
+    getManagingNode().invoke(() -> verifyMBeanProxies(getCache()));
   }
 
   @Test
@@ -79,8 +77,8 @@ public class LuceneManagementDUnitTest extends ManagementTestBase {
     }
 
     // Verify MBean proxies are created in the managing node
-    getManagingNode()
-        .invoke(() -> verifyAllMBeanProxyIndexMetrics(regionName, numIndexes, numIndexes));
+    getManagingNode().invoke(
+        () -> verifyAllMBeanProxyIndexMetrics(regionName, numIndexes, numIndexes, getCache()));
   }
 
   @Test
@@ -107,8 +105,8 @@ public class LuceneManagementDUnitTest extends ManagementTestBase {
     // Verify index metrics in the managing node
     for (int i = 0; i < numRegions; i++) {
       String regionName = baseRegionName + i;
-      getManagingNode().invoke(
-          () -> verifyAllMBeanProxyIndexMetrics(regionName, numIndexes, numIndexes * numRegions));
+      getManagingNode().invoke(() -> verifyAllMBeanProxyIndexMetrics(regionName, numIndexes,
+          numIndexes * numRegions, getCache()));
     }
   }
 
@@ -131,17 +129,17 @@ public class LuceneManagementDUnitTest extends ManagementTestBase {
     getManagedNodeList().get(0).invoke(() -> queryEntries(regionName, indexName));
 
     // Wait for the managed members to be updated a few times in the manager node
-    getManagingNode().invoke(() -> waitForMemberProxiesToRefresh(2));
+    getManagingNode().invoke(() -> waitForMemberProxiesToRefresh(2, getCache()));
 
     // Verify index metrics
     int numManagedNodes = getManagedNodeList().size();
     getManagingNode().invoke(() -> verifyMBeanIndexMetricsValues(regionName, indexName, numPuts,
-        numManagedNodes/* 1 query per managed node */, 1/* 1 result */));
+        numManagedNodes/* 1 query per managed node */, 1/* 1 result */, getCache()));
   }
 
-  private static void waitForMemberProxiesToRefresh(int refreshCount) {
-    Set<DistributedMember> members = GemFireCacheImpl.getInstance().getDistributionManager()
-        .getOtherNormalDistributionManagerIds();
+  private static void waitForMemberProxiesToRefresh(int refreshCount, final InternalCache cache) {
+    Set<DistributedMember> members =
+        cache.getDistributionManager().getOtherNormalDistributionManagerIds();
     // Currently, the LuceneServiceMBean is not updated in the manager since it has no getters,
     // so use the MemberMBean instead.
     for (DistributedMember member : members) {
@@ -164,9 +162,9 @@ public class LuceneManagementDUnitTest extends ManagementTestBase {
     return getManagementService().getMBeanInstance(objectName, LuceneServiceMXBean.class);
   }
 
-  private static void verifyMBeanProxies() {
-    Set<DistributedMember> members = GemFireCacheImpl.getInstance().getDistributionManager()
-        .getOtherNormalDistributionManagerIds();
+  private static void verifyMBeanProxies(final InternalCache cache) {
+    Set<DistributedMember> members =
+        cache.getDistributionManager().getOtherNormalDistributionManagerIds();
     for (DistributedMember member : members) {
       getMBeanProxy(member);
     }
@@ -203,9 +201,9 @@ public class LuceneManagementDUnitTest extends ManagementTestBase {
   }
 
   private static void verifyAllMBeanProxyIndexMetrics(String regionName, int numRegionIndexes,
-      int numTotalIndexes) {
-    Set<DistributedMember> members = GemFireCacheImpl.getInstance().getDistributionManager()
-        .getOtherNormalDistributionManagerIds();
+      int numTotalIndexes, final InternalCache cache) {
+    Set<DistributedMember> members =
+        cache.getDistributionManager().getOtherNormalDistributionManagerIds();
     for (DistributedMember member : members) {
       LuceneServiceMXBean mbean = getMBeanProxy(member);
       verifyMBeanIndexMetrics(mbean, regionName, numRegionIndexes, numTotalIndexes);
@@ -238,10 +236,10 @@ public class LuceneManagementDUnitTest extends ManagementTestBase {
   }
 
   private void verifyMBeanIndexMetricsValues(String regionName, String indexName, int expectedPuts,
-      int expectedQueries, int expectedHits) {
+      int expectedQueries, int expectedHits, final InternalCache cache) {
     // Get index metrics from all members
-    Set<DistributedMember> members = GemFireCacheImpl.getInstance().getDistributionManager()
-        .getOtherNormalDistributionManagerIds();
+    Set<DistributedMember> members =
+        cache.getDistributionManager().getOtherNormalDistributionManagerIds();
     int totalCommits = 0, totalUpdates = 0, totalDocuments = 0, totalQueries = 0, totalHits = 0;
     for (DistributedMember member : members) {
       LuceneServiceMXBean mbean = getMBeanProxy(member);

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/xml/LuceneIndexXmlParserIntegrationJUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/xml/LuceneIndexXmlParserIntegrationJUnitTest.java
@@ -31,7 +31,6 @@ import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.core.KeywordAnalyzer;
 import org.apache.lucene.analysis.core.SimpleAnalyzer;
 import org.apache.lucene.analysis.standard.ClassicAnalyzer;
-import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -45,7 +44,6 @@ import org.apache.geode.cache.lucene.LuceneSerializer;
 import org.apache.geode.cache.lucene.LuceneService;
 import org.apache.geode.cache.lucene.LuceneServiceProvider;
 import org.apache.geode.cache.lucene.test.LuceneTestSerializer;
-import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.cache.extension.Extension;
 import org.apache.geode.internal.cache.xmlcache.CacheCreation;
 import org.apache.geode.internal.cache.xmlcache.CacheXmlParser;
@@ -59,9 +57,7 @@ public class LuceneIndexXmlParserIntegrationJUnitTest {
   @Rule
   public TestName name = new TestName();
 
-  @After
-  public void tearDown() {
-    Cache cache = GemFireCacheImpl.getInstance();
+  public void tearDownCacheAfterCreateIndexTestIsCompleted(Cache cache) {
     if (cache != null) {
       cache.close();
     }
@@ -214,14 +210,18 @@ public class LuceneIndexXmlParserIntegrationJUnitTest {
     cf.set(CACHE_XML_FILE, getXmlFileForTest());
     Cache cache = cf.create();
 
-    LuceneService service = LuceneServiceProvider.get(cache);
-    assertEquals(3, service.getAllIndexes().size());
-    LuceneIndex index1 = service.getIndex("index1", "/region");
-    LuceneIndex index2 = service.getIndex("index2", "/region");
-    LuceneIndex index3 = service.getIndex("index3", "/region");
-    assertArrayEquals(index1.getFieldNames(), new String[] {"a", "b", "c", "d"});
-    assertArrayEquals(index2.getFieldNames(), new String[] {"f", "g"});
-    assertArrayEquals(index3.getFieldNames(), new String[] {"h", "i", "j"});
+    try {
+      LuceneService service = LuceneServiceProvider.get(cache);
+      assertEquals(3, service.getAllIndexes().size());
+      LuceneIndex index1 = service.getIndex("index1", "/region");
+      LuceneIndex index2 = service.getIndex("index2", "/region");
+      LuceneIndex index3 = service.getIndex("index3", "/region");
+      assertArrayEquals(index1.getFieldNames(), new String[] {"a", "b", "c", "d"});
+      assertArrayEquals(index2.getFieldNames(), new String[] {"f", "g"});
+      assertArrayEquals(index3.getFieldNames(), new String[] {"h", "i", "j"});
+    } finally {
+      tearDownCacheAfterCreateIndexTestIsCompleted(cache);
+    }
   }
 
   private String getXmlFileForTest() {


### PR DESCRIPTION
…cene

	* Removed the used of GemFireCacheImpl.getInstance and replaced it with the local instance being used.
	* There was no need to call close on GemFireCacheImpl when CacheCreation was used in the test case.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
