### PR TITLE
GEODE-4487: Remove singleton calls from offheap package

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/internal/offheap/OutOfOffHeapMemoryDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/offheap/OutOfOffHeapMemoryDUnitTest.java
@@ -37,7 +37,6 @@ import org.apache.geode.distributed.DistributedSystemDisconnectedException;
 import org.apache.geode.distributed.internal.ClusterDistributionManager;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.internal.cache.DistributedRegion;
-import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.cache.OffHeapTestUtil;
 import org.apache.geode.internal.util.StopWatch;
 import org.apache.geode.test.dunit.Host;
@@ -146,10 +145,7 @@ public class OutOfOffHeapMemoryDUnitTest extends JUnit4CacheTestCase {
 
     // wait for cache instance to be nulled out
     with().pollInterval(100, TimeUnit.MILLISECONDS).await().atMost(10, TimeUnit.SECONDS)
-        .until(() -> GemFireCacheImpl.getInstance() == null
-            && InternalDistributedSystem.getAnyInstance() == null);
-
-    assertNull(GemFireCacheImpl.getInstance());
+        .until(() -> cache.isClosed() && !system.isConnected());
 
     // verify system was closed out due to OutOfOffHeapMemoryException
     assertFalse(system.isConnected());


### PR DESCRIPTION
One test was using the singletons just to confirm the cache had been shutdown. It was easy to change that test to not confirm the singleton was null but to instead ask if the test's cache was closed.

The other test was testing DataType which is product code that is only used by tests to inspect what is stored in offheap memory. The test was mocking the singleton methods because the product DataType was using the singleton to decode a serialized PDX. I changed DataType to just do less decoding of pdx. Now it will just say it was a pdx and give you the type number.