### PR TITLE
GEODE-4308: Allow two caches in the same JVM if a feature flag is on

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/CacheFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/CacheFactory.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.cache;
 
+import static org.apache.geode.distributed.internal.InternalDistributedSystem.ALLOW_MULTIPLE_SYSTEMS;
+
 import java.util.Properties;
 
 import org.apache.geode.distributed.ConfigurationProperties;
@@ -204,7 +206,7 @@ public class CacheFactory {
       throws TimeoutException, CacheWriterException, GatewayException, RegionExistsException {
     synchronized (CacheFactory.class) {
       DistributedSystem ds = null;
-      if (this.dsProps.isEmpty()) {
+      if (this.dsProps.isEmpty() && !ALLOW_MULTIPLE_SYSTEMS) {
         // any ds will do
         ds = InternalDistributedSystem.getConnectedInstance();
         validateUsabilityOfSecurityCallbacks(ds);

--- a/geode-core/src/main/java/org/apache/geode/distributed/DistributedSystem.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/DistributedSystem.java
@@ -15,6 +15,7 @@
 package org.apache.geode.distributed;
 
 import static org.apache.geode.distributed.ConfigurationProperties.CONSERVE_SOCKETS;
+import static org.apache.geode.distributed.internal.InternalDistributedSystem.ALLOW_MULTIPLE_SYSTEMS;
 
 import java.io.File;
 import java.net.InetAddress;
@@ -155,6 +156,11 @@ public abstract class DistributedSystem implements StatisticsFactory {
       // fix for bug 33992
       config = new Properties();
     }
+
+    if (ALLOW_MULTIPLE_SYSTEMS) {
+      return InternalDistributedSystem.newInstance(config);
+    }
+
     synchronized (existingSystemsLock) {
       if (ClusterDistributionManager.isDedicatedAdminVM()) {
         // For a dedicated admin VM, check to see if there is already

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalDistributedSystem.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalDistributedSystem.java
@@ -137,6 +137,12 @@ public class InternalDistributedSystem extends DistributedSystem
       DistributionConfig.GEMFIRE_PREFIX + "disableManagement";
 
   /**
+   * Feature flag to enable multiple caches within a JVM.
+   */
+  public static boolean ALLOW_MULTIPLE_SYSTEMS =
+      Boolean.getBoolean(DistributionConfig.GEMFIRE_PREFIX + "ALLOW_MULTIPLE_SYSTEMS");
+
+  /**
    * If auto-reconnect is going on this will hold a reference to it
    */
   public static volatile DistributedSystem systemAttemptingReconnect;
@@ -1348,7 +1354,7 @@ public class InternalDistributedSystem extends DistributedSystem
           //
           // However, make sure cache is completely closed before starting
           // the distributed system close.
-          InternalCache currentCache = GemFireCacheImpl.getInstance();
+          InternalCache currentCache = getCache();
           if (currentCache != null && !currentCache.isClosed()) {
             disconnectListenerThread.set(Boolean.TRUE); // bug #42663 - this must be set while
                                                         // closing the cache
@@ -3090,5 +3096,9 @@ public class InternalDistributedSystem extends DistributedSystem
 
   public void setCache(InternalCache instance) {
     this.dm.setCache(instance);
+  }
+
+  public InternalCache getCache() {
+    return this.dm == null ? null : this.dm.getCache();
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
@@ -14,6 +14,9 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.distributed.internal.InternalDistributedSystem.ALLOW_MULTIPLE_SYSTEMS;
+import static org.apache.geode.distributed.internal.InternalDistributedSystem.getAnyInstance;
+
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -259,15 +262,6 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
 
   /** The default "copy on read" attribute value */
   public static final boolean DEFAULT_COPY_ON_READ = false;
-
-  /** the last instance of GemFireCache created */
-  private static volatile GemFireCacheImpl instance = null;
-
-  /**
-   * Just like instance but is valid for a bit longer so that pdx can still find the cache during a
-   * close.
-   */
-  private static volatile GemFireCacheImpl pdxInstance = null;
 
   /**
    * The default amount of time to wait for a {@code netSearch} to complete
@@ -684,7 +678,21 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
    */
   @Deprecated
   public static GemFireCacheImpl getInstance() {
-    return instance;
+    InternalDistributedSystem system = InternalDistributedSystem.getAnyInstance();
+    if (system == null) {
+      return null;
+    }
+    GemFireCacheImpl cache = (GemFireCacheImpl) system.getCache();
+    if (cache == null) {
+      return null;
+    }
+
+    if (cache.isClosing) {
+      return null;
+    }
+
+    return cache;
+
   }
 
   /**
@@ -696,7 +704,7 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
    */
   @Deprecated
   public static GemFireCacheImpl getExisting() {
-    final GemFireCacheImpl result = instance;
+    final GemFireCacheImpl result = getInstance();
     if (result != null && !result.isClosing) {
       return result;
     }
@@ -732,11 +740,17 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
    *             in to your method.
    */
   public static GemFireCacheImpl getForPdx(String reason) {
-    GemFireCacheImpl result = pdxInstance;
-    if (result == null) {
+
+    InternalDistributedSystem system = getAnyInstance();
+    if (system == null) {
       throw new CacheClosedException(reason);
     }
-    return result;
+    GemFireCacheImpl cache = (GemFireCacheImpl) system.getCache();
+    if (cache == null) {
+      throw new CacheClosedException(reason);
+    }
+
+    return cache;
   }
 
   public static GemFireCacheImpl createClient(InternalDistributedSystem system, PoolFactory pf,
@@ -764,7 +778,7 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
       CacheWriterException, GatewayException, RegionExistsException {
     try {
       synchronized (GemFireCacheImpl.class) {
-        GemFireCacheImpl instance = checkExistingCache(existingOk, cacheConfig);
+        GemFireCacheImpl instance = checkExistingCache(existingOk, cacheConfig, system);
         if (instance == null) {
           instance = new GemFireCacheImpl(isClient, pf, system, cacheConfig, asyncEventListeners,
               typeRegistry);
@@ -784,8 +798,10 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
     }
   }
 
-  private static GemFireCacheImpl checkExistingCache(boolean existingOk, CacheConfig cacheConfig) {
-    GemFireCacheImpl instance = getInstance();
+  private static GemFireCacheImpl checkExistingCache(boolean existingOk, CacheConfig cacheConfig,
+      InternalDistributedSystem system) {
+    GemFireCacheImpl instance =
+        ALLOW_MULTIPLE_SYSTEMS ? (GemFireCacheImpl) system.getCache() : getInstance();
 
     if (instance != null && !instance.isClosed()) {
       if (existingOk) {
@@ -1143,13 +1159,6 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
    * references to this instance in this method (vs. the constructor).
    */
   private void initialize() {
-    if (GemFireCacheImpl.instance != null) {
-      Assert.assertTrue(GemFireCacheImpl.instance == null,
-          "Cache instance already in place: " + instance);
-    }
-    GemFireCacheImpl.instance = this;
-    GemFireCacheImpl.pdxInstance = this;
-
     for (CacheLifecycleListener listener : cacheLifecycleListeners) {
       listener.cacheCreated(this);
     }
@@ -1631,7 +1640,7 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
   public static void emergencyClose() {
     final boolean DEBUG = SystemFailure.TRACE_CLOSE;
 
-    GemFireCacheImpl cache = GemFireCacheImpl.instance;
+    GemFireCacheImpl cache = getInstance();
     if (cache == null) {
       if (DEBUG) {
         System.err.println("GemFireCache#emergencyClose: no instance");
@@ -1639,8 +1648,6 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
       return;
     }
 
-    GemFireCacheImpl.instance = null;
-    GemFireCacheImpl.pdxInstance = null;
     // leave the PdxSerializer set if we have one to prevent 43412
 
     // Shut down messaging first
@@ -2130,12 +2137,6 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
       this.isClosing = true;
       logger.info(LocalizedMessage.create(LocalizedStrings.GemFireCache_0_NOW_CLOSING, this));
 
-      // Before anything else...make sure that this instance is not
-      // available to anyone "fishing" for a cache...
-      if (GemFireCacheImpl.instance == this) {
-        GemFireCacheImpl.instance = null;
-      }
-
       // we don't clear the prID map if there is a system failure. Other
       // threads may be hung trying to communicate with the map locked
       if (systemFailureCause == null) {
@@ -2213,9 +2214,6 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
           }
 
           prepareDiskStoresForClose();
-          if (GemFireCacheImpl.pdxInstance == this) {
-            GemFireCacheImpl.pdxInstance = null;
-          }
 
           List<LocalRegion> rootRegionValues;
           synchronized (this.rootRegions) {

--- a/geode-core/src/main/java/org/apache/geode/internal/statistics/HostStatSampler.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/statistics/HostStatSampler.java
@@ -71,7 +71,7 @@ public abstract class HostStatSampler
 
   private static final int WAIT_FOR_SLEEP_INTERVAL = 10;
 
-  private static Thread statThread = null;
+  private Thread statThread = null;
 
   private volatile boolean stopRequested = false;
 

--- a/geode-core/src/test/java/org/apache/geode/pdx/internal/MultipleCacheJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/pdx/internal/MultipleCacheJUnitTest.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.pdx.internal;
+
+import static org.apache.geode.internal.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TemporaryFolder;
+
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.CacheFactory;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.distributed.ConfigurationProperties;
+import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.distributed.Locator;
+import org.apache.geode.distributed.internal.InternalDistributedSystem;
+import org.apache.geode.internal.AvailablePortHelper;
+import org.apache.geode.internal.Config;
+import org.apache.geode.internal.cache.GemFireCacheImpl;
+import org.apache.geode.test.junit.categories.IntegrationTest;
+
+/**
+ * Test that we can create multiple caches in the same JVM
+ */
+@Category(IntegrationTest.class)
+public class MultipleCacheJUnitTest {
+
+  @Rule
+  public TemporaryFolder locatorFolder = new TemporaryFolder();
+
+  private List<Cache> caches = new ArrayList<>();
+  private Properties props;
+  private Locator locator;
+
+  @Before
+  public void startLocator() throws IOException {
+    InternalDistributedSystem.ALLOW_MULTIPLE_SYSTEMS = true;
+    locator = Locator.startLocatorAndDS(0, locatorFolder.newFile("locator.log"), null);
+    props = new Properties();
+    props.setProperty(ConfigurationProperties.LOCATORS, "locahost[" + locator.getPort() + "]");
+  }
+
+  @After
+  public void closeSystemsAndLocator() {
+    try {
+      caches.forEach(Cache::close);
+      locator.stop();
+    } finally {
+      InternalDistributedSystem.ALLOW_MULTIPLE_SYSTEMS = false;
+    }
+  }
+
+  @Test
+  public void cacheCreateTwoPeerCaches() throws IOException {
+    Cache cache1 = createCache("cache1");
+    Cache cache2 = createCache("cache2");
+
+    assertNotEquals(cache1, cache2);
+
+    DistributedMember member1 = cache1.getDistributedSystem().getDistributedMember();
+
+    DistributedMember member2 = cache2.getDistributedSystem().getDistributedMember();
+
+    assertNotEquals(member1, member2);
+    assertTrue(cache2.getDistributedSystem().getAllOtherMembers().contains(member1));
+    assertTrue(cache1.getDistributedSystem().getAllOtherMembers().contains(member2));
+  }
+
+
+  @Test
+  public void canCreateTwoPeerCachesWithReplicatedRegion() throws IOException {
+    Cache cache1 = createCache("cache1");
+    Cache cache2 = createCache("cache2");
+
+    Region<String, String> region1 =
+        cache1.<String, String>createRegionFactory(RegionShortcut.REPLICATE).create("region");
+    Region<String, String> region2 =
+        cache2.<String, String>createRegionFactory(RegionShortcut.REPLICATE).create("region");
+
+    assertNotEquals(region1, region2);
+
+    String value = "value";
+    region1.put("key", value);
+
+    String region2Value = region2.get("key");
+    assertEquals(value, region2Value);
+    // Make sure the value was actually serialized/deserialized between the two caches
+    assertFalse(value == region2Value);
+  }
+
+  private Cache createCache(String memberName) {
+    Cache cache = new CacheFactory(props).set(ConfigurationProperties.NAME, memberName).create();
+    caches.add(cache);
+    return cache;
+  }
+
+}


### PR DESCRIPTION
If the system property gemfire.ALLOW_MULTIPLE_SYSTEMS is set, then we will
allow multiple caches in the same JVM. Otherwise, the we will have the
same behavior as before.

If the system property is set, we will not retain any static instance of
the cache or distributed system.

Removed the static instance variables from GemFireCacheImpl.
GemFireCacheImpl.getInstance calls now look up the cache instance from
the distributed system.

Note that a single distributed system can still only have a single
cache. Users should create caches and distributed systems using
CacheFactory.create.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
