### PR TITLE
GEODE-4246: Skip setting the mcast-port property.

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/TestPropertiesWriter.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/TestPropertiesWriter.groovy
@@ -23,7 +23,6 @@ import org.apache.mina.util.AvailablePortFinder;
 public class TestPropertiesWriter {
   public static void writeTestProperties(File parent, String name) {
     Properties props = new Properties();
-    props.setProperty('mcast-port', Integer.toString(AvailablePortFinder.getNextAvailable()));
     props.setProperty('log-level', 'config');
     File propsFile = new File(testResultsDir(parent, name), 'gemfire.properties');
     BufferedWriter writer = propsFile.newWriter();


### PR DESCRIPTION
Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [n/a] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.

@upthewaterspout @bschuchardt @WireBaron @galen-pivotal 