### PR TITLE
GEODE-4168 Can't get json object stored as PDX using the new protocol

### DIFF
--- a/geode-assembly/src/test/java/org/apache/geode/rest/internal/web/controllers/RestAPIsAndInterOpsDUnitTest.java
+++ b/geode-assembly/src/test/java/org/apache/geode/rest/internal/web/controllers/RestAPIsAndInterOpsDUnitTest.java
@@ -174,7 +174,7 @@ public class RestAPIsAndInterOpsDUnitTest extends LocatorTestBase {
 
     DistributedSystem ds = getSystem(props);
     InternalCache cache = (InternalCache) CacheFactory.create(ds);
-    cache.setReadSerialized(true);
+    cache.setReadSerializedForTest(true);
     AttributesFactory factory = new AttributesFactory();
 
     factory.setEnableBridgeConflation(true);

--- a/geode-assembly/src/test/java/org/apache/geode/rest/internal/web/controllers/RestAPIsWithSSLDUnitTest.java
+++ b/geode-assembly/src/test/java/org/apache/geode/rest/internal/web/controllers/RestAPIsWithSSLDUnitTest.java
@@ -193,7 +193,7 @@ public class RestAPIsWithSSLDUnitTest extends LocatorTestBase {
 
     DistributedSystem ds = getSystem(props);
     InternalCache cache = (InternalCache) CacheFactory.create(ds);
-    cache.setReadSerialized(true);
+    cache.setReadSerializedForTest(true);
 
     AttributesFactory factory = new AttributesFactory();
     factory.setEnableBridgeConflation(true);

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DM.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DM.java
@@ -455,7 +455,10 @@ public interface DM extends ReplySender {
   /**
    * returns the type of node
    *
-   * @return
+   * @see DistributionManager#NORMAL_DM_TYPE
+   * @see DistributionManager#LONER_DM_TYPE
+   * @see DistributionManager#LOCATOR_DM_TYPE
+   * @see DistributionManager#ADMIN_ONLY_DM_TYPE
    */
   int getDMType();
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
@@ -5127,9 +5127,15 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
     }
   }
 
+  @Override
+  public void setReadSerializedForCurrentThread(boolean value) {
+    PdxInstanceImpl.setPdxReadSerialized(value);
+    DefaultQuery.setPdxReadSerialized(value);
+  }
+
   // test hook
   @Override
-  public void setReadSerialized(boolean value) {
+  public void setReadSerializedForTest(boolean value) {
     this.cacheConfig.setPdxReadSerialized(value);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCache.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCache.java
@@ -311,7 +311,17 @@ public interface InternalCache extends Cache, Extensible<Cache>, CacheTime {
 
   CacheServer addCacheServer(boolean isGatewayReceiver);
 
-  void setReadSerialized(boolean value);
+  /**
+   * A test-hook allowing you to alter the cache setting established by
+   * CacheFactory.setPdxReadSerialized()
+   */
+  void setReadSerializedForTest(boolean value);
+
+  /**
+   * Enables or disables the reading of PdxInstances from all cache Regions for the thread that
+   * invokes this method.
+   */
+  void setReadSerializedForCurrentThread(boolean value);
 
   PdxInstanceFactory createPdxInstanceFactory(String className, boolean expectDomainClass);
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheCreation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheCreation.java
@@ -1029,7 +1029,12 @@ public class CacheCreation implements InternalCache {
   }
 
   @Override
-  public void setReadSerialized(final boolean value) {
+  public void setReadSerializedForCurrentThread(final boolean value) {
+    throw new UnsupportedOperationException(LocalizedStrings.SHOULDNT_INVOKE.toLocalizedString());
+  }
+
+  @Override
+  public void setReadSerializedForTest(final boolean value) {
     throw new UnsupportedOperationException(LocalizedStrings.SHOULDNT_INVOKE.toLocalizedString());
   }
 

--- a/geode-core/src/test/java/org/apache/geode/cache/query/dunit/PdxLocalQueryDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/dunit/PdxLocalQueryDUnitTest.java
@@ -154,7 +154,7 @@ public class PdxLocalQueryDUnitTest extends PDXQueryTestBase {
     server2.invoke(new SerializableCallable("Create Server2") {
       @Override
       public Object call() throws Exception {
-        ((GemFireCacheImpl) getCache()).setReadSerialized(true);
+        ((GemFireCacheImpl) getCache()).setReadSerializedForTest(true);
         Region r1 = getCache().createRegionFactory(RegionShortcut.REPLICATE).create(regionName);
 
         QueryService qs = null;
@@ -365,7 +365,7 @@ public class PdxLocalQueryDUnitTest extends PDXQueryTestBase {
         assertEquals(numberOfEntries * 6 + 1 + extra, PortfolioPdx.numInstance);
 
         // set readserealized and query
-        ((GemFireCacheImpl) getCache()).setReadSerialized(true);
+        ((GemFireCacheImpl) getCache()).setReadSerializedForTest(true);
 
         PdxInstanceFactory out = PdxInstanceFactoryImpl
             .newCreator("org.apache.geode.cache.query.data.PositionPdx", false);
@@ -421,7 +421,7 @@ public class PdxLocalQueryDUnitTest extends PDXQueryTestBase {
         }
 
         // reset readserealized and query
-        ((GemFireCacheImpl) getCache()).setReadSerialized(false);
+        ((GemFireCacheImpl) getCache()).setReadSerializedForTest(false);
         return null;
       }
     });

--- a/geode-core/src/test/java/org/apache/geode/cache/query/dunit/PdxQueryDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/dunit/PdxQueryDUnitTest.java
@@ -678,7 +678,7 @@ public class PdxQueryDUnitTest extends PDXQueryTestBase {
       public void run2() throws CacheException {
         // Execute query locally.
         GemFireCacheImpl cache = (GemFireCacheImpl) getCache();
-        cache.setReadSerialized(true);
+        cache.setReadSerializedForTest(true);
         try {
           QueryService queryService = getCache().getQueryService();
           for (int i = 0; i < qs.length; i++) {
@@ -707,7 +707,7 @@ public class PdxQueryDUnitTest extends PDXQueryTestBase {
             }
           }
         } finally {
-          cache.setReadSerialized(false);
+          cache.setReadSerializedForTest(false);
         }
       }
     });
@@ -1442,7 +1442,7 @@ public class PdxQueryDUnitTest extends PDXQueryTestBase {
         GemFireCacheImpl c = (GemFireCacheImpl) region.getCache();
         try {
           // Set read serialized.
-          c.setReadSerialized(true);
+          c.setReadSerializedForTest(true);
 
           QueryService localQueryService = null;
 
@@ -1469,7 +1469,7 @@ public class PdxQueryDUnitTest extends PDXQueryTestBase {
             }
           }
         } finally {
-          c.setReadSerialized(false);
+          c.setReadSerializedForTest(false);
         }
       }
     });
@@ -2992,7 +2992,7 @@ public class PdxQueryDUnitTest extends PDXQueryTestBase {
       @Override
       public Object call() throws Exception {
         GemFireCacheImpl cache = (GemFireCacheImpl) getCache();
-        cache.setReadSerialized(true);
+        cache.setReadSerializedForTest(true);
         QueryService queryService = null;
         try {
           queryService = getCache().getQueryService();
@@ -3165,7 +3165,7 @@ public class PdxQueryDUnitTest extends PDXQueryTestBase {
       @Override
       public Object call() throws Exception {
         GemFireCacheImpl cache = (GemFireCacheImpl) getCache();
-        cache.setReadSerialized(true);
+        cache.setReadSerializedForTest(true);
         QueryService localQueryService = null;
         // Execute query remotely
         try {
@@ -3373,7 +3373,7 @@ public class PdxQueryDUnitTest extends PDXQueryTestBase {
       @Override
       public Object call() throws Exception {
         GemFireCacheImpl cache = (GemFireCacheImpl) getCache();
-        cache.setReadSerialized(true);
+        cache.setReadSerializedForTest(true);
 
         QueryService qs = null;
         SelectResults[][] sr = new SelectResults[1][2];

--- a/geode-core/src/test/java/org/apache/geode/cache/query/dunit/PdxStringQueryDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/dunit/PdxStringQueryDUnitTest.java
@@ -362,7 +362,7 @@ public class PdxStringQueryDUnitTest extends JUnit4CacheTestCase {
     server0.invoke(new CacheSerializableRunnable("Create Bridge Server") {
       public void run2() throws CacheException {
         GemFireCacheImpl cache = (GemFireCacheImpl) getCache();
-        cache.setReadSerialized(true);
+        cache.setReadSerializedForTest(true);
         QueryService localQueryService = getCache().getQueryService();
 
         // Query server1 locally to check if PdxString is not being returned
@@ -387,7 +387,7 @@ public class PdxStringQueryDUnitTest extends JUnit4CacheTestCase {
     client.invoke(new CacheSerializableRunnable("Create client") {
       public void run2() throws CacheException {
         GemFireCacheImpl cache = (GemFireCacheImpl) getCache();
-        cache.setReadSerialized(true);
+        cache.setReadSerializedForTest(true);
         QueryService remoteQueryService = (PoolManager.find(poolName)).getQueryService();
 
         // Query server1 remotely to check if PdxString is not being returned
@@ -594,7 +594,7 @@ public class PdxStringQueryDUnitTest extends JUnit4CacheTestCase {
     server0.invoke(new CacheSerializableRunnable("Create Bridge Server") {
       public void run2() throws CacheException {
         GemFireCacheImpl cache = (GemFireCacheImpl) getCache();
-        cache.setReadSerialized(true);
+        cache.setReadSerializedForTest(true);
         QueryService localQueryService = getCache().getQueryService();
         // Query server1 locally to check if PdxString is not being returned
         for (int i = 0; i < queryString.length; i++) {
@@ -618,7 +618,7 @@ public class PdxStringQueryDUnitTest extends JUnit4CacheTestCase {
     client.invoke(new CacheSerializableRunnable("Create client") {
       public void run2() throws CacheException {
         GemFireCacheImpl cache = (GemFireCacheImpl) getCache();
-        cache.setReadSerialized(true);
+        cache.setReadSerializedForTest(true);
         QueryService remoteQueryService = (PoolManager.find(poolName)).getQueryService();
 
         // Query server1 remotely to check if PdxString is not being returned
@@ -817,7 +817,7 @@ public class PdxStringQueryDUnitTest extends JUnit4CacheTestCase {
     server0.invoke(new CacheSerializableRunnable("Create Bridge Server") {
       public void run2() throws CacheException {
         GemFireCacheImpl cache = (GemFireCacheImpl) getCache();
-        cache.setReadSerialized(true);
+        cache.setReadSerializedForTest(true);
         QueryService localQueryService = getCache().getQueryService();
         // Query server1 locally to check if PdxString is not being returned
         for (int i = 0; i < queryString.length; i++) {
@@ -840,7 +840,7 @@ public class PdxStringQueryDUnitTest extends JUnit4CacheTestCase {
     client.invoke(new CacheSerializableRunnable("Create client") {
       public void run2() throws CacheException {
         GemFireCacheImpl cache = (GemFireCacheImpl) getCache();
-        cache.setReadSerialized(true);
+        cache.setReadSerializedForTest(true);
         QueryService remoteQueryService = (PoolManager.find(poolName)).getQueryService();
         // Query server1 remotely to check if PdxString is not being returned
         for (int i = 0; i < queryString.length; i++) {
@@ -1102,7 +1102,7 @@ public class PdxStringQueryDUnitTest extends JUnit4CacheTestCase {
     server0.invoke(new CacheSerializableRunnable("Create Bridge Server") {
       public void run2() throws CacheException {
         GemFireCacheImpl cache = (GemFireCacheImpl) getCache();
-        cache.setReadSerialized(true);
+        cache.setReadSerializedForTest(true);
         QueryService localQueryService = getCache().getQueryService();
         // Query server1 locally to check if PdxString is not being returned
         for (int i = 0; i < queryString.length; i++) {
@@ -1127,7 +1127,7 @@ public class PdxStringQueryDUnitTest extends JUnit4CacheTestCase {
     client.invoke(new CacheSerializableRunnable("Create client") {
       public void run2() throws CacheException {
         GemFireCacheImpl cache = (GemFireCacheImpl) getCache();
-        cache.setReadSerialized(true);
+        cache.setReadSerializedForTest(true);
         QueryService remoteQueryService = (PoolManager.find(poolName)).getQueryService();
         // Query server1 remotely to check if PdxString is not being returned
         for (int i = 0; i < queryString.length; i++) {
@@ -1345,7 +1345,7 @@ public class PdxStringQueryDUnitTest extends JUnit4CacheTestCase {
     server0.invoke(new CacheSerializableRunnable("Create Bridge Server") {
       public void run2() throws CacheException {
         GemFireCacheImpl cache = (GemFireCacheImpl) getCache();
-        cache.setReadSerialized(true);
+        cache.setReadSerializedForTest(true);
         QueryService localQueryService = getCache().getQueryService();
 
         // Query server1 locally to check if PdxString is not being returned
@@ -1371,7 +1371,7 @@ public class PdxStringQueryDUnitTest extends JUnit4CacheTestCase {
     client.invoke(new CacheSerializableRunnable("Create client") {
       public void run2() throws CacheException {
         GemFireCacheImpl cache = (GemFireCacheImpl) getCache();
-        cache.setReadSerialized(true);
+        cache.setReadSerializedForTest(true);
         QueryService remoteQueryService = (PoolManager.find(poolName)).getQueryService();
 
         // Query server1 remotely to check if PdxString is not being returned
@@ -1590,7 +1590,7 @@ public class PdxStringQueryDUnitTest extends JUnit4CacheTestCase {
     server0.invoke(new CacheSerializableRunnable("Create Bridge Server") {
       public void run2() throws CacheException {
         GemFireCacheImpl cache = (GemFireCacheImpl) getCache();
-        cache.setReadSerialized(true);
+        cache.setReadSerializedForTest(true);
         QueryService localQueryService = getCache().getQueryService();
 
         // Query server1 locally to check if PdxString is not being returned
@@ -1616,7 +1616,7 @@ public class PdxStringQueryDUnitTest extends JUnit4CacheTestCase {
     client.invoke(new CacheSerializableRunnable("Create client") {
       public void run2() throws CacheException {
         GemFireCacheImpl cache = (GemFireCacheImpl) getCache();
-        cache.setReadSerialized(true);
+        cache.setReadSerializedForTest(true);
         QueryService remoteQueryService = (PoolManager.find(poolName)).getQueryService();
 
         // Query server1 remotely to check if PdxString is not being returned

--- a/geode-core/src/test/java/org/apache/geode/cache/query/dunit/SelectStarQueryDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/dunit/SelectStarQueryDUnitTest.java
@@ -1252,7 +1252,7 @@ public class SelectStarQueryDUnitTest extends JUnit4CacheTestCase {
       @Override
       public Object call() throws Exception {
         GemFireCacheImpl cache = (GemFireCacheImpl) getCache();
-        cache.setReadSerialized(true);
+        cache.setReadSerializedForTest(true);
         QueryService qs = null;
         try {
           qs = getCache().getQueryService();
@@ -1463,7 +1463,7 @@ public class SelectStarQueryDUnitTest extends JUnit4CacheTestCase {
       @Override
       public Object call() throws Exception {
         GemFireCacheImpl cache = (GemFireCacheImpl) getCache();
-        cache.setReadSerialized(true);
+        cache.setReadSerializedForTest(true);
         QueryService qs = null;
         try {
           qs = getCache().getQueryService();
@@ -1518,7 +1518,7 @@ public class SelectStarQueryDUnitTest extends JUnit4CacheTestCase {
     final int port = (Integer) server1.invoke(new SerializableCallable("Create Server1") {
       @Override
       public Object call() throws Exception {
-        ((GemFireCacheImpl) getCache()).setReadSerialized(true);
+        ((GemFireCacheImpl) getCache()).setReadSerializedForTest(true);
         Region r1 = getCache().createRegionFactory(RegionShortcut.REPLICATE).create(regName);
         CacheServer server = getCache().addCacheServer();
         int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();

--- a/geode-core/src/test/java/org/apache/geode/pdx/PdxSerializableJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/pdx/PdxSerializableJUnitTest.java
@@ -438,7 +438,7 @@ public class PdxSerializableJUnitTest {
         "Mismatch in write and read value: Value Write..." + pdx + " Value Read..." + actualVal,
         pdx.equals(actualVal));
 
-    c.setReadSerialized(true);
+    c.setReadSerializedForTest(true);
     try {
       in = new DataInputStream(new ByteArrayInputStream(actual));
       PdxInstance pi = (PdxInstance) DataSerializer.readObject(in);
@@ -535,7 +535,7 @@ public class PdxSerializableJUnitTest {
           (byte) (floatBytes >> 16), (byte) (floatBytes >> 8), (byte) floatBytes}),
           reader.getRaw(7));
     } finally {
-      c.setReadSerialized(false);
+      c.setReadSerializedForTest(false);
     }
   }
 
@@ -664,7 +664,7 @@ public class PdxSerializableJUnitTest {
     assertTrue(
         "Mismatch in write and read value: Value Write..." + pdx + " Value Read..." + actualVal,
         pdx.equals(actualVal));
-    c.setReadSerialized(true);
+    c.setReadSerializedForTest(true);
     try {
       in = new DataInputStream(new ByteArrayInputStream(actual));
       PdxInstance pi = (PdxInstance) DataSerializer.readObject(in);
@@ -761,7 +761,7 @@ public class PdxSerializableJUnitTest {
           (byte) (floatBytes >> 16), (byte) (floatBytes >> 8), (byte) floatBytes}),
           reader.getRaw(7));
     } finally {
-      c.setReadSerialized(false);
+      c.setReadSerializedForTest(false);
     }
   }
 

--- a/geode-core/src/test/java/org/apache/geode/security/query/PdxQuerySecurityAllowedQueriesDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/security/query/PdxQuerySecurityAllowedQueriesDUnitTest.java
@@ -14,21 +14,15 @@
  */
 package org.apache.geode.security.query;
 
-import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import junitparams.Parameters;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import org.apache.geode.pdx.PdxReader;
-import org.apache.geode.pdx.PdxSerializable;
-import org.apache.geode.pdx.PdxWriter;
 import org.apache.geode.security.query.data.PdxQueryTestObject;
 import org.apache.geode.test.junit.categories.DistributedTest;
 import org.apache.geode.test.junit.categories.SecurityTest;
@@ -65,7 +59,7 @@ public class PdxQuerySecurityAllowedQueriesDUnitTest extends QuerySecurityBase {
 
   @Test
   public void checkUserAuthorizationsForSelectWithPdxFieldNamedGetQuery() {
-    server.getCache().setReadSerialized(true);
+    server.getCache().setReadSerializedForTest(true);
     String query = "select * from /" + regionName + " r where r.getName = 'Beth'";
     List<Object> expectedResults = Arrays.asList(values[1]);
     executeQueryWithCheckForAccessPermissions(specificUserClient, query, regionName,

--- a/geode-experimental-driver/src/main/java/org/apache/geode/experimental/driver/Driver.java
+++ b/geode-experimental-driver/src/main/java/org/apache/geode/experimental/driver/Driver.java
@@ -44,7 +44,7 @@ public interface Driver {
    * @param regionName String that uniquely identifies the region.
    * @param <K> Type of region keys.
    * @param <V> Type of region values.
-   * @return
+   * @return the region object
    */
   <K, V> Region<K, V> getRegion(String regionName);
 }

--- a/geode-experimental-driver/src/main/java/org/apache/geode/experimental/driver/ProtobufDriver.java
+++ b/geode-experimental-driver/src/main/java/org/apache/geode/experimental/driver/ProtobufDriver.java
@@ -77,13 +77,6 @@ public class ProtobufDriver implements Driver {
     }
   }
 
-  /**
-   * Retrieves a set of unique names of regions in the GemFire server to which this driver is
-   * connected.
-   *
-   * @return Set of strings of names that uniquely identify regions.
-   * @throws IOException
-   */
   @Override
   public Set<String> getRegionNames() throws IOException {
     Set<String> regionNames = new HashSet<>();
@@ -104,15 +97,6 @@ public class ProtobufDriver implements Driver {
     return regionNames;
   }
 
-  /**
-   * Creates an implementation of the region interface for the region with the unique name of
-   * <code>regionName</code>.
-   *
-   * @param regionName String that uniquely identifies the region.
-   * @param <K> Type of region keys.
-   * @param <V> Type of region values.
-   * @return
-   */
   @Override
   public <K, V> Region<K, V> getRegion(String regionName) {
     return new ProtobufRegion(regionName, socket);

--- a/geode-experimental-driver/src/main/java/org/apache/geode/experimental/driver/ProtobufRegion.java
+++ b/geode-experimental-driver/src/main/java/org/apache/geode/experimental/driver/ProtobufRegion.java
@@ -61,32 +61,6 @@ public class ProtobufRegion<K, V> implements Region<K, V> {
     this.socket = socket;
   }
 
-  /**
-   * Captures a snapshot of the attributes (e.g., size) of this region.
-   *
-   * @return Attributes associated with this region.
-   * @throws IOException
-   */
-  @Override
-  public RegionAttributes getRegionAttributes() throws IOException {
-    final OutputStream outputStream = socket.getOutputStream();
-    ClientProtocol.Message.newBuilder()
-        .setRequest(ClientProtocol.Request.newBuilder()
-            .setGetRegionRequest(RegionAPI.GetRegionRequest.newBuilder().setRegionName(name)))
-        .build().writeDelimitedTo(outputStream);
-
-    final InputStream inputStream = socket.getInputStream();
-    return new RegionAttributes(ClientProtocol.Message.parseDelimitedFrom(inputStream).getResponse()
-        .getGetRegionResponse().getRegion());
-  }
-
-  /**
-   * Gets the value, if any, contained in this region for the <code>key</code>.
-   *
-   * @param key Unique key associated with a value.
-   * @return Value, if any, associated with <code>key</code>.
-   * @throws IOException
-   */
   @Override
   public V get(K key) throws IOException {
     final OutputStream outputStream = socket.getOutputStream();
@@ -100,13 +74,20 @@ public class ProtobufRegion<K, V> implements Region<K, V> {
         .getResponse().getGetResponse().getResult());
   }
 
-  /**
-   * Gets the values, if any, contained in this region for the collection of <code>keys</code>.
-   *
-   * @param keys Collection of unique keys associated with values.
-   * @return Map from <code>keys</code> to their associated values.
-   * @throws IOException
-   */
+  @Override
+  public RegionAttributes getRegionAttributes() throws IOException {
+    final OutputStream outputStream = socket.getOutputStream();
+    ClientProtocol.Message.newBuilder()
+        .setRequest(ClientProtocol.Request.newBuilder()
+            .setGetRegionRequest(RegionAPI.GetRegionRequest.newBuilder().setRegionName(name)))
+        .build().writeDelimitedTo(outputStream);
+
+    final InputStream inputStream = socket.getInputStream();
+    return new RegionAttributes(ClientProtocol.Message.parseDelimitedFrom(inputStream).getResponse()
+        .getGetRegionResponse().getRegion());
+  }
+
+
   @Override
   public Map<K, V> getAll(Collection<K> keys) throws IOException {
     Map<K, V> values = new HashMap<>();
@@ -132,13 +113,6 @@ public class ProtobufRegion<K, V> implements Region<K, V> {
     return values;
   }
 
-  /**
-   * Puts the <code>value</code> into this region for the <code>key</code>.
-   *
-   * @param key Unique key to associate with the <code>value</code>.
-   * @param value Value to associate with the <code>key</code>.
-   * @throws IOException
-   */
   @Override
   public void put(K key, V value) throws IOException {
     final OutputStream outputStream = socket.getOutputStream();
@@ -152,13 +126,6 @@ public class ProtobufRegion<K, V> implements Region<K, V> {
     ClientProtocol.Message.parseDelimitedFrom(inputStream).getResponse().getPutResponse();
   }
 
-  /**
-   * Puts the map from keys to <code>values</code> into this region. If any one key/value pair can
-   * not be inserted, the remaining pair insertions will be attempted.
-   *
-   * @param values Map from <code>keys</code> to their associated values.
-   * @throws IOException
-   */
   @Override
   public void putAll(Map<K, V> values) throws IOException {
     final OutputStream outputStream = socket.getOutputStream();
@@ -186,12 +153,7 @@ public class ProtobufRegion<K, V> implements Region<K, V> {
     }
   }
 
-  /**
-   * Removes any value associated with the <code>key</code> from this region.
-   *
-   * @param key Unique key associated with a value.
-   * @throws IOException
-   */
+
   @Override
   public void remove(K key) throws IOException {
     final OutputStream outputStream = socket.getOutputStream();

--- a/geode-experimental-driver/src/main/java/org/apache/geode/experimental/driver/Region.java
+++ b/geode-experimental-driver/src/main/java/org/apache/geode/experimental/driver/Region.java
@@ -76,6 +76,7 @@ public interface Region<K, V> {
    */
   void putAll(Map<K, V> values) throws IOException;
 
+
   /**
    * Removes any value associated with the <code>key</code> from this region.
    *

--- a/geode-experimental-driver/src/test/java/org/apache/geode/experimental/driver/RegionIntegrationTest.java
+++ b/geode-experimental-driver/src/test/java/org/apache/geode/experimental/driver/RegionIntegrationTest.java
@@ -76,7 +76,7 @@ public class RegionIntegrationTest {
   @Test
   public void getShouldReturnPutValue() throws Exception {
     Driver driver = new DriverFactory().addLocator("localhost", locatorPort).create();
-    Region region = driver.getRegion("region");
+    Region<String, String> region = driver.getRegion("region");
 
     region.put("key", "value");
     assertEquals("value", region.get("key"));
@@ -88,15 +88,15 @@ public class RegionIntegrationTest {
   @Test
   public void putWithIntegerKey() throws Exception {
     Driver driver = new DriverFactory().addLocator("localhost", locatorPort).create();
-    Region region = driver.getRegion("region");
+    Region<Integer, Integer> region = driver.getRegion("region");
     region.put(37, 42);
-    assertEquals(42, region.get(37));
+    assertEquals(42, region.get(37).intValue());
   }
 
   @Test
   public void removeWithIntegerKey() throws Exception {
     Driver driver = new DriverFactory().addLocator("localhost", locatorPort).create();
-    Region region = driver.getRegion("region");
+    Region<Integer, Integer> region = driver.getRegion("region");
     region.put(37, 42);
     region.remove(37);
     assertEquals(null, region.get(37));

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/ProtobufSerializationService.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/ProtobufSerializationService.java
@@ -154,7 +154,7 @@ public class ProtobufSerializationService implements SerializationService<BasicT
     public static ProtobufEncodingTypes valueOf(Class unencodedValueClass)
         throws UnknownProtobufEncodingType {
       for (ProtobufEncodingTypes protobufEncodingTypes : values()) {
-        if (protobufEncodingTypes.clazz.equals(unencodedValueClass)) {
+        if (protobufEncodingTypes.clazz.isAssignableFrom(unencodedValueClass)) {
           return protobufEncodingTypes;
         }
       }

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/operations/GetRequestOperationHandler.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/operations/GetRequestOperationHandler.java
@@ -21,6 +21,7 @@ import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.annotations.Experimental;
 import org.apache.geode.cache.Region;
+import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.exception.InvalidExecutionContextException;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.protocol.Failure;
@@ -53,6 +54,8 @@ public class GetRequestOperationHandler
     }
 
     try {
+      ((InternalCache) messageExecutionContext.getCache()).setReadSerializedForCurrentThread(true);
+
       Object decodedKey = serializationService.decode(request.getKey());
       Object resultValue = region.get(decodedKey);
 
@@ -66,6 +69,8 @@ public class GetRequestOperationHandler
       logger.error("Received Get request with unsupported encoding: {}", ex);
       return Failure.of(
           ProtobufResponseUtilities.makeErrorResponse(INVALID_REQUEST, "Encoding not supported."));
+    } finally {
+      ((InternalCache) messageExecutionContext.getCache()).setReadSerializedForCurrentThread(false);
     }
   }
 }

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/operations/GetAndPutJsonDocumentsDUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/operations/GetAndPutJsonDocumentsDUnitTest.java
@@ -1,0 +1,248 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.protocol.protobuf.v1.operations;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import com.google.protobuf.ByteString;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.CacheFactory;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.distributed.ConfigurationProperties;
+import org.apache.geode.internal.protocol.Result;
+import org.apache.geode.internal.protocol.Success;
+import org.apache.geode.internal.protocol.TestExecutionContext;
+import org.apache.geode.internal.protocol.operations.OperationHandler;
+import org.apache.geode.internal.protocol.protobuf.v1.BasicTypes;
+import org.apache.geode.internal.protocol.protobuf.v1.ProtobufSerializationService;
+import org.apache.geode.internal.protocol.protobuf.v1.RegionAPI;
+import org.apache.geode.internal.protocol.protobuf.v1.utilities.ProtobufRequestUtilities;
+import org.apache.geode.internal.protocol.protobuf.v1.utilities.ProtobufUtilities;
+import org.apache.geode.internal.protocol.serialization.exception.EncodingException;
+import org.apache.geode.pdx.PdxInstance;
+import org.apache.geode.pdx.PdxReader;
+import org.apache.geode.pdx.PdxSerializable;
+import org.apache.geode.pdx.PdxWriter;
+import org.apache.geode.test.dunit.Host;
+import org.apache.geode.test.dunit.VM;
+import org.apache.geode.test.dunit.cache.internal.JUnit4CacheTestCase;
+import org.apache.geode.test.junit.categories.DistributedTest;
+
+/**
+ * This integration test uses a Cache to hold PdxInstances in serialized form.
+ * <p>
+ * For "get" operations we put a PdxSerializable object into the cache in another JVM so that it
+ * will be in serialized form in the unit test controller JVM. Then we pull it out using the
+ * protobuf API and ensure that the result is in JSON document form.
+ * <p>
+ * For "put" operations we use the protobuf API to store a JSON document in the cache and then check
+ * to make sure that a PdxInstance with a JSON signature is in the cache.
+ * <p>
+ * This addresses JIRA tickets GEODE-4116 and GEODE-4168.
+ */
+@Category(DistributedTest.class)
+public class GetAndPutJsonDocumentsDUnitTest extends JUnit4CacheTestCase {
+
+  /** this JSON document is used by the "put" the tests */
+  private static final String jsonDocument =
+      "{" + System.lineSeparator() + "  \"name\" : \"Charlemagne\"," + System.lineSeparator()
+          + "  \"age\" : 1275," + System.lineSeparator() + "  \"nationality\" : \"french\","
+          + System.lineSeparator() + "  \"emailAddress\" : \"none\"" + System.lineSeparator() + "}";
+
+  private static final PdxDocument pdxDocument =
+      new PdxDocument("Charlemagne", 1275, "french", "none");
+
+  /** this key is used to store the JSON document in the cache */
+  private static final String key = "aPdxInstance";
+
+  private static final String regionName = "TestRegion";
+
+  private static ProtobufSerializationService serializationService;
+
+  VM storingVM;
+
+  @Before
+  public void setUp() throws Exception {
+    serializationService = new ProtobufSerializationService();
+
+    // create a distributed region in two VMs so that we can store an object
+    // in "storingVM" and so ensure that it is in serialized form in the other
+    // VM
+    getCache().<String, Object>createRegionFactory(RegionShortcut.REPLICATE).create("TestRegion");
+
+    storingVM = Host.getHost(0).getVM(0);
+    storingVM.invoke("create region", () -> {
+      getCache().<String, Object>createRegionFactory(RegionShortcut.REPLICATE).create("TestRegion");
+    });
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    serializationService = null;
+    Cache cache = basicGetCache();
+    if (cache != null) {
+      cache.close();
+    }
+  }
+
+
+
+  @Test
+  public void testThatGetReturnsJSONDocumentForPdxInstance() throws Exception {
+    storeTestDocument();
+
+    RegionAPI.GetRequest getRequest = generateGetRequest(key);
+    GetRequestOperationHandler operationHandler = new GetRequestOperationHandler();
+    Result result = operationHandler.process(serializationService, getRequest,
+        TestExecutionContext.getNoAuthCacheExecutionContext(getCache()));
+
+    Assert.assertTrue(result instanceof Success);
+    RegionAPI.GetResponse response = (RegionAPI.GetResponse) result.getMessage();
+    assertEquals(BasicTypes.EncodedValue.ValueCase.JSONOBJECTRESULT,
+        response.getResult().getValueCase());
+    String actualValue = response.getResult().getJsonObjectResult();
+    assertEquals(jsonDocument, actualValue);
+  }
+
+  @Test
+  public void testThatGetAllReturnsJSONDocumentForPdxInstance() throws Exception {
+    storeTestDocument();
+
+    RegionAPI.GetAllRequest getRequest = generateGetAllRequest(key);
+    GetAllRequestOperationHandler operationHandler = new GetAllRequestOperationHandler();
+    Result result = operationHandler.process(serializationService, getRequest,
+        TestExecutionContext.getNoAuthCacheExecutionContext(getCache()));
+
+    Assert.assertTrue(result instanceof Success);
+    RegionAPI.GetAllResponse response = (RegionAPI.GetAllResponse) result.getMessage();
+    BasicTypes.Entry entry = response.getEntriesList().get(0);
+    BasicTypes.EncodedValue entryValue = entry.getValue();
+    assertEquals(BasicTypes.EncodedValue.ValueCase.JSONOBJECTRESULT, entryValue.getValueCase());
+    String actualValue = entryValue.getJsonObjectResult();
+    assertEquals(jsonDocument, actualValue);
+  }
+
+  @Test
+  public void testThatPutCreatesPdxInstanceFromJsonDocument() throws Exception {
+    RegionAPI.PutRequest putRequest = generatePutRequest(key, jsonDocument);
+    PutRequestOperationHandler operationHandler = new PutRequestOperationHandler();
+    Result result = operationHandler.process(serializationService, putRequest,
+        TestExecutionContext.getNoAuthCacheExecutionContext(getCache()));
+
+    Assert.assertTrue(result instanceof Success);
+    PdxInstance pdxInstance = (PdxInstance) getCache().getRegion(regionName).get(key);
+    assertEquals("__GEMFIRE_JSON", pdxInstance.getClassName());
+  }
+
+  @Test
+  public void testThatPutAllCreatesPdxInstanceFromJsonDocument() throws Exception {
+    RegionAPI.PutAllRequest putRequest = generatePutAllRequest(key, jsonDocument);
+    PutAllRequestOperationHandler operationHandler = new PutAllRequestOperationHandler();
+    Result result = operationHandler.process(serializationService, putRequest,
+        TestExecutionContext.getNoAuthCacheExecutionContext(getCache()));
+
+    Assert.assertTrue(result instanceof Success);
+    PdxInstance pdxInstance = (PdxInstance) getCache().getRegion(regionName).get(key);
+    assertEquals("__GEMFIRE_JSON", pdxInstance.getClassName());
+  }
+
+
+  ///////////////////////////////// methods for encoding messages //////////////////////////////
+
+
+  private void storeTestDocument() {
+    storingVM.invoke("store test document", () -> {
+      getCache().getRegion(regionName).put(key, pdxDocument);
+    });
+  }
+
+  private RegionAPI.GetRequest generateGetRequest(String key) throws EncodingException {
+    BasicTypes.EncodedValue testKey = serializationService.encode(key);
+    return ProtobufRequestUtilities.createGetRequest(regionName, testKey).getGetRequest();
+  }
+
+  private RegionAPI.GetAllRequest generateGetAllRequest(String key) throws EncodingException {
+    HashSet<BasicTypes.EncodedValue> testKeys = new HashSet<>();
+    BasicTypes.EncodedValue testKey = serializationService.encode(key);
+    testKeys.add(testKey);
+    return ProtobufRequestUtilities.createGetAllRequest(regionName, testKeys);
+  }
+
+  private RegionAPI.PutRequest generatePutRequest(String key, String jsonDocument)
+      throws EncodingException {
+    BasicTypes.Entry testEntry = createKVEntry(key, jsonDocument);
+    return ProtobufRequestUtilities.createPutRequest(regionName, testEntry).getPutRequest();
+  }
+
+  private RegionAPI.PutAllRequest generatePutAllRequest(String key, String jsonDocument)
+      throws EncodingException {
+    Set<BasicTypes.Entry> entries = new HashSet<>();
+    entries.add(createKVEntry(key, jsonDocument));
+    return ProtobufRequestUtilities.createPutAllRequest(regionName, entries).getPutAllRequest();
+  }
+
+  private BasicTypes.Entry createKVEntry(String key, String jsonDocument) throws EncodingException {
+    BasicTypes.EncodedValue testKey = serializationService.encode(key);
+    BasicTypes.EncodedValue testValue = encodeJSONDocument(jsonDocument);
+    return ProtobufUtilities.createEntry(testKey, testValue);
+  }
+
+  private BasicTypes.EncodedValue encodeJSONDocument(String jsonDocument) {
+    BasicTypes.EncodedValue.Builder builder = BasicTypes.EncodedValue.newBuilder();
+    return builder.setJsonObjectResultBytes(ByteString.copyFromUtf8(jsonDocument)).build();
+  }
+
+
+  public static class PdxDocument implements PdxSerializable {
+    private String name;
+    private int age;
+    private String nationality;
+    private String emailAddress;
+
+    public PdxDocument() {}
+
+
+    public PdxDocument(String name, int age, String nationality, String emailAddress) {
+      this.name = name;
+      this.age = age;
+      this.nationality = nationality;
+      this.emailAddress = emailAddress;
+    }
+
+    @Override
+    public void toData(PdxWriter writer) {
+      writer.writeString("name", name).writeInt("age", age).writeString("nationality", nationality)
+          .writeString("emailAddress", emailAddress);
+    }
+
+    @Override
+    public void fromData(PdxReader reader) {
+      name = reader.readString("name");
+      age = reader.readInt("age");
+      nationality = reader.readString("nationality");
+      emailAddress = reader.readString("emailAddress");
+    }
+  }
+}

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/operations/OperationHandlerJUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/operations/OperationHandlerJUnitTest.java
@@ -20,6 +20,7 @@ import org.junit.Before;
 import org.junit.experimental.categories.Category;
 
 import org.apache.geode.cache.Cache;
+import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.protocol.operations.OperationHandler;
 import org.apache.geode.internal.protocol.protobuf.v1.ProtobufSerializationService;
 import org.apache.geode.test.junit.categories.UnitTest;
@@ -32,7 +33,7 @@ public class OperationHandlerJUnitTest {
 
   @Before
   public void setUp() throws Exception {
-    cacheStub = mock(Cache.class);
+    cacheStub = mock(InternalCache.class);
     serializationService = new ProtobufSerializationService();
   }
 }


### PR DESCRIPTION
& GEODE-4116 Can't get PDX objects using the new protocol

Added a distributed test to ensure end-to-end handling of JSON documents
is functioning correctly.  For GEODE-4168 I changed the class-check from
equals() to isAssignableFrom().  For GEODE-4116 I modified the Get and
GetAll operation handlers to inhibit deserialization of PdxInstances
when reading values from the cache.  The test for 4116 ensures that
the value is in serialized form by putting it into a distributed Region
in another JVM.

There are unrelated javadoc changes in this commit for DM.java and
a couple of classes in the protobuf Driver module.  I also added
constraints to the Regions in the Driver's unit test to get rid of
compilation warnings.

@galen-pivotal @PivotalSarge @WireBaron @upthewaterspout 

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
