### PR TITLE
GEODE-4374: Allow client calls to complete before shutting down

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/ShutDownFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/ShutDownFunction.java
@@ -72,6 +72,12 @@ public class ShutDownFunction implements Function, InternalEntity {
       throws InterruptedException, ExecutionException {
     ExecutorService exec = Executors.newSingleThreadExecutor();
     Future future = exec.submit(() -> {
+      try {
+        // Allow the function call to exit so we don't get disconnect exceptions in the client
+        // making the call.
+        Thread.sleep(1000);
+      } catch (InterruptedException ignore) {
+      }
       ConnectionTable.threadWantsSharedResources();
       if (ids.isConnected()) {
         ids.disconnect();

--- a/geode-web/src/test/java/org/apache/geode/management/internal/cli/commands/ShutdownCommandOverHttpDUnitTest.java
+++ b/geode-web/src/test/java/org/apache/geode/management/internal/cli/commands/ShutdownCommandOverHttpDUnitTest.java
@@ -21,7 +21,7 @@ import org.apache.geode.test.junit.categories.DistributedTest;
 import org.apache.geode.test.junit.categories.FlakyTest;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
 
-@Category({DistributedTest.class, FlakyTest.class})
+@Category(DistributedTest.class)
 public class ShutdownCommandOverHttpDUnitTest extends ShutdownCommandDUnitTest {
 
   @Override


### PR DESCRIPTION
- This adds a small delay in the async shutdown function so that any client
  responses can be sent. This avoids client getting some form of disconnect
  exception during shutdown.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
