### PR TITLE
GEODE-4184: Handled concurrent access of HashSet

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/PartitionedIndex.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/PartitionedIndex.java
@@ -22,6 +22,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.query.Index;
@@ -77,7 +78,7 @@ public class PartitionedIndex extends AbstractIndex {
    */
   private String imports;
 
-  private HashSet mapIndexKeys = new HashSet();
+  protected Set mapIndexKeys = Collections.newSetFromMap(new ConcurrentHashMap());
 
   // Flag indicating that the populationg of this index is in progress
   private volatile boolean populateInProgress;

--- a/geode-core/src/test/java/org/apache/geode/cache/query/internal/index/PartitionedIndexJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/internal/index/PartitionedIndexJUnitTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache.query.internal.index;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.query.IndexType;
+import org.apache.geode.distributed.DistributedSystem;
+import org.apache.geode.test.junit.categories.IntegrationTest;
+
+@Category(IntegrationTest.class)
+public class PartitionedIndexJUnitTest {
+
+  @Test
+  public void mapIndexKeysMustContainTheCorrectNumberOfKeysWhenThereIsConcurrentAccess() {
+
+    final int DATA_SIZE_TO_BE_POPULATED = 10000;
+    final int THREAD_POOL_SIZE = 20;
+
+    Region region = mock(Region.class);
+    Cache cache = mock(Cache.class);
+    when(region.getCache()).thenReturn(cache);
+    DistributedSystem distributedSystem = mock(DistributedSystem.class);
+    when(cache.getDistributedSystem()).thenReturn(distributedSystem);
+    PartitionedIndex partitionedIndex = new PartitionedIndex(IndexType.FUNCTIONAL, "dummyString",
+        region, "dummyString", "dummyString", "dummyString");
+    Runnable populateSetTask = () -> {
+      for (int i = 0; i < DATA_SIZE_TO_BE_POPULATED; i++) {
+        partitionedIndex.mapIndexKeys.add("" + i);
+      }
+    };
+    Thread[] threads = new Thread[THREAD_POOL_SIZE];
+    for (int i = 0; i < threads.length; i++) {
+      threads[i] = new Thread(populateSetTask);
+      threads[i].start();
+    }
+    try {
+      for (int i = 0; i < threads.length; i++) {
+        threads[i].join();
+      }
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+      fail();
+    }
+
+    assertEquals(DATA_SIZE_TO_BE_POPULATED, partitionedIndex.mapIndexKeys.size());
+
+  }
+}


### PR DESCRIPTION
	* mapIndexKeys was a HashSet and concurrent access to it resulted in inconsistent data to be present.
	* Changed to a set with a concurrent hash map as a backing store.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
