### PR TITLE
GEODE-4291: Avoid asking user input in SocketCreator

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/net/SocketCreator.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/SocketCreator.java
@@ -475,27 +475,14 @@ public class SocketCreator {
   private TrustManager[] getTrustManagers()
       throws KeyStoreException, NoSuchAlgorithmException, CertificateException, IOException {
     TrustManager[] trustManagers = null;
-    GfeConsoleReader consoleReader = GfeConsoleReaderFactory.getDefaultConsoleReader();
 
     String trustStoreType = sslConfig.getTruststoreType();
     if (StringUtils.isEmpty(trustStoreType)) {
-      // read from console, default on empty
-      if (consoleReader.isSupported()) {
-        trustStoreType = consoleReader
-            .readLine("Please enter the trustStoreType (javax.net.ssl.trustStoreType) : ");
-      } else {
-        trustStoreType = KeyStore.getDefaultType();
-      }
+      trustStoreType = KeyStore.getDefaultType();
     }
 
     KeyStore ts = KeyStore.getInstance(trustStoreType);
     String trustStorePath = sslConfig.getTruststore();
-    if (StringUtils.isEmpty(trustStorePath)) {
-      if (consoleReader.isSupported()) {
-        trustStorePath = consoleReader
-            .readLine("Please enter the trustStore location (javax.net.ssl.trustStore) : ");
-      }
-    }
     FileInputStream fis = new FileInputStream(trustStorePath);
     String passwordString = sslConfig.getTruststorePassword();
     char[] password = null;
@@ -505,11 +492,6 @@ public class SocketCreator {
           String toDecrypt = "encrypted(" + passwordString + ")";
           passwordString = PasswordUtil.decrypt(toDecrypt);
           password = passwordString.toCharArray();
-        }
-        // read from the console
-        if (StringUtils.isEmpty(passwordString) && consoleReader.isSupported()) {
-          password = consoleReader.readPassword(
-              "Please enter password for trustStore (javax.net.ssl.trustStorePassword) : ");
         }
       } else {
         password = passwordString.toCharArray();
@@ -533,8 +515,6 @@ public class SocketCreator {
 
   private KeyManager[] getKeyManagers() throws KeyStoreException, IOException,
       NoSuchAlgorithmException, CertificateException, UnrecoverableKeyException {
-    GfeConsoleReader consoleReader = GfeConsoleReaderFactory.getDefaultConsoleReader();
-
     if (sslConfig.getKeystore() == null) {
       return null;
     }
@@ -542,24 +522,13 @@ public class SocketCreator {
     KeyManager[] keyManagers = null;
     String keyStoreType = sslConfig.getKeystoreType();
     if (StringUtils.isEmpty(keyStoreType)) {
-      // read from console, default on empty
-      if (consoleReader.isSupported()) {
-        keyStoreType =
-            consoleReader.readLine("Please enter the keyStoreType (javax.net.ssl.keyStoreType) : ");
-      } else {
-        keyStoreType = KeyStore.getDefaultType();
-      }
+      keyStoreType = KeyStore.getDefaultType();
     }
     KeyStore keyStore = KeyStore.getInstance(keyStoreType);
     String keyStoreFilePath = sslConfig.getKeystore();
     if (StringUtils.isEmpty(keyStoreFilePath)) {
-      if (consoleReader.isSupported()) {
-        keyStoreFilePath = consoleReader
-            .readLine("Please enter the keyStore location (javax.net.ssl.keyStore) : ");
-      } else {
-        keyStoreFilePath =
-            System.getProperty("user.home") + System.getProperty("file.separator") + ".keystore";
-      }
+      keyStoreFilePath =
+          System.getProperty("user.home") + System.getProperty("file.separator") + ".keystore";
     }
 
     FileInputStream fileInputStream = new FileInputStream(keyStoreFilePath);
@@ -572,11 +541,6 @@ public class SocketCreator {
           String toDecrypt = "encrypted(" + encryptedPass + ")";
           passwordString = PasswordUtil.decrypt(toDecrypt);
           password = passwordString.toCharArray();
-        }
-        // read from the console
-        if (StringUtils.isEmpty(passwordString) && consoleReader != null) {
-          password = consoleReader.readPassword(
-              "Please enter password for keyStore (javax.net.ssl.keyStorePassword) : ");
         }
       } else {
         password = passwordString.toCharArray();


### PR DESCRIPTION
  Avoid seeking user inputs on missing SSL parameters in SocketCreator instead 
  use default values so that client does not have to include SpringShell dependency
  in the class path.

  For Gfsh, ConnectCommand checks for missing parameters and prompts user inputs.
  For other clients, consider possible default values.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
