### PR TITLE
GEODE-4247: Pre-populate email subject and body files

### DIFF
--- a/ci/scripts/test-run.sh
+++ b/ci/scripts/test-run.sh
@@ -40,6 +40,12 @@ fi
 EMAIL_SUBJECT="${BUILDROOT}/built-geode/subject"
 EMAIL_BODY="${BUILDROOT}/built-geode/body"
 
+echo "Geode unit tests  '\${BUILD_PIPELINE_NAME}/\${BUILD_JOB_NAME}' took too long to execute" > $EMAIL_SUBJECT
+echo "Pipeline results can be found at:" >$EMAIL_BODY
+echo "" >>$EMAIL_BODY
+echo "Concourse: \${ATC_EXTERNAL_URL}/teams/\${BUILD_TEAM_NAME}/pipelines/\${BUILD_PIPELINE_NAME}/jobs/\${BUILD_JOB_NAME}/builds/\${BUILD_NAME}" >>$EMAIL_BODY
+echo "" >>$EMAIL_BODY
+
 # Called by trap when the script is exiting
 function error_exit() {
   echo "Geode unit tests completed in '\${BUILD_PIPELINE_NAME}/\${BUILD_JOB_NAME}' with non-zero exit code" > $EMAIL_SUBJECT


### PR DESCRIPTION
* If the container running the tests is killed, the error function
* setting up the email contents will never run. Pre-populate the email
* contents with text indicating the task timeout was hit.

[GEODE-4247]

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ X ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ X ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ X ] Is your initial contribution a single, squashed commit?

- [ X ] Does `gradlew build` run cleanly?

- [ N/A ] Have you written or updated unit tests to verify your changes?

- [ N/A ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
