### PR TITLE
GEODE-4122: Add runner annotation to avoid skipping tests with Parameterized

### DIFF
--- a/geode-assembly/src/test/java/org/apache/geode/tools/pulse/PulseConnectivityTest.java
+++ b/geode-assembly/src/test/java/org/apache/geode/tools/pulse/PulseConnectivityTest.java
@@ -35,10 +35,12 @@ import org.apache.geode.test.junit.categories.IntegrationTest;
 import org.apache.geode.test.junit.rules.EmbeddedPulseRule;
 import org.apache.geode.test.junit.rules.HttpClientRule;
 import org.apache.geode.test.junit.rules.LocatorStarterRule;
+import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactory;
 import org.apache.geode.tools.pulse.internal.data.Cluster;
 
-@RunWith(Parameterized.class)
 @Category(IntegrationTest.class)
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
 public class PulseConnectivityTest {
   @Rule
   public LocatorStarterRule locator = new LocatorStarterRule().withJMXManager();

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/PRCacheListenerInvocationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/PRCacheListenerInvocationTest.java
@@ -28,6 +28,7 @@ import org.apache.geode.cache.PartitionAttributesFactory;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionFactory;
 import org.apache.geode.test.junit.categories.DistributedTest;
+import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactory;
 
 /**
  * This class tests event triggering and handling in partitioned regions.
@@ -39,6 +40,7 @@ import org.apache.geode.test.junit.categories.DistributedTest;
  */
 @Category(DistributedTest.class)
 @RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
 @SuppressWarnings("serial")
 public class PRCacheListenerInvocationTest extends ReplicateCacheListenerInvocationTest {
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/PRCacheListenerWithInterestPolicyAllInvocationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/PRCacheListenerWithInterestPolicyAllInvocationTest.java
@@ -30,6 +30,7 @@ import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionFactory;
 import org.apache.geode.cache.SubscriptionAttributes;
 import org.apache.geode.test.junit.categories.DistributedTest;
+import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactory;
 
 /**
  * This class tests event triggering and handling in partitioned regions.
@@ -41,6 +42,7 @@ import org.apache.geode.test.junit.categories.DistributedTest;
  */
 @Category(DistributedTest.class)
 @RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
 @SuppressWarnings("serial")
 public class PRCacheListenerWithInterestPolicyAllInvocationTest
     extends ReplicateCacheListenerInvocationTest {

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/wan/GatewayReceiverXmlParsingValidationsJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/wan/GatewayReceiverXmlParsingValidationsJUnitTest.java
@@ -12,9 +12,6 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-/**
- *
- */
 package org.apache.geode.internal.cache.wan;
 
 import static org.apache.geode.distributed.ConfigurationProperties.CACHE_XML_FILE;
@@ -49,6 +46,7 @@ import org.apache.geode.cache.CacheXmlException;
 import org.apache.geode.cache.wan.GatewayReceiverFactory;
 import org.apache.geode.test.junit.categories.IntegrationTest;
 import org.apache.geode.test.junit.rules.serializable.SerializableTestName;
+import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactory;
 import org.apache.geode.util.test.TestUtil;
 
 @RunWith(PowerMockRunner.class)
@@ -56,6 +54,7 @@ import org.apache.geode.util.test.TestUtil;
 @PrepareForTest(WANServiceProvider.class)
 @PowerMockRunnerDelegate(Parameterized.class)
 @PowerMockIgnore({"javax.management.*", "javax.security.*", "*.IntegrationTest"})
+@Parameterized.UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
 public class GatewayReceiverXmlParsingValidationsJUnitTest {
   private Cache cache;
   private GatewayReceiverFactory receiverFactory;

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ChangeLogLevelCommandDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ChangeLogLevelCommandDUnitTest.java
@@ -32,10 +32,12 @@ import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.junit.categories.DistributedTest;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
+import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactory;
 
 
 @Category(DistributedTest.class)
 @RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
 public class ChangeLogLevelCommandDUnitTest {
   private static final String MANAGER_NAME = "Manager";
   private static final String SERVER1_NAME = "Server1";

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/GcCommandDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/GcCommandDUnitTest.java
@@ -36,10 +36,12 @@ import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.junit.categories.DistributedTest;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
+import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactory;
 
 
 @Category(DistributedTest.class)
 @RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
 public class GcCommandDUnitTest {
   private static final String MANAGER_NAME = "Manager";
   private static final String SERVER1_NAME = "Server1";
@@ -51,7 +53,7 @@ public class GcCommandDUnitTest {
   @Parameterized.Parameter
   public static boolean useHttp;
 
-  @Parameterized.Parameters
+  @Parameterized.Parameters(name = "Use http: {0}")
   public static Object[] data() {
     return new Object[] {true, false};
   }
@@ -123,6 +125,6 @@ public class GcCommandDUnitTest {
     CommandResult result = gfsh.executeCommand(gcCommand);
     assertThat(result.getStatus()).isEqualTo(Result.Status.ERROR);
     assertThat(gfsh.getGfshOutput())
-        .contains("Could not process command due to error. NotAValidMemberMember not found");
+        .contains("Member NotAValidMember could not be found.");
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/GcCommandDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/GcCommandDUnitTest.java
@@ -124,7 +124,6 @@ public class GcCommandDUnitTest {
 
     CommandResult result = gfsh.executeCommand(gcCommand);
     assertThat(result.getStatus()).isEqualTo(Result.Status.ERROR);
-    assertThat(gfsh.getGfshOutput())
-        .contains("Member NotAValidMember could not be found.");
+    assertThat(gfsh.getGfshOutput()).contains("Member NotAValidMember could not be found.");
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ShowLogCommandDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ShowLogCommandDUnitTest.java
@@ -45,9 +45,11 @@ import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.junit.categories.DistributedTest;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
+import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactory;
 
 @Category(DistributedTest.class)
 @RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
 public class ShowLogCommandDUnitTest implements Serializable {
   private static final String MANAGER_NAME = "Manager";
   private static final String SERVER1_NAME = "Server1";

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/converters/BaseStringConverterJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/converters/BaseStringConverterJUnitTest.java
@@ -21,23 +21,20 @@ import java.util.Arrays;
 import java.util.stream.Collectors;
 
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.springframework.shell.core.Converter;
 
-import org.apache.geode.management.cli.ConverterHint;
-import org.apache.geode.management.internal.cli.shell.Gfsh;
 import org.apache.geode.test.junit.categories.UnitTest;
 import org.apache.geode.test.junit.rules.GfshParserRule;
 import org.apache.geode.test.junit.rules.GfshParserRule.CommandCandidate;
+import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactory;
 
 @Category(UnitTest.class)
 @RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
 public class BaseStringConverterJUnitTest {
 
   @ClassRule

--- a/geode-core/src/test/java/org/apache/geode/security/query/IndexSecurityDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/security/query/IndexSecurityDUnitTest.java
@@ -18,11 +18,6 @@ import static org.apache.geode.internal.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 
-import java.util.Arrays;
-import java.util.List;
-
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -36,9 +31,11 @@ import org.apache.geode.cache.query.QueryService;
 import org.apache.geode.security.query.data.QueryTestObject;
 import org.apache.geode.test.junit.categories.DistributedTest;
 import org.apache.geode.test.junit.categories.SecurityTest;
+import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactory;
 
 @Category({DistributedTest.class, SecurityTest.class})
 @RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
 public class IndexSecurityDUnitTest extends QuerySecurityBase {
   public RegionShortcut getRegionType() {
     return RegionShortcut.REPLICATE;

--- a/geode-core/src/test/java/org/apache/geode/security/query/PartitionedIndexSecurityDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/security/query/PartitionedIndexSecurityDUnitTest.java
@@ -14,7 +14,6 @@
  */
 package org.apache.geode.security.query;
 
-import junitparams.JUnitParamsRunner;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -22,9 +21,11 @@ import org.junit.runners.Parameterized;
 import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.test.junit.categories.DistributedTest;
 import org.apache.geode.test.junit.categories.SecurityTest;
+import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactory;
 
 @Category({DistributedTest.class, SecurityTest.class})
 @RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
 public class PartitionedIndexSecurityDUnitTest extends IndexSecurityDUnitTest {
   public RegionShortcut getRegionType() {
     return RegionShortcut.PARTITION;

--- a/geode-core/src/test/java/org/apache/geode/security/query/PdxPartitionedQuerySecurityAllowedQueriesDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/security/query/PdxPartitionedQuerySecurityAllowedQueriesDUnitTest.java
@@ -21,9 +21,11 @@ import org.junit.runners.Parameterized;
 import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.test.junit.categories.DistributedTest;
 import org.apache.geode.test.junit.categories.SecurityTest;
+import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactory;
 
 @Category({DistributedTest.class, SecurityTest.class})
 @RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
 public class PdxPartitionedQuerySecurityAllowedQueriesDUnitTest
     extends PdxQuerySecurityAllowedQueriesDUnitTest {
   public RegionShortcut getRegionType() {

--- a/geode-core/src/test/java/org/apache/geode/security/query/PdxQuerySecurityAllowedQueriesDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/security/query/PdxQuerySecurityAllowedQueriesDUnitTest.java
@@ -14,27 +14,23 @@
  */
 package org.apache.geode.security.query;
 
-import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import junitparams.Parameters;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import org.apache.geode.pdx.PdxReader;
-import org.apache.geode.pdx.PdxSerializable;
-import org.apache.geode.pdx.PdxWriter;
 import org.apache.geode.security.query.data.PdxQueryTestObject;
 import org.apache.geode.test.junit.categories.DistributedTest;
 import org.apache.geode.test.junit.categories.SecurityTest;
+import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactory;
 
 @Category({DistributedTest.class, SecurityTest.class})
 @RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
 public class PdxQuerySecurityAllowedQueriesDUnitTest extends QuerySecurityBase {
   @Parameterized.Parameters
   public static Object[] usersAllowed() {

--- a/geode-core/src/test/java/org/apache/geode/security/query/PdxQuerySecurityRestrictedQueriesDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/security/query/PdxQuerySecurityRestrictedQueriesDUnitTest.java
@@ -14,27 +14,20 @@
  */
 package org.apache.geode.security.query;
 
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
-import junitparams.Parameters;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import org.apache.geode.pdx.PdxReader;
-import org.apache.geode.pdx.PdxSerializable;
-import org.apache.geode.pdx.PdxWriter;
 import org.apache.geode.security.query.data.PdxQueryTestObject;
 import org.apache.geode.test.junit.categories.DistributedTest;
 import org.apache.geode.test.junit.categories.SecurityTest;
+import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactory;
 
 @Category({DistributedTest.class, SecurityTest.class})
 @RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
 public class PdxQuerySecurityRestrictedQueriesDUnitTest extends QuerySecurityBase {
   @Parameterized.Parameters
   public static Object[] usersAllowed() {

--- a/geode-core/src/test/java/org/apache/geode/security/query/QuerySecurityUnauthorizedUserBindParameterDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/security/query/QuerySecurityUnauthorizedUserBindParameterDUnitTest.java
@@ -19,15 +19,12 @@ import java.util.HashSet;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.query.internal.index.DummyQRegion;
 import org.apache.geode.security.query.data.QueryTestObject;
 import org.apache.geode.test.junit.categories.DistributedTest;
 import org.apache.geode.test.junit.categories.SecurityTest;
-import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactory;
 
 @Category({DistributedTest.class, SecurityTest.class})
 public class QuerySecurityUnauthorizedUserBindParameterDUnitTest extends QuerySecurityBase {

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/acceptance/CacheConnectionJUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/acceptance/CacheConnectionJUnitTest.java
@@ -57,7 +57,6 @@ import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.internal.admin.SSLConfig;
 import org.apache.geode.internal.cache.CacheServerImpl;
-import org.apache.geode.internal.cache.tier.CommunicationMode;
 import org.apache.geode.internal.cache.tier.sockets.AcceptorImpl;
 import org.apache.geode.internal.net.SocketCreator;
 import org.apache.geode.internal.net.SocketCreatorFactory;
@@ -65,13 +64,13 @@ import org.apache.geode.internal.protocol.exception.InvalidProtocolMessageExcept
 import org.apache.geode.internal.protocol.protobuf.statistics.ProtobufClientStatisticsImpl;
 import org.apache.geode.internal.protocol.protobuf.v1.BasicTypes;
 import org.apache.geode.internal.protocol.protobuf.v1.ClientProtocol;
-import org.apache.geode.internal.protocol.protobuf.v1.ConnectionAPI;
 import org.apache.geode.internal.protocol.protobuf.v1.MessageUtil;
 import org.apache.geode.internal.protocol.protobuf.v1.ProtobufSerializationService;
 import org.apache.geode.internal.protocol.protobuf.v1.RegionAPI;
 import org.apache.geode.internal.protocol.protobuf.v1.serializer.ProtobufProtocolSerializer;
 import org.apache.geode.internal.protocol.serialization.SerializationService;
 import org.apache.geode.test.junit.categories.IntegrationTest;
+import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactory;
 import org.apache.geode.util.test.TestUtil;
 
 /**
@@ -79,6 +78,7 @@ import org.apache.geode.util.test.TestUtil;
  */
 @Category(IntegrationTest.class)
 @RunWith(value = Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
 public class CacheConnectionJUnitTest {
   private final String TEST_KEY = "testKey";
   private final String TEST_VALUE = "testValue";

--- a/geode-pulse/src/test/java/org/apache/geode/tools/pulse/internal/security/LogoutHandlerUnitTest.java
+++ b/geode-pulse/src/test/java/org/apache/geode/tools/pulse/internal/security/LogoutHandlerUnitTest.java
@@ -40,6 +40,7 @@ import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.core.Authentication;
 
 import org.apache.geode.test.junit.categories.UnitTest;
+import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactory;
 import org.apache.geode.tools.pulse.internal.data.Cluster;
 import org.apache.geode.tools.pulse.internal.data.Repository;
 
@@ -48,6 +49,7 @@ import org.apache.geode.tools.pulse.internal.data.Repository;
 @PrepareForTest(Repository.class)
 @PowerMockRunnerDelegate(Parameterized.class)
 @PowerMockIgnore({"javax.management.*", "javax.security.*", "*.UnitTest"})
+@Parameterized.UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
 public class LogoutHandlerUnitTest {
   private Repository repository;
   private LogoutHandler handler;
@@ -65,7 +67,7 @@ public class LogoutHandlerUnitTest {
         mock(GemFireAuthentication.class, "GemFire Authentication");
     when(gemfireAuthentication.getName()).thenReturn(mockUser);
 
-    return Arrays.asList(new Authentication[] {defaultAuthentication, gemfireAuthentication});
+    return Arrays.asList(defaultAuthentication, gemfireAuthentication);
   }
 
   @Before

--- a/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/GatewayReceiverFactoryImplJUnitTest.java
+++ b/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/GatewayReceiverFactoryImplJUnitTest.java
@@ -40,9 +40,11 @@ import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.xmlcache.CacheCreation;
 import org.apache.geode.test.junit.categories.UnitTest;
+import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactory;
 
 @Category(UnitTest.class)
 @RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
 public class GatewayReceiverFactoryImplJUnitTest {
   @Parameterized.Parameter
   public static InternalCache cache;

--- a/geode-web/src/test/java/org/apache/geode/management/internal/cli/commands/ClusterConfigurationDUnitTest.java
+++ b/geode-web/src/test/java/org/apache/geode/management/internal/cli/commands/ClusterConfigurationDUnitTest.java
@@ -37,9 +37,11 @@ import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.junit.categories.DistributedTest;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
+import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactory;
 
 @Category(DistributedTest.class)
 @RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
 public class ClusterConfigurationDUnitTest {
   @Rule
   public ClusterStartupRule startupRule = new ClusterStartupRule();


### PR DESCRIPTION
* Optimize imports in touched files.
* Fix small error in GcCommandDUnitTest in error phrasing
* The following will be corrected in separate tickets:
* - QueryCommandTest
* - ShutdownCommandDUnitTest
* - CacheServerSSLConnectionDUnitTest

---

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
