### PR TITLE
GEODE-3948 Improve CQ performance under flaky network conditions

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/client/Pool.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/Pool.java
@@ -297,15 +297,9 @@ public interface Pool {
    * A server has an inactivity monitor that ensures a message is sent to a client at least once a
    * minute (60,000 milliseconds). If a subscription timeout multipler is set in the client it
    * enables timing out of the subscription feed with failover to another server.
-   * <p>
-   * A value of zero (the default) disables timeouts
-   * <p>
-   * A value of one will time out the server connection after one of its ping intervals (not
-   * recommended)
-   * <p>
-   * A value of two or more will time out the server connection after that many ping intervals have
-   * elapsed
-   *
+   * 
+   * @see PoolFactory#setSubscriptionTimeoutMultiplier(int)
+   * 
    * @return The timeout multiplier
    */
   int getSubscriptionTimeoutMultiplier();

--- a/geode-core/src/main/java/org/apache/geode/cache/client/Pool.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/Pool.java
@@ -305,7 +305,7 @@ public interface Pool {
    * <p>
    * A value of two or more will time out the server connection after that many ping intervals have
    * elapsed
-   * 
+   *
    * @return The timeout multiplier
    */
   int getSubscriptionTimeoutMultiplier();

--- a/geode-core/src/main/java/org/apache/geode/cache/client/Pool.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/Pool.java
@@ -293,4 +293,20 @@ public interface Pool {
    */
   public int getPendingEventCount();
 
+  /**
+   * A server has an inactivity monitor that ensures a message is sent to a client at least once a
+   * minute (60,000 milliseconds). If a subscription timeout multipler is set in the client it
+   * enables timing out of the subscription feed with failover to another server.
+   * <p>
+   * A value of zero (the default) disables timeouts
+   * <p>
+   * A value of one will time out the server connection after one of its ping intervals (not
+   * recommended)
+   * <p>
+   * A value of two or more will time out the server connection after that many ping intervals have
+   * elapsed
+   * 
+   * @return The timeout multiplier
+   */
+  int getSubscriptionTimeoutMultiplier();
 }

--- a/geode-core/src/main/java/org/apache/geode/cache/client/PoolFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/PoolFactory.java
@@ -440,11 +440,8 @@ public interface PoolFactory {
    * <p>
    * A value of zero (the default) disables timeouts
    * <p>
-   * A value of one will time out the server connection after one of its ping intervals (not
-   * recommended)
-   * <p>
-   * A value of two or more will time out the server connection after that many ping intervals have
-   * elapsed
+   * The resulting timeout will be multiplied by 1.25 in order to avoid race conditions with the
+   * server sending its "ping" message.
    */
   public PoolFactory setSubscriptionTimeoutMultiplier(int multiplier);
 

--- a/geode-core/src/main/java/org/apache/geode/cache/client/PoolFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/PoolFactory.java
@@ -173,6 +173,14 @@ public interface PoolFactory {
   public static final int DEFAULT_SUBSCRIPTION_ACK_INTERVAL = 100;
 
   /**
+   * The default number of server "ping" intervals that can elapse with no activity before a
+   * subscription connection is deemed dead and failover is initiated.
+   * <p>
+   * Current value: 0
+   */
+  public static final int DEFAULT_SUBSCRIPTION_TIMEOUT_MULTIPLIER = 0;
+
+  /**
    * The default server group.
    * <p>
    * Current value: <code>""</code>.
@@ -424,6 +432,21 @@ public interface PoolFactory {
    *         to <code>0</code>.
    */
   public PoolFactory setSubscriptionMessageTrackingTimeout(int messageTrackingTimeout);
+
+  /**
+   * A server has an inactivity monitor that ensures a message is sent to a client at least once a
+   * minute (60,000 milliseconds). If a subscription timeout multipler is set in the client it
+   * enables timing out of the subscription feed with failover to another server.
+   * <p>
+   * A value of zero (the default) disables timeouts
+   * <p>
+   * A value of one will time out the server connection after one of its ping intervals (not
+   * recommended)
+   * <p>
+   * A value of two or more will time out the server connection after that many ping intervals have
+   * elapsed
+   */
+  public PoolFactory setSubscriptionTimeoutMultiplier(int multiplier);
 
   /**
    * Sets the interval in milliseconds to wait before sending acknowledgements to the cache server

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/AbstractOp.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/AbstractOp.java
@@ -205,7 +205,7 @@ public abstract class AbstractOp implements Op {
         }
       } else {
         try {
-          msg.recv();
+          msg.receive();
         } finally {
           msg.unsetComms();
           processSecureBytes(cnx, msg);

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/AuthenticateUserOp.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/AuthenticateUserOp.java
@@ -195,7 +195,7 @@ public class AuthenticateUserOp {
           }
         } else {
           try {
-            msg.recv();
+            msg.receive();
           } finally {
             msg.unsetComms();
             processSecureBytes(cnx, msg);

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/PoolImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/PoolImpl.java
@@ -110,6 +110,7 @@ public class PoolImpl implements InternalPool {
   private final int subscriptionRedundancyLevel;
   private final int subscriptionMessageTrackingTimeout;
   private final int subscriptionAckInterval;
+  private final int subscriptionTimeoutMultiplier;
   private final String serverGroup;
   private final List<HostAddress> locatorAddresses;
   private final List<InetSocketAddress> locators;
@@ -201,6 +202,10 @@ public class PoolImpl implements InternalPool {
     this.subscriptionRedundancyLevel = attributes.getSubscriptionRedundancy();
     this.subscriptionMessageTrackingTimeout = attributes.getSubscriptionMessageTrackingTimeout();
     this.subscriptionAckInterval = attributes.getSubscriptionAckInterval();
+    this.subscriptionTimeoutMultiplier = attributes.getSubscriptionTimeoutMultiplier();
+    if (this.subscriptionTimeoutMultiplier < 0) {
+      throw new IllegalArgumentException("The subscription timeout multipler must not be negative");
+    }
     this.serverGroup = attributes.getServerGroup();
     this.multiuserSecureModeEnabled = attributes.getMultiuserAuthentication();
     this.locatorAddresses = locAddresses;
@@ -1586,5 +1591,10 @@ public class PoolImpl implements InternalPool {
               .toLocalizedString());
     }
     return this.primaryQueueSize.get();
+  }
+
+  @Override
+  public int getSubscriptionTimeoutMultiplier() {
+    return subscriptionTimeoutMultiplier;
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/PutOp.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/PutOp.java
@@ -466,7 +466,7 @@ public class PutOp {
           }
         } else {
           try {
-            msg.recv();
+            msg.receive();
           } finally {
             msg.unsetComms();
             processSecureBytes(cnx, msg);

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/pooling/ConnectionManagerImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/pooling/ConnectionManagerImpl.java
@@ -174,7 +174,6 @@ public class ConnectionManagerImpl implements ConnectionManager {
     this.idleTimeoutNanos = this.idleTimeout * NANOS_PER_MS;
     this.securityLogWriter = securityLogger;
     this.prefillRetry = pingInterval;
-    // this.pingInterval = pingInterval;
     this.cancelCriterion = cancelCriterion;
     this.endpointListener = new EndpointManager.EndpointListenerAdapter() {
       @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/Version.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/Version.java
@@ -59,7 +59,7 @@ public class Version implements Comparable<Version> {
   /** byte used as ordinal to represent this <code>Version</code> */
   private final short ordinal;
 
-  public static final int HIGHEST_VERSION = 75;
+  public static final int HIGHEST_VERSION = 80;
 
   private static final Version[] VALUES = new Version[HIGHEST_VERSION + 1];
 
@@ -208,11 +208,15 @@ public class Version implements Comparable<Version> {
   public static final Version GEODE_140 =
       new Version("GEODE", "1.4.0", (byte) 1, (byte) 4, (byte) 0, (byte) 0, GEODE_140_ORDINAL);
 
+  private static final byte GEODE_150_ORDINAL = 80;
+
+  public static final Version GEODE_150 =
+      new Version("GEODE", "1.5.0", (byte) 1, (byte) 5, (byte) 0, (byte) 0, GEODE_150_ORDINAL);
   /**
    * This constant must be set to the most current version of the product. !!! NOTE: update
    * HIGHEST_VERSION when changing CURRENT !!!
    */
-  public static final Version CURRENT = GEODE_140;
+  public static final Version CURRENT = GEODE_150;
 
   /**
    * A lot of versioning code needs access to the current version's ordinal

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PoolFactoryImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PoolFactoryImpl.java
@@ -220,6 +220,12 @@ public class PoolFactoryImpl implements PoolFactory {
     return this;
   }
 
+  @Override
+  public PoolFactory setSubscriptionTimeoutMultiplier(int multiplier) {
+    this.attributes.subscriptionTimeoutMultipler = multiplier;
+    return this;
+  }
+
   private InetSocketAddress getInetSocketAddress(String host, int port) {
     if (port == 0) {
       throw new IllegalArgumentException("port must be greater than 0 but was " + port);
@@ -369,6 +375,7 @@ public class PoolFactoryImpl implements PoolFactory {
     public int queueRedundancyLevel = DEFAULT_SUBSCRIPTION_REDUNDANCY;
     public int queueMessageTrackingTimeout = DEFAULT_SUBSCRIPTION_MESSAGE_TRACKING_TIMEOUT;
     public int queueAckInterval = DEFAULT_SUBSCRIPTION_ACK_INTERVAL;
+    public int subscriptionTimeoutMultipler = DEFAULT_SUBSCRIPTION_TIMEOUT_MULTIPLIER;
     public String serverGroup = DEFAULT_SERVER_GROUP;
     public boolean multiuserSecureModeEnabled = DEFAULT_MULTIUSER_AUTHENTICATION;
     public ArrayList/* <InetSocketAddress> */ locators = new ArrayList();
@@ -381,74 +388,92 @@ public class PoolFactoryImpl implements PoolFactory {
      */
     public boolean gateway = false;
 
+    @Override
     public int getSocketConnectTimeout() {
       return this.socketConnectTimeout;
     }
 
+    @Override
     public int getFreeConnectionTimeout() {
       return this.connectionTimeout;
     }
 
+    @Override
     public int getLoadConditioningInterval() {
       return this.connectionLifetime;
     }
 
+    @Override
     public int getSocketBufferSize() {
       return this.socketBufferSize;
     }
 
+    @Override
     public int getMinConnections() {
       return minConnections;
     }
 
+    @Override
     public int getMaxConnections() {
       return maxConnections;
     }
 
+    @Override
     public long getIdleTimeout() {
       return idleTimeout;
     }
 
+    @Override
     public int getRetryAttempts() {
       return retryAttempts;
     }
 
+    @Override
     public long getPingInterval() {
       return pingInterval;
     }
 
+    @Override
     public int getStatisticInterval() {
       return statisticInterval;
     }
 
+    @Override
     public boolean getThreadLocalConnections() {
       return this.threadLocalConnections;
     }
 
+    @Override
     public int getReadTimeout() {
       return this.readTimeout;
     }
 
+    @Override
     public boolean getSubscriptionEnabled() {
       return this.queueEnabled;
     }
 
+    @Override
     public boolean getPRSingleHopEnabled() {
       return this.prSingleHopEnabled;
     }
 
+    @Override
     public int getSubscriptionRedundancy() {
       return this.queueRedundancyLevel;
     }
 
+    @Override
     public int getSubscriptionMessageTrackingTimeout() {
       return this.queueMessageTrackingTimeout;
     }
 
+    @Override
     public int getSubscriptionAckInterval() {
       return queueAckInterval;
     }
 
+    @Override
     public String getServerGroup() {
       return this.serverGroup;
     }
@@ -469,12 +494,18 @@ public class PoolFactoryImpl implements PoolFactory {
       return this.gatewaySender;
     }
 
+    @Override
     public boolean getMultiuserAuthentication() {
       return this.multiuserSecureModeEnabled;
     }
 
     public void setMultiuserSecureModeEnabled(boolean v) {
       this.multiuserSecureModeEnabled = v;
+    }
+
+    @Override
+    public int getSubscriptionTimeoutMultiplier() {
+      return this.subscriptionTimeoutMultipler;
     }
 
     public List/* <InetSocketAddress> */ getLocators() {
@@ -528,10 +559,8 @@ public class PoolFactoryImpl implements PoolFactory {
       throw new UnsupportedOperationException();
     }
 
-    public RegionService createAuthenticatedCacheView(Properties properties) {
-      throw new UnsupportedOperationException();
-    }
 
+    @Override
     public void toData(DataOutput out) throws IOException {
       DataSerializer.writePrimitiveInt(this.connectionTimeout, out);
       DataSerializer.writePrimitiveInt(this.connectionLifetime, out);
@@ -554,6 +583,7 @@ public class PoolFactoryImpl implements PoolFactory {
       DataSerializer.writePrimitiveInt(this.socketConnectTimeout, out);
     }
 
+    @Override
     public void fromData(DataInput in) throws IOException, ClassNotFoundException {
       this.connectionTimeout = DataSerializer.readPrimitiveInt(in);
       this.connectionLifetime = DataSerializer.readPrimitiveInt(in);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/ClientHandShake.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/ClientHandShake.java
@@ -39,6 +39,6 @@ public interface ClientHandShake {
 
   public Version getVersion();
 
-  public void accept(OutputStream out, InputStream in, byte epType, int qSize,
-      CommunicationMode communicationMode, Principal principal) throws IOException;
+  public void handshakeWithClient(OutputStream out, InputStream in, byte epType, int pingInterval,
+      int qSize, CommunicationMode communicationMode, Principal principal) throws IOException;
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/AcceptorImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/AcceptorImpl.java
@@ -1831,7 +1831,7 @@ public class AcceptorImpl implements Acceptor, Runnable, CommBufferPool {
 
     @Override
     public void run() {
-      logger.info(":Bridge server: Initializing {} server-to-client communication socket: {}",
+      logger.info(":Cache server: Initializing {} server-to-client communication socket: {}",
           isPrimaryServerToClient ? "primary" : "secondary", socket);
       try {
         acceptor.getCacheClientNotifier().registerClient(socket, isPrimaryServerToClient,

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/BaseCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/BaseCommand.java
@@ -848,7 +848,7 @@ public abstract class BaseCommand implements Command {
     Message requestMsg = null;
     try {
       requestMsg = servConn.getRequestMessage();
-      requestMsg.recv(servConn, MAX_INCOMING_DATA, INCOMING_DATA_LIMITER, INCOMING_MSG_LIMITER);
+      requestMsg.receive(servConn, MAX_INCOMING_DATA, INCOMING_DATA_LIMITER, INCOMING_MSG_LIMITER);
       return requestMsg;
     } catch (EOFException eof) {
       handleEOFException(null, servConn, eof);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientNotifier.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientNotifier.java
@@ -159,20 +159,21 @@ public class CacheClientNotifier {
    */
   private void writeMessage(DataOutputStream dos, byte type, String p_msg, Version clientVersion)
       throws IOException {
-    writeMessage(dos, type, p_msg, clientVersion, (byte) 0x00, 0);
+    writeHandshakeMessage(dos, type, p_msg, clientVersion, (byte) 0x00, 0);
   }
 
-  private void writeMessage(DataOutputStream dos, byte type, String p_msg, Version clientVersion,
-      byte epType, int qSize) throws IOException {
+  private void writeHandshakeMessage(DataOutputStream dos, byte type, String p_msg,
+      Version clientVersion, byte epType, int qSize) throws IOException {
     String msg = p_msg;
 
     // write the message type
     dos.writeByte(type);
 
-    // dummy epType
     dos.writeByte(epType);
-    // dummy qSize
     dos.writeInt(qSize);
+    if (clientVersion.compareTo(Version.GEODE_150) >= 0) {
+      dos.writeInt(CLIENT_PING_TASK_PERIOD);
+    }
 
     if (msg == null) {
       msg = "";
@@ -295,7 +296,7 @@ public class CacheClientNotifier {
     ClientProxyMembershipID proxyID = null;
     CacheClientProxy proxy;
     AccessControl authzCallback = null;
-    byte clientConflation = HandShake.CONFLATION_DEFAULT;
+    byte clientConflation;
     try {
       proxyID = ClientProxyMembershipID.readCanonicalized(dis);
       if (getBlacklistedClient().contains(proxyID)) {
@@ -558,7 +559,7 @@ public class CacheClientNotifier {
       DataOutputStream dos =
           new DataOutputStream(new BufferedOutputStream(socket.getOutputStream()));
       // write the message type, message length and the error message (if any)
-      writeMessage(dos, responseByte, unsuccessfulMsg, clientVersion, epType, qSize);
+      writeHandshakeMessage(dos, responseByte, unsuccessfulMsg, clientVersion, epType, qSize);
     } catch (IOException ioe) {// remove the added proxy if we get IOException.
       if (l_proxy != null) {
         boolean keepProxy = l_proxy.close(false, false); // do not check for queue, just close it
@@ -2193,14 +2194,19 @@ public class CacheClientNotifier {
 
   private final SocketCloser socketCloser;
 
-  private static final long CLIENT_PING_TASK_PERIOD =
-      Long.getLong(DistributionConfig.GEMFIRE_PREFIX + "serverToClientPingPeriod", 60000);
+  private static final int CLIENT_PING_TASK_PERIOD =
+      Integer.getInteger(DistributionConfig.GEMFIRE_PREFIX + "serverToClientPingPeriod", 60000);
 
   private static final long CLIENT_PING_TASK_COUNTER =
       Long.getLong(DistributionConfig.GEMFIRE_PREFIX + "serverToClientPingCounter", 3);
 
   public long getLogFrequency() {
     return this.logFrequency;
+  }
+
+  /** returns the interval between "ping" messages sent to clients on idle connections */
+  public static int getClientPingInterval() {
+    return CLIENT_PING_TASK_PERIOD;
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientUpdater.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientUpdater.java
@@ -1561,6 +1561,10 @@ public class CacheClientUpdater extends Thread implements ClientUpdater, Disconn
    */
   private void processMessages() {
     final boolean isDebugEnabled = logger.isDebugEnabled();
+
+    final int headerReadTimeout = (int) Math.round(serverQueueStatus.getPingInterval()
+        * qManager.getPool().getSubscriptionTimeoutMultiplier() * 1.25);
+
     try {
       Message clientMessage = initializeMessage();
 
@@ -1595,7 +1599,7 @@ public class CacheClientUpdater extends Thread implements ClientUpdater, Disconn
 
         try {
           // Read the message
-          clientMessage.receiveWithHeaderReadTimeout(serverQueueStatus.getPingInterval() * 2);
+          clientMessage.receiveWithHeaderReadTimeout(headerReadTimeout);
 
           // Wait for the previously failed cache client updater
           // to finish. This will avoid out of order messages.

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CommandInitializer.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CommandInitializer.java
@@ -355,6 +355,11 @@ public class CommandInitializer {
       commands.putAll(ALL_COMMANDS.get(Version.GEODE_130));
       ALL_COMMANDS.put(Version.GEODE_140, commands);
     }
+    {
+      Map<Integer, Command> commands = new HashMap<Integer, Command>();
+      commands.putAll(ALL_COMMANDS.get(Version.GEODE_140));
+      ALL_COMMANDS.put(Version.GEODE_150, commands);
+    }
 
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/HandShake.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/HandShake.java
@@ -1110,8 +1110,9 @@ public class HandShake implements ClientHandShake {
     }
   }
 
-  public void accept(OutputStream out, InputStream in, byte epType, int qSize,
-      CommunicationMode communicationMode, Principal principal) throws IOException {
+  @Override
+  public void handshakeWithClient(OutputStream out, InputStream in, byte epType, int pingInterval,
+      int qSize, CommunicationMode communicationMode, Principal principal) throws IOException {
     DataOutputStream dos = new DataOutputStream(out);
     DataInputStream dis;
     if (clientVersion.compareTo(Version.CURRENT) < 0) {
@@ -1135,6 +1136,12 @@ public class HandShake implements ClientHandShake {
 
     dos.writeByte(epType);
     dos.writeInt(qSize);
+    if (clientVersion.compareTo(Version.GEODE_150) >= 0) {
+      logger.info("writing ping interval");
+      dos.writeInt(pingInterval);
+    }
+    // GEODE-3948 - write the server's Ping interval setting if the client will read it (based on
+    // client version)
 
     // Write the server's member
     DistributedMember member = this.system.getDistributedMember();
@@ -1241,14 +1248,13 @@ public class HandShake implements ClientHandShake {
         }
       }
 
-      // No need to check for return value since DataInputStream already throws
-      // EOFException in case of EOF
       byte epType = dis.readByte();
       int qSize = dis.readInt();
+      int pingInterval = dis.readInt();
 
       // Read the server member
       member = readServerMember(dis);
-      serverQStatus = new ServerQueueStatus(epType, qSize, member);
+      serverQStatus = new ServerQueueStatus(epType, qSize, member, pingInterval);
 
       // Read the message (if any)
       readMessage(dis, dos, acceptanceCode, member);
@@ -1318,12 +1324,10 @@ public class HandShake implements ClientHandShake {
             LocalizedStrings.HandShake_SERVER_EXPECTING_SSL_CONNECTION.toLocalizedString());
       }
 
-      // No need to check for return value since DataInputStream already throws
-      // EOFException in case of EOF
       byte qType = dis.readByte();
-      // read and ignore qSize flag
       int qSize = dis.readInt();
-      sqs = new ServerQueueStatus(qType, qSize, member);
+      int pingInterval = dis.readInt();
+      sqs = new ServerQueueStatus(qType, qSize, member, pingInterval);
 
       // Read the message (if any)
       readMessage(dis, dos, acceptanceCode, member);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/HandShake.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/HandShake.java
@@ -1137,11 +1137,8 @@ public class HandShake implements ClientHandShake {
     dos.writeByte(epType);
     dos.writeInt(qSize);
     if (clientVersion.compareTo(Version.GEODE_150) >= 0) {
-      logger.info("writing ping interval");
       dos.writeInt(pingInterval);
     }
-    // GEODE-3948 - write the server's Ping interval setting if the client will read it (based on
-    // client version)
 
     // Write the server's member
     DistributedMember member = this.system.getDistributedMember();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/Message.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/Message.java
@@ -889,7 +889,7 @@ public class Message {
           cb.get(partBytes, 0, alreadyReadBytes);
         }
 
-        // now we need to readHeaderAndBody partLen - alreadyReadBytes off the wire
+        // now we need to read partLen - alreadyReadBytes off the wire
         int off = alreadyReadBytes;
         int remaining = partLen - off;
         while (remaining > 0) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/Message.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/Message.java
@@ -109,6 +109,8 @@ public class Message {
   private static final byte[] TRUE = defineTrue();
   private static final byte[] FALSE = defineFalse();
 
+  private static final int NO_HEADER_READ_TIMEOUT = 0;
+
   private static byte[] defineTrue() {
     try (HeapDataOutputStream hdos = new HeapDataOutputStream(10, null)) {
       BlobHelper.serializeTo(Boolean.TRUE, hdos);
@@ -647,61 +649,18 @@ public class Message {
     cb.clear();
   }
 
-  private void read() throws IOException {
+  private void readHeaderAndBody(int headerReadTimeoutMillis) throws IOException {
     clearParts();
     // TODO: for server changes make sure sc is not null as this class also used by client
-    readHeaderAndPayload();
-  }
 
-  /**
-   * Read the actual bytes of the header off the socket
-   */
-  void fetchHeader() throws IOException {
-    final ByteBuffer cb = getCommBuffer();
-    cb.clear();
-
-    // messageType is invalidated here and can be used as an indicator
-    // of problems reading the message
-    this.messageType = MessageType.INVALID;
-
-    final int headerLength = getHeaderLength();
-    if (this.socketChannel != null) {
-      cb.limit(headerLength);
-      do {
-        int bytesRead = this.socketChannel.read(cb);
-        if (bytesRead == -1) {
-          throw new EOFException(
-              LocalizedStrings.Message_THE_CONNECTION_HAS_BEEN_RESET_WHILE_READING_THE_HEADER
-                  .toLocalizedString());
-        }
-        if (this.messageStats != null) {
-          this.messageStats.incReceivedBytes(bytesRead);
-        }
-      } while (cb.remaining() > 0);
-      cb.flip();
-
-    } else {
-      int hdr = 0;
-      do {
-        int bytesRead = this.inputStream.read(cb.array(), hdr, headerLength - hdr);
-        if (bytesRead == -1) {
-          throw new EOFException(
-              LocalizedStrings.Message_THE_CONNECTION_HAS_BEEN_RESET_WHILE_READING_THE_HEADER
-                  .toLocalizedString());
-        }
-        hdr += bytesRead;
-        if (this.messageStats != null) {
-          this.messageStats.incReceivedBytes(bytesRead);
-        }
-      } while (hdr < headerLength);
-
-      // now setup the commBuffer for the caller to parse it
-      cb.rewind();
+    int timeout = socket.getSoTimeout();
+    try {
+      socket.setSoTimeout(headerReadTimeoutMillis);
+      fetchHeader();
+    } finally {
+      socket.setSoTimeout(timeout);
     }
-  }
 
-  private void readHeaderAndPayload() throws IOException {
-    fetchHeader();
     final ByteBuffer cb = getCommBuffer();
     final int type = cb.getInt();
     final int len = cb.getInt();
@@ -818,6 +777,53 @@ public class Message {
   }
 
   /**
+   * Read the actual bytes of the header off the socket
+   */
+  void fetchHeader() throws IOException {
+    final ByteBuffer cb = getCommBuffer();
+    cb.clear();
+
+    // messageType is invalidated here and can be used as an indicator
+    // of problems reading the message
+    this.messageType = MessageType.INVALID;
+
+    final int headerLength = getHeaderLength();
+    if (this.socketChannel != null) {
+      cb.limit(headerLength);
+      do {
+        int bytesRead = this.socketChannel.read(cb);
+        if (bytesRead == -1) {
+          throw new EOFException(
+              LocalizedStrings.Message_THE_CONNECTION_HAS_BEEN_RESET_WHILE_READING_THE_HEADER
+                  .toLocalizedString());
+        }
+        if (this.messageStats != null) {
+          this.messageStats.incReceivedBytes(bytesRead);
+        }
+      } while (cb.remaining() > 0);
+      cb.flip();
+
+    } else {
+      int hdr = 0;
+      do {
+        int bytesRead = this.inputStream.read(cb.array(), hdr, headerLength - hdr);
+        if (bytesRead == -1) {
+          throw new EOFException(
+              LocalizedStrings.Message_THE_CONNECTION_HAS_BEEN_RESET_WHILE_READING_THE_HEADER
+                  .toLocalizedString());
+        }
+        hdr += bytesRead;
+        if (this.messageStats != null) {
+          this.messageStats.incReceivedBytes(bytesRead);
+        }
+      } while (hdr < headerLength);
+
+      // now setup the commBuffer for the caller to parse it
+      cb.rewind();
+    }
+  }
+
+  /**
    * TODO: refactor overly long method readPayloadFields
    */
   void readPayloadFields(final int numParts, final int len) throws IOException {
@@ -883,7 +889,7 @@ public class Message {
           cb.get(partBytes, 0, alreadyReadBytes);
         }
 
-        // now we need to read partLen - alreadyReadBytes off the wire
+        // now we need to readHeaderAndBody partLen - alreadyReadBytes off the wire
         int off = alreadyReadBytes;
         int remaining = partLen - off;
         while (remaining > 0) {
@@ -1043,12 +1049,14 @@ public class Message {
     return sb.toString();
   }
 
+  // Set up a message on the server side.
   void setComms(ServerConnection sc, Socket socket, ByteBuffer bb, MessageStats msgStats)
       throws IOException {
     this.serverConnection = sc;
     setComms(socket, bb, msgStats);
   }
 
+  // Set up a message on the client side.
   void setComms(Socket socket, ByteBuffer bb, MessageStats msgStats) throws IOException {
     this.socketChannel = socket.getChannel();
     if (this.socketChannel == null) {
@@ -1058,6 +1066,7 @@ public class Message {
     }
   }
 
+  // Set up a message on the client side.
   public void setComms(Socket socket, InputStream is, OutputStream os, ByteBuffer bb,
       MessageStats msgStats) {
     Assert.assertTrue(socket != null);
@@ -1104,25 +1113,36 @@ public class Message {
   }
 
   /**
-   * Populates the stats of this {@code Message} with information received via its socket
+   * Read a message, populating the state of this {@code Message} with information received via its
+   * socket
+   *
+   * @param timeoutMillis timeout setting for reading the header (0 = no timeout)
+   * @throws IOException
    */
-  public void recv() throws IOException {
+  public void receiveWithHeaderReadTimeout(int timeoutMillis) throws IOException {
     if (this.socket != null) {
       synchronized (getCommBuffer()) {
-        read();
+        readHeaderAndBody(timeoutMillis);
       }
     } else {
       throw new IOException(LocalizedStrings.Message_DEAD_CONNECTION.toLocalizedString());
     }
   }
 
-  public void recv(ServerConnection sc, int maxMessageLength, Semaphore dataLimiter,
+  /**
+   * Populates the state of this {@code Message} with information received via its socket
+   */
+  public void receive() throws IOException {
+    receiveWithHeaderReadTimeout(NO_HEADER_READ_TIMEOUT);
+  }
+
+  public void receive(ServerConnection sc, int maxMessageLength, Semaphore dataLimiter,
       Semaphore msgLimiter) throws IOException {
     this.serverConnection = sc;
     this.maxIncomingMessageLength = maxMessageLength;
     this.dataLimiter = dataLimiter;
     this.messageLimiter = msgLimiter;
-    recv();
+    receive();
   }
 
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/OriginalServerConnection.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/OriginalServerConnection.java
@@ -62,8 +62,9 @@ public class OriginalServerConnection extends ServerConnection {
   @Override
   protected boolean doHandShake(byte epType, int qSize) {
     try {
-      this.handshake.accept(theSocket.getOutputStream(), theSocket.getInputStream(), epType, qSize,
-          this.communicationMode, this.principal);
+      handshake.handshakeWithClient(theSocket.getOutputStream(), theSocket.getInputStream(), epType,
+          CacheClientNotifier.getClientPingInterval(), qSize, this.communicationMode,
+          this.principal);
     } catch (IOException ioe) {
       if (!crHelper.isShutdown() && !isTerminated()) {
         logger.warn(LocalizedMessage.create(

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ServerQueueStatus.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ServerQueueStatus.java
@@ -26,6 +26,8 @@ import org.apache.geode.distributed.DistributedMember;
  *
  */
 public class ServerQueueStatus {
+  /** interval that server sends pings if connection is idle */
+  private final int pingInterval;
   /** queueSize of HARegionQueue for this client */
   private int qSize = 0;
   /** Endpoint type for this endpoint */
@@ -35,23 +37,17 @@ public class ServerQueueStatus {
   private int pdxSize = 0;
 
   /**
-   * Default constructor Called when connectionsPerServer=0
-   */
-  public ServerQueueStatus(DistributedMember memberId) {
-    this((byte) 0, 0, memberId);
-  }
-
-  /**
    * Constructor Called when connectionsPerServer is nto equal to 0
    *
    * @param epType
    * @param qSize
+   * @param pingInterval
    */
-  public ServerQueueStatus(byte epType, int qSize, DistributedMember memberId) {
+  public ServerQueueStatus(byte epType, int qSize, DistributedMember memberId, int pingInterval) {
     this.qSize = qSize;
     this.epType = epType;
     this.memberId = memberId;
-
+    this.pingInterval = pingInterval;
   }
 
   /**
@@ -90,10 +86,16 @@ public class ServerQueueStatus {
     return this.qSize;
   }
 
+  /** returns the time between server-to-client ping messages on idle subscription connections */
+  public int getPingInterval() {
+    return this.pingInterval;
+  }
+
   public String toString() {
     StringBuffer buffer = new StringBuffer();
     buffer.append("ServerQueueStatus [").append("qSize=").append(this.qSize).append("; epType=")
-        .append(getTypeAsString()).append("]");
+        .append(getTypeAsString()).append("; pingInterval=").append(this.pingInterval)
+        .append(" ms]");
     return buffer.toString();
   }
 

--- a/geode-core/src/test/java/org/apache/geode/cache/client/internal/AutoConnectionSourceImplJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/client/internal/AutoConnectionSourceImplJUnitTest.java
@@ -638,6 +638,11 @@ public class AutoConnectionSourceImplJUnitTest {
       return 0;
     }
 
+    @Override
+    public int getSubscriptionTimeoutMultiplier() {
+      return 0;
+    }
+
     public RegionService createAuthenticatedCacheView(Properties properties) {
       return null;
     }

--- a/geode-core/src/test/java/org/apache/geode/cache/client/internal/QueueManagerJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/client/internal/QueueManagerJUnitTest.java
@@ -493,6 +493,11 @@ public class QueueManagerJUnitTest {
       return 0;
     }
 
+    @Override
+    public int getSubscriptionTimeoutMultiplier() {
+      return 0;
+    }
+
     public RegionService createAuthenticatedCacheView(Properties properties) {
       return null;
     }
@@ -549,20 +554,26 @@ public class QueueManagerJUnitTest {
     public ClientUpdater createServerToClientConnection(Endpoint endpoint,
         QueueManager queueManager, boolean isPrimary, ClientUpdater failedUpdater) {
       return new ClientUpdater() {
+        @Override
         public void close() {}
 
+        @Override
         public boolean isAlive() {
           return true;
         }
 
+        @Override
         public void join(long wait) throws InterruptedException {}
 
+        @Override
         public void setFailedUpdater(ClientUpdater failedUpdater) {}
 
+        @Override
         public boolean isProcessing() {
           return true;
         }
 
+        @Override
         public boolean isPrimary() {
           return true;
         }
@@ -573,15 +584,18 @@ public class QueueManagerJUnitTest {
   private class DummySource implements ConnectionSource {
     int nextPort = 0;
 
+    @Override
     public ServerLocation findServer(Set excludedServers) {
       return new ServerLocation("localhost", nextPort++);
     }
 
+    @Override
     public ServerLocation findReplacementServer(ServerLocation currentServer,
         Set/* <ServerLocation> */ excludedServers) {
       return new ServerLocation("localhost", nextPort++);
     }
 
+    @Override
     public List findServersForQueue(Set excludedServers, int numServers,
         ClientProxyMembershipID proxyId, boolean findDurableQueue) {
       numServers =
@@ -593,12 +607,13 @@ public class QueueManagerJUnitTest {
       return locations;
     }
 
+    @Override
     public void start(InternalPool poolImpl) {}
 
-    public void stop() {
+    @Override
+    public void stop() {}
 
-    }
-
+    @Override
     public boolean isBalanced() {
       return false;
     }
@@ -622,72 +637,88 @@ public class QueueManagerJUnitTest {
 
     public DummyConnection(int epType, int queueSize, int port) throws UnknownHostException {
       InternalDistributedMember member = new InternalDistributedMember("localhost", 555);
-      ServerQueueStatus status = new ServerQueueStatus((byte) epType, queueSize, member);
+      ServerQueueStatus status = new ServerQueueStatus((byte) epType, queueSize, member, 0);
       this.status = status;
       this.location = new ServerLocation("localhost", port);
       this.endpoint = endpoints.referenceEndpoint(location, member);
     }
 
-    public void internalDestroy() {}
-
+    @Override
     public void close(boolean keepAlive) throws Exception {}
 
+    @Override
     public void destroy() {}
 
+    @Override
     public Object execute(Op op) throws Exception {
       return null;
     }
 
+    @Override
     public int getDistributedSystemId() {
       return 0;
     }
 
+    @Override
     public ByteBuffer getCommBuffer() {
       return null;
     }
 
+    @Override
     public Endpoint getEndpoint() {
       return endpoint;
     }
 
+    @Override
     public ServerQueueStatus getQueueStatus() {
       return status;
     }
 
+    @Override
     public ServerLocation getServer() {
       return location;
     }
 
+    @Override
     public Socket getSocket() {
       return null;
     }
 
+    @Override
     public ConnectionStats getStats() {
       return null;
     }
 
+    @Override
     public boolean isDestroyed() {
       return false;
     }
 
+    @Override
     public void emergencyClose() {}
 
+    @Override
     public short getWanSiteVersion() {
       return -1;
     }
 
+    @Override
     public void setWanSiteVersion(short wanSiteVersion) {}
 
+    @Override
     public OutputStream getOutputStream() {
       return null;
     }
 
+    @Override
     public InputStream getInputStream() {
       return null;
     }
 
+    @Override
     public void setConnectionID(long id) {}
 
+    @Override
     public long getConnectionID() {
       return 0;
     }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ClientServerMiscDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ClientServerMiscDUnitTest.java
@@ -192,7 +192,7 @@ public class ClientServerMiscDUnitTest extends JUnit4CacheTestCase {
    * When a client's subscription thread connects to a server it should receive the server's
    * pingInterval setting. This is used by the client to set a read-timeout in order to avoid
    * hanging should the server's machine crash.
-   * 
+   *
    * @see MessageJUnitTest#messageWillTimeoutDuringRecvOnInactiveSocket
    */
   @Test

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ClientServerMiscDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ClientServerMiscDUnitTest.java
@@ -18,6 +18,7 @@ import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -26,6 +27,7 @@ import static org.junit.Assert.fail;
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Properties;
@@ -52,13 +54,16 @@ import org.apache.geode.cache.RegionEvent;
 import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.cache.Scope;
 import org.apache.geode.cache.client.ClientCacheFactory;
+import org.apache.geode.cache.client.ClientRegionShortcut;
 import org.apache.geode.cache.client.NoAvailableServersException;
 import org.apache.geode.cache.client.Pool;
 import org.apache.geode.cache.client.PoolFactory;
 import org.apache.geode.cache.client.PoolManager;
 import org.apache.geode.cache.client.internal.Connection;
+import org.apache.geode.cache.client.internal.ConnectionFactory;
 import org.apache.geode.cache.client.internal.Op;
 import org.apache.geode.cache.client.internal.PoolImpl;
+import org.apache.geode.cache.client.internal.QueueConnectionImpl;
 import org.apache.geode.cache.client.internal.RegisterInterestTracker;
 import org.apache.geode.cache.server.CacheServer;
 import org.apache.geode.cache.util.CacheListenerAdapter;
@@ -67,6 +72,7 @@ import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.distributed.DistributedSystemDisconnectedException;
 import org.apache.geode.distributed.internal.DistributionConfig;
+import org.apache.geode.distributed.internal.ServerLocation;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.AvailablePort;
 import org.apache.geode.internal.cache.CacheServerImpl;
@@ -180,6 +186,54 @@ public class ClientServerMiscDUnitTest extends JUnit4CacheTestCase {
         .info("Testing concurrent map operations from a client with a partitioned region");
     concurrentMapTest(host.getVM(testVersion, 0), "/" + PR_REGION_NAME);
     // TODO add verification in vm1
+  }
+
+  /**
+   * When a client's subscription thread connects to a server it should receive the server's
+   * pingInterval setting. This is used by the client to set a read-timeout in order to avoid
+   * hanging should the server's machine crash.
+   * 
+   * @see MessageJUnitTest#messageWillTimeoutDuringRecvOnInactiveSocket
+   */
+  @Test
+  public void testClientReceivesPingIntervalSetting() {
+    VM clientVM = Host.getHost(0).getVM(testVersion, 0);
+
+    final int port = initServerCache(true);
+    final String host = NetworkUtils.getServerHostName(server1.getHost());
+
+    clientVM.invoke("create client cache and verify", () -> {
+      createClientCacheAndVerifyPingIntervalIsSet(host, port);
+    });
+  }
+
+  void createClientCacheAndVerifyPingIntervalIsSet(String host, int port) throws Exception {
+    PoolImpl pool = null;
+    try {
+      Properties props = new Properties();
+      props.setProperty(MCAST_PORT, "0");
+      props.setProperty(LOCATORS, "");
+
+      createCache(props);
+
+      pool = (PoolImpl) PoolManager.createFactory().addServer(host, port)
+          .setSubscriptionEnabled(true).setThreadLocalConnections(false).setReadTimeout(1000)
+          .setSocketBufferSize(32768).setMinConnections(1).setSubscriptionRedundancy(-1)
+          .setPingInterval(2000).create("test pool");
+
+      Region<Object, Object> region = cache.createRegionFactory(RegionShortcut.LOCAL)
+          .setPoolName("test pool").create(REGION_NAME1);
+      region.registerInterest(".*");
+
+      /** get the subscription connection and verify that it has the correct timeout setting */
+      QueueConnectionImpl primaryConnection = (QueueConnectionImpl) pool.getPrimaryConnection();
+      int pingInterval = primaryConnection.getQueueStatus().getPingInterval();
+      assertNotEquals(0, pingInterval);
+      assertEquals(CacheClientNotifier.getClientPingInterval(), pingInterval);
+    } finally {
+      cache.close();
+    }
+
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/MessageJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/MessageJUnitTest.java
@@ -17,9 +17,18 @@ package org.apache.geode.internal.cache.tier.sockets;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
 import java.net.Socket;
+import java.net.SocketTimeoutException;
 import java.nio.ByteBuffer;
+import java.util.concurrent.TimeUnit;
 
+import org.awaitility.Awaitility;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -112,4 +121,53 @@ public class MessageJUnitTest {
     verify(mockPart1, times(2)).clear();
   }
 
+  /**
+   * Client subscription threads establish a timeout when reading a message header in order to avoid
+   * hanging should the server's machine fail, or should the network path to the server have
+   * problems. This test ensures that the method Message.receiveWithHeaderReadTimeout correctly
+   * times out when trying to read a message header.
+   * 
+   * @See ClientServerMiscDUnitTest#testClientReceivesPingIntervalSetting
+   */
+  @Test(expected = SocketTimeoutException.class)
+  public void messageWillTimeoutDuringRecvOnInactiveSocket() throws Exception {
+    final ServerSocket serverSocket = new ServerSocket();
+    serverSocket.bind(new InetSocketAddress(InetAddress.getLocalHost(), 0));
+    Thread serverThread = new Thread("acceptor thread") {
+      public void run() {
+        Socket client = null;
+        try {
+          client = serverSocket.accept();
+          Thread.sleep(12000);
+        } catch (InterruptedException e) {
+
+        } catch (IOException e) {
+
+        } finally {
+          if (client != null && !client.isClosed()) {
+            try {
+              client.close();
+            } catch (IOException e) {
+            }
+          }
+        }
+      }
+    };
+    serverThread.setDaemon(true);
+    serverThread.start();
+
+    try {
+      Socket socket = new Socket(serverSocket.getInetAddress(), serverSocket.getLocalPort());
+      MessageStats messageStats = mock(MessageStats.class);
+
+      message.setComms(socket, ByteBuffer.allocate(100), messageStats);
+      message.receiveWithHeaderReadTimeout(500);
+
+    } finally {
+      serverThread.interrupt();
+      if (serverSocket != null && !serverSocket.isClosed()) {
+        serverSocket.close();
+      }
+    }
+  }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/MessageJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/MessageJUnitTest.java
@@ -126,7 +126,7 @@ public class MessageJUnitTest {
    * hanging should the server's machine fail, or should the network path to the server have
    * problems. This test ensures that the method Message.receiveWithHeaderReadTimeout correctly
    * times out when trying to read a message header.
-   * 
+   *
    * @See ClientServerMiscDUnitTest#testClientReceivesPingIntervalSetting
    */
   @Test(expected = SocketTimeoutException.class)

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ServerConnectionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ServerConnectionTest.java
@@ -170,7 +170,7 @@ public class ServerConnectionTest {
     }
 
     @Override
-    public void recv() throws IOException {
+    public void receive() throws IOException {
       try {
         lock.lock();
         testGate.await(10, TimeUnit.SECONDS);

--- a/geode-cq/src/test/java/org/apache/geode/internal/cache/tier/sockets/ClientServerMiscBCDUnitTest.java
+++ b/geode-cq/src/test/java/org/apache/geode/internal/cache/tier/sockets/ClientServerMiscBCDUnitTest.java
@@ -43,6 +43,7 @@ import org.apache.geode.cache.query.CqListener;
 import org.apache.geode.cache.query.CqQuery;
 import org.apache.geode.cache.server.CacheServer;
 import org.apache.geode.distributed.DistributedSystem;
+import org.apache.geode.internal.Version;
 import org.apache.geode.internal.cache.EventID;
 import org.apache.geode.internal.cache.LocalRegion;
 import org.apache.geode.test.dunit.Host;
@@ -72,6 +73,15 @@ public class ClientServerMiscBCDUnitTest extends ClientServerMiscDUnitTest {
   public ClientServerMiscBCDUnitTest(String version) {
     super();
     testVersion = version;
+  }
+
+  @Override
+  void createClientCacheAndVerifyPingIntervalIsSet(String host, int port) throws Exception {
+    // this functionality was introduced in 1.5. If we let the test run in older
+    // clients it will throw a NoSuchMethodError
+    if (Version.CURRENT_ORDINAL >= 80 /* GEODE_150 */) {
+      super.createClientCacheAndVerifyPingIntervalIsSet(host, port);
+    }
   }
 
   @Test

--- a/geode-wan/src/main/java/org/apache/geode/cache/client/internal/GatewaySenderBatchOp.java
+++ b/geode-wan/src/main/java/org/apache/geode/cache/client/internal/GatewaySenderBatchOp.java
@@ -30,7 +30,6 @@ import org.apache.geode.internal.cache.tier.sockets.Message;
 import org.apache.geode.internal.cache.tier.sockets.Part;
 import org.apache.geode.internal.cache.wan.BatchException70;
 import org.apache.geode.internal.cache.wan.GatewaySenderEventImpl;
-import org.apache.geode.internal.cache.wan.GatewaySenderEventRemoteDispatcher;
 import org.apache.geode.internal.cache.wan.GatewaySenderEventRemoteDispatcher.GatewayAck;
 import org.apache.geode.internal.i18n.LocalizedStrings;
 import org.apache.geode.internal.logging.LogService;
@@ -202,7 +201,7 @@ public class GatewaySenderBatchOp {
         }
 
         try {
-          msg.recv();
+          msg.receive();
         } finally {
           msg.unsetComms();
           processSecureBytes(cnx, msg);


### PR DESCRIPTION
This adds a new PoolFactory setting allowing subscription connections to
time out and initiate failover to a backup server.  The new setting is
setSubscriptionTimeoutMultiplier:

 _A server has an inactivity monitor that ensures a message is sent to a client at least once a_
 _minute (60,000 milliseconds). If a subscription timeout multipler is set in the client it_
 _enables timing out of the subscription feed with failover to another server._

 _A value of zero (the default) disables timeouts_

 _A value of one will time out the server connection after one of its ping intervals (not_
 _recommended)_

 _A value of two or more will time out the server connection after that many ping intervals have_
 _elapsed_

The client/server handshake is modified for clients having version 1.5 or
later.  The server sends its ping-interval setting to the client.  The client
then uses this and the multiplier to establish a read-timeout in the
CacheClientUpdater subscription processor.

Two tests are added to ensure that 1) the Message method that allows a
read to timeout functions correctly and 2) the CacheClientUpdater
correctly receives the multiplier setting.

@upthewaterspout @PivotalSarge @galen-pivotal @WireBaron 



Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [na] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
