### PR TITLE
GEODE-4275: Improved StartMemberUtils.addMaxHeap

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartMemberUtils.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartMemberUtils.java
@@ -126,8 +126,16 @@ public class StartMemberUtils {
   static void addMaxHeap(final List<String> commandLine, final String maxHeap) {
     if (StringUtils.isNotBlank(maxHeap)) {
       commandLine.add("-Xmx" + maxHeap);
-      commandLine.add("-XX:+UseConcMarkSweepGC");
-      commandLine.add("-XX:CMSInitiatingOccupancyFraction=" + CMS_INITIAL_OCCUPANCY_FRACTION);
+
+      String collectorKey = "-XX:+UseConcMarkSweepGC";
+      if (!commandLine.contains(collectorKey)) {
+        commandLine.add(collectorKey);
+      }
+
+      String occupancyFractionKey = "-XX:CMSInitiatingOccupancyFraction=";
+      if (commandLine.stream().noneMatch(s -> s.contains(occupancyFractionKey))) {
+        commandLine.add(occupancyFractionKey + CMS_INITIAL_OCCUPANCY_FRACTION);
+      }
     }
   }
 

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/StartMemberUtilsTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/StartMemberUtilsTest.java
@@ -24,6 +24,10 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.Rule;
@@ -99,6 +103,32 @@ public class StartMemberUtilsTest {
 
     gemfireClasspath = StartMemberUtils.toClasspath(false, otherJars);
     assertThat(gemfireClasspath).startsWith(customGeodeCore);
+  }
+
+  @Test
+  public void testAddMaxHeap() {
+    List<String> baseCommandLine = new ArrayList<>();
+
+    // Empty Max Heap Option
+    StartMemberUtils.addMaxHeap(baseCommandLine, null);
+    assertThat(baseCommandLine.size()).isEqualTo(0);
+
+    StartMemberUtils.addMaxHeap(baseCommandLine, "");
+    assertThat(baseCommandLine.size()).isEqualTo(0);
+
+    // Only Max Heap Option Set
+    StartMemberUtils.addMaxHeap(baseCommandLine, "32g");
+    assertThat(baseCommandLine.size()).isEqualTo(3);
+    assertThat(baseCommandLine).containsExactly("-Xmx32g", "-XX:+UseConcMarkSweepGC",
+        "-XX:CMSInitiatingOccupancyFraction=" + StartMemberUtils.CMS_INITIAL_OCCUPANCY_FRACTION);
+
+    // All Options Set
+    List<String> customCommandLine = new ArrayList<>(
+        Arrays.asList("-XX:+UseConcMarkSweepGC", "-XX:CMSInitiatingOccupancyFraction=30"));
+    StartMemberUtils.addMaxHeap(customCommandLine, "16g");
+    assertThat(customCommandLine.size()).isEqualTo(3);
+    assertThat(customCommandLine).containsExactly("-XX:+UseConcMarkSweepGC",
+        "-XX:CMSInitiatingOccupancyFraction=30", "-Xmx16g");
   }
 
   private void writePid(final File pidFile, final int pid) throws IOException {


### PR DESCRIPTION
GEODE-4275: Improved StartMemberUtils.addMaxHeap

- Added test methods.
- Modified the method to avoid adding `"-XX:+UseConcMarkSweepGC"` if
  the user already specified parameter as a jvm argument.
- Modified the logic to avoid setting the default value for
  `"-XX:CMSInitiatingOccupancyFraction="` if the user already specified
  one as a jvm argument.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
