### PR TITLE
GEODE-4139: Add javac processor to ensure correct RunWith options are…

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -21,5 +21,7 @@ repositories {
 }
 
 dependencies {
-  compile group: 'org.apache.mina', name: 'mina-core', version: '2.0.14'
+  compile group: 'org.apache.geode', name: 'geode-junit', version: '1.3.0'
+  compile group: 'junit', name: 'junit', version: '4.12'
+  compile files("${System.getProperty('java.home')}/../lib/tools.jar")
 }

--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/TestPropertiesWriter.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/TestPropertiesWriter.groovy
@@ -18,8 +18,6 @@
 
 package org.apache.geode.gradle;
 
-import org.apache.mina.util.AvailablePortFinder;
-
 public class TestPropertiesWriter {
   public static void writeTestProperties(File parent, String name) {
     Properties props = new Properties();

--- a/buildSrc/src/main/java/org/apache/geode/javac/EnsureCorrectRunsWithProcessor.java
+++ b/buildSrc/src/main/java/org/apache/geode/javac/EnsureCorrectRunsWithProcessor.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.javac;
+
+import java.util.Set;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.Messager;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.MirroredTypeException;
+import javax.tools.Diagnostic;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactory;
+
+@SupportedAnnotationTypes("org.junit.runner.RunWith")
+@SupportedSourceVersion(SourceVersion.RELEASE_8)
+public class EnsureCorrectRunsWithProcessor extends AbstractProcessor {
+
+  private static final String RUNWITH = RunWith.class.getCanonicalName();
+
+  private Messager messager;
+
+  @Override
+  public synchronized void init(ProcessingEnvironment env) {
+    super.init(env);
+    messager = env.getMessager();
+  }
+
+  @Override
+  public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+    boolean hasErrors = false;
+
+    for (Element annotatedElement : roundEnv.getElementsAnnotatedWith(RunWith.class)) {
+      if (annotatedElement.getKind() != ElementKind.CLASS) {
+        continue;
+      }
+
+      TypeElement typeElement = (TypeElement) annotatedElement;
+
+      boolean hasUseParameterizedRunnerFactory = false;
+      boolean hasRunWithParameterized = false;
+
+      for (AnnotationMirror am : typeElement.getAnnotationMirrors()) {
+        String clazz = am.getAnnotationType().toString();
+        if (clazz.equals(RunWith.class.getCanonicalName())) {
+          hasRunWithParameterized = isRunWithParameterized(typeElement);
+        }
+
+        if (clazz.equals(Parameterized.UseParametersRunnerFactory.class.getCanonicalName())) {
+          hasUseParameterizedRunnerFactory = isUseParameterizedRunnerFactory(typeElement);
+        }
+      }
+
+      if (hasRunWithParameterized && !hasUseParameterizedRunnerFactory) {
+        error(typeElement, "class is annotated with @RunWith(Parameterized.class) but is missing the annotation @Parameterized.UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)");
+        hasErrors = true;
+      }
+    }
+
+    return hasErrors;
+  }
+
+  private boolean isRunWithParameterized(TypeElement typeElement) {
+    RunWith runWith = typeElement.getAnnotation(RunWith.class);
+
+    String runWithValue;
+    try {
+      runWithValue = runWith.value().getSimpleName();
+    } catch (MirroredTypeException mex) {
+      DeclaredType classTypeMirror = (DeclaredType) mex.getTypeMirror();
+      TypeElement classTypeElement = (TypeElement) classTypeMirror.asElement();
+      runWithValue = classTypeElement.getSimpleName().toString();
+    }
+
+    if (runWithValue == null) {
+      return false;
+    }
+
+    return runWithValue.equals(Parameterized.class.getCanonicalName())
+        || runWithValue.equals(Parameterized.class.getSimpleName());
+  }
+
+  private boolean isUseParameterizedRunnerFactory(TypeElement typeElement) {
+    Parameterized.UseParametersRunnerFactory
+        runnerFactory = typeElement.getAnnotation(Parameterized.UseParametersRunnerFactory.class);
+
+    String runnerFactoryValue;
+    try {
+      runnerFactoryValue = runnerFactory.value().getSimpleName();
+    } catch (MirroredTypeException mex) {
+      DeclaredType classTypeMirror = (DeclaredType) mex.getTypeMirror();
+      TypeElement classTypeElement = (TypeElement) classTypeMirror.asElement();
+      runnerFactoryValue = classTypeElement.getSimpleName().toString();
+    }
+
+    if (runnerFactoryValue == null) {
+      return false;
+    }
+
+    return runnerFactoryValue.equals(CategoryWithParameterizedRunnerFactory.class.getCanonicalName())
+        || runnerFactoryValue.equals(CategoryWithParameterizedRunnerFactory.class.getSimpleName());
+  }
+
+  private void error(Element e, String msg, Object... args) {
+    messager.printMessage(
+        Diagnostic.Kind.ERROR,
+        String.format(msg, args),
+        e);
+  }
+}

--- a/buildSrc/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/buildSrc/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+org.apache.geode.javac.EnsureCorrectRunsWithProcessor

--- a/buildSrc/src/test/java/org/apache/geode/javac/SimpleClassFile.java
+++ b/buildSrc/src/test/java/org/apache/geode/javac/SimpleClassFile.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.javac;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URI;
+
+import javax.tools.SimpleJavaFileObject;
+
+public class SimpleClassFile extends SimpleJavaFileObject {
+
+  private ByteArrayOutputStream out;
+
+  public SimpleClassFile(URI uri) {
+    super(uri, Kind.CLASS);
+  }
+
+  @Override
+  public OutputStream openOutputStream() throws IOException {
+    return out = new ByteArrayOutputStream();
+  }
+
+  public byte[] getCompiledBinaries() {
+    return out.toByteArray();
+  }
+
+}

--- a/buildSrc/src/test/java/org/apache/geode/javac/SimpleFileManager.java
+++ b/buildSrc/src/test/java/org/apache/geode/javac/SimpleFileManager.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.javac;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.tools.FileObject;
+import javax.tools.ForwardingJavaFileManager;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardJavaFileManager;
+
+public class SimpleFileManager extends ForwardingJavaFileManager<StandardJavaFileManager> {
+
+  private List<SimpleClassFile> compiled = new ArrayList<>();
+
+  public SimpleFileManager(StandardJavaFileManager fileManager) {
+    super(fileManager);
+  }
+
+  @Override
+  public JavaFileObject getJavaFileForOutput(Location location, String className,
+      JavaFileObject.Kind kind, FileObject sibling) {
+    SimpleClassFile result = new SimpleClassFile(URI.create("string://" + className));
+    compiled.add(result);
+    return result;
+  }
+
+  public List<SimpleClassFile> getCompiled() {
+    return compiled;
+  }
+}

--- a/buildSrc/src/test/java/org/apache/geode/javac/SimpleSourceFile.java
+++ b/buildSrc/src/test/java/org/apache/geode/javac/SimpleSourceFile.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.javac;
+
+import java.net.URI;
+
+import javax.tools.SimpleJavaFileObject;
+
+public class SimpleSourceFile extends SimpleJavaFileObject {
+  private String content;
+
+  public SimpleSourceFile(String qualifiedClassName, String testSource) {
+    super(URI.create(String.format("file://%s%s", qualifiedClassName.replaceAll("\\.", "/"),
+        Kind.SOURCE.extension)), Kind.SOURCE);
+    content = testSource;
+  }
+
+  @Override
+  public CharSequence getCharContent(boolean ignoreEncodingErrors) {
+    return content;
+  }
+}

--- a/buildSrc/src/test/java/org/apache/geode/javac/TestAnnotationProcessor.java
+++ b/buildSrc/src/test/java/org/apache/geode/javac/TestAnnotationProcessor.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.javac;
+
+import org.junit.Test;
+import sun.tools.java.CompilerError;
+
+public class TestAnnotationProcessor {
+  private static final String VALID_CLASS_TEMPLATE = "package org.apache.geode;\n"
+      + "import org.junit.runner.RunWith;\n" + "import org.junit.runners.Parameterized;\n"
+      + "import org.junit.experimental.categories.Category;\n"
+      + "import org.apache.geode.test.junit.categories.UnitTest;\n"
+      + "import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactory;\n"
+      + "@Category(UnitTest.class)\n"
+      + "@Parameterized.UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)\n"
+      + "@RunWith(Parameterized.class)\n" + "public class Test {\n" + "}\n";
+
+  private static final String INVALID_CLASS_TEMPLATE = "package org.apache.geode;\n"
+      + "import org.junit.runner.RunWith;\n" + "import org.junit.runners.Parameterized;\n"
+      + "import org.junit.experimental.categories.Category;\n"
+      + "import org.apache.geode.test.junit.categories.UnitTest;\n"
+      + "@Category(UnitTest.class)\n"
+      + "@RunWith(Parameterized.class)\n" + "public class Test {\n" + "}\n";
+
+  private TestCompiler compiler = new TestCompiler();
+
+  @Test
+  public void checkValidAnnotations() {
+    String qualifiedClassName = "org.apache.geode.Test";
+    compiler.compile(qualifiedClassName, VALID_CLASS_TEMPLATE);
+  }
+
+  @Test (expected = CompilerError.class)
+  public void checkInvalidAnnotations() {
+    String qualifiedClassName = "org.apache.geode.Test";
+    compiler.compile(qualifiedClassName, INVALID_CLASS_TEMPLATE);
+  }
+}

--- a/buildSrc/src/test/java/org/apache/geode/javac/TestCompiler.java
+++ b/buildSrc/src/test/java/org/apache/geode/javac/TestCompiler.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.javac;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import javax.tools.JavaCompiler;
+import javax.tools.ToolProvider;
+
+import sun.tools.java.CompilerError;
+
+public class TestCompiler {
+  public byte[] compile(String qualifiedClassName, String testSource) {
+
+    JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+    SimpleFileManager fileManager =
+        new SimpleFileManager(compiler.getStandardFileManager(null, null, null));
+
+    List<SimpleSourceFile> compilationUnits =
+        Collections.singletonList(new SimpleSourceFile(qualifiedClassName, testSource));
+
+    List<String> arguments = new ArrayList<>();
+    arguments.addAll(Arrays.asList("-classpath", System.getProperty("java.class.path"),
+        "-processor", EnsureCorrectRunsWithProcessor.class.getName()));
+
+    JavaCompiler.CompilationTask task =
+        compiler.getTask(null, fileManager, null, arguments, null, compilationUnits);
+
+    if (!task.call()) {
+      throw new CompilerError("Compilation errors");
+    }
+
+    return fileManager.getCompiled().iterator().next().getCompiledBinaries();
+  }
+}

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -56,7 +56,27 @@ subprojects {
 
     testRuntime 'cglib:cglib:' + project.'cglib.version'
   }
-  
+
+  configurations {
+    apt
+  }
+
+  dependencies {
+    apt files("${rootProject.projectDir}/buildSrc/build/libs/buildSrc.jar")
+    apt(group: 'junit', name: 'junit', version: project.'junit.version') {
+      transitive = false
+    }
+    // Because EnsureCorrectRunsWithProcessor needs access to
+    // CategoryWithParameterizedRunnerFactory. The specific version of geode-junit is not important.
+    apt(group: 'org.apache.geode', name: 'geode-junit', version: '1.3.0') {
+      transitive = false
+    }
+  }
+
+  compileTestJava {
+    options.annotationProcessorPath = files(configurations['apt'])
+  }
+
   //This target does not run any tests. Rather, it validates that there are no
   //tests that are missing a category annotation
   task checkMissedTests(type: Test) {


### PR DESCRIPTION
… enabled for parameterized tests

- This ensures that if @RunWith(Parameterized.class) is specified for a test class, then
  @Parameterized.UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
  is also specified for that class. Without that, the tests are not correctly run as the
  presence of @Category breaks the parameterization.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
