### PR TITLE
GEODE-4293: Pulse works correctly when jmx-manager-password-file is set

### DIFF
--- a/geode-assembly/src/test/java/org/apache/geode/tools/pulse/PulseJmxPasswordFileTest.java
+++ b/geode-assembly/src/test/java/org/apache/geode/tools/pulse/PulseJmxPasswordFileTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.tools.pulse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.util.Collections;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.http.HttpResponse;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TemporaryFolder;
+
+import org.apache.geode.test.junit.categories.IntegrationTest;
+import org.apache.geode.test.junit.rules.HttpClientRule;
+import org.apache.geode.test.junit.rules.LocatorStarterRule;
+
+
+@Category(IntegrationTest.class)
+public class PulseJmxPasswordFileTest {
+  @Rule
+  public LocatorStarterRule locator = new LocatorStarterRule();
+
+  @Rule
+  public HttpClientRule client = new HttpClientRule(locator::getHttpPort);
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Before
+  public void setUp() throws Exception {
+    File passwordFile = temporaryFolder.newFile("password.properties");
+    FileUtils.writeLines(passwordFile, Collections.singleton("user user"));
+    locator.withProperty("jmx-manager-password-file", passwordFile.getAbsolutePath());
+    locator.startLocator();
+  }
+
+  @Test
+  public void testLogin() throws Exception {
+    client.loginToPulseAndVerify("user", "user");
+
+    HttpResponse response = client.post("/pulse/pulseUpdate");
+    assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/management/internal/ManagementAgent.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/ManagementAgent.java
@@ -213,8 +213,11 @@ public class ManagementAgent {
         if (logger.isDebugEnabled()) {
           logger.debug(message);
         }
-      } else if (securityService.isIntegratedSecurity()) {
-        System.setProperty("spring.profiles.active", "pulse.authentication.gemfire");
+      } else {
+        String pwFile = this.config.getJmxManagerPasswordFile();
+        if (securityService.isIntegratedSecurity() || StringUtils.isNotBlank(pwFile)) {
+          System.setProperty("spring.profiles.active", "pulse.authentication.gemfire");
+        }
       }
 
       // Find developer REST WAR file
@@ -477,7 +480,6 @@ public class ManagementAgent {
       // should take care of that
       MBeanServerWrapper mBeanServerWrapper = new MBeanServerWrapper(this.securityService);
       jmxConnectorServer.setMBeanServerForwarder(mBeanServerWrapper);
-      registerAccessControlMBean();
     } else {
       /* Disable the old authenticator mechanism */
       String pwFile = this.config.getJmxManagerPasswordFile();
@@ -492,6 +494,7 @@ public class ManagementAgent {
         controller.setMBeanServer(mbs);
       }
     }
+    registerAccessControlMBean();
     registerFileUploaderMBean();
 
     jmxConnectorServer.start();


### PR DESCRIPTION
Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
