### PR TITLE
GEODE-4292: Update scm refs in maven pom to github

### DIFF
--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -78,9 +78,9 @@ subprojects {
       url 'http://geode.apache.org'
   
       scm {
-        url 'https://git-wip-us.apache.org/repos/asf?p=geode.git;a=tree'
-        connection 'scm:https://git-wip-us.apache.org/repos/asf/geode.git'
-        developerConnection 'scm:https://git-wip-us.apache.org/repos/asf/geode.git'
+        url 'https://github.com/apache/geode'
+        connection 'scm:git:https://github.com:apache/geode.git'
+        developerConnection 'scm:git:https://github.com:apache/geode.git'
       }
   
       licenses {


### PR DESCRIPTION
  Updated `scm refs` with appropriate github URLs.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
