### PR TITLE
GEODE-4290 add operation time statistics to the protobuf server

### DIFF
--- a/geode-client-protocol/src/main/java/org/apache/geode/internal/protocol/statistics/NoOpStatistics.java
+++ b/geode-client-protocol/src/main/java/org/apache/geode/internal/protocol/statistics/NoOpStatistics.java
@@ -44,4 +44,14 @@ public class NoOpStatistics implements ProtocolClientStatistics {
   public void incAuthenticationFailures() {
 
   }
+
+  @Override
+  public long startOperation() {
+    return 0;
+  }
+
+  @Override
+  public void endOperation(long startOperationTime) {
+
+  }
 }

--- a/geode-client-protocol/src/main/java/org/apache/geode/internal/protocol/statistics/ProtocolClientStatistics.java
+++ b/geode-client-protocol/src/main/java/org/apache/geode/internal/protocol/statistics/ProtocolClientStatistics.java
@@ -30,4 +30,16 @@ public interface ProtocolClientStatistics {
   void incAuthorizationViolations();
 
   void incAuthenticationFailures();
+
+  /**
+   * Invoke this at the start of an operation and then invoke endOperation in a finally block
+   */
+  long startOperation();
+
+  /**
+   * record the end of an operation. The parameter value should be from startOperation and
+   * endOperation must be invoked in the same thread as startOperation because we're using
+   * System.nanoTime()
+   */
+  void endOperation(long startOperationTime);
 }

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/statistics/ProtobufClientStatisticsImpl.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/statistics/ProtobufClientStatisticsImpl.java
@@ -35,6 +35,7 @@ public class ProtobufClientStatisticsImpl implements ProtocolClientStatistics {
   private final int messagesSentId;
   private final int authorizationViolationsId;
   private final int authenticationFailuresId;
+  private final int operationTimeId;
 
   public ProtobufClientStatisticsImpl(StatisticsFactory statisticsFactory, String statisticsName) {
     if (statisticsFactory == null) {
@@ -58,7 +59,9 @@ public class ProtobufClientStatisticsImpl implements ProtocolClientStatistics {
         statisticsFactory.createLongCounter("messagesReceived", "Messages received from clients.",
             "messages"),
         statisticsFactory.createLongCounter("messagesSent", "Messages sent to clients.",
-            "messages")};
+            "messages"),
+        statisticsFactory.createLongCounter("operationTime", "Time spent performing operations",
+            "nanoseconds")};
     statType = statisticsFactory.createType(getStatsName(), "Protobuf client/server statistics",
         serverStatDescriptors);
     this.stats = statisticsFactory.createAtomicStatistics(statType, statisticsName);
@@ -71,6 +74,7 @@ public class ProtobufClientStatisticsImpl implements ProtocolClientStatistics {
     bytesSentId = this.stats.nameToId("bytesSent");
     messagesReceivedId = this.stats.nameToId("messagesReceived");
     messagesSentId = this.stats.nameToId("messagesSent");
+    operationTimeId = this.stats.nameToId("operationTime");
   }
 
 
@@ -111,5 +115,15 @@ public class ProtobufClientStatisticsImpl implements ProtocolClientStatistics {
   @Override
   public void incAuthenticationFailures() {
     stats.incLong(authenticationFailuresId, 1);
+  }
+
+  @Override
+  public long startOperation() {
+    return System.nanoTime();
+  }
+
+  @Override
+  public void endOperation(long startOperationTime) {
+    stats.incLong(operationTimeId, System.nanoTime() - startOperationTime);
   }
 }

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/operations/GetAllRequestOperationHandler.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/operations/GetAllRequestOperationHandler.java
@@ -59,6 +59,7 @@ public class GetAllRequestOperationHandler
           .of(ProtobufResponseUtilities.makeErrorResponse(SERVER_ERROR, "Region not found"));
     }
 
