### PR TITLE
GEODE-4368: Rename server connection classes.

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/admin/internal/CacheServerImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/CacheServerImpl.java
@@ -14,9 +14,15 @@
  */
 package org.apache.geode.admin.internal;
 
-import static org.apache.geode.distributed.ConfigurationProperties.*;
+import static org.apache.geode.distributed.ConfigurationProperties.CACHE_XML_FILE;
 
-import org.apache.geode.admin.*;
+import org.apache.geode.admin.AdminException;
+import org.apache.geode.admin.CacheServer;
+import org.apache.geode.admin.CacheServerConfig;
+import org.apache.geode.admin.CacheVm;
+import org.apache.geode.admin.CacheVmConfig;
+import org.apache.geode.admin.ManagedEntityConfig;
+import org.apache.geode.admin.SystemMemberType;
 import org.apache.geode.distributed.internal.ClusterDistributionManager;
 import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.internal.admin.GemFireVM;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/CacheServerImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/CacheServerImpl.java
@@ -68,6 +68,8 @@ import org.apache.geode.internal.cache.tier.Acceptor;
 import org.apache.geode.internal.cache.tier.sockets.AcceptorImpl;
 import org.apache.geode.internal.cache.tier.sockets.CacheClientNotifier;
 import org.apache.geode.internal.cache.tier.sockets.ClientProxyMembershipID;
+import org.apache.geode.internal.cache.tier.sockets.OriginalServerConnection;
+import org.apache.geode.internal.cache.tier.sockets.ProtobufServerConnection;
 import org.apache.geode.internal.cache.tier.sockets.ServerConnectionFactory;
 import org.apache.geode.internal.i18n.LocalizedStrings;
 import org.apache.geode.internal.logging.LogService;
@@ -92,9 +94,8 @@ public class CacheServerImpl extends AbstractCacheServer implements Distribution
   private final SecurityService securityService;
 
   /**
-   * The server connection factory, that provides either a
-   * {@link org.apache.geode.internal.cache.tier.sockets.LegacyServerConnection} or a new
-   * {@link org.apache.geode.internal.cache.tier.sockets.GenericProtocolServerConnection}
+   * The server connection factory, that provides either a {@link OriginalServerConnection} or a new
+   * {@link ProtobufServerConnection}
    */
   private final ServerConnectionFactory serverConnectionFactory = new ServerConnectionFactory();
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/OriginalServerConnection.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/OriginalServerConnection.java
@@ -30,7 +30,7 @@ import org.apache.geode.internal.security.SecurityService;
  *
  * Legacy is therefore a bit of a misnomer; do you have a better name?
  */
