### PR TITLE
GEODE-4149: Replace CacheFactory.getInstance(getSystem()) with JUnit4CacheTestCase.getCache().

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/cache30/MultiVMRegionTestCase.java
+++ b/geode-core/src/test/java/org/apache/geode/cache30/MultiVMRegionTestCase.java
@@ -2676,7 +2676,7 @@ public abstract class MultiVMRegionTestCase extends RegionTestCase {
           }, getRepeatTimeoutMs());
 
     } catch (Exception e) {
-      CacheFactory.getInstance(getSystem()).close();
+      getCache().close();
       getSystem().getLogWriter().fine("testDistributedPut: Caused exception in createRegion");
       throw e;
     }
@@ -6232,7 +6232,7 @@ public abstract class MultiVMRegionTestCase extends RegionTestCase {
           }, getRepeatTimeoutMs());
 
     } catch (Exception e) {
-      CacheFactory.getInstance(getSystem()).close();
+      getCache().close();
       getSystem().getLogWriter().fine("testTXSimpleOps: Caused exception in createRegion");
       throw e;
     }
@@ -6489,7 +6489,7 @@ public abstract class MultiVMRegionTestCase extends RegionTestCase {
       txMgr.rollback();
       assertSame(localCmtValue, rgn.getEntry("key").getValue());
     } catch (Exception e) {
-      CacheFactory.getInstance(getSystem()).close();
+      getCache().close();
       getSystem().getLogWriter()
           .fine("testTXUpdateLoadNoConflict: Caused exception in createRegion");
       throw e;
@@ -7248,7 +7248,7 @@ public abstract class MultiVMRegionTestCase extends RegionTestCase {
       rgn2.destroyRegion();
       rgn3.destroyRegion();
     } catch (Exception e) {
-      CacheFactory.getInstance(getSystem()).close();
+      getCache().close();
       getSystem().getLogWriter().fine("testTXMultiRegion: Caused exception in createRegion");
       throw e;
     }
@@ -7386,7 +7386,7 @@ public abstract class MultiVMRegionTestCase extends RegionTestCase {
       // Make sure that a remote put, that modifies an existing entry,
       // done in a tx is dropped in a remote mirror that does not have the entry.
     } catch (Exception e) {
-      CacheFactory.getInstance(getSystem()).close();
+      getCache().close();
       getSystem().getLogWriter().fine("textTXRmtMirror: Caused exception in createRegion");
       throw e;
     }
@@ -7859,7 +7859,7 @@ public abstract class MultiVMRegionTestCase extends RegionTestCase {
 
 
     } catch (Exception e) {
-      CacheFactory.getInstance(getSystem()).close();
+      getCache().close();
       getSystem().getLogWriter().fine("testTXAlgebra: Caused exception in createRegion");
       throw e;
     }


### PR DESCRIPTION
Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
