### PR TITLE
GEODE-4332: Gfsh start locator should not retrieve cluster status when --connect=false

### DIFF
--- a/geode-assembly/src/test/java/org/apache/geode/management/internal/cli/commands/StartLocatorAcceptanceTest.java
+++ b/geode-assembly/src/test/java/org/apache/geode/management/internal/cli/commands/StartLocatorAcceptanceTest.java
@@ -40,17 +40,11 @@ public class StartLocatorAcceptanceTest {
   }
 
   @Test
-  public void startLocatorWithConnectFalseShouldNotBeConnected() throws Exception {
-    GfshExecution execution =
-        GfshScript.of("start locator --name=locator1 --connect=false").execute(gfshRule);
-    assertThat(execution.getOutputText()).doesNotContain("Successfully connected to: JMX Manager");
-  }
-
-  @Test
-  public void startLocatorWithConnectFalseShouldNotRetrieveClusterConfigurationStatus()
+  public void startLocatorWithConnectFalseShouldNotBeConnectedAndNotRetrieveClusterConfigurationStatus()
       throws Exception {
     GfshExecution execution =
         GfshScript.of("start locator --name=locator1 --connect=false").execute(gfshRule);
+    assertThat(execution.getOutputText()).doesNotContain("Successfully connected to: JMX Manager");
     assertThat(execution.getOutputText())
         .doesNotContain("Cluster configuration service is up and running.");
   }

--- a/geode-assembly/src/test/java/org/apache/geode/management/internal/cli/commands/StartLocatorAcceptanceTest.java
+++ b/geode-assembly/src/test/java/org/apache/geode/management/internal/cli/commands/StartLocatorAcceptanceTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.management.internal.cli.commands;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.test.junit.categories.AcceptanceTest;
+import org.apache.geode.test.junit.rules.gfsh.GfshExecution;
+import org.apache.geode.test.junit.rules.gfsh.GfshRule;
+import org.apache.geode.test.junit.rules.gfsh.GfshScript;
+
+@Category(AcceptanceTest.class)
+public class StartLocatorAcceptanceTest {
+  @Rule
+  public GfshRule gfshRule = new GfshRule();
+
+  @Test
+  public void startLocatorWithAutoConnectShouldBeConnectedAndRetrieveClusterConfigurationStatus()
+      throws Exception {
+    GfshExecution execution = GfshScript.of("start locator --name=locator1").execute(gfshRule);
+    assertThat(execution.getOutputText()).contains("Successfully connected to: JMX Manager");
+    assertThat(execution.getOutputText())
+        .contains("Cluster configuration service is up and running.");
+  }
+
+  @Test
+  public void startLocatorWithConnectFalseShouldNotBeConnected() throws Exception {
+    GfshExecution execution =
+        GfshScript.of("start locator --name=locator1 --connect=false").execute(gfshRule);
+    assertThat(execution.getOutputText()).doesNotContain("Successfully connected to: JMX Manager");
+  }
+
+  @Test
+  public void startLocatorWithConnectFalseShouldNotRetrieveClusterConfigurationStatus()
+      throws Exception {
+    GfshExecution execution =
+        GfshScript.of("start locator --name=locator1 --connect=false").execute(gfshRule);
+    assertThat(execution.getOutputText())
+        .doesNotContain("Cluster configuration service is up and running.");
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartLocatorCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartLocatorCommand.java
@@ -294,12 +294,12 @@ public class StartLocatorCommand implements GfshCommand {
     // Else, ask the user to use the "connect" command to connect to the Locator.
     if (shouldAutoConnect(connect)) {
       doAutoConnect(locatorHostName, locatorPort, configProperties, infoResultData);
-    }
 
-    // Report on the state of the Shared Configuration service if enabled...
-    if (enableSharedConfiguration) {
-      infoResultData.addLine(ClusterConfigurationStatusRetriever.fromLocator(locatorHostName,
-          locatorPort, configProperties));
+      // Report on the state of the Shared Configuration service if enabled...
+      if (enableSharedConfiguration) {
+        infoResultData.addLine(ClusterConfigurationStatusRetriever.fromLocator(locatorHostName,
+            locatorPort, configProperties));
+      }
     }
 
     return ResultBuilder.buildResult(infoResultData);


### PR DESCRIPTION
Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
