### PR TITLE
GEODE-4590: pass executor in to clear

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegionMap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegionMap.java
@@ -21,6 +21,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.logging.log4j.Logger;
@@ -42,6 +43,7 @@ import org.apache.geode.cache.query.internal.index.IndexManager;
 import org.apache.geode.cache.query.internal.index.IndexProtocol;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.internal.DistributionConfig;
+import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.Assert;
 import org.apache.geode.internal.cache.DiskInitFile.DiskRegionFlag;
@@ -360,7 +362,15 @@ public abstract class AbstractRegionMap
   }
 
   private void _mapClear() {
-    getEntryMap().clear();
+    Executor executor = null;
+    InternalCache cache = this.owner.getCache();
+    if (cache != null) {
+      DistributionManager manager = cache.getDistributionManager();
+      if (manager != null) {
+        executor = manager.getWaitingThreadPool();
+      }
+    }
+    getCustomEntryConcurrentHashMap().clearWithExecutor(executor);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalRegion.java
@@ -135,8 +135,6 @@ public interface InternalRegion extends Region, HasCachePerfStats, RegionEntryCo
 
   void addCacheServiceProfile(CacheServiceProfile profile);
 
-  InternalCache getCache();
-
   void setEvictionMaximum(int maximum);
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/RegionMapOwner.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/RegionMapOwner.java
@@ -15,4 +15,5 @@
 package org.apache.geode.internal.cache;
 
 public interface RegionMapOwner {
+  InternalCache getCache();
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/util/concurrent/ConcurrentMapWithReusableEntries.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/util/concurrent/ConcurrentMapWithReusableEntries.java
@@ -17,6 +17,7 @@ package org.apache.geode.internal.util.concurrent;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Executor;
 
 public interface ConcurrentMapWithReusableEntries<K, V> extends ConcurrentMap<K, V> {
 
@@ -38,4 +39,12 @@ public interface ConcurrentMapWithReusableEntries<K, V> extends ConcurrentMap<K,
    * <code>Map.Entry</code> objects.
    */
   Set<Map.Entry<K, V>> entrySetWithReusableEntries();
+
+  /**
+   * Clear the map. If any work needs to be done asynchronously then use the given executor.
+   *
+   * @param executor possibly null. If it is null and asynchronous work needs to be done then a new
+   *        Thread is created.
+   */
+  void clearWithExecutor(Executor executor);
 }


### PR DESCRIPTION
Instead of looking up the waiting pool executor
from a singleton, it is now passed in based on
the owner of the AbstractRegionMap.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
