### PR TITLE
GEODE-4101: Remove test assertions that mask failure information

### DIFF
--- a/geode-assembly/src/test/java/org/apache/geode/management/internal/cli/commands/StartLocatorCommandTest.java
+++ b/geode-assembly/src/test/java/org/apache/geode/management/internal/cli/commands/StartLocatorCommandTest.java
@@ -246,7 +246,6 @@ public class StartLocatorCommandTest {
 
     assertNotNull(commandLineElements);
     assertTrue(commandLineElements.length > 0);
-    assertEquals(commandLineElements.length, expectedCommandLineElements.size());
 
     for (String commandLineElement : commandLineElements) {
       expectedCommandLineElements.remove(commandLineElement);

--- a/geode-assembly/src/test/java/org/apache/geode/management/internal/cli/commands/StartServerCommandTest.java
+++ b/geode-assembly/src/test/java/org/apache/geode/management/internal/cli/commands/StartServerCommandTest.java
@@ -231,7 +231,6 @@ public class StartServerCommandTest {
 
     assertNotNull(commandLineElements);
     assertTrue(commandLineElements.length > 0);
-    assertEquals(commandLineElements.length, expectedCommandLineElements.size());
 
     for (String commandLineElement : commandLineElements) {
       expectedCommandLineElements.remove(commandLineElement);


### PR DESCRIPTION
This is a fix for new test that broke the build.

StartServerCommandTest failed in CI build, but the assertion caused an
early failure. By removing this assertion the comparison of expected and
actual command line elements can proceed show where the problem is.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
