### PR TITLE
GEODE-2665: Document Gfsh command to delete async event queues

### DIFF
--- a/geode-docs/tools_modules/gfsh/command-pages/destroy.html.md.erb
+++ b/geode-docs/tools_modules/gfsh/command-pages/destroy.html.md.erb
@@ -22,9 +22,13 @@ limitations under the License.
 
 Delete or unregister functions, remove indexes, disk stores and regions.
 
+-   **[destroy async-event-queue](#topic_destroy-async-event-queue)**
+
+    Destroy an asynchronous event queue.
+
 -   **[destroy disk-store](#topic_yfr_l2z_ck)**
 
-    Deletes a disk store and all files on disk used by the disk store. Data for closed regions that previously used this disk store is lost.
+    Delete a disk store and all files on disk used by the disk store.
 
 -   **[destroy function](#topic_E48C2DF809054C12A162026D8A2139BB)**
 
@@ -46,16 +50,43 @@ Delete or unregister functions, remove indexes, disk stores and regions.
 
     Destroy or remove a region.
 
-## <a id="topic_yfr_l2z_ck" class="no-quick-link"></a>destroy disk-store
+## <a id="topic_destroy-async-event-queue" class="no-quick-link"></a>destroy async-event-queue
 
-Deletes a disk store and all files on disk used by the disk store. Data for closed regions that previously used this disk store are lost.
+Destroy an asynchronous event queue.
 
 **Availability:** Online. You must be connected in `gfsh` to a JMX Manager member to use this command.
 
 **Syntax:**
 
 ``` pre
-destroy disk-store --name=value [--groups=value(,value)*]
+destroy async-event-queue --id=value [--groups=value(,value)*] [--if-exists=value]
+```
+
+**Parameters, destroy async-event-queue:**
+
+| Name                                          | Description                                                                                       |
+|-----------------------------------------------|---------------------------------------------------------------------------------------------------|
+| <span class="keyword parmname">\\-\\-id</span>  | *Required.* ID of the async event queue to be deleted.                                          |
+| <span class="keyword parmname">&#8209;&#8209;groups</span> | Group(s) of members on which the async event queue will be destroyed. If no group is specified, the queue is destroyed on all members. |
+| &#8209;&#8209;if&#8209;exists | If the specified async event queue does not exist, gfsh responds with a message to that effect. If this parameter is true, the response is prefixed with the label "Skipping: ". Useful for scripted tests. Default (if the parameter is not specified): false. Default (if the parameter is specified without value): true.     |
+
+
+**Example Commands:**
+
+``` pre
+destroy async-event-queue --id=myAsyncEventQueue
+```
+
+## <a id="topic_yfr_l2z_ck" class="no-quick-link"></a>destroy disk-store
+
+Delete a disk store and all files on disk used by the disk store. Data for closed regions that previously used this disk store are lost.
+
+**Availability:** Online. You must be connected in `gfsh` to a JMX Manager member to use this command.
+
+**Syntax:**
+
+``` pre
+destroy disk-store --name=value [--groups=value(,value)*] [--if-exists=value]
 ```
 
 **Parameters, destroy disk-store:**
@@ -64,6 +95,7 @@ destroy disk-store --name=value [--groups=value(,value)*]
 |-----------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
 | <span class="keyword parmname">\\-\\-name</span>  | *Required.* Name of the disk store to be deleted.                                                                                    |
 | <span class="keyword parmname">&#8209;&#8209;groups</span> | Group(s) of members on which the disk store will be destroyed. If no group is specified, the disk store is destroyed on all members. |
+| &#8209;&#8209;if&#8209;exists | If the specified disk store does not exist, gfsh responds with a message to that effect. If this parameter is true, the response is prefixed with the label "Skipping: ". Useful for scripted tests. Default (if the parameter is not specified): false. Default (if the parameter is specified without value): true.     |
 
 
 **Example Commands:**
@@ -139,7 +171,7 @@ gfsh>alter region --name=regionA --gateway-sender-id=""
 
 ``` pre
 destroy gateway-sender --id=value [--groups=value(,value)*]
-  [--members=value(,value)*]
+  [--members=value(,value)*] [--if-exists=value]
 ```
 
 **Parameters, destroy gateway-sender:**
@@ -149,6 +181,7 @@ destroy gateway-sender --id=value [--groups=value(,value)*]
 | <span class="keyword parmname">\\-\\-id</span>     | *Required.* Unique gateway sender identifier. Use the `list gateways` command to obtain the ID. |
 | <span class="keyword parmname">\\-\\-groups</span> | One or more groups of members from which this gateway sender will be destroyed.       |
 | <span class="keyword parmname">&#8209;&#8209;members</span> | Name or ID of the member(s) from which this gateway sender will be destroyed.   |
+| &#8209;&#8209;if&#8209;exists | If the specified gateway sender does not exist, gfsh responds with a message to that effect. If this parameter is true, the response is prefixed with the label "Skipping: ". Useful for scripted tests. Default (if the parameter is not specified): false. Default (if the parameter is specified without value): true.     |
 
 **Example Commands:**
 
@@ -166,7 +199,7 @@ Destroy or remove the specified index.
 
 ``` pre
 destroy index [--name=value] [--region=value] [--members=value(,value)*]
-[--groups=value(,value)*]
+[--groups=value(,value)*] [--if-exists=value]
 ```
 
 **Note:**
@@ -177,9 +210,10 @@ You must specify at least one of the parameter options. If you enter `destroy in
 | Name                                           | Description                                                                  |
 |------------------------------------------------|------------------------------------------------------------------------------|
 | <span class="keyword parmname">\\-\\-name</span>   | Name of the index to be removed.                                            |
-| <span class="keyword parmname">\\-\\-members</span> | Id of the member(s) on which index is to be removed.                            |
+| &#8209;&#8209;members | Id of the member(s) on which index is to be removed.                            |
 | <span class="keyword parmname">\\-\\-region</span> | Name of the region from which an index or all indexes are to be destroyed. |
 | <span class="keyword parmname">\\-\\-groups</span>  | The index will be removed on all the members in the group(s).           |
+| &#8209;&#8209;if&#8209;exists | If the specified index does not exist, gfsh responds with a message to that effect. If this parameter is true, the response is prefixed with the label "Skipping: ". Useful for scripted tests. Default (if the parameter is not specified): false. Default (if the parameter is specified without value): true.     |
 
 
 **Example Commands:**
@@ -227,7 +261,7 @@ Destroy or remove a region.
 **Syntax:**
 
 ``` pre
-destroy region --name=value
+destroy region --name=value [--if-exists=value]
 ```
 
 **Parameters, destroy region:**
@@ -235,6 +269,7 @@ destroy region --name=value
 | Name                                         | Description                                            |
 |----------------------------------------------|--------------------------------------------------------|
 | <span class="keyword parmname">\\-\\-name</span> | *Required.* Name and path of the region to be removed. |
+| &#8209;&#8209;if&#8209;exists | If the specified region does not exist, gfsh responds with a message to that effect. If this parameter is true, the response is prefixed with the label "Skipping: ". Useful for scripted tests. Default (if the parameter is not specified): false. Default (if the parameter is specified without value): true.     |
 
 
 **Example Commands:**


### PR DESCRIPTION
Documented the gfsh command `destroy async-event-queue`.
While I was at it, added documentation for the `--if-exists` option for some other destroy commands.