### PR TITLE
GEODE-4379: Move RemoteOutputStreamServer from gfsh to the manager

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/ManagementAgent.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/ManagementAgent.java
@@ -538,7 +538,7 @@ public class ManagementAgent {
 
       Set<ObjectName> names = platformMBeanServer.queryNames(mbeanON, null);
       if (names.isEmpty()) {
-        platformMBeanServer.registerMBean(new FileUploader(), mbeanON);
+        platformMBeanServer.registerMBean(new FileUploader(getRemoteStreamExporter()), mbeanON);
         logger.info("Registered FileUploaderMBean on " + mbeanON);
       }
     } catch (InstanceAlreadyExistsException | MBeanRegistrationException

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/FileUploaderMBean.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/FileUploaderMBean.java
@@ -17,9 +17,6 @@ package org.apache.geode.management.internal.beans;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
-
-import com.healthmarketscience.rmiio.RemoteInputStream;
 
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
@@ -28,7 +25,7 @@ import org.apache.geode.security.ResourcePermission;
     operation = ResourcePermission.Operation.MANAGE, target = ResourcePermission.Target.DEPLOY)
 public interface FileUploaderMBean {
 
-  List<String> uploadFile(Map<String, RemoteInputStream> remoteFiles) throws IOException;
+  FileUploader.RemoteFile uploadFile(String filename) throws IOException;
 
   void deleteFiles(List<String> files);
 }

--- a/geode-core/src/main/resources/org/apache/geode/internal/sanctioned-geode-core-serializables.txt
+++ b/geode-core/src/main/resources/org/apache/geode/internal/sanctioned-geode-core-serializables.txt
@@ -468,6 +468,7 @@ org/apache/geode/management/internal/JmxManagerLocator$StartJmxManagerFunction,t
 org/apache/geode/management/internal/ManagementAgent$GemFireRMIServerSocketFactory,true,-811909050641332716,bindAddr:java/net/InetAddress
 org/apache/geode/management/internal/ManagementFunction,true,1,mbeanServer:javax/management/MBeanServer,notificationHub:org/apache/geode/management/internal/NotificationHub
 org/apache/geode/management/internal/NotificationKey,false,currentTime:long,objectName:javax/management/ObjectName
+org/apache/geode/management/internal/beans/FileUploader$RemoteFile,false,filename:java/lang/String,outputStream:com/healthmarketscience/rmiio/RemoteOutputStream
 org/apache/geode/management/internal/beans/QueryDataFunction,true,1
 org/apache/geode/management/internal/beans/QueryDataFunction$LocalQueryFunction,true,1,id:java/lang/String,optimizeForWrite:boolean,regionName:java/lang/String,showMembers:boolean,this$0:org/apache/geode/management/internal/beans/QueryDataFunction
 org/apache/geode/management/internal/beans/QueryDataFunction$QueryDataFunctionResult,true,1,compressedBytes:byte[],message:java/lang/String

--- a/geode-core/src/test/java/org/apache/geode/management/internal/beans/FileUploaderTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/beans/FileUploaderTest.java
@@ -45,7 +45,7 @@ public class FileUploaderTest {
 
   @Before
   public void before() {
-    fileUploader = new FileUploader();
+    fileUploader = new FileUploader(null);
     files = new ArrayList<>();
   }
 
@@ -58,7 +58,7 @@ public class FileUploaderTest {
   }
 
   @Test
-  public void delteFileNotInTheUploadedDir() throws IOException {
+  public void deleteFileNotInTheUploadedDir() throws IOException {
     File file = temporaryFolder.newFile("a.jar");
     files.add(file.getAbsolutePath());
 


### PR DESCRIPTION
- This flips the deployment of jars from a pull (by server) to a push (from
  gfsh).

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
