### PR TITLE
GEODE-4305: encapsulate the concurrencyChecksEnabled field

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegion.java
@@ -171,7 +171,7 @@ public abstract class AbstractRegion implements InternalRegion, AttributesMutato
 
   protected int concurrencyLevel;
 
-  protected volatile boolean concurrencyChecksEnabled;
+  private volatile boolean concurrencyChecksEnabled;
 
   protected boolean earlyAck;
 
@@ -433,7 +433,7 @@ public abstract class AbstractRegion implements InternalRegion, AttributesMutato
     buf.append(getClass().getName());
     buf.append("[path='").append(getFullPath()).append("';scope=").append(getScope())
         .append("';dataPolicy=").append(this.dataPolicy);
-    if (this.concurrencyChecksEnabled) {
+    if (this.getConcurrencyChecksEnabled()) {
       buf.append("; concurrencyChecksEnabled");
     }
     return buf;
@@ -720,6 +720,10 @@ public abstract class AbstractRegion implements InternalRegion, AttributesMutato
   @Override
   public boolean getConcurrencyChecksEnabled() {
     return this.concurrencyChecksEnabled;
+  }
+
+  public void setConcurrencyChecksEnabled(boolean concurrencyChecksEnabled) {
+    this.concurrencyChecksEnabled = concurrencyChecksEnabled;
   }
 
   @Override
@@ -1602,8 +1606,8 @@ public abstract class AbstractRegion implements InternalRegion, AttributesMutato
     this.initialCapacity = attrs.getInitialCapacity();
     this.loadFactor = attrs.getLoadFactor();
     this.concurrencyLevel = attrs.getConcurrencyLevel();
-    this.concurrencyChecksEnabled =
-        attrs.getConcurrencyChecksEnabled() && supportsConcurrencyChecks();
+    this.setConcurrencyChecksEnabled(
+        attrs.getConcurrencyChecksEnabled() && supportsConcurrencyChecks());
     this.earlyAck = attrs.getEarlyAck();
     this.gatewaySenderIds = attrs.getGatewaySenderIds();
     this.asyncEventQueueIds = attrs.getAsyncEventQueueIds();
@@ -1840,11 +1844,6 @@ public abstract class AbstractRegion implements InternalRegion, AttributesMutato
   @Override
   public boolean getOffHeap() {
     return this.offHeap;
-  }
-
-  @Override
-  public boolean isConcurrencyChecksEnabled() {
-    return this.concurrencyChecksEnabled;
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractUpdateOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractUpdateOperation.java
@@ -85,9 +85,10 @@ public abstract class AbstractUpdateOperation extends DistributedCacheOperation 
   private static boolean shouldDoRemoteCreate(LocalRegion rgn, EntryEventImpl ev) {
     DataPolicy dp = rgn.getAttributes().getDataPolicy();
     if (!rgn.isAllEvents() || (dp.withReplication() && rgn.isInitialized()
-        && ev.getOperation().isUpdate() && !rgn.concurrencyChecksEnabled // misordered CREATE and
-                                                                         // UPDATE messages can
-                                                                         // cause inconsistencies
+        && ev.getOperation().isUpdate() && !rgn.getConcurrencyChecksEnabled()
+        // misordered CREATE and
+        // UPDATE messages can
+        // cause inconsistencies
         && !ALWAYS_REPLICATE_UPDATES)) {
       // we are not accepting all events
       // or we are a replicate and initialized and it was an update

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/BucketRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/BucketRegion.java
@@ -998,7 +998,7 @@ public class BucketRegion extends DistributedRegion implements Bucket {
     if (event.getOperation().isLocal()) { // bug #45402 - localDestroy generated a version tag
       return false;
     }
-    return this.concurrencyChecksEnabled
+    return this.getConcurrencyChecksEnabled()
         && ((event.getVersionTag() == null) || event.getVersionTag().isGatewayTag());
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistTXState.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistTXState.java
@@ -440,8 +440,9 @@ public class DistTXState extends TXState {
       if (dtop.op.isPutAll()) {
         assert (dtop.getPutAllOperation() != null);
         // [DISTTX] TODO what do with versions next?
-        final VersionedObjectList versions = new VersionedObjectList(
-            dtop.getPutAllOperation().putAllDataSize, true, dtop.region.concurrencyChecksEnabled);
+        final VersionedObjectList versions =
+            new VersionedObjectList(dtop.getPutAllOperation().putAllDataSize, true,
+                dtop.region.getConcurrencyChecksEnabled());
         postPutAll(dtop.getPutAllOperation(), versions, dtop.region);
       } else {
         result = putEntryOnRemote(dtop, false/* ifNew */, false/* ifOld */,
@@ -456,7 +457,7 @@ public class DistTXState extends TXState {
         // [DISTTX] TODO what do with versions next?
         final VersionedObjectList versions =
             new VersionedObjectList(dtop.getRemoveAllOperation().removeAllDataSize, true,
-                dtop.region.concurrencyChecksEnabled);
+                dtop.region.getConcurrencyChecksEnabled());
         postRemoveAll(dtop.getRemoveAllOperation(), versions, dtop.region);
       } else {
         destroyOnRemote(dtop, false/* TODO [DISTTX] */, null/*

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistTXStateOnCoordinator.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistTXStateOnCoordinator.java
@@ -333,8 +333,9 @@ public class DistTXStateOnCoordinator extends DistTXState implements DistTXCoord
       if (dtop.op.isPutAll()) {
         assert (dtop.getPutAllOperation() != null);
         // [DISTTX] TODO what do with versions next?
-        final VersionedObjectList versions = new VersionedObjectList(
-            dtop.getPutAllOperation().putAllDataSize, true, dtop.region.concurrencyChecksEnabled);
+        final VersionedObjectList versions =
+            new VersionedObjectList(dtop.getPutAllOperation().putAllDataSize, true,
+                dtop.region.getConcurrencyChecksEnabled());
         postPutAll(dtop.getPutAllOperation(), versions, dtop.region);
       } else {
         result = putEntry(dtop, false/* ifNew */, false/* ifOld */, null/* expectedOldValue */,
@@ -348,7 +349,7 @@ public class DistTXStateOnCoordinator extends DistTXState implements DistTXCoord
         // [DISTTX] TODO what do with versions next?
         final VersionedObjectList versions =
             new VersionedObjectList(dtop.getRemoveAllOperation().removeAllDataSize, true,
-                dtop.region.concurrencyChecksEnabled);
+                dtop.region.getConcurrencyChecksEnabled());
         postRemoveAll(dtop.getRemoveAllOperation(), versions, dtop.region);
       } else {
         destroyExistingEntry(dtop, false/* TODO [DISTTX] */, null/*

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedPutAllOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedPutAllOperation.java
@@ -225,7 +225,7 @@ public class DistributedPutAllOperation extends AbstractUpdateOperation {
     boolean returnedEv = false;
     try {
       ev.setPossibleDuplicate(entry.isPossibleDuplicate());
-      if (entry.versionTag != null && region.concurrencyChecksEnabled) {
+      if (entry.versionTag != null && region.getConcurrencyChecksEnabled()) {
         VersionSource id = entry.versionTag.getMemberID();
         if (id != null) {
           entry.versionTag.setMemberID(ev.getRegion().getVersionVector().getCanonicalId(id));
@@ -962,7 +962,7 @@ public class DistributedPutAllOperation extends AbstractUpdateOperation {
     // thread, so
     // we require an ACK if concurrency checks are enabled to make sure that the previous op has
     // finished first.
-    return super.shouldAck() || getRegion().concurrencyChecksEnabled;
+    return super.shouldAck() || getRegion().getConcurrencyChecksEnabled();
   }
 
   private PutAllEntryData[] selectVersionlessEntries() {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRemoveAllOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRemoveAllOperation.java
@@ -215,7 +215,7 @@ public class DistributedRemoveAllOperation extends AbstractUpdateOperation {
     try {
       ev.setPossibleDuplicate(entry.isPossibleDuplicate());
       ev.setIsRedestroyedEntry(entry.getRedestroyedEntry());
-      if (entry.versionTag != null && region.concurrencyChecksEnabled) {
+      if (entry.versionTag != null && region.getConcurrencyChecksEnabled()) {
         VersionSource id = entry.versionTag.getMemberID();
         if (id != null) {
           entry.versionTag.setMemberID(ev.getRegion().getVersionVector().getCanonicalId(id));
@@ -741,7 +741,7 @@ public class DistributedRemoveAllOperation extends AbstractUpdateOperation {
     // thread, so
     // we require an ACK if concurrency checks are enabled to make sure that the previous op has
     // finished first.
-    return super.shouldAck() || getRegion().concurrencyChecksEnabled;
+    return super.shouldAck() || getRegion().getConcurrencyChecksEnabled();
   }
 
   private RemoveAllEntryData[] selectVersionlessEntries() {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/EntryEventImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/EntryEventImpl.java
@@ -2732,8 +2732,8 @@ public class EntryEventImpl
    * returns true if it is okay to process this event even though it has a null version
    */
   public boolean noVersionReceivedFromServer() {
-    return versionTag == null && region.concurrencyChecksEnabled && region.getServerProxy() != null
-        && !op.isLocal() && !isOriginRemote();
+    return versionTag == null && region.getConcurrencyChecksEnabled()
+        && region.getServerProxy() != null && !op.isLocal() && !isOriginRemote();
   }
 
   /** returns a copy of this event with the additional fields for WAN conflict resolution */

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InitialImageOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InitialImageOperation.java
@@ -326,7 +326,7 @@ public class InitialImageOperation {
       Set keysOfUnfinishedOps = null;
       RegionVersionVector received_rvv = null;
       RegionVersionVector remote_rvv = null;
-      if (this.region.concurrencyChecksEnabled
+      if (this.region.getConcurrencyChecksEnabled()
           && recipient.getVersionObject().compareTo(Version.GFE_80) >= 0) {
         if (internalBeforeRequestRVV != null
             && internalBeforeRequestRVV.getRegionName().equals(this.region.getName())) {
@@ -430,7 +430,7 @@ public class InitialImageOperation {
       m.targetReinitialized = targetReinitialized;
       m.setRecipient(recipient);
 
-      if (this.region.concurrencyChecksEnabled) {
+      if (this.region.getConcurrencyChecksEnabled()) {
         if (allowDeltaGII && recoveredFromDisk) {
           if (!this.region.getDiskRegion().getRVVTrusted()) {
             if (isDebugEnabled) {
@@ -699,7 +699,7 @@ public class InitialImageOperation {
     // We have to check all of the received versions for members that
     // left during GII to see if the RVV contains them.
     RegionVersionVector rvv = this.region.getVersionVector();
-    if (this.region.concurrencyChecksEnabled && rvv != null) {
+    if (this.region.getConcurrencyChecksEnabled() && rvv != null) {
       ImageState state = this.region.getImageState();
       if (state.hasLeftMembers()) {
         Set<VersionSource> needsSync = null;
@@ -1722,14 +1722,14 @@ public class InitialImageOperation {
             }
           } else if (getSender().getVersionObject().compareTo(Version.GFE_80) < 0) {
             // older versions of the product expect a RegionStateMessage at this point
-            if (rgn.concurrencyChecksEnabled && this.versionVector == null
+            if (rgn.getConcurrencyChecksEnabled() && this.versionVector == null
                 && !recoveringForLostMember) {
               RegionVersionVector rvv = rgn.getVersionVector().getCloneForTransmission();
               RegionStateMessage.send(dm, getSender(), this.processorId, rvv, false);
             }
           }
           if (this.checkTombstoneVersions && this.versionVector != null
-              && rgn.concurrencyChecksEnabled) {
+              && rgn.getConcurrencyChecksEnabled()) {
             synchronized (rgn.getCache().getTombstoneService().getBlockGCLock()) {
               if (goWithFullGII(rgn, this.versionVector)) {
                 if (isGiiDebugEnabled) {
@@ -1901,8 +1901,8 @@ public class InitialImageOperation {
       ClusterDistributionManager dm = (ClusterDistributionManager) rgn.getDistributionManager();
 
       List chunkEntries = null;
-      chunkEntries =
-          new InitialImageVersionedEntryList(rgn.concurrencyChecksEnabled, MAX_ENTRIES_PER_CHUNK);
+      chunkEntries = new InitialImageVersionedEntryList(rgn.getConcurrencyChecksEnabled(),
+          MAX_ENTRIES_PER_CHUNK);
       DiskRegion dr = rgn.getDiskRegion();
       if (dr != null) {
         dr.setClearCountReference();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalRegion.java
@@ -97,8 +97,6 @@ public interface InternalRegion<K, V>
 
   IndexManager getIndexManager();
 
-  boolean isConcurrencyChecksEnabled();
-
   boolean isThisRegionBeingClosedOrDestroyed();
 
   CancelCriterion getCancelCriterion();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
@@ -700,7 +700,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
 
   /** returns object used to guard the size() operation during tombstone removal */
   Object getSizeGuard() {
-    if (!this.concurrencyChecksEnabled) {
+    if (!this.getConcurrencyChecksEnabled()) {
       return new Object();
     } else {
       return this.fullPath; // avoids creating another sync object - could be anything unique to
@@ -1920,7 +1920,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
   public boolean containsTombstone(Object key) {
     checkReadiness();
     checkForNoAccess();
-    if (!this.concurrencyChecksEnabled) {
+    if (!this.getConcurrencyChecksEnabled()) {
       return false;
     } else {
       try {
@@ -2037,7 +2037,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
       int result = getRegionMap().size();
       // if this is a client with no tombstones then we subtract the number
       // of entries being affected by register-interest refresh
-      if (this.imageState.isClient() && !this.concurrencyChecksEnabled) {
+      if (this.imageState.isClient() && !this.getConcurrencyChecksEnabled()) {
         return result - this.imageState.getDestroyedEntriesCount();
       }
       return result - this.tombstoneCount.get();
@@ -2283,7 +2283,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
     }
 
     // if we're versioning entries we need a region-level version vector
-    if (this.concurrencyChecksEnabled && this.versionVector == null) {
+    if (this.getConcurrencyChecksEnabled() && this.versionVector == null) {
       createVersionVector();
     }
     // if not local, then recovery happens in InitialImageOperation
@@ -2687,7 +2687,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
       } else {
         closeAllCallbacks();
       }
-      if (this.concurrencyChecksEnabled && this.dataPolicy.withReplication()
+      if (this.getConcurrencyChecksEnabled() && this.dataPolicy.withReplication()
           && !this.cache.isClosed()) {
         this.cache.getTombstoneService().unscheduleTombstones(this);
       }
@@ -2779,7 +2779,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
 
     // don't allow tombstones into a client cache if it doesn't
     // have concurrency checks enabled
-    if (fromServer && value == Token.TOMBSTONE && !this.concurrencyChecksEnabled) {
+    if (fromServer && value == Token.TOMBSTONE && !this.getConcurrencyChecksEnabled()) {
       value = null;
     }
 
@@ -3267,7 +3267,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
    */
   public void expireTombstones(Map<VersionSource, Long> regionGCVersions, EventID eventID,
       FilterInfo clientRouting) {
-    if (!this.concurrencyChecksEnabled) {
+    if (!this.getConcurrencyChecksEnabled()) {
       return;
     }
     Set<Object> keys = null;
@@ -3285,7 +3285,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
   }
 
   public void expireTombstoneKeys(Set<Object> tombstoneKeys) {
-    if (this.concurrencyChecksEnabled) {
+    if (this.getConcurrencyChecksEnabled()) {
       this.cache.getTombstoneService().gcTombstoneKeys(this, tombstoneKeys);
     }
   }
@@ -3329,13 +3329,13 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
     if (this.getDataPolicy().withPersistence()) {
       return true;
     } else {
-      return this.concurrencyChecksEnabled
+      return this.getConcurrencyChecksEnabled()
           && (entry.getVersionStamp().hasValidVersion() || this.dataPolicy.withReplication());
     }
   }
 
   protected void enableConcurrencyChecks() {
-    this.concurrencyChecksEnabled = true;
+    this.setConcurrencyChecksEnabled(true);
     if (this.dataPolicy.withStorage()) {
       RegionEntryFactory versionedEntryFactory = this.entries.getEntryFactory().makeVersioned();
       Assert.assertTrue(this.entries.isEmpty(),
@@ -3346,7 +3346,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
   }
 
   protected boolean getEnableConcurrencyChecks() {
-    return this.concurrencyChecksEnabled;
+    return this.getConcurrencyChecksEnabled();
   }
 
   /**
@@ -4277,7 +4277,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
             Object val = entry.getObject();
             boolean isBytes = entry.isBytes();
             boolean isKeyOnServer = !entry.isKeyNotOnServer();
-            boolean isTombstone = this.concurrencyChecksEnabled && entry.isKeyNotOnServer()
+            boolean isTombstone = this.getConcurrencyChecksEnabled() && entry.isKeyNotOnServer()
                 && entry.getVersionTag() != null;
             final VersionTag tag = entry.getVersionTag();
             if (val instanceof Throwable) {
@@ -4529,7 +4529,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
 
         // If versioning is enabled, we will give the entry a "fake" version.
         VersionTag tag = null;
-        if (this.concurrencyChecksEnabled) {
+        if (this.getConcurrencyChecksEnabled()) {
           tag = VersionTag.create(getVersionMember());
         }
         map.initialImagePut(key, cacheTimeMillis(), value, false, false, tag, null, false);
@@ -4796,7 +4796,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
   @Override
   public void recordRecoveredVersonHolder(VersionSource member, RegionVersionHolder versionHolder,
       boolean latestOplog) {
-    if (this.concurrencyChecksEnabled) {
+    if (this.getConcurrencyChecksEnabled()) {
       // We need to update the RVV in memory
       this.versionVector.initRecoveredVersion(member, versionHolder, latestOplog);
       DiskRegion region = this.getDiskRegion();
@@ -4809,7 +4809,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
 
   @Override
   public void recordRecoveredVersionTag(VersionTag tag) {
-    if (this.concurrencyChecksEnabled) {
+    if (this.getConcurrencyChecksEnabled()) {
       this.versionVector.recordVersion(tag.getMemberID(), tag.getRegionVersion());
       DiskRegion region = this.getDiskRegion();
       // We also need to update the RVV that represents what we have persisted on disk
@@ -4821,7 +4821,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
 
   @Override
   public void setRVVTrusted(boolean rvvTrusted) {
-    if (this.concurrencyChecksEnabled) {
+    if (this.getConcurrencyChecksEnabled()) {
       DiskRegion region = this.getDiskRegion();
       // Update whether or not the RVV we have recovered is trusted (accurately represents what we
       // have on disk).
@@ -4919,7 +4919,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
         logger.trace(LogMarker.DM, "LR.basicInvalidate: this cache has already seen this event {}",
             event);
       }
-      if (this.concurrencyChecksEnabled && event.getVersionTag() != null
+      if (this.getConcurrencyChecksEnabled() && event.getVersionTag() != null
           && !event.getVersionTag().isRecorded()) {
         getVersionVector().recordVersion((InternalDistributedMember) event.getDistributedMember(),
             event.getVersionTag());
@@ -5248,11 +5248,12 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
    * expectations
    */
   private void concurrencyConfigurationCheck(VersionTag tag) {
-    if (!this.concurrencyMessageIssued && tag == null && this.concurrencyChecksEnabled) {
+    if (!this.concurrencyMessageIssued && tag == null && this.getConcurrencyChecksEnabled()) {
       this.concurrencyMessageIssued = true;
       logger.info(LocalizedMessage.create(
           LocalizedStrings.LocalRegion_SERVER_HAS_CONCURRENCY_CHECKS_ENABLED_0_BUT_CLIENT_HAS_1_FOR_REGION_2,
-          new Object[] {!this.concurrencyChecksEnabled, this.concurrencyChecksEnabled, this}));
+          new Object[] {!this.getConcurrencyChecksEnabled(), this.getConcurrencyChecksEnabled(),
+              this}));
     }
   }
 
@@ -5347,7 +5348,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
         // callbacks.
         if (processedMarker) {
           // changed to force new entry creation for consistency
-          final boolean forceNewEntry = this.concurrencyChecksEnabled;
+          final boolean forceNewEntry = this.getConcurrencyChecksEnabled();
           basicInvalidate(event, true, forceNewEntry);
           if (event.isConcurrencyConflict()) {
             // bug #45520 - we must throw this for the CacheClientUpdater
@@ -5541,7 +5542,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
         logger.trace(LogMarker.DM, "LR.basicDestroy: this cache has already seen this event {}",
             event);
       }
-      if (this.concurrencyChecksEnabled && event.getVersionTag() != null
+      if (this.getConcurrencyChecksEnabled() && event.getVersionTag() != null
           && !event.getVersionTag().isRecorded()) {
         getVersionVector().recordVersion((InternalDistributedMember) event.getDistributedMember(),
             event.getVersionTag());
@@ -5955,11 +5956,6 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
   @Override
   public void recordEvent(InternalCacheEvent event) {
     getEventTracker().recordEvent(event);
-  }
-
-  @Override
-  public boolean isConcurrencyChecksEnabled() {
-    return this.concurrencyChecksEnabled;
   }
 
   /**
@@ -6391,7 +6387,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
         logger.trace(LogMarker.DM, "LR.basicDestroy: this cache has already seen this event {}",
             event);
       }
-      if (this.concurrencyChecksEnabled && event.getVersionTag() != null
+      if (this.getConcurrencyChecksEnabled() && event.getVersionTag() != null
           && !event.getVersionTag().isRecorded()) {
         getVersionVector().recordVersion((InternalDistributedMember) event.getDistributedMember(),
             event.getVersionTag());
@@ -6647,7 +6643,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
      * completes. RI does not create Tombstones because it would flood the TombstoneService with
      * unnecessary work.
      */
-    if (inTokenMode && !(this.concurrencyChecksEnabled || event.isFromRILocalDestroy())) {
+    if (inTokenMode && !(this.getConcurrencyChecksEnabled() || event.isFromRILocalDestroy())) {
       if (re.isDestroyed()) {
         getImageState().addDestroyedEntry(event.getKey());
         if (!(this instanceof HARegion)) {
@@ -6657,7 +6653,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
         }
       }
     } else {
-      if (this.concurrencyChecksEnabled && !(this instanceof HARegion)) {
+      if (this.getConcurrencyChecksEnabled() && !(this instanceof HARegion)) {
         if (logger.isDebugEnabled()) {
           logger.debug("basicDestroyPart2: {}, version={}", event.getKey(), v);
         }
@@ -8948,7 +8944,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
   // TODO: what does cmn refer to?
   void cmnClearRegion(RegionEventImpl regionEvent, boolean cacheWrite, boolean useRVV) {
     RegionVersionVector rvv = null;
-    if (useRVV && this.dataPolicy.withReplication() && this.concurrencyChecksEnabled) {
+    if (useRVV && this.dataPolicy.withReplication() && this.getConcurrencyChecksEnabled()) {
       rvv = this.versionVector.getCloneForTransmission();
     }
     clearRegionLocally(regionEvent, cacheWrite, rvv);
@@ -9192,7 +9188,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
           // in 8.0 we added transfer of tombstones with RI/getAll results for bug #40791
           boolean createTombstone = false;
           if (notOnServer) {
-            createTombstone = entry.getVersionTag() != null && this.concurrencyChecksEnabled;
+            createTombstone = entry.getVersionTag() != null && this.getConcurrencyChecksEnabled();
             allResults.put(key, null);
             if (isDebugEnabled) {
               logger.debug("Added remote result for missing key: {}", key);
@@ -9513,7 +9509,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
     }
 
     final VersionedObjectList succeeded =
-        new VersionedObjectList(map.size(), true, this.concurrencyChecksEnabled);
+        new VersionedObjectList(map.size(), true, this.getConcurrencyChecksEnabled());
 
     // if this is a transactional putAll, we will not have version information as it is only
     // generated at commit
@@ -9566,7 +9562,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
                 if (isDebugEnabled) {
                   logger.debug("putAll key {} -> {} version={}", key, value, versionTag);
                 }
-                if (versionTag == null && serverIsVersioned && concurrencyChecksEnabled
+                if (versionTag == null && serverIsVersioned && getConcurrencyChecksEnabled()
                     && dataPolicy.withStorage()) {
                   // server was unable to determine the version for this operation.
                   // I'm not sure this can still happen as described below on a pr.
@@ -9729,7 +9725,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
     }
 
     final VersionedObjectList succeeded =
-        new VersionedObjectList(keys.size(), true, this.concurrencyChecksEnabled);
+        new VersionedObjectList(keys.size(), true, this.getConcurrencyChecksEnabled());
 
     // If this is a transactional removeAll, we will not have version information as it is only
     // generated at commit
@@ -10086,7 +10082,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
   public void postPutAllFireEvents(DistributedPutAllOperation putAllOp,
       VersionedObjectList successfulPuts) {
 
-    if (!this.dataPolicy.withStorage() && this.concurrencyChecksEnabled
+    if (!this.dataPolicy.withStorage() && this.getConcurrencyChecksEnabled()
         && putAllOp.getBaseEvent().isBridgeEvent()) {
       // if there is no local storage we need to transfer version information
       // to the successfulPuts list for transmission back to the client
@@ -10120,7 +10116,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
   public void postRemoveAllFireEvents(DistributedRemoveAllOperation removeAllOp,
       VersionedObjectList successfulOps) {
 
-    if (!this.dataPolicy.withStorage() && this.concurrencyChecksEnabled
+    if (!this.dataPolicy.withStorage() && this.getConcurrencyChecksEnabled()
         && removeAllOp.getBaseEvent().isBridgeEvent()) {
       // if there is no local storage we need to transfer version information
       // to the successfulOps list for transmission back to the client
@@ -10259,7 +10255,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
    * @return true if synchronization should be attempted
    */
   public boolean shouldSyncForCrashedMember(InternalDistributedMember id) {
-    return this.concurrencyChecksEnabled && this.dataPolicy.withReplication()
+    return this.getConcurrencyChecksEnabled() && this.dataPolicy.withReplication()
         && !this.isUsedForPartitionedRegionAdmin && !this.isUsedForMetaRegion
         && !this.isUsedForSerialGatewaySenderQueue;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegionDataView.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegionDataView.java
@@ -313,7 +313,7 @@ public class LocalRegionDataView implements InternalDataView {
   @Override
   public void postPutAll(DistributedPutAllOperation putallOp, VersionedObjectList successfulPuts,
       LocalRegion region) {
-    if (!region.dataPolicy.withStorage() && region.concurrencyChecksEnabled
+    if (!region.dataPolicy.withStorage() && region.getConcurrencyChecksEnabled()
         && putallOp.getBaseEvent().isBridgeEvent()) {
       // if there is no local storage we need to transfer version information
       // to the successfulPuts list for transmission back to the client
@@ -335,7 +335,7 @@ public class LocalRegionDataView implements InternalDataView {
   @Override
   public void postRemoveAll(DistributedRemoveAllOperation op, VersionedObjectList successfulOps,
       LocalRegion region) {
-    if (!region.dataPolicy.withStorage() && region.concurrencyChecksEnabled
+    if (!region.dataPolicy.withStorage() && region.getConcurrencyChecksEnabled()
         && op.getBaseEvent().isBridgeEvent()) {
       // if there is no local storage we need to transfer version information
       // to the successfulOps list for transmission back to the client

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
@@ -56,8 +56,6 @@ import org.apache.geode.StatisticsFactory;
 import org.apache.geode.SystemFailure;
 import org.apache.geode.cache.AttributesFactory;
 import org.apache.geode.cache.AttributesMutator;
-import org.apache.geode.cache.Cache;
-import org.apache.geode.cache.CacheClosedException;
 import org.apache.geode.cache.CacheException;
 import org.apache.geode.cache.CacheListener;
 import org.apache.geode.cache.CacheLoader;
@@ -903,12 +901,12 @@ public class PartitionedRegion extends LocalRegion
 
   private void createAndValidatePersistentConfig() {
     DiskStoreImpl dsi = this.getDiskStore();
-    if (this.dataPolicy.withPersistence() && !this.concurrencyChecksEnabled
+    if (this.dataPolicy.withPersistence() && !this.getConcurrencyChecksEnabled()
         && supportsConcurrencyChecks()) {
       logger.info(LocalizedMessage.create(
           LocalizedStrings.PartitionedRegion_ENABLING_CONCURRENCY_CHECKS_FOR_PERSISTENT_PR,
           this.getFullPath()));
-      this.concurrencyChecksEnabled = true;
+      this.setConcurrencyChecksEnabled(true);
     }
     if (dsi != null && this.getDataPolicy().withPersistence()) {
       String colocatedWith = colocatedWithRegion == null ? "" : colocatedWithRegion.getFullPath();
@@ -1005,7 +1003,7 @@ public class PartitionedRegion extends LocalRegion
       // after toggling the concurrencyChecksEnabled flag. This is
       // required because for persistent regions, we enforce concurrencyChecks
       if (!this.isDataStore() && supportsConcurrencyChecks()) {
-        this.concurrencyChecksEnabled = !this.concurrencyChecksEnabled;
+        this.setConcurrencyChecksEnabled(!this.getConcurrencyChecksEnabled());
         new CreateRegionProcessor(this).initializeRegion();
       } else {
         throw e;
@@ -2052,7 +2050,7 @@ public class PartitionedRegion extends LocalRegion
     }
     if (!result) {
       checkReadiness();
-      if (!ifNew && !ifOld && !this.concurrencyChecksEnabled) {
+      if (!ifNew && !ifOld && !this.getConcurrencyChecksEnabled()) {
         // may fail due to concurrency conflict
         // failed for unknown reason
         // throw new PartitionedRegionStorageException("unable to execute operation");
@@ -2176,7 +2174,7 @@ public class PartitionedRegion extends LocalRegion
         if (versions.size() > 0) {
           partialKeys.addKeysAndVersions(versions);
           versions.saveVersions(keyToVersionMap);
-        } else if (!this.concurrencyChecksEnabled) { // no keys returned if not versioned
+        } else if (!this.getConcurrencyChecksEnabled()) { // no keys returned if not versioned
           Set keys = prMsg.getKeys();
           partialKeys.addKeys(keys);
         }
@@ -2267,7 +2265,7 @@ public class PartitionedRegion extends LocalRegion
         if (versions.size() > 0) {
           partialKeys.addKeysAndVersions(versions);
           versions.saveVersions(keyToVersionMap);
-        } else if (!this.concurrencyChecksEnabled) { // no keys returned if not versioned
+        } else if (!this.getConcurrencyChecksEnabled()) { // no keys returned if not versioned
           Set keys = prMsg.getKeys();
           partialKeys.addKeys(keys);
         }
@@ -8032,7 +8030,7 @@ public class PartitionedRegion extends LocalRegion
   @Override
   protected void enableConcurrencyChecks() {
     if (supportsConcurrencyChecks()) {
-      this.concurrencyChecksEnabled = true;
+      this.setConcurrencyChecksEnabled(true);
       assert !isDataStore();
     }
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegionDataStore.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegionDataStore.java
@@ -695,7 +695,7 @@ public class PartitionedRegionDataStore implements HasCachePerfStats {
     } else {
       factory.setScope(Scope.DISTRIBUTED_ACK);
     }
-    factory.setConcurrencyChecksEnabled(this.partitionedRegion.concurrencyChecksEnabled);
+    factory.setConcurrencyChecksEnabled(this.partitionedRegion.getConcurrencyChecksEnabled());
     factory.setIndexMaintenanceSynchronous(this.partitionedRegion.getIndexMaintenanceSynchronous());
 
     if (this.partitionedRegion.getValueConstraint() != null) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/RemotePutAllMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/RemotePutAllMessage.java
@@ -370,7 +370,7 @@ public class RemotePutAllMessage extends RemoteOperationMessageWithDirectReply {
           new DistributedPutAllOperation(baseEvent, putAllDataCount, false);
       try {
         final VersionedObjectList versions =
-            new VersionedObjectList(putAllDataCount, true, dr.concurrencyChecksEnabled);
+            new VersionedObjectList(putAllDataCount, true, dr.getConcurrencyChecksEnabled());
         dr.syncBulkOp(new Runnable() {
           @SuppressWarnings("synthetic-access")
           public void run() {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/RemoteRemoveAllMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/RemoteRemoveAllMessage.java
@@ -360,7 +360,7 @@ public class RemoteRemoveAllMessage extends RemoteOperationMessageWithDirectRepl
           new DistributedRemoveAllOperation(baseEvent, removeAllDataCount, false);
       try {
         final VersionedObjectList versions =
-            new VersionedObjectList(removeAllDataCount, true, dr.concurrencyChecksEnabled);
+            new VersionedObjectList(removeAllDataCount, true, dr.getConcurrencyChecksEnabled());
         dr.syncBulkOp(new Runnable() {
           @SuppressWarnings("synthetic-access")
           public void run() {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXEntryState.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXEntryState.java
@@ -1862,7 +1862,7 @@ public class TXEntryState implements Releasable {
     DataSerializer.writeObject(getFilterRoutingInfo(), out);
     if (sendVersionTag) {
       DataSerializer.writeObject(getVersionTag(), out);
-      assert getVersionTag() != null || !txRegionState.getRegion().concurrencyChecksEnabled
+      assert getVersionTag() != null || !txRegionState.getRegion().getConcurrencyChecksEnabled()
           || txRegionState.getRegion().dataPolicy != DataPolicy.REPLICATE : "tag:" + getVersionTag()
               + " r:" + txRegionState.getRegion() + " op:" + opToString() + " key:";
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/AbstractRegionEntry.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/AbstractRegionEntry.java
@@ -892,7 +892,7 @@ public abstract class AbstractRegionEntry implements RegionEntry, HashEntry<Obje
 
       boolean removeEntry = false;
       VersionTag v = event.getVersionTag();
-      if (region.isConcurrencyChecksEnabled() && !removeRecoveredEntry
+      if (region.getConcurrencyChecksEnabled() && !removeRecoveredEntry
           && !event.isFromRILocalDestroy()) {
         // bug #46780, don't retain tombstones for entries destroyed for register-interest
         // Destroy will write a tombstone instead

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/DiskEntry.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/DiskEntry.java
@@ -938,7 +938,7 @@ public interface DiskEntry extends RegionEntry {
           } else {
             // If we have concurrency checks enabled for a persistent region, we need
             // to add an entry to the async queue for every update to maintain the RVV
-            boolean maintainRVV = region.isConcurrencyChecksEnabled();
+            boolean maintainRVV = region.getConcurrencyChecksEnabled();
 
             if (!did.isPendingAsync() || maintainRVV) {
               // if the entry is not async, we need to schedule it
@@ -1571,7 +1571,7 @@ public interface DiskEntry extends RegionEntry {
       } else {
         // If we have concurrency checks enabled for a persistent region, we need
         // to add an entry to the async queue for every update to maintain the RVV
-        boolean maintainRVV = region.isConcurrencyChecksEnabled() && dr.isBackup();
+        boolean maintainRVV = region.getConcurrencyChecksEnabled() && dr.isBackup();
         if (!did.isPendingAsync() || maintainRVV) {
           did.setPendingAsync(true);
           VersionTag tag = null;

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/AbstractRegionJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/AbstractRegionJUnitTest.java
@@ -560,11 +560,6 @@ public class AbstractRegionJUnitTest {
     }
 
     @Override
-    public boolean isConcurrencyChecksEnabled() {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
     public boolean isThisRegionBeingClosedOrDestroyed() {
       throw new UnsupportedOperationException();
     }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/ClientServerInvalidAndDestroyedEntryDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/ClientServerInvalidAndDestroyedEntryDUnitTest.java
@@ -475,16 +475,18 @@ public class ClientServerInvalidAndDestroyedEntryDUnitTest extends JUnit4CacheTe
                 event.setRegion(bucket);
                 org.apache.geode.test.dunit.LogWriterUtils.getLogWriter()
                     .info("performing local destroy in " + bucket + " ccEnabled="
-                        + bucket.concurrencyChecksEnabled + " rvv=" + bucket.getVersionVector());
-                bucket.concurrencyChecksEnabled = false; // turn off cc so entry is removed
+                        + bucket.getConcurrencyChecksEnabled() + " rvv="
+                        + bucket.getVersionVector());
+                bucket.setConcurrencyChecksEnabled(false); // turn off cc so entry is removed
                 bucket.mapDestroy(event, false, false, null);
-                bucket.concurrencyChecksEnabled = true;
+                bucket.setConcurrencyChecksEnabled(true);
               }
             } else {
-              ((LocalRegion) myRegion).concurrencyChecksEnabled = false; // turn off cc so entry is
-                                                                         // removed
+              ((LocalRegion) myRegion).setConcurrencyChecksEnabled(false); // turn off cc so entry
+                                                                           // is
+              // removed
               ((LocalRegion) myRegion).mapDestroy(event, false, false, null);
-              ((LocalRegion) myRegion).concurrencyChecksEnabled = true;
+              ((LocalRegion) myRegion).setConcurrencyChecksEnabled(true);
             }
           }
         };


### PR DESCRIPTION
The concurrencyChecksEnabled is now always accessed using
getConcurrencyChecksEnabled and setConcurrencyChecksEnabled.
