### PR TITLE
Fix script so passing.txt is branch-dependent.

### DIFF
--- a/ci/scripts/update-passing-ref.sh
+++ b/ci/scripts/update-passing-ref.sh
@@ -21,7 +21,7 @@
 export BUILDROOT=$(pwd)
 REPOSITORY_DIR=$(pwd)/geode
 LOCAL_FILE=${BUILDROOT}/results/passing.txt
-DESTINATION_URL=gs://${PUBLIC_BUCKET}/passing.txt
+DESTINATION_URL=gs://${PUBLIC_BUCKET}/${MAINTENANCE_VERSION}/passing.txt
 pushd ${REPOSITORY_DIR}
 git rev-parse HEAD > ${LOCAL_FILE}
 popd


### PR DESCRIPTION
[GEODE-4185]

The endpoint is changed to
http://files.apachegeode-ci.info/<branch>/passing.txt

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ X ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ X ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ X ] Is your initial contribution a single, squashed commit?

- [ X ] Does `gradlew build` run cleanly?

- [ N/A ] Have you written or updated unit tests to verify your changes?

- [ N/A ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
