### PR TITLE
GEODE-4615 Deadlock shutting down client cache

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/pooling/ConnectionManagerImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/pooling/ConnectionManagerImpl.java
@@ -16,6 +16,7 @@ package org.apache.geode.cache.client.internal.pooling;
 
 import java.net.SocketException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -52,7 +53,6 @@ import org.apache.geode.cache.client.internal.PoolImpl;
 import org.apache.geode.cache.client.internal.PoolImpl.PoolTask;
 import org.apache.geode.cache.client.internal.QueueConnectionImpl;
 import org.apache.geode.distributed.PoolCancelledException;
-import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.ServerLocation;
 import org.apache.geode.i18n.StringId;
 import org.apache.geode.internal.cache.PoolManagerImpl;
@@ -1024,8 +1024,12 @@ public class ConnectionManagerImpl implements ConnectionManager {
 
   protected class ConnectionMap {
     private final HashMap/* <Endpoint, HashSet<PooledConnection> */ map = new HashMap();
-    private final LinkedList/* <PooledConnection> */ allConnections =
-        new LinkedList/* <PooledConnection> */(); // in the order they were created
+    private List/* <PooledConnection> */ allConnections = new LinkedList/* <PooledConnection> */(); // in
+                                                                                                    // the
+                                                                                                    // order
+                                                                                                    // they
+                                                                                                    // were
+                                                                                                    // created
     private boolean haveLifetimeExpireConnectionsTask;
     volatile boolean closing;
 
@@ -1056,40 +1060,41 @@ public class ConnectionManagerImpl implements ConnectionManager {
       return sb.toString();
     }
 
-    public void addConnection(PooledConnection connection) {
+    public synchronized void addConnection(PooledConnection connection) {
       if (this.closing) {
         throw new CacheClosedException("This pool is closing");
       }
-      synchronized (this) {
-        addToEndpointMap(connection);
 
-        // we want the smallest birthDate (e.g. oldest cnx) at the front of the list
-        getPoolStats().incPoolConnections(1);
-        // logger.info("DEBUG: addConnection incPoolConnections(1)->" +
-        // getPoolStats().getPoolConnections() + " con="+connection,
-        // new RuntimeException("STACK"));
-        this.allConnections.addLast(connection);
-        if (isIdleExpirePossible()) {
-          startBackgroundExpiration();
-        }
-        if (lifetimeTimeout != -1 && !haveLifetimeExpireConnectionsTask) {
-          if (checkForReschedule(true)) {
-            // something has already expired so start processing with no delay
-            // logger.info("DEBUG: rescheduling lifetime expire to be now");
-            startBackgroundLifetimeExpiration(0);
-          } else {
-            // either no possible lifetime expires or we scheduled one
-          }
+      getPoolStats().incPoolConnections(1);
+
+      // we want the smallest birthDate (e.g. oldest cnx) at the front of the list
+      this.allConnections.add(connection);
+
+      addToEndpointMap(connection);
+
+      if (isIdleExpirePossible()) {
+        startBackgroundExpiration();
+      }
+      if (lifetimeTimeout != -1 && !haveLifetimeExpireConnectionsTask) {
+        if (checkForReschedule(true)) {
+          // something has already expired so start processing with no delay
+          // logger.info("DEBUG: rescheduling lifetime expire to be now");
+          startBackgroundLifetimeExpiration(0);
+        } else {
+          // either no possible lifetime expires or we scheduled one
         }
       }
     }
 
     public synchronized void addReplacedCnx(PooledConnection con, Endpoint oldEndpoint) {
+      if (this.closing) {
+        throw new CacheClosedException("This pool is closing");
+      }
       if (this.allConnections.remove(con)) {
         // otherwise someone else has removed it and closed it
         removeFromEndpointMap(oldEndpoint, con);
         addToEndpointMap(con);
-        this.allConnections.addLast(con);
+        this.allConnections.add(con);
         if (isIdleExpirePossible()) {
           startBackgroundExpiration();
         }
@@ -1158,12 +1163,21 @@ public class ConnectionManagerImpl implements ConnectionManager {
       }
     }
 
-    public synchronized void close(boolean keepAlive) {
-      closing = true;
-      map.clear();
+    public void close(boolean keepAlive) {
+      List<PooledConnection> connections;
       int count = 0;
-      while (!this.allConnections.isEmpty()) {
-        PooledConnection pc = (PooledConnection) this.allConnections.removeFirst();
+
+      synchronized (this) {
+        if (closing) {
+          return;
+        }
+        closing = true;
+        map.clear();
+        connections = allConnections;
+        allConnections = new ClosedPoolConnectionList();
+      }
+
+      for (PooledConnection pc : connections) {
         count++;
         if (!pc.isDestroyed()) {
           try {
@@ -1190,7 +1204,7 @@ public class ConnectionManagerImpl implements ConnectionManager {
       closing = true;
       map.clear();
       while (!this.allConnections.isEmpty()) {
-        PooledConnection pc = (PooledConnection) this.allConnections.removeFirst();
+        PooledConnection pc = (PooledConnection) this.allConnections.remove(0);
         pc.emergencyClose();
       }
     }
@@ -1280,56 +1294,6 @@ public class ConnectionManagerImpl implements ConnectionManager {
     }
 
     /**
-     * See if any of the expired connections (that have not idle expired) are already connected to
-     * this sl and have not idle expired. If so then just update them in-place to simulate a
-     * replace.
-     *
-     * @param sl the location of the server we should see if we are connected to
-     * @return true if we were able to extend an existing connection's lifetime or if we have no
-     *         connection's whose lifetime has expired. false if we need to create a replacement
-     *         connection.
-     */
-    public synchronized boolean tryToExtendLifeTime(ServerLocation sl) {
-      // a better approach might be to get the most loaded server
-      // (if they are not balanced) and then scan through and extend the lifetime
-      // of everyone not connected to that server and do a replace on just one
-      // of the guys who has lifetime expired to the most loaded server
-      boolean result = true;
-      if (!this.allConnections.isEmpty()) {
-        final long now = System.nanoTime();
-        for (Iterator it = this.allConnections.iterator(); it.hasNext();) {
-          PooledConnection pc = (PooledConnection) it.next();
-          if (pc.remainingLife(now, lifetimeTimeoutNanos) > 0) {
-            // no more connections whose lifetime could have expired
-            break;
-            // note don't ignore idle guys because they are still connected
-            // } else if (pc.remainingIdle(now, idleTimeoutNanos) <= 0) {
-            // // this con has already idle expired so ignore it
-          } else if (pc.shouldDestroy()) {
-            // this con has already been destroyed so ignore it
-          } else if (sl.equals(pc.getEndpoint().getLocation())) {
-            // we found a guy to whose lifetime we can extend
-            it.remove();
-            // logger.fine("DEBUG: tryToExtendLifeTime extending life of: " + pc);
-            pc.setBirthDate(now);
-            getPoolStats().incLoadConditioningExtensions();
-            this.allConnections.addLast(pc);
-            return true;
-          } else {
-            // the current pc is a candidate for reconnection to another server
-            // so set result to false which will stick unless we find another con
-            // whose life can be extended.
-            result = false;
-          }
-        }
-      }
-      // if (result) {
-      // logger.fine("DEBUG: tryToExtendLifeTime found no one to extend");
-      // }
-      return result;
-    }
-
-    /**
      * Extend the life of the first expired connection to sl.
      */
     public synchronized void extendLifeOfCnxToServer(ServerLocation sl) {
@@ -1351,7 +1315,7 @@ public class ConnectionManagerImpl implements ConnectionManager {
             // logger.fine("DEBUG: tryToExtendLifeTime extending life of: " + pc);
             pc.setBirthDate(now);
             getPoolStats().incLoadConditioningExtensions();
-            this.allConnections.addLast(pc);
+            this.allConnections.add(pc);
             // break so we only do this to the oldest guy
             break;
           }
@@ -1536,9 +1500,6 @@ public class ConnectionManagerImpl implements ConnectionManager {
       startBackgroundLifetimeExpiration(lifetimeTimeoutNanos);
     }
 
-    public synchronized int size() {
-      return this.allConnections.size();
-    }
   }
 
   private void logInfo(StringId message, Throwable t) {
@@ -1567,5 +1528,37 @@ public class ConnectionManagerImpl implements ConnectionManager {
   public void passivate(Connection conn, boolean accessed) {
     assert conn instanceof PooledConnection;
     ((PooledConnection) conn).passivate(accessed);
+  }
+
+  private static class ClosedPoolConnectionList extends ArrayList {
+    @Override
+    public Object set(int index, Object element) {
+      throw new CacheClosedException("This pool has been closed");
+    }
+
+    @Override
+    public boolean add(Object element) {
+      throw new CacheClosedException("This pool has been closed");
+    }
+
+    @Override
+    public void add(int index, Object element) {
+      throw new CacheClosedException("This pool has been closed");
+    }
+
+    @Override
+    public Object remove(int index) {
+      throw new CacheClosedException("This pool has been closed");
+    }
+
+    @Override
+    public boolean addAll(Collection c) {
+      throw new CacheClosedException("This pool has been closed");
+    }
+
+    @Override
+    public boolean addAll(int index, Collection c) {
+      throw new CacheClosedException("This pool has been closed");
+    }
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/pooling/PooledConnection.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/pooling/PooledConnection.java
@@ -348,6 +348,10 @@ class PooledConnection implements Connection {
     getConnection().setWanSiteVersion(wanSiteVersion);
   }
 
+  public void setConnection(Connection newConnection) {
+    this.connection = newConnection;
+  }
+
   public void setConnectionID(long id) {
     this.connection.setConnectionID(id);
   }

--- a/geode-core/src/test/java/org/apache/geode/cache/client/internal/pooling/ConnectionManagerJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/client/internal/pooling/ConnectionManagerJUnitTest.java
@@ -14,8 +14,10 @@
  */
 package org.apache.geode.cache.client.internal.pooling;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
+import static org.apache.geode.internal.Assert.assertTrue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
@@ -28,9 +30,11 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -38,11 +42,13 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import org.apache.geode.CancelCriterion;
+import org.apache.geode.cache.CacheClosedException;
 import org.apache.geode.cache.client.AllConnectionsInUseException;
 import org.apache.geode.cache.client.NoAvailableServersException;
 import org.apache.geode.cache.client.internal.ClientUpdater;
 import org.apache.geode.cache.client.internal.Connection;
 import org.apache.geode.cache.client.internal.ConnectionFactory;
+import org.apache.geode.cache.client.internal.ConnectionImpl;
 import org.apache.geode.cache.client.internal.ConnectionStats;
 import org.apache.geode.cache.client.internal.Endpoint;
 import org.apache.geode.cache.client.internal.EndpointManager;
@@ -52,6 +58,7 @@ import org.apache.geode.cache.client.internal.QueueManager;
 import org.apache.geode.cache.client.internal.ServerBlackList;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.DistributedSystem;
+import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.ServerLocation;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.PoolStats;
@@ -584,6 +591,74 @@ public class ConnectionManagerJUnitTest {
     Assert.assertEquals(2, manager.getConnectionCount());
 
     manager.returnConnection(conn4);
+  }
+
+  /**
+   * This tests that a deadlock between connection formation and connection pool closing has been
+   * fixed. See GEODE-4615
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testThatMapCloseCausesCacheClosedException() throws Exception {
+    final ConnectionManagerImpl connectionManager = new ConnectionManagerImpl("pool", factory,
+        endpointManager, 2, 0, -1, -1, logger, 60 * 1000, cancelCriterion, poolStats);
+    manager = connectionManager;
+    connectionManager.start(background);
+    final ConnectionManagerImpl.ConnectionMap connectionMap = connectionManager.allConnectionsMap;
+
+    final int thread1 = 0;
+    final int thread2 = 1;
+    final boolean[] ready = new boolean[2];
+    Thread thread = new Thread("ConnectionManagerJUnitTest thread") {
+      public void run() {
+        setReady(ready, thread1);
+        waitUntilReady(ready, thread2);
+        connectionMap.close(false);
+      }
+    };
+    thread.setDaemon(true);
+    thread.start();
+    try {
+      Connection firstConnection = connectionManager.borrowConnection(0);
+      synchronized (firstConnection) {
+        setReady(ready, thread2);
+        waitUntilReady(ready, thread1);
+        // the other thread will now try to close the connection map but it will block
+        // because this thread has locked one of the connections
+        Awaitility.await().atMost(5, SECONDS).until(() -> connectionMap.closing);
+        try {
+          connectionManager.borrowConnection(0);
+          fail("expected a CacheClosedException");
+        } catch (CacheClosedException e) {
+          // expected
+        }
+      }
+    } finally {
+      if (thread.isAlive()) {
+        System.out.println("stopping background thread");
+        thread.interrupt();
+        thread.join();
+      }
+    }
+  }
+
+  private void setReady(boolean[] ready, int index) {
+    System.out.println(
+        Thread.currentThread().getName() + ": setting that thread" + (index + 1) + " is ready");
+    synchronized (ready) {
+      ready[index] = true;
+    }
+  }
+
+  private void waitUntilReady(boolean[] ready, int index) {
+    System.out.println(
+        Thread.currentThread().getName() + ": waiting for thread" + (index + 1) + " to be ready");
+    Awaitility.await().atMost(20, SECONDS).until(() -> {
+      synchronized (ready) {
+        return (ready[index]);
+      }
+    });
   }
 
   @Test


### PR DESCRIPTION
This modifies the synchronization in addConnection to perform a
shutdown check in ConnectionMap prior to allowing a new connection
to be added.  This prevents the lock-inversion seen in the deadlock.

I attempted to refactor ConnectionMap into a static class for easier
unit testing but it proved to be too intertwined with
ConnectionManagerImpl, so the new unit test had to be a little more
complicated than I would have liked.  I've opened GEODE-4617
to address refactoring this class.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
