### PR TITLE
GEODE-4387: Removing calls to setInstanceForTests

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/CompactRangeIndex.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/CompactRangeIndex.java
@@ -104,7 +104,8 @@ public class CompactRangeIndex extends AbstractIndex {
       indexStore = new MapIndexStore(
           ((LocalRegion) region).getIndexMap(indexName, indexedExpression, origFromClause), region);
     } else {
-      indexStore = new MemoryIndexStore(region, internalIndexStats);
+      indexStore =
+          new MemoryIndexStore(region, internalIndexStats, (InternalCache) region.getCache());
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/MemoryIndexStore.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/MemoryIndexStore.java
@@ -83,12 +83,7 @@ public class MemoryIndexStore implements IndexStore {
   // new collection
   private final Object TRANSITIONING_TOKEN = new IndexElemArray(1);
 
-  MemoryIndexStore(Region region, InternalIndexStatistics internalIndexStats) {
-    this(region, internalIndexStats, GemFireCacheImpl.getInstance());
-  }
-
-  private MemoryIndexStore(Region region, InternalIndexStatistics internalIndexStats,
-      InternalCache cache) {
+  MemoryIndexStore(Region region, InternalIndexStatistics internalIndexStats, InternalCache cache) {
     this.region = region;
     RegionAttributes ra = region.getAttributes();
     // Initialize the reverse-map if in-place modification is set by the

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
@@ -688,15 +688,6 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
   }
 
   /**
-   * Used for testing, retain the old instance in the test and re-set the value when test completes
-   */
-  public static GemFireCacheImpl setInstanceForTests(GemFireCacheImpl cache) {
-    GemFireCacheImpl oldInstance = instance;
-    instance = cache;
-    return oldInstance;
-  }
-
-  /**
    * Returns an existing instance. If a cache does not exist throws a cache closed exception.
    *
    * @return the existing cache

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/DistributedSystemBridge.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/DistributedSystemBridge.java
@@ -240,7 +240,7 @@ public class DistributedSystemBridge {
    *
    * @param service Management service
    */
-  public DistributedSystemBridge(SystemManagementService service) {
+  public DistributedSystemBridge(SystemManagementService service, InternalCache cache) {
     this.distrLockServiceMap = new ConcurrentHashMap<>();
     this.distrRegionMap = new ConcurrentHashMap<>();
     this.mapOfMembers = new ConcurrentHashMap<>();
@@ -248,7 +248,7 @@ public class DistributedSystemBridge {
     this.mapOfGatewayReceivers = new ConcurrentHashMap<>();
     this.mapOfGatewaySenders = new ConcurrentHashMap<>();
     this.service = service;
-    this.cache = GemFireCacheImpl.getInstance();
+    this.cache = cache;
     this.system = cache.getInternalDistributedSystem();
     this.dm = system.getDistributionManager();
     this.alertLevel = ManagementConstants.DEFAULT_ALERT_LEVEL;

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/ManagementAdapter.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/ManagementAdapter.java
@@ -200,7 +200,7 @@ public class ManagementAdapter {
     MBeanJMXAdapter jmxAdapter = service.getJMXAdapter();
     Map<ObjectName, Object> registeredMBeans = jmxAdapter.getLocalGemFireMBean();
 
-    DistributedSystemBridge dsBridge = new DistributedSystemBridge(service);
+    DistributedSystemBridge dsBridge = new DistributedSystemBridge(service, internalCache);
     this.aggregator = new MBeanAggregator(dsBridge);
     // register the aggregator for Federation framework to use
     service.addProxyListener(aggregator);

--- a/geode-core/src/test/java/org/apache/geode/cache/query/internal/index/MemoryIndexStoreJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/internal/index/MemoryIndexStoreJUnitTest.java
@@ -68,9 +68,6 @@ public class MemoryIndexStoreJUnitTest {
     });
   }
 
-  @After
-  public void teardown() {}
-
   @Test
   public void createIteratorWhenCacheNulledWhenShuttingDownShouldNotThrowNPE() {
     store.get("T");

--- a/geode-core/src/test/java/org/apache/geode/cache/query/internal/index/MemoryIndexStoreJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/internal/index/MemoryIndexStoreJUnitTest.java
@@ -58,10 +58,9 @@ public class MemoryIndexStoreJUnitTest {
     subclassPreSetup();
     region = createRegion();
     cache = mock(GemFireCacheImpl.class);
-    actualInstance = GemFireCacheImpl.setInstanceForTests(cache);
     mockStats = mock(AbstractIndex.InternalIndexStatistics.class);
 
-    store = new MemoryIndexStore(region, mockStats);
+    store = new MemoryIndexStore(region, mockStats, cache);
     store.setIndexOnValues(true);
     mockEntries = new RegionEntry[numMockEntries];
     IntStream.range(0, numMockEntries).forEach(i -> {
@@ -70,13 +69,10 @@ public class MemoryIndexStoreJUnitTest {
   }
 
   @After
-  public void teardown() {
-    GemFireCacheImpl.setInstanceForTests(actualInstance);
-  }
+  public void teardown() {}
 
   @Test
   public void createIteratorWhenCacheNulledWhenShuttingDownShouldNotThrowNPE() {
-    GemFireCacheImpl.setInstanceForTests(null);
     store.get("T");
   }
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/ColocationHelperTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/ColocationHelperTest.java
@@ -94,15 +94,6 @@ public class ColocationHelperTest {
     pa = mock(PartitionAttributes.class);
     prc = mock(PartitionRegionConfig.class);
     cache = Fakes.cache();
-    oldCacheInstance = GemFireCacheImpl.setInstanceForTests(cache);
-  }
-
-  /**
-   * @throws java.lang.Exception
-   */
-  @After
-  public void tearDown() throws Exception {
-    GemFireCacheImpl.setInstanceForTests(oldCacheInstance);
   }
 
   /**

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/control/RebalanceOperationDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/control/RebalanceOperationDUnitTest.java
@@ -1029,8 +1029,6 @@ public class RebalanceOperationDUnitTest extends JUnit4CacheTestCase {
       @Override
       public void run() {
         GemFireCacheImpl cache = spy(getGemfireCache());
-        // set the spied cache instance
-        GemFireCacheImpl origCache = GemFireCacheImpl.setInstanceForTests(cache);
 
         PartitionedRegion origRegion = (PartitionedRegion) cache.getRegion("region1");
         PartitionedRegion spyRegion = spy(origRegion);
@@ -1043,6 +1041,7 @@ public class RebalanceOperationDUnitTest extends JUnit4CacheTestCase {
 
         doReturn(parRegions).when(cache).getPartitionedRegions();
         doReturn(redundancyProvider).when(spyRegion).getRedundancyProvider();
+
 
         // simulate create bucket fails on member2 and test if it creates on member3
         doReturn(false).when(redundancyProvider).createBackupBucketOnMember(anyInt(),
@@ -1097,9 +1096,6 @@ public class RebalanceOperationDUnitTest extends JUnit4CacheTestCase {
         assertEquals(results.getTotalBucketCreatesCompleted(),
             stats.getRebalanceBucketCreatesCompleted());
         assertEquals(1, stats.getRebalanceBucketCreatesFailed());
-
-        // set the original cache
-        GemFireCacheImpl.setInstanceForTests(origCache);
       }
     });
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/wan/parallel/ParallelQueueRemovalMessageJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/wan/parallel/ParallelQueueRemovalMessageJUnitTest.java
@@ -99,7 +99,6 @@ public class ParallelQueueRemovalMessageJUnitTest {
   private void createCache() {
     // Mock cache
     this.cache = Fakes.cache();
-    GemFireCacheImpl.setInstanceForTests(this.cache);
   }
 
   private void createQueueRegion() {
@@ -184,11 +183,6 @@ public class ParallelQueueRemovalMessageJUnitTest {
 
     this.bucketRegionQueueHelper =
         new BucketRegionQueueHelper(this.cache, this.queueRegion, this.bucketRegionQueue);
-  }
-
-  @After
-  public void tearDownGemFire() {
-    GemFireCacheImpl.setInstanceForTests(null);
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/management/internal/beans/DistributedSystemBridgeJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/beans/DistributedSystemBridgeJUnitTest.java
@@ -56,12 +56,10 @@ public class DistributedSystemBridgeJUnitTest {
     when(dlock.lock(any(), anyLong(), anyLong())).thenReturn(true);
 
     DLockService.addLockServiceForTests(BackupDataStoreHelper.LOCK_SERVICE_NAME, dlock);
-    GemFireCacheImpl.setInstanceForTests(cache);
   }
 
   @After
   public void clearCache() {
-    GemFireCacheImpl.setInstanceForTests(null);
     DLockService.removeLockServiceForTests(BackupDataStoreHelper.LOCK_SERVICE_NAME);
   }
 
@@ -69,7 +67,7 @@ public class DistributedSystemBridgeJUnitTest {
   public void testSuccessfulBackup() throws Exception {
     DistributionManager dm = cache.getDistributionManager();
 
-    DistributedSystemBridge bridge = new DistributedSystemBridge(null);
+    DistributedSystemBridge bridge = new DistributedSystemBridge(null, cache);
     bridge.backupAllMembers("/tmp", null);
 
     InOrder inOrder = inOrder(dm, backupManager);
@@ -91,7 +89,7 @@ public class DistributedSystemBridgeJUnitTest {
         .thenThrow(new RuntimeException("Fail the prepare"));
 
 
-    DistributedSystemBridge bridge = new DistributedSystemBridge(null);
+    DistributedSystemBridge bridge = new DistributedSystemBridge(null, cache);
     try {
       bridge.backupAllMembers("/tmp", null);
       fail("Should have failed with an exception");

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/functions/ShowMissingDiskStoresFunctionJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/functions/ShowMissingDiskStoresFunctionJUnitTest.java
@@ -132,7 +132,6 @@ public class ShowMissingDiskStoresFunctionJUnitTest {
     List<?> results = null;
 
     when(cache.getPersistentMemberManager()).thenReturn(memberManager);
-    GemFireCacheImpl.setInstanceForTests(null);
 
     smdsFunc.execute(context);
     results = resultSender.getResults();

--- a/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/AckReaderThreadJUnitTest.java
+++ b/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/AckReaderThreadJUnitTest.java
@@ -46,7 +46,6 @@ public class AckReaderThreadJUnitTest {
   private void createCache() {
     // Mock cache
     this.cache = Fakes.cache();
-    GemFireCacheImpl.setInstanceForTests(this.cache);
   }
 
   private void createSender() {
@@ -57,11 +56,6 @@ public class AckReaderThreadJUnitTest {
 
   private void createDispatcher() {
     this.dispatcher = mock(GatewaySenderEventRemoteDispatcher.class);
-  }
-
-  @After
-  public void tearDownGemFire() {
-    GemFireCacheImpl.setInstanceForTests(null);
   }
 
   @Test


### PR DESCRIPTION
These calls were trying to set the instance variable to a mock instance.
None of them were actually needed.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.

@WireBaron 