### PR TITLE
GEODE-4397: refactor RegionMapDestroy destroy operation

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegionMap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegionMap.java
@@ -3188,8 +3188,9 @@ public abstract class AbstractRegionMap
   public void lockForCacheModification(InternalRegion owner, EntryEventImpl event) {
     boolean lockedByBulkOp = event.isBulkOpInProgress() && owner.getDataPolicy().withReplication();
 
-    if (armLockTestHook != null)
+    if (armLockTestHook != null) {
       armLockTestHook.beforeLock(owner, event);
+    }
 
     if (!event.isOriginRemote() && !lockedByBulkOp && !owner.hasServerProxy()) {
       RegionVersionVector vector = owner.getVersionVector();
@@ -3198,9 +3199,9 @@ public abstract class AbstractRegionMap
       }
     }
 
-    if (armLockTestHook != null)
+    if (armLockTestHook != null) {
       armLockTestHook.afterLock(owner, event);
-
+    }
   }
 
   /** release version-generation permission from the region's version vector */

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/map/RegionMapDestroyTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/map/RegionMapDestroyTest.java
@@ -39,6 +39,7 @@ import org.apache.geode.cache.Operation;
 import org.apache.geode.internal.cache.AbstractRegionMap;
 import org.apache.geode.internal.cache.CachePerfStats;
 import org.apache.geode.internal.cache.EntryEventImpl;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.KeyInfo;
 import org.apache.geode.internal.cache.LocalRegion;
 import org.apache.geode.internal.cache.RegionClearedException;
@@ -58,9 +59,9 @@ import org.apache.geode.test.junit.categories.UnitTest;
 @Category(UnitTest.class)
 public class RegionMapDestroyTest {
 
-  private static EvictionAttributes evictionAttributes =
+  private static final EvictionAttributes evictionAttributes =
       EvictionAttributes.createLRUEntryAttributes();
-  private static Object KEY = "key";
+  private static final Object KEY = "key";
 
   private AbstractRegionMap arm;
   private boolean withConcurrencyChecks;
@@ -370,6 +371,8 @@ public class RegionMapDestroyTest {
     givenConcurrencyChecks(true);
     givenEvictionWithMockedEntryMap();
     givenExistingEvictableEntryWithMockedIsTombstone();
+
+    isEviction = false;
 
     assertThat(arm.destroy(event, inTokenMode, duringRI, cacheWrite, isEviction, expectedOldValue,
         removeRecoveredEntry)).isTrue();


### PR DESCRIPTION
This change breaks up the monolithic RegionMapDestroy.destroy method into many methods.