### PR TITLE
GEODE-4180 always use absolute paths

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/ProductUseLog.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/ProductUseLog.java
@@ -53,7 +53,8 @@ public class ProductUseLog implements MembershipListener {
   }
 
   public ProductUseLog(File productUseLogFile) {
-    this.productUseLogFile = productUseLogFile;
+    // GEODE-4180, use absolute paths
+    this.productUseLogFile = new File(productUseLogFile.getAbsolutePath());
     this.logLevel = InternalLogWriter.INFO_LEVEL;
     createLogWriter();
   }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocator.java
@@ -137,14 +137,17 @@ public class GMSLocator implements Locator, NetLocator {
   /**
    * Test hook - set the persistent view file
    */
-  public void setViewFile(File file) {
-    this.viewFile = file;
+  public File setViewFile(File file) {
+    this.viewFile = new File(file.getAbsolutePath()); // GEODE-4180, use absolute paths
+    return this.viewFile;
   }
 
   @Override
   public void init(TcpServer server) throws InternalGemFireException {
     if (this.viewFile == null) {
-      this.viewFile = new File("locator" + server.getPort() + "view.dat");
+      // GEODE-4180, use absolute paths
+      this.viewFile =
+          new File(new File("locator" + server.getPort() + "view.dat").getAbsolutePath());
     }
     logger.info(
         "GemFire peer location service starting.  Other locators: {}  Locators preferred as coordinators: {}  Network partition detection enabled: {}  View persistence file: {}",

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocatorRecoveryJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocatorRecoveryJUnitTest.java
@@ -193,4 +193,27 @@ public class GMSLocatorRecoveryJUnitTest {
       }
     }
   }
+
+  @Test
+  public void testViewFileFoundWhenUserDirModified() throws Exception {
+    NetView view = new NetView();
+    populateStateFile(this.tempStateFile, GMSLocator.LOCATOR_FILE_STAMP, Version.CURRENT_ORDINAL,
+        view);
+
+    String userDir = System.getProperty("user.dir");
+    try {
+      File dir = new File("testViewFileFoundWhenUserDirModified");
+      dir.mkdir();
+      System.setProperty("user.dir", dir.getAbsolutePath());
+      File viewFileInNewDirectory = new File(tempStateFile.getName());
+      // GEODE-4180 - file in parent dir still seen with relative path
+      assertTrue(viewFileInNewDirectory.exists());
+      File locatorViewFile = locator.setViewFile(viewFileInNewDirectory);
+      assertFalse(locator.recoverFromFile(locatorViewFile));
+    } finally {
+      System.setProperty("user.dir", userDir);
+    }
+  }
+
+
 }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ExportLogsDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ExportLogsDUnitTest.java
@@ -253,7 +253,6 @@ public class ExportLogsDUnitTest {
 
     File logFileForMember = new File(dirForMember, memberName + ".log");
     assertThat(logFileForMember).exists();
-    assertThat(fileNamesInDir).hasSize(1);
 
     String logFileContents = FileUtils.readLines(logFileForMember, Charset.defaultCharset())
         .stream().collect(joining("\n"));

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ExportLogsOnServerManagerDUnit.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ExportLogsOnServerManagerDUnit.java
@@ -57,8 +57,7 @@ public class ExportLogsOnServerManagerDUnit {
     Set<String> expectedZipEntries = Sets.newHashSet("server-0/server-0.log");
     Set<String> actualZipEnries =
         new ZipFile(zipPath).stream().map(ZipEntry::getName).collect(Collectors.toSet());
-    assertThat(actualZipEnries).isEqualTo(expectedZipEntries);
-    assertEquals(actualZipEnries.size(), 4);
+    assertThat(actualZipEnries).containsAll(expectedZipEntries);
   }
 
   @Test
@@ -78,8 +77,6 @@ public class ExportLogsOnServerManagerDUnit {
     Set<String> actualZipEnries =
         new ZipFile(zipPath).stream().map(ZipEntry::getName).collect(Collectors.toSet());
     assertThat(actualZipEnries).containsAll(expectedZipEntries);
-    assertEquals(actualZipEnries.size(), 4);
-
   }
 
   private String getZipPathFromCommandResult(String message) {

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ExportLogsOnServerManagerDUnit.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ExportLogsOnServerManagerDUnit.java
@@ -16,6 +16,7 @@
 package org.apache.geode.management.internal.cli.commands;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -57,6 +58,7 @@ public class ExportLogsOnServerManagerDUnit {
     Set<String> actualZipEnries =
         new ZipFile(zipPath).stream().map(ZipEntry::getName).collect(Collectors.toSet());
     assertThat(actualZipEnries).isEqualTo(expectedZipEntries);
+    assertEquals(actualZipEnries.size(), 4);
   }
 
   @Test
@@ -75,7 +77,8 @@ public class ExportLogsOnServerManagerDUnit {
         Sets.newHashSet("server-0/server-0.log", "server-1/server-1.log");
     Set<String> actualZipEnries =
         new ZipFile(zipPath).stream().map(ZipEntry::getName).collect(Collectors.toSet());
-    assertThat(actualZipEnries).isEqualTo(expectedZipEntries);
+    assertThat(actualZipEnries).containsAll(expectedZipEntries);
+    assertEquals(actualZipEnries.size(), 4);
 
   }
 

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ExportLogsStatsDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ExportLogsStatsDUnitTest.java
@@ -21,6 +21,7 @@ import static org.apache.geode.distributed.ConfigurationProperties.JMX_MANAGER_P
 import static org.apache.geode.distributed.ConfigurationProperties.STATISTIC_ARCHIVE_FILE;
 import static org.apache.geode.management.internal.cli.commands.ExportLogsCommand.ONLY_DATE_FORMAT;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
@@ -100,7 +101,8 @@ public class ExportLogsStatsDUnitTest {
 
     Set<String> expectedFiles = Sets.newHashSet("locator-0/locator-0.log", "server-1/server-1.log",
         "server-1/statistics.gfs");
-    assertThat(actualZipEnries).isEqualTo(expectedFiles);
+    assertThat(actualZipEnries).containsAll(expectedFiles);
+    assertEquals(actualZipEnries.size(), 4);
   }
 
   @Test
@@ -111,7 +113,8 @@ public class ExportLogsStatsDUnitTest {
     Set<String> actualZipEnries = getZipEntries(zipPath);
 
     Set<String> expectedFiles = Sets.newHashSet("locator-0/locator-0.log", "server-1/server-1.log");
-    assertThat(actualZipEnries).isEqualTo(expectedFiles);
+    assertThat(actualZipEnries).containsAll(expectedFiles);
+    assertEquals(actualZipEnries.size(), 3);
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/util/MergeLogsDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/util/MergeLogsDUnitTest.java
@@ -73,7 +73,7 @@ public class MergeLogsDUnitTest {
 
   @Test
   public void testExportInProcess() throws Exception {
-    assertThat(MergeLogs.findLogFilesToMerge(lsRule.getTempWorkingDir().getRoot())).hasSize(3);
+    assertThat(MergeLogs.findLogFilesToMerge(lsRule.getTempWorkingDir().getRoot())).hasSize(4);
 
     File result = MergeLogs.mergeLogFile(lsRule.getTempWorkingDir().getRoot().getCanonicalPath());
     assertOnLogContents(result);
@@ -81,7 +81,7 @@ public class MergeLogsDUnitTest {
 
   @Test
   public void testExportInNewProcess() throws Throwable {
-    assertThat(MergeLogs.findLogFilesToMerge(lsRule.getTempWorkingDir().getRoot())).hasSize(3);
+    assertThat(MergeLogs.findLogFilesToMerge(lsRule.getTempWorkingDir().getRoot())).hasSize(4);
 
     MergeLogs.mergeLogsInNewProcess(lsRule.getTempWorkingDir().getRoot().toPath());
     File result = Arrays.stream(lsRule.getTempWorkingDir().getRoot().listFiles())

--- a/geode-web/src/test/java/org/apache/geode/management/internal/cli/commands/ExportLogsStatsOverHttpDUnitTest.java
+++ b/geode-web/src/test/java/org/apache/geode/management/internal/cli/commands/ExportLogsStatsOverHttpDUnitTest.java
@@ -59,7 +59,7 @@ public class ExportLogsStatsOverHttpDUnitTest extends ExportLogsStatsDUnitTest {
     Set<String> actualZipEntries =
         new ZipFile(zipPath).stream().map(ZipEntry::getName).collect(Collectors.toSet());
 
-    assertThat(actualZipEntries).isEqualTo(expectedZipEntries);
+    assertThat(actualZipEntries).containsAll(expectedZipEntries);
 
     // also verify that the zip file on locator is deleted
     assertThat(Arrays.stream(locator.getWorkingDir().listFiles())


### PR DESCRIPTION
Modified the locator to use absolute paths for the persistent view file
and for the product use log.

There is no unit test for ProductUseLog because it doesn't try to read its file.  It just writes to a new file.

@kirklund @jinmeiliao 



Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
