### PR TITLE
Feature/geode 4087

### DIFF
--- a/geode-assembly/src/test/java/org/apache/geode/test/junit/rules/HttpClientRule.java
+++ b/geode-assembly/src/test/java/org/apache/geode/test/junit/rules/HttpClientRule.java
@@ -16,9 +16,19 @@ package org.apache.geode.test.junit.rules;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
 
 import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
@@ -27,10 +37,23 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.conn.ClientConnectionManager;
+import org.apache.http.conn.scheme.Scheme;
+import org.apache.http.conn.scheme.SchemeRegistry;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.conn.ssl.SSLSocketFactory;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.SingleClientConnManager;
 import org.apache.http.message.BasicNameValuePair;
 import org.junit.rules.ExternalResource;
+
+import org.apache.geode.internal.net.SocketCreatorFactory;
+import org.apache.geode.internal.security.SecurableCommunicationChannel;
+import org.apache.geode.rest.internal.web.GeodeRestClient;
 
 /**
  * this rules simplifies creating a httpClient for verification of pulse behaviors or any http
@@ -46,6 +69,7 @@ public class HttpClientRule extends ExternalResource {
   private Supplier<Integer> portSupplier;
   private HttpHost host;
   private HttpClient httpClient;
+  private boolean useSSL;
 
   public HttpClientRule(String hostName, Supplier<Integer> portSupplier) {
     this.hostName = hostName;
@@ -56,10 +80,40 @@ public class HttpClientRule extends ExternalResource {
     this("localhost", portSupplier);
   }
 
+  public HttpClientRule withSSL() {
+    this.useSSL = true;
+    return this;
+  }
+
   @Override
   protected void before() {
-    host = new HttpHost(hostName, portSupplier.get());
-    httpClient = HttpClients.createDefault();
+    host = new HttpHost(hostName, portSupplier.get(), useSSL ? "https" : "http");
+    if (useSSL) {
+      HttpClientBuilder clientBuilder = HttpClients.custom();
+      SSLContext ctx = SocketCreatorFactory
+          .getSocketCreatorForComponent(SecurableCommunicationChannel.WEB).getSslContext();
+      clientBuilder.setSSLContext(ctx);
+      clientBuilder.setSSLHostnameVerifier(new NoopHostnameVerifier());
+      httpClient = clientBuilder.build();
+    } else {
+      httpClient = HttpClients.createDefault();
+    }
+  }
+
+  private static class DefaultTrustManager implements X509TrustManager {
+
+    @Override
+    public void checkClientTrusted(X509Certificate[] arg0, String arg1)
+        throws CertificateException {}
+
+    @Override
+    public void checkServerTrusted(X509Certificate[] arg0, String arg1)
+        throws CertificateException {}
+
+    @Override
+    public X509Certificate[] getAcceptedIssuers() {
+      return null;
+    }
   }
 
   public HttpResponse loginToPulse(String username, String password) throws Exception {
@@ -78,11 +132,13 @@ public class HttpClientRule extends ExternalResource {
   }
 
   public HttpResponse get(String uri, String... params) throws Exception {
-    return httpClient.execute(host, buildHttpGet(uri, params));
+    HttpClientContext clientContext = HttpClientContext.create();
+    return httpClient.execute(host, buildHttpGet(uri, params), clientContext);
   }
 
   public HttpResponse post(String uri, String... params) throws Exception {
-    return httpClient.execute(host, buildHttpPost(uri, params));
+    HttpClientContext clientContext = HttpClientContext.create();
+    return httpClient.execute(host, buildHttpPost(uri, params), clientContext);
   }
 
   private HttpPost buildHttpPost(String uri, String... params) throws Exception {

--- a/geode-assembly/src/test/java/org/apache/geode/tools/pulse/PulseSecurityWithSSLTest.java
+++ b/geode-assembly/src/test/java/org/apache/geode/tools/pulse/PulseSecurityWithSSLTest.java
@@ -35,6 +35,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import org.apache.geode.distributed.internal.DistributionConfigImpl;
+import org.apache.geode.internal.net.SocketCreatorFactory;
+import org.apache.geode.internal.security.SecurableCommunicationChannel;
 import org.apache.geode.security.SecurableCommunicationChannels;
 import org.apache.geode.security.SimpleTestSecurityManager;
 import org.apache.geode.test.junit.categories.IntegrationTest;
@@ -54,7 +57,7 @@ public class PulseSecurityWithSSLTest {
   @BeforeClass
   public static void beforeClass() throws Exception {
     Properties securityProps = new Properties();
-    securityProps.setProperty(SSL_ENABLED_COMPONENTS, SecurableCommunicationChannels.JMX);
+    securityProps.setProperty(SSL_ENABLED_COMPONENTS, SecurableCommunicationChannels.WEB);
     securityProps.setProperty(SSL_KEYSTORE, jks.getCanonicalPath());
     securityProps.setProperty(SSL_KEYSTORE_PASSWORD, "password");
     securityProps.setProperty(SSL_TRUSTSTORE, jks.getCanonicalPath());
@@ -64,10 +67,13 @@ public class PulseSecurityWithSSLTest {
 
     locator.withSecurityManager(SimpleTestSecurityManager.class).withProperties(securityProps)
         .startLocator();
+
+    // initialize SocketCreatorFactory so that the client will have the correct configuration
+    SocketCreatorFactory.setDistributionConfig(new DistributionConfigImpl(securityProps));
   }
 
   @Rule
-  public HttpClientRule client = new HttpClientRule(locator::getHttpPort);
+  public HttpClientRule client = new HttpClientRule(locator::getHttpPort).withSSL();
 
 
   @Test

--- a/geode-core/src/main/java/org/apache/geode/internal/net/SocketCreator.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/SocketCreator.java
@@ -350,7 +350,16 @@ public class SocketCreator {
       try {
         if (this.sslConfig.isEnabled() && sslContext == null) {
           sslContext = createAndConfigureSSLContext();
-          SSLContext.setDefault(sslContext);
+          // if (SecurableCommunicationChannel.JMX
+          // .equals(sslConfig.getSecuredCommunicationChannel())) {
+          // // JMX connections use the default SSL context so we must override it
+          // if (System.getProperty("javax.net.ssl.keyStore") != null) {
+          // logger.warn("Overriding the default SSL context that was established through system
+          // properties");
+          // }
+          // logger.error("Setting a default SSLContext", new Exception());
+          // SSLContext.setDefault(sslContext);
+          // }
         }
       } catch (Exception e) {
         throw new GemFireConfigException("Error configuring GemFire ssl ", e);
@@ -379,6 +388,11 @@ public class SocketCreator {
       re.printStackTrace();
       throw re;
     }
+  }
+
+  /** returns the SSLContext for this SocketCreator, or null if SSL is not configured */
+  public SSLContext getSslContext() {
+    return this.sslContext;
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/management/internal/JettyHelper.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/JettyHelper.java
@@ -80,50 +80,6 @@ public class JettyHelper {
       SslContextFactory sslContextFactory = new SslContextFactory();
       sslContextFactory.setSslContext(socketCreator.getSslContext());
 
-      // SSLConfig sslConfig = SSLConfigurationFactory.getSSLConfigForComponent(component);
-      // if (StringUtils.isNotBlank(sslConfig.getAlias())) {
-      // sslContextFactory.setCertAlias(sslConfig.getAlias());
-      // }
-      //
-      // sslContextFactory.setNeedClientAuth(sslConfig.isRequireAuth());
-      //
-      // if (StringUtils.isNotBlank(sslConfig.getCiphers())
-      // && !"any".equalsIgnoreCase(sslConfig.getCiphers())) {
-      // // If use has mentioned "any" let the SSL layer decide on the ciphers
-      // sslContextFactory.setIncludeCipherSuites(SSLUtil.readArray(sslConfig.getCiphers()));
-      // }
-      //
-      // String protocol = SSLUtil.getSSLAlgo(SSLUtil.readArray(sslConfig.getProtocols()));
-      // if (protocol != null) {
-      // sslContextFactory.setProtocol(protocol);
-      // } else {
-      // logger.warn(ManagementStrings.SSL_PROTOCOAL_COULD_NOT_BE_DETERMINED);
-      // }
-      //
-      //
-      // if (StringUtils.isBlank(sslConfig.getKeystore())) {
-      // throw new GemFireConfigException(
-      // "Key store can't be empty if SSL is enabled for HttpService");
-      // }
-      //
-      // sslContextFactory.setKeyStorePath(sslConfig.getKeystore());
-      //
-      // if (StringUtils.isNotBlank(sslConfig.getKeystoreType())) {
-      // sslContextFactory.setKeyStoreType(sslConfig.getKeystoreType());
-      // }
-      //
-      // if (StringUtils.isNotBlank(sslConfig.getKeystorePassword())) {
-      // sslContextFactory.setKeyStorePassword(sslConfig.getKeystorePassword());
-      // }
-      //
-      // if (StringUtils.isNotBlank(sslConfig.getTruststore())) {
-      // sslContextFactory.setTrustStorePath(sslConfig.getTruststore());
-      // }
-      //
-      // if (StringUtils.isNotBlank(sslConfig.getTruststorePassword())) {
-      // sslContextFactory.setTrustStorePassword(sslConfig.getTruststorePassword());
-      // }
-
       httpConfig.addCustomizer(new SecureRequestCustomizer());
 
       // Somehow With HTTP_2.0 Jetty throwing NPE. Need to investigate further whether all GemFire

--- a/geode-core/src/main/java/org/apache/geode/management/internal/ManagementAgent.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/ManagementAgent.java
@@ -40,12 +40,14 @@ import javax.management.remote.JMXServiceURL;
 import javax.management.remote.rmi.RMIConnectorServer;
 import javax.management.remote.rmi.RMIJRMPServerImpl;
 import javax.management.remote.rmi.RMIServerImpl;
+import javax.net.ssl.SSLContext;
 import javax.rmi.ssl.SslRMIClientSocketFactory;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
 
 import org.apache.geode.GemFireConfigException;
 import org.apache.geode.cache.CacheFactory;
@@ -235,8 +237,10 @@ public class ManagementAgent {
 
           boolean isRestWebAppAdded = false;
 
-          this.httpServer = JettyHelper.initJetty(bindAddress, port,
-              SSLConfigurationFactory.getSSLConfigForComponent(SecurableCommunicationChannel.WEB));
+          SocketCreator webSocketCreator =
+              SocketCreatorFactory.getSocketCreatorForComponent(SecurableCommunicationChannel.WEB);
+          this.httpServer =
+              JettyHelper.initJetty(bindAddress, port, SecurableCommunicationChannel.WEB);
 
           if (agentUtil.isWebApplicationAvailable(gemfireWar)) {
             this.httpServer =

--- a/geode-core/src/main/java/org/apache/geode/management/internal/RestAgent.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/RestAgent.java
@@ -33,6 +33,7 @@ import org.apache.geode.internal.cache.InternalRegionArguments;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.net.SSLConfigurationFactory;
 import org.apache.geode.internal.net.SocketCreator;
+import org.apache.geode.internal.net.SocketCreatorFactory;
 import org.apache.geode.internal.security.SecurableCommunicationChannel;
 import org.apache.geode.management.ManagementService;
 
@@ -131,8 +132,8 @@ public class RestAgent {
 
         final int port = this.config.getHttpServicePort();
 
-        this.httpServer = JettyHelper.initJetty(httpServiceBindAddress, port,
-            SSLConfigurationFactory.getSSLConfigForComponent(SecurableCommunicationChannel.WEB));
+        this.httpServer =
+            JettyHelper.initJetty(httpServiceBindAddress, port, SecurableCommunicationChannel.WEB);
 
         this.httpServer = JettyHelper.addWebApplication(httpServer, "/gemfire-api", gemfireAPIWar);
         this.httpServer = JettyHelper.addWebApplication(httpServer, "/geode", gemfireAPIWar);

--- a/geode-core/src/test/java/org/apache/geode/management/internal/JettyHelperJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/JettyHelperJUnitTest.java
@@ -28,6 +28,7 @@ import org.junit.experimental.categories.Category;
 import org.apache.geode.GemFireConfigException;
 import org.apache.geode.distributed.internal.DistributionConfigImpl;
 import org.apache.geode.internal.net.SSLConfigurationFactory;
+import org.apache.geode.internal.net.SocketCreatorFactory;
 import org.apache.geode.internal.security.SecurableCommunicationChannel;
 import org.apache.geode.test.junit.categories.UnitTest;
 
@@ -58,8 +59,7 @@ public class JettyHelperJUnitTest {
 
     final Server jetty;
     try {
-      jetty = JettyHelper.initJetty(null, 8090,
-          SSLConfigurationFactory.getSSLConfigForComponent(SecurableCommunicationChannel.WEB));
+      jetty = JettyHelper.initJetty(null, 8090, SecurableCommunicationChannel.WEB);
       assertNotNull(jetty);
       assertNotNull(jetty.getConnectors()[0]);
       assertEquals(8090, ((ServerConnector) jetty.getConnectors()[0]).getPort());
@@ -71,8 +71,8 @@ public class JettyHelperJUnitTest {
   @Test
   public void testSetPortWithBindAddress() throws Exception {
     try {
-      final Server jetty = JettyHelper.initJetty("10.123.50.1", 10480,
-          SSLConfigurationFactory.getSSLConfigForComponent(SecurableCommunicationChannel.WEB));
+      final Server jetty =
+          JettyHelper.initJetty("10.123.50.1", 10480, SecurableCommunicationChannel.WEB);
 
       assertNotNull(jetty);
       assertNotNull(jetty.getConnectors()[0]);

--- a/geode-pulse/src/test/java/org/apache/geode/tools/pulse/tests/rules/ServerRule.java
+++ b/geode-pulse/src/test/java/org/apache/geode/tools/pulse/tests/rules/ServerRule.java
@@ -21,8 +21,11 @@ import java.util.Properties;
 import org.awaitility.Awaitility;
 import org.junit.rules.ExternalResource;
 
+import org.apache.geode.distributed.internal.DistributionConfigImpl;
 import org.apache.geode.internal.AvailablePort;
 import org.apache.geode.internal.admin.SSLConfig;
+import org.apache.geode.internal.net.SocketCreatorFactory;
+import org.apache.geode.internal.security.SecurableCommunicationChannel;
 import org.apache.geode.management.internal.JettyHelper;
 import org.apache.geode.tools.pulse.internal.data.PulseConstants;
 import org.apache.geode.tools.pulse.tests.Server;
@@ -44,8 +47,9 @@ public class ServerRule extends ExternalResource {
     System.setProperty(PulseConstants.SYSTEM_PROPERTY_PULSE_HOST, LOCALHOST);
     System.setProperty(PulseConstants.SYSTEM_PROPERTY_PULSE_PORT, Integer.toString(jmxPort));
 
+    SocketCreatorFactory.setDistributionConfig(new DistributionConfigImpl(new Properties()));
     int httpPort = AvailablePort.getRandomAvailablePort(AvailablePort.SOCKET);
-    jetty = JettyHelper.initJetty(LOCALHOST, httpPort, new SSLConfig());
+    jetty = JettyHelper.initJetty(LOCALHOST, httpPort, SecurableCommunicationChannel.WEB);
     JettyHelper.addWebApplication(jetty, PULSE_CONTEXT, getPulseWarPath());
     pulseURL = "http://" + LOCALHOST + ":" + httpPort + PULSE_CONTEXT;
     System.out.println("Pulse started at " + pulseURL);


### PR DESCRIPTION
*GEODE-4087 modify SocketCreator to not set the default SSLContext for the JVM*

_SocketCreator no longer installs a default SSL context._



Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
@jinmeiliao @PurelyApplied @PivotalSarge @galen-pivotal @upthewaterspout @WireBaron 