### PR TITLE
Feature/geode 4296 Protobuf driver should turn off TCP delay, or make it configurable

### DIFF
--- a/geode-experimental-driver/src/main/java/org/apache/geode/experimental/driver/Driver.java
+++ b/geode-experimental-driver/src/main/java/org/apache/geode/experimental/driver/Driver.java
@@ -47,4 +47,14 @@ public interface Driver {
    * @return the region object
    */
   <K, V> Region<K, V> getRegion(String regionName);
+
+  /**
+   * Close this Driver, rendering it useless
+   */
+  void close();
+
+  /**
+   * Is this driver connected?
+   */
+  boolean isConnected();
 }

--- a/geode-experimental-driver/src/main/java/org/apache/geode/experimental/driver/ProtobufDriver.java
+++ b/geode-experimental-driver/src/main/java/org/apache/geode/experimental/driver/ProtobufDriver.java
@@ -60,6 +60,9 @@ public class ProtobufDriver implements Driver {
     this.locators = locators;
     InetSocketAddress server = findAServer();
     socket = new Socket(server.getAddress(), server.getPort());
+    socket.setTcpNoDelay(true);
+    socket.setSendBufferSize(65535);
+    socket.setReceiveBufferSize(65535);
 
     final OutputStream outputStream = socket.getOutputStream();
     ProtocolVersion.NewConnectionClientVersion.newBuilder()

--- a/geode-experimental-driver/src/main/java/org/apache/geode/experimental/driver/ProtobufDriver.java
+++ b/geode-experimental-driver/src/main/java/org/apache/geode/experimental/driver/ProtobufDriver.java
@@ -99,6 +99,20 @@ public class ProtobufDriver implements Driver {
     return new ProtobufRegion(regionName, socket);
   }
 
+  @Override
+  public void close() {
+    try {
+      this.socket.close();
+    } catch (IOException e) {
+      // ignore
+    }
+  }
+
+  @Override
+  public boolean isConnected() {
+    return !this.socket.isClosed();
+  }
+
   /**
    * Queries locators for a Geode server that has Protobuf enabled.
    *

--- a/geode-experimental-driver/src/test/java/org/apache/geode/experimental/driver/DriverConnectionTest.java
+++ b/geode-experimental-driver/src/test/java/org/apache/geode/experimental/driver/DriverConnectionTest.java
@@ -56,7 +56,7 @@ public class DriverConnectionTest {
   private int locatorPort;
 
   @Before
-  public void createServerAndDriver() throws Exception {
+  public void createServer() throws Exception {
     System.setProperty("geode.feature-protobuf-protocol", "true");
 
     // Create a cache
@@ -77,8 +77,6 @@ public class DriverConnectionTest {
     cache.close();
   }
 
-
-
   @Test
   public void driverFailsToConnectWhenThereAreNoServers() throws Exception {
     try {
@@ -96,6 +94,18 @@ public class DriverConnectionTest {
     server.setPort(0);
     server.start();
     driver = new DriverFactory().addLocator("localhost", locatorPort).create();
+    assertTrue(driver.isConnected());
   }
+
+  @Test
+  public void driverReportsItIsDisconnected() throws Exception {
+    CacheServer server = cache.addCacheServer();
+    server.setPort(0);
+    server.start();
+    driver = new DriverFactory().addLocator("localhost", locatorPort).create();
+    driver.close();
+    assertFalse(driver.isConnected());
+  }
+
 
 }


### PR DESCRIPTION
Turning off tcp-delay and setting socket buffer size to something reasonable.


@upthewaterspout @PivotalSarge @galen-pivotal @WireBaron 


Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
