### PR TITLE
GEODE-4225: getVM(n) call does not accidentally bounce the VM with current version

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/test/dunit/rules/ClusterStartupRule.java
+++ b/geode-core/src/test/java/org/apache/geode/test/dunit/rules/ClusterStartupRule.java
@@ -373,7 +373,7 @@ public class ClusterStartupRule extends ExternalResource implements Serializable
   }
 
   public VM getVM(int index) {
-    return getVM(index, VersionManager.CURRENT_VERSION);
+    return getHost(0).getVM(index);
   }
 
   public void stopVM(int index) {


### PR DESCRIPTION
this is just an enhancement, 

sometimes if user id a VM vm = cluster.getVM(n, "130"), and later on, wants to get the same vm again, they probably would just do a cluster.getVM(n), but this call would bounce the VM to current version without the fix.