### PR TITLE
GEODE-4298: Restore public access to StartServer method.

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/ServerLauncher.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/ServerLauncher.java
@@ -891,7 +891,7 @@ public class ServerLauncher extends AbstractLauncher<String> {
   /**
    * Causes the calling Thread to block until the GemFire Cache Server/Data Member stops.
    */
-  void waitOnServer() {
+  public void waitOnServer() {
     assert getCache() != null : "The Cache Server must first be started with a call to start!";
 
     if (!isServing(getCache())) {


### PR DESCRIPTION
Backwards compatability was inadvertently broken.  This restores the lost method's publicity.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
