### PR TITLE
GEODE-4255: Remove mandatory failure on macOS.

### DIFF
--- a/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/misc/WANConfigurationJUnitTest.java
+++ b/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/misc/WANConfigurationJUnitTest.java
@@ -418,16 +418,12 @@ public class WANConfigurationJUnitTest {
   }
 
   /**
-   * This test takes a minimum of 120s to execute. It is known to hang on Mac OS X Yosemite do to
-   * changes in the the message string checked in GatewayReceiverImpl around line 167. Expects
-   * "Cannot assign requested address" but gets "Can't assign requested address". Timeout after 150s
-   * to safeguard against hanging on other platforms that may differ.
+   * This test takes a minimum of 120s to execute. Based on the experiences of the Yosemite release
+   * of macOS, timeout after 150s to safeguard against hanging on other platforms that may have
+   * different error messages.
    */
   @Test(timeout = 150000)
   public void test_ValidateGatewayReceiverAttributes_WrongBindAddress() {
-    if (System.getProperty("os.name").equals("Mac OS X")) {
-      fail("Failing to avoid known hang on Mac OS X.");
-    }
     cache = new CacheFactory().set(MCAST_PORT, "0").create();
     GatewayReceiverFactory fact = cache.createGatewayReceiverFactory();
     fact.setStartPort(50504);


### PR DESCRIPTION
Since GatewayReceiverImpl uses a much less brittle string comparison now, the case that this mandatory failure was trying to avoid no longer exists.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.

@jhuynh1 @nabarunnag 