+    long startTime = messageExecutionContext.getStatistics().startOperation();
     Map<Boolean, List<Object>> resultsCollection;
     try {
       ((InternalCache) messageExecutionContext.getCache()).setReadSerializedForCurrentThread(true);
@@ -68,6 +69,7 @@ public class GetAllRequestOperationHandler
           .collect(Collectors.partitioningBy(x -> x instanceof BasicTypes.Entry));
     } finally {
       ((InternalCache) messageExecutionContext.getCache()).setReadSerializedForCurrentThread(false);
+      messageExecutionContext.getStatistics().endOperation(startTime);
     }
     RegionAPI.GetAllResponse.Builder responseBuilder = RegionAPI.GetAllResponse.newBuilder();
 

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/operations/GetRequestOperationHandler.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/operations/GetRequestOperationHandler.java
@@ -52,6 +52,7 @@ public class GetRequestOperationHandler
       return Failure
           .of(ProtobufResponseUtilities.makeErrorResponse(SERVER_ERROR, "Region not found"));
     }
+    long startOperationTime = messageExecutionContext.getStatistics().startOperation();
 
     try {
       ((InternalCache) messageExecutionContext.getCache()).setReadSerializedForCurrentThread(true);
@@ -71,6 +72,7 @@ public class GetRequestOperationHandler
           ProtobufResponseUtilities.makeErrorResponse(INVALID_REQUEST, "Encoding not supported."));
     } finally {
       ((InternalCache) messageExecutionContext.getCache()).setReadSerializedForCurrentThread(false);
+      messageExecutionContext.getStatistics().endOperation(startOperationTime);
     }
   }
 }

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/operations/PutAllRequestOperationHandler.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/operations/PutAllRequestOperationHandler.java
@@ -59,10 +59,12 @@ public class PutAllRequestOperationHandler
           "Region passed does not exist: " + regionName));
     }
 
+    long startTime = messageExecutionContext.getStatistics().startOperation();
     RegionAPI.PutAllResponse.Builder builder = RegionAPI.PutAllResponse.newBuilder()
         .addAllFailedKeys(putAllRequest.getEntryList().stream()
             .map((entry) -> singlePut(serializationService, region, entry)).filter(Objects::nonNull)
             .collect(Collectors.toList()));
+    messageExecutionContext.getStatistics().endOperation(startTime);
     return Success.of(builder.build());
   }
 

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/operations/PutRequestOperationHandler.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/operations/PutRequestOperationHandler.java
@@ -52,6 +52,7 @@ public class PutRequestOperationHandler
           "Region passed by client did not exist: " + regionName));
     }
 
+    long startTime = messageExecutionContext.getStatistics().startOperation();
     try {
       BasicTypes.Entry entry = request.getEntry();
 
@@ -68,6 +69,8 @@ public class PutRequestOperationHandler
       logger.error("Got error when decoding Put request: {}", ex);
       return Failure
           .of(ProtobufResponseUtilities.makeErrorResponse(INVALID_REQUEST, ex.toString()));
+    } finally {
+      messageExecutionContext.getStatistics().endOperation(startTime);
     }
   }
 }

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/operations/RemoveRequestOperationHandler.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/operations/RemoveRequestOperationHandler.java
@@ -52,6 +52,7 @@ public class RemoveRequestOperationHandler
           .of(ProtobufResponseUtilities.makeErrorResponse(SERVER_ERROR, "Region not found"));
     }
 
+    long startTime = messageExecutionContext.getStatistics().startOperation();
     try {
       Object decodedKey = serializationService.decode(request.getKey());
       region.remove(decodedKey);
@@ -62,6 +63,8 @@ public class RemoveRequestOperationHandler
       logger.error("Received Remove request with unsupported encoding: {}", ex);
       return Failure.of(ProtobufResponseUtilities.makeErrorResponse(INVALID_REQUEST,
           "Encoding not supported: " + ex.getMessage()));
+    } finally {
+      messageExecutionContext.getStatistics().endOperation(startTime);
     }
   }
 }


### PR DESCRIPTION
Time spent processing operations is now captured using System.nanoTime().

@upthewaterspout @WireBaron @galen-pivotal @PivotalSarge 



Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
