### PR TITLE
GEODE-4317 add error handling to the experimental ProtobufDriver's Re…

### DIFF
--- a/geode-experimental-driver/src/test/java/org/apache/geode/experimental/driver/DriverConnectionTest.java
+++ b/geode-experimental-driver/src/test/java/org/apache/geode/experimental/driver/DriverConnectionTest.java
@@ -43,13 +43,6 @@ public class DriverConnectionTest {
   @Rule
   public RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
 
-  /** a JSON document */
-  private static final String jsonDocument =
-      "{" + System.lineSeparator() + "  \"name\" : \"Charlemagne\"," + System.lineSeparator()
-          + "  \"age\" : 1276," + System.lineSeparator() + "  \"nationality\" : \"french\","
-          + System.lineSeparator() + "  \"emailAddress\" : \"none\"" + System.lineSeparator() + "}";
-
-
   private Locator locator;
   private Cache cache;
   private Driver driver;

--- a/geode-experimental-driver/src/test/java/org/apache/geode/experimental/driver/RegionIntegrationTest.java
+++ b/geode-experimental-driver/src/test/java/org/apache/geode/experimental/driver/RegionIntegrationTest.java
@@ -14,13 +14,17 @@
  */
 package org.apache.geode.experimental.driver;
 
-import static org.apache.geode.internal.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 
 import org.junit.After;
 import org.junit.Before;
@@ -145,4 +149,42 @@ public class RegionIntegrationTest {
     assertNull(region.get(document));
   }
 
+  @Test(expected = IOException.class)
+  public void putWithBadJSONKeyAndValue() throws IOException {
+    Region<JSONWrapper, JSONWrapper> region = driver.getRegion("region");
+    JSONWrapper document = JSONWrapper.wrapJSON("{\"name\":\"Johan\"]");
+    region.put(document, document);
+  }
+
+  @Test(expected = IOException.class)
+  public void putAllWithBadJSONKeyAndValue() throws IOException {
+    Region<JSONWrapper, JSONWrapper> region = driver.getRegion("region");
+    Map<JSONWrapper, JSONWrapper> putAllMap = new HashMap<>();
+    JSONWrapper document = JSONWrapper.wrapJSON("{\"name\":\"Johan\"]");
+    putAllMap.put(document, document);
+    region.putAll(putAllMap);
+  }
+
+  @Test(expected = IOException.class)
+  public void getWithBadJSONKey() throws IOException {
+    Region<JSONWrapper, JSONWrapper> region = driver.getRegion("region");
+    region.get(JSONWrapper.wrapJSON("{\"name\":\"Johan\"]"));
+  }
+
+  @Test(expected = IOException.class)
+  public void getAllWithBadJSONKeyAndValue() throws IOException {
+    Region<JSONWrapper, JSONWrapper> region = driver.getRegion("region");
+    Set<JSONWrapper> getAllKeys = new HashSet<>();
+    JSONWrapper document = JSONWrapper.wrapJSON("{\"name\":\"Johan\"]");
+    getAllKeys.add(document);
+    Map<JSONWrapper, JSONWrapper> result = region.getAll(getAllKeys);
+    assertTrue("missing key " + document + " in " + result, result.containsKey(document));
+    assertNull(result.get(document));
+  }
+
+  @Test(expected = IOException.class)
+  public void removeWithBadJSONKey() throws IOException {
+    Region<JSONWrapper, JSONWrapper> region = driver.getRegion("region");
+    region.remove(JSONWrapper.wrapJSON("{\"name\":\"Johan\"]"));
+  }
 }


### PR DESCRIPTION
…gion implementation

I've added checks to ProtobufRegion for "error" responses from the server.
Along the way I found we were converting some keys to their string
representations and fixed that as well.

The exceptions thrown show the error text returned by the server.  The
handling of putAll responses was already looking for errors but wasn't
including the server's message text so I changed it to do so.

@upthewaterspout @WireBaron @PivotalSarge @galen-pivotal 


Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
