### PR TITLE
GEODE-4300 Server logs warning message when protobuf client closes socket

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/GenericProtocolServerConnection.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/GenericProtocolServerConnection.java
@@ -62,8 +62,8 @@ public class GenericProtocolServerConnection extends ServerConnection {
 
   @Override
   protected void doOneMessage() {
+    Socket socket = this.getSocket();
     try {
-      Socket socket = this.getSocket();
       InputStream inputStream = socket.getInputStream();
       OutputStream outputStream = socket.getOutputStream();
 
@@ -77,7 +77,9 @@ public class GenericProtocolServerConnection extends ServerConnection {
       setClientDisconnectedException(e);
       logger.debug("Encountered EOF while processing message: {}", e);
     } catch (IOException | IncompatibleVersionException e) {
-      logger.warn(e);
+      if (!socket.isClosed()) { // GEODE-4300, IOException may be thrown thrown on EOF
+        logger.warn(e);
+      }
       this.setFlagProcessMessagesAsFalse();
       setClientDisconnectedException(e);
     } finally {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ServerConnection.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ServerConnection.java
@@ -1708,10 +1708,6 @@ public abstract class ServerConnection implements Runnable {
     this.processMessages = false;
   }
 
-  boolean getFlagProcessMessages() {
-    return this.processMessages;
-  }
-
   public InternalLogWriter getLogWriter() {
     return this.logWriter; // TODO:LOG:CONVERT: remove getLogWriter after callers are converted
   }

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/cache/tier/sockets/OutputCapturingServerConnectionTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/cache/tier/sockets/OutputCapturingServerConnectionTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.tier.sockets;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.SystemOutRule;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.cache.IncompatibleVersionException;
+import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.client.protocol.ClientProtocolProcessor;
+import org.apache.geode.internal.cache.tier.CachedRegionHelper;
+import org.apache.geode.internal.cache.tier.CommunicationMode;
+import org.apache.geode.internal.security.SecurityService;
+import org.apache.geode.test.junit.categories.UnitTest;
+
+
+@Category(UnitTest.class)
+public class OutputCapturingServerConnectionTest {
+
+  @Rule
+  public SystemOutRule systemOutRule = new SystemOutRule().enableLog();
+
+  @Test
+  public void testEOFDoesNotCauseWarningMessage() throws IOException, IncompatibleVersionException {
+    Socket socketMock = mock(Socket.class);
+    when(socketMock.getInetAddress()).thenReturn(InetAddress.getByName("localhost"));
+    when(socketMock.isClosed()).thenReturn(true);
+
+    AcceptorImpl acceptorStub = mock(AcceptorImpl.class);
+    ClientProtocolProcessor clientProtocolProcessor = mock(ClientProtocolProcessor.class);
+    doThrow(new IOException()).when(clientProtocolProcessor).processMessage(any(), any());
+
+    ServerConnection serverConnection =
+        getServerConnection(socketMock, clientProtocolProcessor, acceptorStub);
+
+    String expectedMessage = "invoking doOneMessage";
+    String unexpectedMessage = "IOException";
+
+    // Create some stdout content so we can tell that the capture worked.
+    System.out.println(expectedMessage);
+
+    serverConnection.doOneMessage();
+
+    // verify that an IOException wasn't logged
+    String stdoutCapture = systemOutRule.getLog();
+    assertTrue(stdoutCapture.contains(expectedMessage));
+    assertFalse(stdoutCapture.contains(unexpectedMessage));
+  }
+
+  private GenericProtocolServerConnection getServerConnection(Socket socketMock,
+      ClientProtocolProcessor clientProtocolProcessorMock, AcceptorImpl acceptorStub)
+      throws UnknownHostException {
+    ClientHealthMonitor clientHealthMonitorMock = mock(ClientHealthMonitor.class);
+    when(acceptorStub.getClientHealthMonitor()).thenReturn(clientHealthMonitorMock);
+    InetSocketAddress inetSocketAddressStub = InetSocketAddress.createUnresolved("localhost", 9071);
+    InetAddress inetAddressStub = mock(InetAddress.class);
+    when(socketMock.getInetAddress()).thenReturn(InetAddress.getByName("localhost"));
+    when(socketMock.getRemoteSocketAddress()).thenReturn(inetSocketAddressStub);
+    when(socketMock.getInetAddress()).thenReturn(inetAddressStub);
+
+    return new GenericProtocolServerConnection(socketMock, mock(InternalCache.class),
+        mock(CachedRegionHelper.class), mock(CacheServerStats.class), 0, 0, "",
+        CommunicationMode.ProtobufClientServerProtocol.getModeNumber(), acceptorStub,
+        clientProtocolProcessorMock, mock(SecurityService.class));
+  }
+
+}


### PR DESCRIPTION
Inhibit logging of a warning message on IOExceptions if the socket is
closed.


@upthewaterspout @WireBaron @PivotalSarge @galen-pivotal 

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [na] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
