### PR TITLE
GEODE-4365: do not call GemFireCacheImpl.getExisting

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXCommitMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXCommitMessage.java
@@ -688,7 +688,7 @@ public class TXCommitMessage extends PooledDistributionMessage
       if (isAckRequired()) {
         ack();
       }
-      if (!GemFireCacheImpl.getExisting("Applying TXCommitMessage").isClient()) {
+      if (!dm.getExistingCache().isClient()) {
         getTracker().saveTXForClientFailover(txIdent, this);
       }
       if (logger.isDebugEnabled()) {


### PR DESCRIPTION
The method already had an instance of DistributionManager
so it is now used.
