### PR TITLE
GEODE-4096: Fixed race condition for connection global variable

### DIFF
--- a/geode-wan/src/main/java/org/apache/geode/internal/cache/wan/GatewaySenderEventRemoteDispatcher.java
+++ b/geode-wan/src/main/java/org/apache/geode/internal/cache/wan/GatewaySenderEventRemoteDispatcher.java
@@ -48,7 +48,7 @@ public class GatewaySenderEventRemoteDispatcher implements GatewaySenderEventDis
 
   private static final Logger logger = LogService.getLogger();
 
-  private final AbstractGatewaySenderEventProcessor processor;
+  protected final AbstractGatewaySenderEventProcessor processor;
 
   private volatile Connection connection;
 
@@ -67,6 +67,10 @@ public class GatewaySenderEventRemoteDispatcher implements GatewaySenderEventDis
    */
   private int failedConnectCount = 0;
 
+  void setAckReaderThread(AckReaderThread ackReaderThread) {
+    this.ackReaderThread = ackReaderThread;
+  }
+
   public GatewaySenderEventRemoteDispatcher(AbstractGatewaySenderEventProcessor eventProcessor) {
     this.processor = eventProcessor;
     this.sender = eventProcessor.getSender();
@@ -77,7 +81,15 @@ public class GatewaySenderEventRemoteDispatcher implements GatewaySenderEventDis
       if (e.getCause() instanceof GemFireSecurityException) {
         throw e;
       }
+
     }
+  }
+
+  GatewaySenderEventRemoteDispatcher(AbstractGatewaySenderEventProcessor processor,
+      Connection connection) {
+    this.processor = processor;
+    this.sender = processor.getSender();
+    this.connection = connection;
   }
 
   protected GatewayAck readAcknowledgement() {
@@ -299,6 +311,7 @@ public class GatewaySenderEventRemoteDispatcher implements GatewaySenderEventDis
    */
   public Connection getConnection(boolean startAckReaderThread) throws GatewaySenderException {
     if (this.processor.isStopped()) {
+      stop();
       return null;
     }
     // IF the connection is null
@@ -364,7 +377,7 @@ public class GatewaySenderEventRemoteDispatcher implements GatewaySenderEventDis
    */
   private void initializeConnection() throws GatewaySenderException, GemFireSecurityException {
     if (ackReaderThread != null) {
-      ackReaderThread.shutDownAckReaderConnection();
+      ackReaderThread.shutDownAckReaderConnection(connection);
     }
     this.connectionLifeCycleLock.writeLock().lock();
     try {
@@ -560,6 +573,10 @@ public class GatewaySenderEventRemoteDispatcher implements GatewaySenderEventDis
       this(sender, processor.getName());
     }
 
+    boolean isShutdown() {
+      return shutdown;
+    }
+
     public AckReaderThread(GatewaySender sender, String name) {
       super("AckReaderThread for : " + name);
       this.setDaemon(true);
@@ -751,7 +768,7 @@ public class GatewaySenderEventRemoteDispatcher implements GatewaySenderEventDis
       // get chance to destroy unless that returns.
       Connection conn = connection;
       if (conn != null) {
-        shutDownAckReaderConnection();
+        shutDownAckReaderConnection(conn);
         if (!conn.isDestroyed()) {
           conn.destroy();
           sender.getProxy().returnConnection(conn);
@@ -774,7 +791,7 @@ public class GatewaySenderEventRemoteDispatcher implements GatewaySenderEventDis
       }
     }
 
-    private void shutDownAckReaderConnection() {
+    private void shutDownAckReaderConnection(Connection connection) {
       Connection conn = connection;
       // attempt to unblock the ackReader thread by shutting down the inputStream, if it was stuck
       // on a read
@@ -808,7 +825,7 @@ public class GatewaySenderEventRemoteDispatcher implements GatewaySenderEventDis
 
   public void shutDownAckReaderConnection() {
     if (ackReaderThread != null) {
-      ackReaderThread.shutDownAckReaderConnection();
+      ackReaderThread.shutDownAckReaderConnection(connection);
     }
   }
 

--- a/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/GatewaySenderEventRemoteDispatcherJUnitTest.java
+++ b/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/GatewaySenderEventRemoteDispatcherJUnitTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.wan;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.test.junit.categories.UnitTest;
+
+@Category(UnitTest.class)
+public class GatewaySenderEventRemoteDispatcherJUnitTest {
+  @Test
+  public void getConnectionShouldShutdownTheAckThreadReaderWhenEventProcessorIsShutDown() {
+    AbstractGatewaySender sender = mock(AbstractGatewaySender.class);
+    AbstractGatewaySenderEventProcessor eventProcessor =
+        mock(AbstractGatewaySenderEventProcessor.class);
+    GatewaySenderEventRemoteDispatcher dispatcher =
+        new GatewaySenderEventRemoteDispatcher(eventProcessor, null);
+    GatewaySenderEventRemoteDispatcher.AckReaderThread ackReaderThread =
+        dispatcher.new AckReaderThread(sender, "AckReaderThread");
+    dispatcher.setAckReaderThread(ackReaderThread);
+    assertFalse(ackReaderThread.isShutdown());
+    when(eventProcessor.isStopped()).thenReturn(true);
+    assertNull(dispatcher.getConnection(false));
+    assertTrue(ackReaderThread.isShutdown());
+  }
+}


### PR DESCRIPTION
	* Information on how the race condition occurs is provided in the GEODE-4096 ticket.
	* getConnection before returning null and clearing out the global variable connection calls stop on the dispatcher.
	* This makes sure that AckReaderThreads for the dispatcher is shutdown and prevents lingering threads holding the connection life cycle lock.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
