### PR TITLE
GEODE-4146: fix XmlEntity matching for JdbcConnectorService

### DIFF
--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/FunctionContextArgumentProvider.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/FunctionContextArgumentProvider.java
@@ -16,6 +16,7 @@ package org.apache.geode.connectors.jdbc.internal.cli;
 
 import static org.apache.geode.connectors.jdbc.internal.xml.ElementType.CONNECTION_SERVICE;
 import static org.apache.geode.connectors.jdbc.internal.xml.JdbcConnectorServiceXmlGenerator.PREFIX;
+import static org.apache.geode.connectors.jdbc.internal.xml.JdbcConnectorServiceXmlParser.NAME;
 import static org.apache.geode.connectors.jdbc.internal.xml.JdbcConnectorServiceXmlParser.NAMESPACE;
 import static org.apache.geode.internal.cache.xmlcache.CacheXml.CACHE;
 
@@ -23,6 +24,7 @@ import java.io.Serializable;
 
 import org.apache.geode.cache.execute.FunctionContext;
 import org.apache.geode.connectors.jdbc.internal.InternalJdbcConnectorService;
+import org.apache.geode.connectors.jdbc.internal.xml.JdbcConnectorServiceXmlParser;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.configuration.domain.XmlEntity;
@@ -60,7 +62,7 @@ class FunctionContextArgumentProvider implements Serializable {
    */
   XmlEntity createXmlEntity(FunctionContext<?> context) {
     return new XmlEntity(createCacheProvider(context), CACHE, PREFIX, NAMESPACE,
-        CONNECTION_SERVICE.getTypeName());
+        CONNECTION_SERVICE.getTypeName(), NAME, CONNECTION_SERVICE.getTypeName());
   }
 
   private XmlEntity.CacheProvider createCacheProvider(FunctionContext<?> context) {

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/xml/JdbcConnectorServiceXmlGenerator.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/xml/JdbcConnectorServiceXmlGenerator.java
@@ -70,8 +70,10 @@ public class JdbcConnectorServiceXmlGenerator implements XmlGenerator<Cache> {
     final ContentHandler handler = cacheXmlGenerator.getContentHandler();
 
     handler.startPrefixMapping(PREFIX, NAMESPACE);
+    AttributesImpl attributes = new AttributesImpl();
+    XmlGeneratorUtils.addAttribute(attributes, NAME, ElementType.CONNECTION_SERVICE.getTypeName());
     XmlGeneratorUtils.startElement(handler, PREFIX, ElementType.CONNECTION_SERVICE.getTypeName(),
-        EMPTY);
+        attributes);
     for (ConnectionConfiguration connection : connections) {
       outputConnectionConfiguration(handler, connection);
     }

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/xml/JdbcConnectorServiceXmlParser.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/xml/JdbcConnectorServiceXmlParser.java
@@ -22,7 +22,7 @@ import org.apache.geode.internal.cache.xmlcache.AbstractXmlParser;
 public class JdbcConnectorServiceXmlParser extends AbstractXmlParser {
   public static final String NAMESPACE = "http://geode.apache.org/schema/jdbc";
   public static final String PARAMS_DELIMITER = ":";
-  static final String NAME = "name";
+  public static final String NAME = "name";
   static final String URL = "url";
   static final String USER = "user";
   static final String PASSWORD = "password";

--- a/geode-connectors/src/main/resources/META-INF/services/schemas/geode.apache.org/schema/jdbc/jdbc-1.0.xsd
+++ b/geode-connectors/src/main/resources/META-INF/services/schemas/geode.apache.org/schema/jdbc/jdbc-1.0.xsd
@@ -80,6 +80,7 @@ XML schema for JDBC Connector Service in Geode.
                     </xsd:complexType>
                 </xsd:element>
             </xsd:sequence>
+            <xsd:attribute name="name" type="xsd:string" fixed="connector-service"/>
         </xsd:complexType>
     </xsd:element>
 </xsd:schema>

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/JdbcClusterConfigDistributedTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/JdbcClusterConfigDistributedTest.java
@@ -1,3 +1,17 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.apache.geode.connectors.jdbc.internal.cli;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
@@ -77,10 +91,8 @@ public class JdbcClusterConfigDistributedTest implements Serializable {
       System.setProperty("user.dir", temporaryFolder.newFolder(locatorFolder).getAbsolutePath());
       Properties config = new Properties();
       config.setProperty(LOCATORS, "");
-      InternalLocator locator =
-          (InternalLocator) Locator.startLocatorAndDS(0, null, config);
-      await().atMost(2, MINUTES)
-          .until(() -> assertTrue(locator.isSharedConfigurationRunning()));
+      InternalLocator locator = (InternalLocator) Locator.startLocatorAndDS(0, null, config);
+      await().atMost(2, MINUTES).until(() -> assertTrue(locator.isSharedConfigurationRunning()));
       return Locator.getLocator().getPort();
     });
     locators = Host.getHost(0).getHostName() + "[" + port + "]";
@@ -88,12 +100,12 @@ public class JdbcClusterConfigDistributedTest implements Serializable {
     cache = (InternalCache) new CacheFactory().set(LOCATORS, locators).create();
 
     locator.invoke(() -> {
-      Result
-          result = new CreateConnectionCommand().createConnection(connectionName, connectionUrl, null, null, null);
+      Result result = new CreateConnectionCommand().createConnection(connectionName, connectionUrl,
+          null, null, null);
       assertThat(result.getStatus()).isSameAs(Result.Status.OK);
 
-      result = new CreateMappingCommand().createMapping(regionName, connectionName,
-          tableName, pdxClass, keyInValue, fieldMappings);
+      result = new CreateMappingCommand().createMapping(regionName, connectionName, tableName,
+          pdxClass, keyInValue, fieldMappings);
 
       assertThat(result.getStatus()).isSameAs(Result.Status.OK);
     });

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/JdbcClusterConfigDistributedTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/JdbcClusterConfigDistributedTest.java
@@ -1,0 +1,132 @@
+package org.apache.geode.connectors.jdbc.internal.cli;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
+import static org.apache.geode.test.dunit.Disconnect.disconnectAllFromDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.junit.Assert.assertTrue;
+
+import java.io.Serializable;
+import java.util.Properties;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.cache.CacheFactory;
+import org.apache.geode.connectors.jdbc.internal.InternalJdbcConnectorService;
+import org.apache.geode.connectors.jdbc.internal.RegionMapping;
+import org.apache.geode.distributed.Locator;
+import org.apache.geode.distributed.internal.InternalLocator;
+import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.management.cli.Result;
+import org.apache.geode.test.dunit.Host;
+import org.apache.geode.test.dunit.VM;
+import org.apache.geode.test.dunit.rules.DistributedRestoreSystemProperties;
+import org.apache.geode.test.dunit.rules.DistributedTestRule;
+import org.apache.geode.test.junit.categories.DistributedTest;
+import org.apache.geode.test.junit.rules.serializable.SerializableTemporaryFolder;
+import org.apache.geode.test.junit.rules.serializable.SerializableTestName;
+
+@Category(DistributedTest.class)
+public class JdbcClusterConfigDistributedTest implements Serializable {
+
+  private transient InternalCache cache;
+  private transient VM locator;
+
+  private String regionName;
+  private String connectionName;
+  private String connectionUrl;
+  private String tableName;
+  private String pdxClass;
+  private String locators;
+  private String[] fieldMappings;
+  private boolean keyInValue;
+
+  @ClassRule
+  public static DistributedTestRule distributedTestRule = new DistributedTestRule();
+
+  @Rule
+  public DistributedRestoreSystemProperties restoreSystemProperties =
+      new DistributedRestoreSystemProperties();
+
+  @Rule
+  public SerializableTemporaryFolder temporaryFolder = new SerializableTemporaryFolder();
+
+  @Rule
+  public SerializableTestName testName = new SerializableTestName();
+
+  @Before
+  public void setUp() {
+    regionName = "regionName";
+    connectionName = "connection";
+    connectionUrl = "url";
+    tableName = "testTable";
+    pdxClass = "myPdxClass";
+    keyInValue = true;
+    fieldMappings = new String[] {"field1:column1", "field2:column2"};
+
+    locator = Host.getHost(0).getVM(0);
+    String locatorFolder = "vm-" + locator.getId() + "-" + testName.getMethodName();
+
+    int port = locator.invoke(() -> {
+      System.setProperty("user.dir", temporaryFolder.newFolder(locatorFolder).getAbsolutePath());
+      Properties config = new Properties();
+      config.setProperty(LOCATORS, "");
+      InternalLocator locator =
+          (InternalLocator) Locator.startLocatorAndDS(0, null, config);
+      await().atMost(2, MINUTES)
+          .until(() -> assertTrue(locator.isSharedConfigurationRunning()));
+      return Locator.getLocator().getPort();
+    });
+    locators = Host.getHost(0).getHostName() + "[" + port + "]";
+
+    cache = (InternalCache) new CacheFactory().set(LOCATORS, locators).create();
+
+    locator.invoke(() -> {
+      Result
+          result = new CreateConnectionCommand().createConnection(connectionName, connectionUrl, null, null, null);
+      assertThat(result.getStatus()).isSameAs(Result.Status.OK);
+
+      result = new CreateMappingCommand().createMapping(regionName, connectionName,
+          tableName, pdxClass, keyInValue, fieldMappings);
+
+      assertThat(result.getStatus()).isSameAs(Result.Status.OK);
+    });
+
+    InternalJdbcConnectorService service = cache.getService(InternalJdbcConnectorService.class);
+    validateRegionMapping(service.getMappingForRegion(regionName));
+
+    cache.close();
+  }
+
+  @After
+  public void tearDown() {
+    disconnectAllFromDS();
+  }
+
+  @Test
+  public void recreatesCacheFromClusterConfig() {
+    cache = (InternalCache) new CacheFactory().set(LOCATORS, locators).create();
+
+    InternalJdbcConnectorService service = cache.getService(InternalJdbcConnectorService.class);
+    assertThat(service.getConnectionConfig(connectionName)).isNotNull();
+    validateRegionMapping(service.getMappingForRegion(regionName));
+  }
+
+  private void validateRegionMapping(RegionMapping regionMapping) {
+    assertThat(regionMapping).isNotNull();
+    assertThat(regionMapping.getRegionName()).isEqualTo(regionName);
+    assertThat(regionMapping.getConnectionConfigName()).isEqualTo(connectionName);
+    assertThat(regionMapping.getTableName()).isEqualTo(tableName);
+    assertThat(regionMapping.getPdxClassName()).isEqualTo(pdxClass);
+    assertThat(regionMapping.isPrimaryKeyInValue()).isEqualTo(keyInValue);
+    assertThat(regionMapping.getColumnNameForField("field1")).isEqualTo("column1");
+    assertThat(regionMapping.getColumnNameForField("field2")).isEqualTo("column2");
+  }
+
+}

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/xml/JdbcConnectorServiceXmlGeneratorIntegrationTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/xml/JdbcConnectorServiceXmlGeneratorIntegrationTest.java
@@ -114,6 +114,8 @@ public class JdbcConnectorServiceXmlGeneratorIntegrationTest {
 
     Element serviceElement = (Element) serviceElements.item(0);
     assertThat(serviceElement.getAttribute("xmlns:" + PREFIX)).isEqualTo(NAMESPACE);
+    assertThat(serviceElement.getAttribute(NAME))
+        .isEqualTo(ElementType.CONNECTION_SERVICE.getTypeName());
 
     NodeList connectionElements = getElementsByName(document, ElementType.CONNECTION);
     assertThat(connectionElements.getLength()).isEqualTo(1);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/configuration/domain/XmlEntity.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/configuration/domain/XmlEntity.java
@@ -172,18 +172,16 @@ public class XmlEntity implements VersionedDataSerializable {
     initializeSearchString(parentKey, parentValue, childPrefix, childKey, childValue);
   }
 
-  public XmlEntity(final String parentType, final String childPrefix, final String childNamespace,
-      final String childType) {
-    this(createDefaultCacheProvider(), parentType, childPrefix, childNamespace, childType);
-  }
-
   public XmlEntity(final CacheProvider cacheProvider, final String parentType,
-      final String childPrefix, final String childNamespace, final String childType) {
+      final String childPrefix, final String childNamespace, final String childType, final String key, final String value) {
     this.cacheProvider = cacheProvider;
     this.parentType = parentType;
     this.type = childType;
+    this.prefix = childPrefix;
+    this.namespace = childNamespace;
     this.childPrefix = childPrefix;
     this.childNamespace = childNamespace;
+    this.attributes.put(key, value);
 
     StringBuilder sb = new StringBuilder();
     sb.append("//").append(this.parentType);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/configuration/domain/XmlEntity.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/configuration/domain/XmlEntity.java
@@ -173,7 +173,8 @@ public class XmlEntity implements VersionedDataSerializable {
   }
 
   public XmlEntity(final CacheProvider cacheProvider, final String parentType,
-      final String childPrefix, final String childNamespace, final String childType, final String key, final String value) {
+      final String childPrefix, final String childNamespace, final String childType,
+      final String key, final String value) {
     this.cacheProvider = cacheProvider;
     this.parentType = parentType;
     this.type = childType;


### PR DESCRIPTION
The JdbcConnectorService usage of XmlEntity was resulting in multiple jdbc connector service elements being written to cluster config. This then results in already exists exceptions during startup.

JdbcClusterConfigDistributedTest reproduced the problem we saw during manual testing and verifies the fix.