### PR TITLE
GEODE-4315 Convert JSONWrapper to an interface

### DIFF
--- a/geode-experimental-driver/src/main/java/org/apache/geode/experimental/driver/JSONWrapper.java
+++ b/geode-experimental-driver/src/main/java/org/apache/geode/experimental/driver/JSONWrapper.java
@@ -33,44 +33,51 @@ import org.apache.geode.annotations.Experimental;
  *
  */
 @Experimental
-public class JSONWrapper implements Comparable<JSONWrapper> {
-
-  protected final String jsonDocument;
+public interface JSONWrapper extends Comparable<JSONWrapper> {
 
   public static JSONWrapper wrapJSON(String jsonDocument) {
     if (jsonDocument == null) {
       throw new IllegalArgumentException("wrapped document may not be null");
     }
-    return new JSONWrapper(jsonDocument);
+    return new JSONWrapperImpl(jsonDocument);
   }
 
-  private JSONWrapper(String jsonDocument) {
-    this.jsonDocument = jsonDocument;
-  }
+  public String getJSON();
 
-  public String getJSON() {
-    return jsonDocument;
-  }
 
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
+  static class JSONWrapperImpl implements JSONWrapper {
+
+
+    protected final String jsonDocument;
+
+    private JSONWrapperImpl(String jsonDocument) {
+      this.jsonDocument = jsonDocument;
     }
-    if (!(o instanceof JSONWrapper)) {
-      return false;
+
+    public String getJSON() {
+      return jsonDocument;
     }
-    JSONWrapper that = (JSONWrapper) o;
-    return jsonDocument.equals(that.jsonDocument);
-  }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(jsonDocument);
-  }
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof JSONWrapper)) {
+        return false;
+      }
+      JSONWrapper that = (JSONWrapper) o;
+      return jsonDocument.equals(that.getJSON());
+    }
 
-  @Override
-  public int compareTo(JSONWrapper o) {
-    return jsonDocument.compareTo(o.jsonDocument);
+    @Override
+    public int hashCode() {
+      return Objects.hash(jsonDocument);
+    }
+
+    @Override
+    public int compareTo(JSONWrapper o) {
+      return jsonDocument.compareTo(o.getJSON());
+    }
   }
 }

--- a/geode-experimental-driver/src/main/java/org/apache/geode/experimental/driver/ValueEncoder.java
+++ b/geode-experimental-driver/src/main/java/org/apache/geode/experimental/driver/ValueEncoder.java
@@ -53,7 +53,7 @@ class ValueEncoder {
       builder.setBooleanResult((Boolean) unencodedValue);
     } else if (String.class.equals(unencodedValue.getClass())) {
       builder.setStringResult((String) unencodedValue);
-    } else if (JSONWrapper.class == unencodedValue.getClass()) {
+    } else if (JSONWrapper.class.isAssignableFrom(unencodedValue.getClass())) {
       builder.setJsonObjectResult(((JSONWrapper) unencodedValue).getJSON());
     } else {
       throw new IllegalStateException("We don't know how to handle an object of type "


### PR DESCRIPTION
JSONWrapper is now an interface.  JSONWrapperImpl is what will be returned
by the experimental driver but it will accept anything implementing
JSONWrapper as input.

@PivotalSarge @galen-pivotal @WireBaron @upthewaterspout 


Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [na] Have you written or updated unit tests to verify your changes?

- [na] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
