### PR TITLE
GEODE-3583: Avoid CacheFactory.getInstance() by passing cache.

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PoolFactoryImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PoolFactoryImpl.java
@@ -335,7 +335,7 @@ public class PoolFactoryImpl implements PoolFactory {
         registry.creatingPool();
       }
     }
-    return PoolImpl.create(this.pm, name, this.attributes, this.locatorAddresses);
+    return PoolImpl.create(this.pm, name, this.attributes, this.locatorAddresses, cache);
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/internal/i18n/LocalizedStrings.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/i18n/LocalizedStrings.java
@@ -7713,6 +7713,8 @@ public class LocalizedStrings {
       new StringId(6664, "{0}: Providing synchronization event for key={1}; timestamp={2}: {3}");
   public static final StringId AbstractGatewaySender_ENQUEUEING_SYNCHRONIZATION_EVENT =
       new StringId(6665, "{0}: Enqueueing synchronization event: {1}");
+  public static final StringId PoolImpl_CACHE_MUST_BE_CREATED_BEFORE_CREATING_POOL =
+      new StringId(6666, "Cache must be created before creating pool");
 
   /** Testing strings, messageId 90000-99999 **/
 


### PR DESCRIPTION
Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [n/a] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