-public class LegacyServerConnection extends ServerConnection {
+public class OriginalServerConnection extends ServerConnection {
   /**
    * Set to false once handshake has been done
    */
@@ -51,7 +51,7 @@ public class LegacyServerConnection extends ServerConnection {
    * @param acceptor
    * @param securityService
    */
-  public LegacyServerConnection(Socket socket, InternalCache internalCache,
+  public OriginalServerConnection(Socket socket, InternalCache internalCache,
       CachedRegionHelper helper, CacheServerStats stats, int hsTimeout, int socketBufferSize,
       String communicationModeStr, byte communicationMode, Acceptor acceptor,
       SecurityService securityService) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ProtobufServerConnection.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ProtobufServerConnection.java
@@ -37,17 +37,17 @@ import org.apache.geode.internal.security.SecurityService;
 /**
  * Holds the socket and protocol handler for the new client protocol.
  */
-public class GenericProtocolServerConnection extends ServerConnection {
+public class ProtobufServerConnection extends ServerConnection {
   // The new protocol lives in a separate module and gets loaded when this class is instantiated.
   private final ClientProtocolProcessor protocolProcessor;
   private boolean cleanedUp;
   private ClientProxyMembershipID clientProxyMembershipID;
 
   /**
-   * Creates a new <code>GenericProtocolServerConnection</code> that processes messages received
-   * from an edge client over a given <code>Socket</code>.
+   * Creates a new <code>ProtobufServerConnection</code> that processes messages received from an
+   * edge client over a given <code>Socket</code>.
    */
-  public GenericProtocolServerConnection(Socket socket, InternalCache c, CachedRegionHelper helper,
+  public ProtobufServerConnection(Socket socket, InternalCache c, CachedRegionHelper helper,
       CacheServerStats stats, int hsTimeout, int socketBufferSize, String communicationModeStr,
       byte communicationMode, Acceptor acceptor, ClientProtocolProcessor clientProtocolProcessor,
       SecurityService securityService) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ServerConnectionFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ServerConnectionFactory.java
@@ -61,7 +61,7 @@ public class ServerConnectionFactory {
         throw new IOException("Server received unknown communication mode: " + communicationMode);
       } else {
         try {
-          return createGenericProtocolServerConnection(socket, cache, helper, stats, hsTimeout,
+          return createProtobufServerConnection(socket, cache, helper, stats, hsTimeout,
               socketBufferSize, communicationModeStr, communicationMode, acceptor, securityService);
         } catch (ServiceLoadingFailureException ex) {
           throw new IOException("Could not load protobuf client protocol", ex);
@@ -70,12 +70,12 @@ public class ServerConnectionFactory {
         }
       }
     } else {
-      return new LegacyServerConnection(socket, cache, helper, stats, hsTimeout, socketBufferSize,
+      return new OriginalServerConnection(socket, cache, helper, stats, hsTimeout, socketBufferSize,
           communicationModeStr, communicationMode, acceptor, securityService);
     }
   }
 
-  private ServerConnection createGenericProtocolServerConnection(Socket socket, InternalCache cache,
+  private ServerConnection createProtobufServerConnection(Socket socket, InternalCache cache,
       CachedRegionHelper helper, CacheServerStats stats, int hsTimeout, int socketBufferSize,
       String communicationModeStr, byte communicationMode, Acceptor acceptor,
       SecurityService securityService) {
@@ -84,8 +84,7 @@ public class ServerConnectionFactory {
 
     ClientProtocolProcessor processor = service.createProcessorForCache(cache, securityService);
 
-    return new GenericProtocolServerConnection(socket, cache, helper, stats, hsTimeout,
-        socketBufferSize, communicationModeStr, communicationMode, acceptor, processor,
-        securityService);
+    return new ProtobufServerConnection(socket, cache, helper, stats, hsTimeout, socketBufferSize,
+        communicationModeStr, communicationMode, acceptor, processor, securityService);
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ServerConnectionFactoryTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ServerConnectionFactoryTest.java
@@ -86,7 +86,7 @@ public class ServerConnectionFactoryTest {
     for (CommunicationMode communicationMode : communicationModes) {
       ServerConnection serverConnection =
           serverConnectionMockedExceptForCommunicationMode(communicationMode.getModeNumber());
-      assertTrue(serverConnection instanceof LegacyServerConnection);
+      assertTrue(serverConnection instanceof OriginalServerConnection);
     }
   }
 
@@ -102,7 +102,7 @@ public class ServerConnectionFactoryTest {
     for (CommunicationMode communicationMode : communicationModes) {
       ServerConnection serverConnection =
           serverConnectionMockedExceptForCommunicationMode(communicationMode.getModeNumber());
-      assertTrue(serverConnection instanceof LegacyServerConnection);
+      assertTrue(serverConnection instanceof OriginalServerConnection);
     }
   }
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ServerConnectionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ServerConnectionTest.java
@@ -192,7 +192,7 @@ public class ServerConnectionTest {
     }
   }
 
-  class TestServerConnection extends LegacyServerConnection {
+  class TestServerConnection extends OriginalServerConnection {
 
     private TestMessage testMessage;
 

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/cache/tier/sockets/OutputCapturingServerConnectionTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/cache/tier/sockets/OutputCapturingServerConnectionTest.java
@@ -74,7 +74,7 @@ public class OutputCapturingServerConnectionTest {
     assertFalse(stdoutCapture.contains(unexpectedMessage));
   }
 
-  private GenericProtocolServerConnection getServerConnection(Socket socketMock,
+  private ProtobufServerConnection getServerConnection(Socket socketMock,
       ClientProtocolProcessor clientProtocolProcessorMock, AcceptorImpl acceptorStub)
       throws UnknownHostException {
     ClientHealthMonitor clientHealthMonitorMock = mock(ClientHealthMonitor.class);
@@ -85,7 +85,7 @@ public class OutputCapturingServerConnectionTest {
     when(socketMock.getRemoteSocketAddress()).thenReturn(inetSocketAddressStub);
     when(socketMock.getInetAddress()).thenReturn(inetAddressStub);
 
-    return new GenericProtocolServerConnection(socketMock, mock(InternalCache.class),
+    return new ProtobufServerConnection(socketMock, mock(InternalCache.class),
         mock(CachedRegionHelper.class), mock(CacheServerStats.class), 0, 0, "",
         CommunicationMode.ProtobufClientServerProtocol.getModeNumber(), acceptorStub,
         clientProtocolProcessorMock, mock(SecurityService.class));

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/cache/tier/sockets/ProtobufServerConnectionTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/cache/tier/sockets/ProtobufServerConnectionTest.java
@@ -43,7 +43,7 @@ import org.apache.geode.internal.security.SecurityService;
 import org.apache.geode.test.junit.categories.UnitTest;
 
 @Category(UnitTest.class)
-public class GenericProtocolServerConnectionTest {
+public class ProtobufServerConnectionTest {
 
   private ClientHealthMonitor clientHealthMonitorMock;
 
@@ -62,10 +62,10 @@ public class GenericProtocolServerConnectionTest {
 
     AcceptorImpl acceptorStub = mock(AcceptorImpl.class);
     ClientProtocolProcessor clientProtocolProcessorMock = mock(ClientProtocolProcessor.class);
-    GenericProtocolServerConnection genericProtocolServerConnection =
+    ProtobufServerConnection protobufServerConnection =
         getServerConnection(socketMock, clientProtocolProcessorMock, acceptorStub);
 
-    genericProtocolServerConnection.emergencyClose();
+    protobufServerConnection.emergencyClose();
 
     Mockito.verify(socketMock).close();
   }
@@ -108,14 +108,14 @@ public class GenericProtocolServerConnectionTest {
         clientProxyMembershipIDArgumentCaptor.getValue().toString());
   }
 
-  private GenericProtocolServerConnection IOExceptionThrowingServerConnection()
+  private ProtobufServerConnection IOExceptionThrowingServerConnection()
       throws IOException, IncompatibleVersionException {
     ClientProtocolProcessor clientProtocolProcessor = mock(ClientProtocolProcessor.class);
     doThrow(new IOException()).when(clientProtocolProcessor).processMessage(any(), any());
     return getServerConnection(clientProtocolProcessor, mock(AcceptorImpl.class));
   }
 
-  private GenericProtocolServerConnection getServerConnection(Socket socketMock,
+  private ProtobufServerConnection getServerConnection(Socket socketMock,
       ClientProtocolProcessor clientProtocolProcessorMock, AcceptorImpl acceptorStub)
       throws UnknownHostException {
     clientHealthMonitorMock = mock(ClientHealthMonitor.class);
@@ -126,13 +126,13 @@ public class GenericProtocolServerConnectionTest {
     when(socketMock.getRemoteSocketAddress()).thenReturn(inetSocketAddressStub);
     when(socketMock.getInetAddress()).thenReturn(inetAddressStub);
 
-    return new GenericProtocolServerConnection(socketMock, mock(InternalCache.class),
+    return new ProtobufServerConnection(socketMock, mock(InternalCache.class),
         mock(CachedRegionHelper.class), mock(CacheServerStats.class), 0, 0, "",
         CommunicationMode.ProtobufClientServerProtocol.getModeNumber(), acceptorStub,
         clientProtocolProcessorMock, mock(SecurityService.class));
   }
 
-  private GenericProtocolServerConnection getServerConnection(
+  private ProtobufServerConnection getServerConnection(
       ClientProtocolProcessor clientProtocolProcessorMock, AcceptorImpl acceptorStub)
       throws UnknownHostException {
     Socket socketMock = mock(Socket.class);


### PR DESCRIPTION
- Rename LegacyServerConnection to OriginalServerConnection.
- Rename GenericProtocolServerConnection to ProtocolServerConnection.
- Rename GenericProtocolServerConnectionTest to ProtocolServerConnectionTest.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.

@WireBaron @galen-pivotal @bschuchardt @upthewaterspout 