### PR TITLE
GEODE-4092 New protocol does not have an API to get the best server t…

### DIFF
--- a/geode-experimental-driver/src/main/java/org/apache/geode/experimental/driver/ProtobufDriver.java
+++ b/geode-experimental-driver/src/main/java/org/apache/geode/experimental/driver/ProtobufDriver.java
@@ -19,8 +19,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.Socket;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -60,9 +58,8 @@ public class ProtobufDriver implements Driver {
    */
   ProtobufDriver(Set<InetSocketAddress> locators) throws IOException {
     this.locators = locators;
-    Collection<InetSocketAddress> servers = getAvailableServers();
-    InetSocketAddress anyServer = servers.iterator().next();
-    socket = new Socket(anyServer.getAddress(), anyServer.getPort());
+    InetSocketAddress server = findAServer();
+    socket = new Socket(server.getAddress(), server.getPort());
 
     final OutputStream outputStream = socket.getOutputStream();
     ProtocolVersion.NewConnectionClientVersion.newBuilder()
@@ -119,13 +116,12 @@ public class ProtobufDriver implements Driver {
   }
 
   /**
-   * Queries a locator for the GemFire servers that have Protobuf enabled.
+   * Queries locators for a Geode server that has Protobuf enabled.
    *
-   * @return Set of Internet-address-or-host-name/port pairs of the GemFire servers that have
-   *         Protobuf enabled.
+   * @return The server chosen by the Locator service for this client
    * @throws IOException
    */
-  private Collection<InetSocketAddress> getAvailableServers() throws IOException {
+  private InetSocketAddress findAServer() throws IOException {
     IOException lastException = null;
 
     for (InetSocketAddress locator : locators) {
@@ -147,22 +143,17 @@ public class ProtobufDriver implements Driver {
 
         ClientProtocol.Message.newBuilder()
             .setRequest(ClientProtocol.Request.newBuilder()
-                .setGetAvailableServersRequest(LocatorAPI.GetAvailableServersRequest.newBuilder()))
+                .setGetServerRequest(LocatorAPI.GetServerRequest.newBuilder()))
             .build().writeDelimitedTo(outputStream);
 
-        LocatorAPI.GetAvailableServersResponse getAvailableServersResponse = ClientProtocol.Message
-            .parseDelimitedFrom(inputStream).getResponse().getGetAvailableServersResponse();
-        if (getAvailableServersResponse.getServersCount() < 1) {
+        LocatorAPI.GetServerResponse getServerResponse = ClientProtocol.Message
+            .parseDelimitedFrom(inputStream).getResponse().getGetServerResponse();
+        if (!getServerResponse.hasServer()) {
           continue;
         }
 
-        ArrayList<InetSocketAddress> availableServers =
-            new ArrayList<>(getAvailableServersResponse.getServersCount());
-        for (int i = 0; i < getAvailableServersResponse.getServersCount(); ++i) {
-          final BasicTypes.Server server = getAvailableServersResponse.getServers(i);
-          availableServers.add(new InetSocketAddress(server.getHostname(), server.getPort()));
-        }
-        return availableServers;
+        BasicTypes.Server server = getServerResponse.getServer();
+        return new InetSocketAddress(server.getHostname(), server.getPort());
       } catch (IOException e) {
         lastException = e;
       }

--- a/geode-protobuf-messages/src/main/proto/v1/clientProtocol.proto
+++ b/geode-protobuf-messages/src/main/proto/v1/clientProtocol.proto
@@ -41,7 +41,8 @@ message Request {
         GetAllRequest getAllRequest = 13;
         RemoveRequest removeRequest = 14;
 
-        GetAvailableServersRequest getAvailableServersRequest = 40;
+        GetServerRequest getServerRequest = 40;
+
         GetRegionNamesRequest getRegionNamesRequest = 41;
         GetRegionRequest getRegionRequest = 42;
 
@@ -57,7 +58,8 @@ message Response {
         GetAllResponse getAllResponse = 13;
         RemoveResponse removeResponse = 14;
 
-        GetAvailableServersResponse getAvailableServersResponse = 40;
+        GetServerResponse getServerResponse = 40;
+
         GetRegionNamesResponse getRegionNamesResponse = 41;
         GetRegionResponse getRegionResponse = 42;
 

--- a/geode-protobuf-messages/src/main/proto/v1/locator_API.proto
+++ b/geode-protobuf-messages/src/main/proto/v1/locator_API.proto
@@ -23,10 +23,11 @@ package org.apache.geode.internal.protocol.protobuf.v1;
 
 import "v1/basicTypes.proto";
 
-message GetAvailableServersRequest {
-
+message GetServerRequest {
+    repeated Server excludedServers = 1;
+    string serverGroup = 2;
 }
 
-message GetAvailableServersResponse {
-    repeated Server servers = 1;
+message GetServerResponse {
+    Server server = 1;
 }

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/registry/ProtobufOperationContextRegistry.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/registry/ProtobufOperationContextRegistry.java
@@ -23,10 +23,10 @@ import org.apache.geode.internal.protocol.protobuf.v1.ClientProtocol;
 import org.apache.geode.internal.protocol.protobuf.v1.ClientProtocol.Request.RequestAPICase;
 import org.apache.geode.internal.protocol.protobuf.v1.ProtobufOperationContext;
 import org.apache.geode.internal.protocol.protobuf.v1.operations.GetAllRequestOperationHandler;
-import org.apache.geode.internal.protocol.protobuf.v1.operations.GetAvailableServersOperationHandler;
 import org.apache.geode.internal.protocol.protobuf.v1.operations.GetRegionNamesRequestOperationHandler;
 import org.apache.geode.internal.protocol.protobuf.v1.operations.GetRegionRequestOperationHandler;
 import org.apache.geode.internal.protocol.protobuf.v1.operations.GetRequestOperationHandler;
+import org.apache.geode.internal.protocol.protobuf.v1.operations.GetServerOperationHandler;
 import org.apache.geode.internal.protocol.protobuf.v1.operations.PutAllRequestOperationHandler;
 import org.apache.geode.internal.protocol.protobuf.v1.operations.PutRequestOperationHandler;
 import org.apache.geode.internal.protocol.protobuf.v1.operations.RemoveRequestOperationHandler;
@@ -103,10 +103,10 @@ public class ProtobufOperationContextRegistry {
             new ResourcePermission(ResourcePermission.Resource.DATA,
                 ResourcePermission.Operation.READ)));
 
-    operationContexts.put(RequestAPICase.GETAVAILABLESERVERSREQUEST,
-        new ProtobufOperationContext<>(ClientProtocol.Request::getGetAvailableServersRequest,
-            new GetAvailableServersOperationHandler(),
-            opsResp -> ClientProtocol.Response.newBuilder().setGetAvailableServersResponse(opsResp),
+    operationContexts.put(RequestAPICase.GETSERVERREQUEST,
+        new ProtobufOperationContext<>(ClientProtocol.Request::getGetServerRequest,
+            new GetServerOperationHandler(),
+            opsResp -> ClientProtocol.Response.newBuilder().setGetServerResponse(opsResp),
             new ResourcePermission(ResourcePermission.Resource.CLUSTER,
                 ResourcePermission.Operation.READ)));
   }

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/utilities/ProtobufRequestUtilities.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/utilities/ProtobufRequestUtilities.java
@@ -110,9 +110,8 @@ public abstract class ProtobufRequestUtilities {
     return ClientProtocol.Request.newBuilder().setPutAllRequest(putAllRequestBuilder).build();
   }
 
-  public static LocatorAPI.GetAvailableServersRequest createGetAvailableServersRequest() {
-    LocatorAPI.GetAvailableServersRequest.Builder builder =
-        LocatorAPI.GetAvailableServersRequest.newBuilder();
+  public static LocatorAPI.GetServerRequest createGetServerRequest() {
+    LocatorAPI.GetServerRequest.Builder builder = LocatorAPI.GetServerRequest.newBuilder();
     return builder.build();
   }
 }

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/acceptance/LocatorConnectionDUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/acceptance/LocatorConnectionDUnitTest.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.internal.protocol.protobuf.v1.acceptance;
 
+import static org.apache.geode.internal.Assert.assertTrue;
 import static org.apache.geode.internal.cache.tier.CommunicationMode.ProtobufClientServerProtocol;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -84,9 +85,9 @@ public class LocatorConnectionDUnitTest extends JUnit4CacheTestCase {
   public void testGetAvailableServersWithStats() throws Throwable {
     ClientProtocol.Request.Builder protobufRequestBuilder =
         ProtobufUtilities.createProtobufRequestBuilder();
-    ClientProtocol.Message getAvailableServersRequestMessage = ProtobufUtilities
-        .createProtobufMessage(protobufRequestBuilder.setGetAvailableServersRequest(
-            ProtobufRequestUtilities.createGetAvailableServersRequest()).build());
+    ClientProtocol.Message getAvailableServersRequestMessage =
+        ProtobufUtilities.createProtobufMessage(protobufRequestBuilder
+            .setGetServerRequest(ProtobufRequestUtilities.createGetServerRequest()).build());
 
     ProtobufProtocolSerializer protobufProtocolSerializer = new ProtobufProtocolSerializer();
 
@@ -220,11 +221,10 @@ public class LocatorConnectionDUnitTest extends JUnit4CacheTestCase {
     assertEquals(ClientProtocol.Message.MessageTypeCase.RESPONSE,
         getAvailableServersResponseMessage.getMessageTypeCase());
     ClientProtocol.Response messageResponse = getAvailableServersResponseMessage.getResponse();
-    assertEquals(ClientProtocol.Response.ResponseAPICase.GETAVAILABLESERVERSRESPONSE,
+    assertEquals(ClientProtocol.Response.ResponseAPICase.GETSERVERRESPONSE,
         messageResponse.getResponseAPICase());
-    LocatorAPI.GetAvailableServersResponse getAvailableServersResponse =
-        messageResponse.getGetAvailableServersResponse();
-    assertEquals(1, getAvailableServersResponse.getServersCount());
+    LocatorAPI.GetServerResponse getServerResponse = messageResponse.getGetServerResponse();
+    assertTrue(getServerResponse.hasServer());
   }
 
   private void validateStats(long messagesReceived, long messagesSent, long bytesReceived,


### PR DESCRIPTION
…o connect to

GetAllAvailableServers has been replaced by GetServer.  The handler uses
the ServerLocator's processRequest API to ensure we have the same
functionality as existing non-protobuf locator request handling.

If a server isn't found we are returning Success with a null server
location.  Should this be changed to return an error code?

@upthewaterspout @WireBaron @PivotalSarge @galen-pivotal 


Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
