### PR TITLE
GEODE-4161: fix gfsh describe jdbc-mapping

### DIFF
--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/DescribeMappingCommand.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/DescribeMappingCommand.java
@@ -102,9 +102,11 @@ public class DescribeMappingCommand implements GfshCommand {
 
     TabularResultData tabularResultData = sectionResult.addTable(FIELD_TO_COLUMN_TABLE);
     tabularResultData.setHeader("Field to Column Mappings:");
-    mapping.getFieldToColumnMap().entrySet().forEach((entry) -> {
-      tabularResultData.accumulate("Field", entry.getKey());
-      tabularResultData.accumulate("Column", entry.getValue());
-    });
+    if (mapping.getFieldToColumnMap() != null) {
+      mapping.getFieldToColumnMap().entrySet().forEach((entry) -> {
+        tabularResultData.accumulate("Field", entry.getKey());
+        tabularResultData.accumulate("Column", entry.getValue());
+      });
+    }
   }
 }

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/DescribeMappingCommandIntegrationTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/DescribeMappingCommandIntegrationTest.java
@@ -110,4 +110,35 @@ public class DescribeMappingCommandIntegrationTest {
       assertThat(tableContent.get("Column").toString()).contains(entry.getValue());
     });
   }
+
+  @Test
+  public void displaysMappingInformationWhenMappingWithNoFieldToColumnsExists() throws Exception {
+    regionMapping = new RegionMappingBuilder().withRegionName(REGION_NAME)
+        .withConnectionConfigName("connection").withTableName("testTable")
+        .withPdxClassName("myPdxClass").withPrimaryKeyInValue(true).withFieldToColumnMappings(null)
+        .build();
+    service.createRegionMapping(regionMapping);
+    Result result = command.describeMapping(REGION_NAME);
+
+    assertThat(result.getStatus()).isSameAs(Result.Status.OK);
+    CommandResult commandResult = (CommandResult) result;
+    GfJsonObject sectionContent = commandResult.getTableContent()
+        .getJSONObject(SECTION_DATA_ACCESSOR + "-" + RESULT_SECTION_NAME);
+
+    assertThat(sectionContent.get(CREATE_MAPPING__REGION_NAME))
+        .isEqualTo(regionMapping.getRegionName());
+    assertThat(sectionContent.get(CREATE_MAPPING__CONNECTION_NAME))
+        .isEqualTo(regionMapping.getConnectionConfigName());
+    assertThat(sectionContent.get(CREATE_MAPPING__TABLE_NAME))
+        .isEqualTo(regionMapping.getTableName());
+    assertThat(sectionContent.get(CREATE_MAPPING__PDX_CLASS_NAME))
+        .isEqualTo(regionMapping.getPdxClassName());
+    assertThat(sectionContent.get(CREATE_MAPPING__VALUE_CONTAINS_PRIMARY_KEY))
+        .isEqualTo(regionMapping.isPrimaryKeyInValue());
+
+    GfJsonObject tableContent = sectionContent
+        .getJSONObject(TABLE_DATA_ACCESSOR + "-" + FIELD_TO_COLUMN_TABLE).getJSONObject("content");
+    assertThat(tableContent.get("Field")).isNull();
+    assertThat(tableContent.get("Column")).isNull();
+  }
 }


### PR DESCRIPTION
If the jdbc-mapping had no field to column items,
then describe jdbc-mapping would fail with an NPE.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
