### PR TITLE
GEODE-4101: Only check for specific command line arguments

### DIFF
--- a/geode-assembly/src/test/java/org/apache/geode/management/internal/cli/commands/StartLocatorCommandTest.java
+++ b/geode-assembly/src/test/java/org/apache/geode/management/internal/cli/commands/StartLocatorCommandTest.java
@@ -17,6 +17,7 @@ package org.apache.geode.management.internal.cli.commands;
 
 import static org.apache.geode.distributed.ConfigurationProperties.HTTP_SERVICE_BIND_ADDRESS;
 import static org.apache.geode.distributed.ConfigurationProperties.HTTP_SERVICE_PORT;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -226,15 +227,6 @@ public class StartLocatorCommandTest {
     expectedCommandLineElements.add("-Dgemfire.statistic-sample-rate=1500");
     expectedCommandLineElements.add("-Dgemfire.disable-auto-reconnect=true");
     expectedCommandLineElements.addAll(Arrays.asList(jvmArguments));
-    expectedCommandLineElements.add("-Xms".concat(heapSize));
-    expectedCommandLineElements.add("-Xmx".concat(heapSize));
-    expectedCommandLineElements.add("-XX:+UseConcMarkSweepGC");
-    expectedCommandLineElements.add("-XX:CMSInitiatingOccupancyFraction="
-        .concat(String.valueOf(StartMemberUtils.CMS_INITIAL_OCCUPANCY_FRACTION)));
-    expectedCommandLineElements.add("-Dgemfire.launcher.registerSignalHandlers=true");
-    expectedCommandLineElements.add("-Djava.awt.headless=true");
-    expectedCommandLineElements.add("-Dsun.rmi.dgc.server.gcInterval=9223372036854775806");
-    expectedCommandLineElements.add("-Dgemfire.OSProcess.DISABLE_REDIRECTION_CONFIGURATION=true");
     expectedCommandLineElements.add("org.apache.geode.distributed.LocatorLauncher");
     expectedCommandLineElements.add("start");
     expectedCommandLineElements.add("customLocator");
@@ -247,11 +239,6 @@ public class StartLocatorCommandTest {
     assertNotNull(commandLineElements);
     assertTrue(commandLineElements.length > 0);
 
-    for (String commandLineElement : commandLineElements) {
-      expectedCommandLineElements.remove(commandLineElement);
-    }
-
-    assertTrue(String.format("Expected ([]); but was (%1$s)", expectedCommandLineElements),
-        expectedCommandLineElements.isEmpty());
+    assertThat(commandLineElements).containsAll(expectedCommandLineElements);
   }
 }

--- a/geode-assembly/src/test/java/org/apache/geode/management/internal/cli/commands/StartServerCommandTest.java
+++ b/geode-assembly/src/test/java/org/apache/geode/management/internal/cli/commands/StartServerCommandTest.java
@@ -18,6 +18,7 @@ package org.apache.geode.management.internal.cli.commands;
 import static org.apache.geode.distributed.ConfigurationProperties.HTTP_SERVICE_BIND_ADDRESS;
 import static org.apache.geode.distributed.ConfigurationProperties.HTTP_SERVICE_PORT;
 import static org.apache.geode.distributed.ConfigurationProperties.START_DEV_REST_API;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -197,16 +198,6 @@ public class StartServerCommandTest {
     expectedCommandLineElements.add("-Dgemfire.statistic-sample-rate=1500");
     expectedCommandLineElements.add("-Dgemfire.disable-auto-reconnect=true");
     expectedCommandLineElements.addAll(Arrays.asList(jvmArguments));
-    expectedCommandLineElements.add("-XX:OnOutOfMemoryError=kill -KILL %p");
-    expectedCommandLineElements.add("-Xms".concat(heapSize));
-    expectedCommandLineElements.add("-Xmx".concat(heapSize));
-    expectedCommandLineElements.add("-XX:+UseConcMarkSweepGC");
-    expectedCommandLineElements.add("-XX:CMSInitiatingOccupancyFraction="
-        .concat(String.valueOf(StartMemberUtils.CMS_INITIAL_OCCUPANCY_FRACTION)));
-    expectedCommandLineElements.add("-Dgemfire.launcher.registerSignalHandlers=true");
-    expectedCommandLineElements.add("-Djava.awt.headless=true");
-    expectedCommandLineElements.add("-Dsun.rmi.dgc.server.gcInterval=9223372036854775806");
-    expectedCommandLineElements.add("-Dgemfire.OSProcess.DISABLE_REDIRECTION_CONFIGURATION=true");
     expectedCommandLineElements.add("org.apache.geode.distributed.ServerLauncher");
     expectedCommandLineElements.add("start");
     expectedCommandLineElements.add("fullServer");
@@ -232,11 +223,6 @@ public class StartServerCommandTest {
     assertNotNull(commandLineElements);
     assertTrue(commandLineElements.length > 0);
 
-    for (String commandLineElement : commandLineElements) {
-      expectedCommandLineElements.remove(commandLineElement);
-    }
-
-    assertTrue(String.format("Expected ([]); but was (%1$s)", expectedCommandLineElements),
-        expectedCommandLineElements.isEmpty());
+    assertThat(commandLineElements).containsAll(expectedCommandLineElements);
   }
 }


### PR DESCRIPTION
StartServerCommandTest failed in CI build, but the assertion that failed
didn't provide any useful debugging information

Change the assertion to use assertj so more information will be lgged
regarding mismatches between expected and actual command arguments.

Also changed expectedCommandLineElements to only contain the command args that
we really care about - those that are specific to the command. Other arguments
maythat are dependant on the test environment may vary and ignored in
these tests.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
