### PR TITLE
GEODE-3653: Remove testHook from AGSEP

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/AbstractGatewaySenderEventProcessor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/AbstractGatewaySenderEventProcessor.java
@@ -71,8 +71,6 @@ public abstract class AbstractGatewaySenderEventProcessor extends Thread {
 
   private static final Logger logger = LogService.getLogger();
 
-  public static boolean TEST_HOOK = false;
-
   protected RegionQueue queue;
 
   protected GatewaySenderEventDispatcher dispatcher;
@@ -133,6 +131,9 @@ public abstract class AbstractGatewaySenderEventProcessor extends Thread {
 
   private volatile boolean resetLastPeekedEvents;
 
+  /**
+   * Cumulative count of events dispatched by this event processor.
+   */
   private long numEventsDispatched;
 
   /**
@@ -640,9 +641,8 @@ public abstract class AbstractGatewaySenderEventProcessor extends Thread {
             for (GatewaySenderEventImpl pdxGatewaySenderEvent : pdxEventsToBeDispatched) {
               pdxGatewaySenderEvent.isDispatched = true;
             }
-            if (TEST_HOOK) {
-              this.numEventsDispatched += conflatedEventsToBeDispatched.size();
-            }
+
+            increaseNumEventsDispatched(conflatedEventsToBeDispatched.size());
           } // successful batch
           else { // The batch was unsuccessful.
             if (this.dispatcher instanceof GatewaySenderEventCallbackDispatcher) {
@@ -1255,8 +1255,13 @@ public abstract class AbstractGatewaySenderEventProcessor extends Thread {
     }
   }
 
+
   public long getNumEventsDispatched() {
     return numEventsDispatched;
+  }
+
+  public void increaseNumEventsDispatched(long newEventsDispatched) {
+    this.numEventsDispatched += newEventsDispatched;
   }
 
   public void clear(PartitionedRegion pr, int bucketId) {


### PR DESCRIPTION
GEODE-3653: Remove testHook from AGSEP

- Removed `TEST_HOOK` from AbstractGatewaySenderEventProcessor.
- The property `numEventsDispatched` was being used only by test
  classes, no functionality impact.
- Updated `ConcurrentParallelGatewaySenderDUnitTest`, removed unused
  imports and verified that current tests finish correctly.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
