### PR TITLE
GEODE-4221: Restore the ability to access the debugging VM.

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/test/dunit/standalone/DUnitLauncher.java
+++ b/geode-core/src/test/java/org/apache/geode/test/dunit/standalone/DUnitLauncher.java
@@ -62,7 +62,6 @@ import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.InternalLocator;
 import org.apache.geode.distributed.internal.membership.gms.membership.GMSJoinLeave;
 import org.apache.geode.internal.AvailablePortHelper;
-import org.apache.geode.internal.Version;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.test.dunit.DUnitEnv;
 import org.apache.geode.test.dunit.Host;
@@ -96,8 +95,19 @@ public class DUnitLauncher {
 
   static int locatorPort;
 
+  /**
+   * Number of VMs to use during initialization.
+   */
   public static final int NUM_VMS = 4;
+
+  /**
+   * VM ID for the VM to use for the debugger.
+   */
   private static final int DEBUGGING_VM_NUM = -1;
+
+  /**
+   * VM ID for the VM to use for the locator.
+   */
   private static final int LOCATOR_VM_NUM = -2;
 
   static final long STARTUP_TIMEOUT = 120 * 1000;
@@ -484,12 +494,17 @@ public class DUnitLauncher {
     }
 
     /**
-     * this will not bounce VM to a different version. It will only get the current running VM or
-     * launch a new one if not already launched.
+     * Retrieves one of this host's VMs based on the specified VM ID. This will not bounce VM to a
+     * different version. It will only get the current running VM or launch a new one if not already
+     * launched.
+     *
+     * @param n ID of the requested VM; a value of <code>-1</code> will return the controller VM,
+     *        which may be useful for debugging.
+     * @return VM for the requested VM ID.
      */
     @Override
     public VM getVM(int n) {
-      if (n < getVMCount()) {
+      if (n < getVMCount() && n != DEBUGGING_VM_NUM) {
         VM current = super.getVM(n);
         return getVM(current.getVersion(), n);
       } else {


### PR DESCRIPTION
Modified DUnitLauncher.getVM(int n) to again allow -1 to get at the debugging VM.


Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [n/a] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.

@upthewaterspout  @jhuynh1 @nabarunnag 