### PR TITLE
GEODE-4051: change StateMarkerMessage to always reply

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/StateFlushOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/StateFlushOperation.java
@@ -347,24 +347,37 @@ public class StateFlushOperation {
     protected void process(DistributionManager dm) {
       logger.trace(LogMarker.STATE_FLUSH_OP, "Processing {}", this);
       if (dm.getDistributionManagerId().equals(relayRecipient)) {
-        // wait for inflight operations to the aeqs even if the recipient is the primary
-        Set<DistributedRegion> regions = getRegions(dm);
-        for (DistributedRegion r : regions) {
-          if (r != null) {
-            if (this.allRegions && r.doesNotDistribute()) {
-              // no need to flush a region that does no distribution
-              continue;
+        try {
+          // wait for inflight operations to the aeqs even if the recipient is the primary
+          Set<DistributedRegion> regions = getRegions(dm);
+          for (DistributedRegion r : regions) {
+            if (r != null) {
+              if (this.allRegions && r.doesNotDistribute()) {
+                // no need to flush a region that does no distribution
+                continue;
+              }
+              waitForCurrentOperations(r, r.isInitialized());
             }
-            waitForCurrentOperations(r, r.isInitialized());
           }
+        } catch (CancelException ignore) {
+          // cache is closed - no distribution advisor available for the region so nothing to do but
+          // send the stabilization message
+        } catch (Exception e) {
+          logger.fatal(LocalizedMessage.create(
+              LocalizedStrings.StateFlushOperation_0__EXCEPTION_CAUGHT_WHILE_DETERMINING_CHANNEL_STATE,
+              this), e);
+        } finally {
+          // no need to send a relay request to this process - just send the
+          // ack back to the sender
+          StateStabilizedMessage ga = new StateStabilizedMessage();
+          ga.sendingMember = relayRecipient;
+          ga.setRecipient(this.getSender());
+          ga.setProcessorId(processorId);
+          if (logger.isTraceEnabled(LogMarker.STATE_FLUSH_OP)) {
+            logger.trace(LogMarker.STATE_FLUSH_OP, "Sending {}", ga);
+          }
+          dm.putOutgoing(ga);
         }
-        // no need to send a relay request to this process - just send the
-        // ack back to the sender
-        StateStabilizedMessage ga = new StateStabilizedMessage();
-        ga.sendingMember = relayRecipient;
-        ga.setRecipient(this.getSender());
-        ga.setProcessorId(processorId);
-        dm.putOutgoing(ga);
       } else {
         // 1) wait for all messages based on the membership version (or older)
         // at which the sender "joined" this region to be put on the pipe
@@ -416,23 +429,6 @@ public class StateFlushOperation {
           logger.fatal(LocalizedMessage.create(
               LocalizedStrings.StateFlushOperation_0__EXCEPTION_CAUGHT_WHILE_DETERMINING_CHANNEL_STATE,
               this), e);
-        } catch (ThreadDeath td) {
-          throw td;
-        } catch (VirtualMachineError err) {
-          SystemFailure.initiateFailure(err);
-          // If this ever returns, rethrow the error. We're poisoned
-          // now, so don't let this thread continue.
-          throw err;
-        } catch (Throwable t) {
-          // Whenever you catch Error or Throwable, you must also
-          // catch VirtualMachineError (see above). However, there is
-          // _still_ a possibility that you are dealing with a cascading
-          // error condition, so you also need to check to see if the JVM
-          // is still usable:
-          SystemFailure.checkFailure();
-          logger.fatal(LocalizedMessage.create(
-              LocalizedStrings.StateFlushOperation_0__THROWABLE_CAUGHT_WHILE_DETERMINING_CHANNEL_STATE,
-              this), t);
         } finally {
           if (logger.isTraceEnabled(LogMarker.STATE_FLUSH_OP)) {
             logger.trace(LogMarker.STATE_FLUSH_OP, "Sending {}", gr);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/StateMarkerMessageTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/StateMarkerMessageTest.java
@@ -15,12 +15,20 @@
 package org.apache.geode.internal.cache;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import org.apache.geode.GemFireIOException;
+import org.apache.geode.distributed.internal.DistributionManager;
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.StateFlushOperation.StateMarkerMessage;
 import org.apache.geode.test.junit.categories.UnitTest;
 
@@ -32,5 +40,29 @@ public class StateMarkerMessageTest {
     StateMarkerMessage mockStateMarkerMessage = mock(StateMarkerMessage.class);
     when(mockStateMarkerMessage.getProcessorType()).thenReturn(1);
     assertThat(mockStateMarkerMessage.getProcessorType()).isEqualTo(1);
+  }
+
+  @Test
+  public void testProcessWithWaitForCurrentOperationsThatTimesOut() {
+    InternalDistributedMember relayRecipient = mock(InternalDistributedMember.class);
+    DistributionManager dm = mock(DistributionManager.class);
+    InternalCache gfc = mock(InternalCache.class);
+    DistributedRegion region = mock(DistributedRegion.class);
+    CacheDistributionAdvisor distributionAdvisor = mock(CacheDistributionAdvisor.class);
+
+    when(dm.getDistributionManagerId()).thenReturn(relayRecipient);
+    when(dm.getExistingCache()).thenReturn(gfc);
+    when(region.isInitialized()).thenReturn(true);
+    when(region.getDistributionAdvisor()).thenReturn(distributionAdvisor);
+    when(gfc.getRegionByPathForProcessing(any())).thenReturn(region);
+    doThrow(new GemFireIOException("expected in fatal log message")).when(distributionAdvisor)
+        .waitForCurrentOperations();
+
+    StateMarkerMessage message = new StateMarkerMessage();
+    message.relayRecipient = relayRecipient;
+
+    message.process(dm);
+
+    verify(dm, times(1)).putOutgoing(any());
   }
 }


### PR DESCRIPTION
One of the calls in StateMarkerMessage process would not end
up sending a reply if waitForCurrentOperations threw an exception.
It now has a finally block that makes sure the reply message is
always sent.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
