### PR TITLE
GEODE-4134: use ExecutorService for CompletableFuture

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/internal/cache/versions/RegionVersionVectorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/versions/RegionVersionVectorTest.java
@@ -35,9 +35,12 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -47,7 +50,6 @@ import org.apache.geode.DataSerializer;
 import org.apache.geode.InternalGemFireError;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.HeapDataOutputStream;
-import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.internal.Version;
 import org.apache.geode.internal.cache.LocalRegion;
 import org.apache.geode.internal.cache.persistence.DiskStoreID;
@@ -57,16 +59,19 @@ import org.apache.geode.test.junit.categories.UnitTest;
 @Category(UnitTest.class)
 public class RegionVersionVectorTest {
 
-  private Future<Void> result;
+  private ExecutorService executorService;
 
   @Rule
   public ExpectedException expectedException = ExpectedException.none();
 
+  @Before
+  public void setUp() throws Exception {
+    executorService = Executors.newSingleThreadExecutor();
+  }
+
   @After
   public void tearDown() throws Exception {
-    if (result != null && !result.isDone()) {
-      result.cancel(true);
-    }
+    assertThat(executorService.shutdownNow()).isEmpty();
   }
 
   @Test
@@ -317,11 +322,11 @@ public class RegionVersionVectorTest {
     assertTrue(rvv.sameAs(rvv.getCloneForTransmission()));
 
     HeapDataOutputStream out = new HeapDataOutputStream(Version.CURRENT);
-    InternalDataSerializer.writeObject(rvv.getCloneForTransmission(), out);
+    DataSerializer.writeObject(rvv.getCloneForTransmission(), out);
     byte[] bytes = out.toByteArray();
 
     DataInputStream dis = new DataInputStream(new ByteArrayInputStream(bytes));
-    DiskRegionVersionVector rvv2 = InternalDataSerializer.readObject(dis);
+    DiskRegionVersionVector rvv2 = DataSerializer.readObject(dis);
 
     assertTrue(rvv.sameAs(rvv2));
   }
@@ -622,7 +627,8 @@ public class RegionVersionVectorTest {
     long newVersion = 2;
 
     RegionVersionVector rvv = new VersionRaceConditionRegionVersionVector(ownerId, oldVersion);
-    result = CompletableFuture.runAsync(() -> rvv.updateLocalVersion(newVersion));
+    Future<Void> result =
+        CompletableFuture.runAsync(() -> rvv.updateLocalVersion(newVersion), executorService);
 
     assertThatCode(() -> result.get(2, SECONDS)).doesNotThrowAnyException();
     assertThat(rvv.getVersionForMember(ownerId)).isEqualTo(newVersion);
@@ -676,7 +682,7 @@ public class RegionVersionVectorTest {
     assertEquals(0, rvv.getExceptionCount(id));
   }
 
-  private class TestableRegionVersionVector
+  private static class TestableRegionVersionVector
       extends RegionVersionVector<VersionSource<InternalDistributedMember>> {
 
     TestableRegionVersionVector(VersionSource<InternalDistributedMember> ownerId, long version) {
@@ -707,7 +713,7 @@ public class RegionVersionVectorTest {
     }
   }
 
-  private class VersionRaceConditionRegionVersionVector extends TestableRegionVersionVector {
+  private static class VersionRaceConditionRegionVersionVector extends TestableRegionVersionVector {
 
     VersionRaceConditionRegionVersionVector(VersionSource<InternalDistributedMember> ownerId,
         long version) {


### PR DESCRIPTION
By using an ExecutorService, tearDown can invoke shutdownNow which will interrupt any Executor task threads including the hung thread in doesNotHangIfOtherThreadChangedVersion.