### PR TITLE
GEODE-4147: Add variability to client rebalance logic.

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/cache/client/internal/ConnectionPoolImplJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/client/internal/ConnectionPoolImplJUnitTest.java
@@ -16,7 +16,9 @@ package org.apache.geode.cache.client.internal;
 
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.net.InetSocketAddress;
 import java.net.SocketTimeoutException;
@@ -266,5 +268,4 @@ public class ConnectionPoolImplJUnitTest {
     assertEquals(location1, pool.executeOnPrimary(testOp));
     assertEquals(location1, pool.executeOnQueuesAndReturnPrimaryResult(testOp));
   }
-
 }

--- a/geode-core/src/test/java/org/apache/geode/cache/client/internal/pooling/ConnectionManagerJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/client/internal/pooling/ConnectionManagerJUnitTest.java
@@ -16,12 +16,12 @@ package org.apache.geode.cache.client.internal.pooling;
 
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Socket;
-import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.Properties;
@@ -40,7 +40,16 @@ import org.junit.experimental.categories.Category;
 import org.apache.geode.CancelCriterion;
 import org.apache.geode.cache.client.AllConnectionsInUseException;
 import org.apache.geode.cache.client.NoAvailableServersException;
-import org.apache.geode.cache.client.internal.*;
+import org.apache.geode.cache.client.internal.ClientUpdater;
+import org.apache.geode.cache.client.internal.Connection;
+import org.apache.geode.cache.client.internal.ConnectionFactory;
+import org.apache.geode.cache.client.internal.ConnectionStats;
+import org.apache.geode.cache.client.internal.Endpoint;
+import org.apache.geode.cache.client.internal.EndpointManager;
+import org.apache.geode.cache.client.internal.EndpointManagerImpl;
+import org.apache.geode.cache.client.internal.Op;
+import org.apache.geode.cache.client.internal.QueueManager;
+import org.apache.geode.cache.client.internal.ServerBlackList;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.distributed.internal.ServerLocation;
@@ -102,6 +111,17 @@ public class ConnectionManagerJUnitTest {
       manager.close(false);
     }
     background.shutdownNow();
+  }
+
+  @Test
+  public void testAddVarianceToInterval() {
+    assertThat(ConnectionManagerImpl.addVarianceToInterval(0)).as("Zero gets zero variance")
+        .isEqualTo(0);
+    assertThat(ConnectionManagerImpl.addVarianceToInterval(300000))
+        .as("Large value gets +/-10% variance").isNotEqualTo(300000).isGreaterThanOrEqualTo(270000)
+        .isLessThanOrEqualTo(330000);
+    assertThat(ConnectionManagerImpl.addVarianceToInterval(9)).as("Small value gets +/-1 variance")
+        .isNotEqualTo(9).isGreaterThanOrEqualTo(8).isLessThanOrEqualTo(10);
   }
 
   @Test


### PR DESCRIPTION
I moved the application of the variance from the pool implementation to the connection manager implementation to avoid impacting too much of the code, which lead to some failing tests.

For some reason the combination of IntelliJ and Spotless expanded some wildcard import statements but I left those as-is.

@upthewaterspout @bschuchardt @WireBaron @galen-pivotal 

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
