### PR TITLE
GEODE-4087 modify SocketCreator to not set the default SSLContext for…

### DIFF
--- a/geode-assembly/src/test/java/org/apache/geode/tools/pulse/PulseSecurityWithSSLTest.java
+++ b/geode-assembly/src/test/java/org/apache/geode/tools/pulse/PulseSecurityWithSSLTest.java
@@ -54,7 +54,7 @@ public class PulseSecurityWithSSLTest {
   @BeforeClass
   public static void beforeClass() throws Exception {
     Properties securityProps = new Properties();
-    securityProps.setProperty(SSL_ENABLED_COMPONENTS, SecurableCommunicationChannels.JMX);
+    securityProps.setProperty(SSL_ENABLED_COMPONENTS, SecurableCommunicationChannels.WEB);
     securityProps.setProperty(SSL_KEYSTORE, jks.getCanonicalPath());
     securityProps.setProperty(SSL_KEYSTORE_PASSWORD, "password");
     securityProps.setProperty(SSL_TRUSTSTORE, jks.getCanonicalPath());
@@ -67,7 +67,7 @@ public class PulseSecurityWithSSLTest {
   }
 
   @Rule
-  public HttpClientRule client = new HttpClientRule(locator::getHttpPort);
+  public HttpClientRule client = new HttpClientRule(locator::getHttpPort).withSSL();
 
 
   @Test

--- a/geode-core/src/main/java/org/apache/geode/internal/net/SocketCreator.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/SocketCreator.java
@@ -350,7 +350,6 @@ public class SocketCreator {
       try {
         if (this.sslConfig.isEnabled() && sslContext == null) {
           sslContext = createAndConfigureSSLContext();
-          SSLContext.setDefault(sslContext);
         }
       } catch (Exception e) {
         throw new GemFireConfigException("Error configuring GemFire ssl ", e);
@@ -604,6 +603,10 @@ public class SocketCreator {
     }
 
     return extendedKeyManagers;
+  }
+
+  public SSLContext getSslContext() {
+    return sslContext;
   }
 
   private static class ExtendedAliasKeyManager extends X509ExtendedKeyManager {

--- a/geode-core/src/test/java/org/apache/geode/internal/net/SSLSocketIntegrationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/net/SSLSocketIntegrationTest.java
@@ -22,6 +22,8 @@ import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.apache.geode.internal.security.SecurableCommunicationChannel.CLUSTER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 
 import java.io.File;
 import java.io.IOException;
@@ -37,6 +39,8 @@ import java.util.Properties;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+
+import javax.net.ssl.SSLContext;
 
 import org.apache.commons.io.FileUtils;
 import org.awaitility.Awaitility;
@@ -125,6 +129,20 @@ public class SSLSocketIntegrationTest {
       this.serverThread.interrupt();
     }
     SocketCreatorFactory.close();
+  }
+
+  @Test
+  /**
+   * see GEODE-4087. Geode should not establish a default SSLContext, preventing apps from using
+   * different ssl settings via standard system properties. Since this test class sets these system
+   * properties to establish a default context we merely need to perform an equality check between
+   * the cluster's context and the default context and assert that they aren't the same.
+   */
+  public void ensureSocketCreatorDoesNotOverrideDefaultSSLContext() throws Exception {
+    SSLContext defaultContext = SSLContext.getDefault();
+    SSLContext clusterContext = SocketCreatorFactory
+        .getSocketCreatorForComponent(SecurableCommunicationChannel.CLUSTER).getSslContext();
+    assertNotEquals(clusterContext, defaultContext);
   }
 
   @Test


### PR DESCRIPTION
This is a revised fix for the problem that is much less invasive.

- Removed setting of the default SSLContext in SocketCreator.
- Modified PulseSecurityWithSSLTest to use SSL in its HTTP client.
- Added a new unit test that failed before making the change to SocketCreator.







Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
@WireBaron @upthewaterspout @PivotalSarge @galen-pivotal @jinmeiliao @PurelyApplied 