### PR TITLE
GEODE-4586: remove getAnyInstance calls from RegionVersionVector

### DIFF
--- a/extensions/geode-modules/src/main/java/org/apache/geode/modules/util/BootstrappingFunction.java
+++ b/extensions/geode-modules/src/main/java/org/apache/geode/modules/util/BootstrappingFunction.java
@@ -184,19 +184,21 @@ public class BootstrappingFunction implements Function, MembershipListener, Data
   }
 
   @Override
-  public void memberDeparted(InternalDistributedMember id, boolean crashed) {}
+  public void memberDeparted(DistributionManager distributionManager, InternalDistributedMember id,
+      boolean crashed) {}
 
   @Override
-  public void memberJoined(InternalDistributedMember id) {
+  public void memberJoined(DistributionManager distributionManager, InternalDistributedMember id) {
     bootstrapMember(id);
   }
 
   @Override
-  public void memberSuspect(InternalDistributedMember id, InternalDistributedMember whoSuspected,
-      String reason) {}
+  public void memberSuspect(DistributionManager distributionManager, InternalDistributedMember id,
+      InternalDistributedMember whoSuspected, String reason) {}
 
   @Override
-  public void quorumLost(Set<InternalDistributedMember> internalDistributedMembers,
+  public void quorumLost(DistributionManager distributionManager,
+      Set<InternalDistributedMember> internalDistributedMembers,
       List<InternalDistributedMember> internalDistributedMembers2) {}
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/DistributedSystemHealthEvaluator.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/DistributedSystemHealthEvaluator.java
@@ -135,14 +135,16 @@ class DistributedSystemHealthEvaluator extends AbstractHealthEvaluator
     this.dm.removeMembershipListener(this);
   }
 
-  public void memberJoined(InternalDistributedMember id) {
+  public void memberJoined(DistributionManager distributionManager, InternalDistributedMember id) {
 
   }
 
   /**
    * Keeps track of which members depart unexpectedly
    */
-  public void memberDeparted(InternalDistributedMember id, boolean crashed) {
+  @Override
+  public void memberDeparted(DistributionManager distributionManager, InternalDistributedMember id,
+      boolean crashed) {
     if (!crashed)
       return;
     synchronized (this) {
@@ -158,10 +160,10 @@ class DistributedSystemHealthEvaluator extends AbstractHealthEvaluator
     } // synchronized
   }
 
-  public void quorumLost(Set<InternalDistributedMember> failures,
-      List<InternalDistributedMember> remaining) {}
+  public void quorumLost(DistributionManager distributionManager,
+      Set<InternalDistributedMember> failures, List<InternalDistributedMember> remaining) {}
 
-  public void memberSuspect(InternalDistributedMember id, InternalDistributedMember whoSuspected,
-      String reason) {}
+  public void memberSuspect(DistributionManager distributionManager, InternalDistributedMember id,
+      InternalDistributedMember whoSuspected, String reason) {}
 
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/ClusterDistributionManager.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/ClusterDistributionManager.java
@@ -2872,7 +2872,7 @@ public class ClusterDistributionManager implements DistributionManager {
 
     for (Iterator iter = allMembershipListeners.iterator(); iter.hasNext();) {
       MembershipListener listener = (MembershipListener) iter.next();
-      listener.memberJoined(theId);
+      listener.memberJoined(this, theId);
     }
     logger.info(LocalizedMessage.create(
         LocalizedStrings.DistributionManager_DMMEMBERSHIP_ADMITTING_NEW_ADMINISTRATION_MEMBER__0_,
@@ -2952,7 +2952,7 @@ public class ClusterDistributionManager implements DistributionManager {
     if (removedMember) {
       for (Iterator iter = allMembershipListeners.iterator(); iter.hasNext();) {
         MembershipListener listener = (MembershipListener) iter.next();
-        listener.memberDeparted(theId, crashed);
+        listener.memberDeparted(this, theId, crashed);
       }
     }
     if (removedConsole) {
@@ -3385,25 +3385,29 @@ public class ClusterDistributionManager implements DistributionManager {
           if (l == null) {
             l = new MembershipListener() {
               @Override
-              public void memberJoined(InternalDistributedMember theId) {
+              public void memberJoined(DistributionManager distributionManager,
+                  InternalDistributedMember theId) {
                 // nothing needed
               }
 
               @Override
-              public void memberDeparted(InternalDistributedMember theId, boolean crashed) {
+              public void memberDeparted(DistributionManager distributionManager,
+                  InternalDistributedMember theId, boolean crashed) {
                 if (desiredElder.equals(theId)) {
                   notifyElderChangeWaiters();
                 }
               }
 
               @Override
-              public void memberSuspect(InternalDistributedMember id,
-                  InternalDistributedMember whoSuspected, String reason) {}
+              public void memberSuspect(DistributionManager distributionManager,
+                  InternalDistributedMember id, InternalDistributedMember whoSuspected,
+                  String reason) {}
 
               public void viewInstalled(NetView view) {}
 
               @Override
-              public void quorumLost(Set<InternalDistributedMember> failures,
+              public void quorumLost(DistributionManager distributionManager,
+                  Set<InternalDistributedMember> failures,
                   List<InternalDistributedMember> remaining) {}
             };
             addMembershipListener(l);
@@ -4100,13 +4104,14 @@ public class ClusterDistributionManager implements DistributionManager {
       handleEvent(manager, manager.allMembershipListeners);
     }
 
-    protected abstract void handleEvent(MembershipListener listener);
+    protected abstract void handleEvent(ClusterDistributionManager manager,
+        MembershipListener listener);
 
     private void handleEvent(ClusterDistributionManager manager,
         Set<MembershipListener> membershipListeners) {
       for (MembershipListener listener : membershipListeners) {
         try {
-          handleEvent(listener);
+          handleEvent(manager, listener);
         } catch (CancelException e) {
           if (manager.isCloseInProgress()) {
             if (logger.isTraceEnabled()) {
@@ -4153,8 +4158,8 @@ public class ClusterDistributionManager implements DistributionManager {
     }
 
     @Override
-    protected void handleEvent(MembershipListener listener) {
-      listener.memberJoined(getId());
+    protected void handleEvent(ClusterDistributionManager manager, MembershipListener listener) {
+      listener.memberJoined(manager, getId());
     }
   }
 
@@ -4176,8 +4181,8 @@ public class ClusterDistributionManager implements DistributionManager {
     }
 
     @Override
-    protected void handleEvent(MembershipListener listener) {
-      listener.memberDeparted(getId(), false);
+    protected void handleEvent(ClusterDistributionManager manager, MembershipListener listener) {
+      listener.memberDeparted(manager, getId(), false);
     }
   }
 
@@ -4201,8 +4206,8 @@ public class ClusterDistributionManager implements DistributionManager {
     }
 
     @Override
-    protected void handleEvent(MembershipListener listener) {
-      listener.memberDeparted(getId(), true/* crashed */);
+    protected void handleEvent(ClusterDistributionManager manager, MembershipListener listener) {
+      listener.memberDeparted(manager, getId(), true/* crashed */);
     }
   }
 
@@ -4235,8 +4240,8 @@ public class ClusterDistributionManager implements DistributionManager {
     }
 
     @Override
-    protected void handleEvent(MembershipListener listener) {
-      listener.memberSuspect(getId(), whoSuspected(), reason);
+    protected void handleEvent(ClusterDistributionManager manager, MembershipListener listener) {
+      listener.memberSuspect(manager, getId(), whoSuspected(), reason);
     }
   }
 
@@ -4263,7 +4268,7 @@ public class ClusterDistributionManager implements DistributionManager {
     }
 
     @Override
-    protected void handleEvent(MembershipListener listener) {
+    protected void handleEvent(ClusterDistributionManager manager, MembershipListener listener) {
       throw new UnsupportedOperationException();
     }
   }
@@ -4293,8 +4298,8 @@ public class ClusterDistributionManager implements DistributionManager {
     }
 
     @Override
-    protected void handleEvent(MembershipListener listener) {
-      listener.quorumLost(getFailures(), getRemaining());
+    protected void handleEvent(ClusterDistributionManager manager, MembershipListener listener) {
+      listener.quorumLost(manager, getFailures(), getRemaining());
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionAdvisor.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionAdvisor.java
@@ -215,15 +215,17 @@ public class DistributionAdvisor {
     this.advisee = advisee;
     this.ml = new MembershipListener() {
 
-      public void memberJoined(InternalDistributedMember id) {
+      public void memberJoined(DistributionManager distributionManager,
+          InternalDistributedMember id) {
         // Ignore
       }
 
-      public void quorumLost(Set<InternalDistributedMember> failures,
-          List<InternalDistributedMember> remaining) {}
+      public void quorumLost(DistributionManager distributionManager,
+          Set<InternalDistributedMember> failures, List<InternalDistributedMember> remaining) {}
 
       @SuppressWarnings("synthetic-access")
-      public void memberDeparted(final InternalDistributedMember id, boolean crashed) {
+      public void memberDeparted(DistributionManager distributionManager,
+          final InternalDistributedMember id, boolean crashed) {
         boolean shouldSync = crashed && shouldSyncForCrashedMember(id);
         final Profile profile = getProfile(id);
         boolean removed =
@@ -236,8 +238,8 @@ public class DistributionAdvisor {
         }
       }
 
-      public void memberSuspect(InternalDistributedMember id,
-          InternalDistributedMember whoSuspected, String reason) {}
+      public void memberSuspect(DistributionManager distributionManager,
+          InternalDistributedMember id, InternalDistributedMember whoSuspected, String reason) {}
 
     };
   }
@@ -1208,7 +1210,7 @@ public class DistributionAdvisor {
     Iterator it = membershipListeners.keySet().iterator();
     while (it.hasNext()) {
       try {
-        ((MembershipListener) it.next()).memberJoined(member);
+        ((MembershipListener) it.next()).memberJoined(getDistributionManager(), member);
       } catch (Exception e) {
         logger.fatal(
             LocalizedMessage.create(LocalizedStrings.DistributionAdvisor_UNEXPECTED_EXCEPTION), e);
@@ -1220,7 +1222,7 @@ public class DistributionAdvisor {
     Iterator it = membershipListeners.keySet().iterator();
     while (it.hasNext()) {
       try {
-        ((MembershipListener) it.next()).memberDeparted(member, crashed);
+        ((MembershipListener) it.next()).memberDeparted(getDistributionManager(), member, crashed);
       } catch (Exception e) {
         logger.fatal(
             LocalizedMessage.create(LocalizedStrings.DistributionAdvisor_UNEXPECTED_EXCEPTION), e);

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/MembershipListener.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/MembershipListener.java
@@ -65,7 +65,7 @@ public interface MembershipListener {
    * This is notification that more than 50% of member weight has been lost in a single view change.
    * Notification is performed before the view has been installed.
    *
-   * @param distributionManager TODO
+   * @param distributionManager that is calling this listener
    * @param failures members that have been lost
    * @param remaining members that remain
    */

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/MembershipListener.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/MembershipListener.java
@@ -33,38 +33,43 @@ public interface MembershipListener {
   /**
    * This method is invoked when a new member joins the system
    *
+   * @param distributionManager that is calling this listener
    * @param id The id of the new member that has joined the system
    */
-  void memberJoined(InternalDistributedMember id);
+  void memberJoined(DistributionManager distributionManager, InternalDistributedMember id);
 
   /**
    * This method is invoked after a member has explicitly left the system. It may not get invoked if
    * a member becomes unreachable due to crash or network problems.
    *
+   * @param distributionManager that is calling this listener
    * @param id The id of the new member that has joined the system
    * @param crashed True if member did not depart in an orderly manner.
    */
-  void memberDeparted(InternalDistributedMember id, boolean crashed);
+  void memberDeparted(DistributionManager distributionManager, InternalDistributedMember id,
+      boolean crashed);
 
   /**
    * This method is invoked after the group membership service has suspected that a member is no
    * longer alive, but has not yet been removed from the membership view
    *
+   * @param distributionManager that is calling this listener
    * @param id the suspected member
    * @param whoSuspected the member that initiated suspect processing
    * @param reason the reason the member was suspected
    */
-  void memberSuspect(InternalDistributedMember id, InternalDistributedMember whoSuspected,
-      String reason);
+  void memberSuspect(DistributionManager distributionManager, InternalDistributedMember id,
+      InternalDistributedMember whoSuspected, String reason);
 
   /**
    * This is notification that more than 50% of member weight has been lost in a single view change.
    * Notification is performed before the view has been installed.
    *
+   * @param distributionManager TODO
    * @param failures members that have been lost
    * @param remaining members that remain
    */
-  void quorumLost(Set<InternalDistributedMember> failures,
+  void quorumLost(DistributionManager distributionManager, Set<InternalDistributedMember> failures,
       List<InternalDistributedMember> remaining);
 
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/ProductUseLog.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/ProductUseLog.java
@@ -128,19 +128,20 @@ public class ProductUseLog implements MembershipListener {
   }
 
   @Override
-  public void memberJoined(InternalDistributedMember id) {
+  public void memberJoined(DistributionManager distributionManager, InternalDistributedMember id) {
     log("A new member joined: " + id + ".  " + system.getDM().getMembershipManager().getView());
   }
 
   @Override
-  public void memberDeparted(InternalDistributedMember id, boolean crashed) {}
+  public void memberDeparted(DistributionManager distributionManager, InternalDistributedMember id,
+      boolean crashed) {}
 
   @Override
-  public void memberSuspect(InternalDistributedMember id, InternalDistributedMember whoSuspected,
-      String reason) {}
+  public void memberSuspect(DistributionManager distributionManager, InternalDistributedMember id,
+      InternalDistributedMember whoSuspected, String reason) {}
 
   @Override
-  public void quorumLost(Set<InternalDistributedMember> failures,
-      List<InternalDistributedMember> remaining) {}
+  public void quorumLost(DistributionManager distributionManager,
+      Set<InternalDistributedMember> failures, List<InternalDistributedMember> remaining) {}
 
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/ReliableReplyProcessor21.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/ReliableReplyProcessor21.java
@@ -58,7 +58,8 @@ public class ReliableReplyProcessor21 extends ReplyProcessor21 {
    * Note: race condition exists between membershipListener and processing of replies.
    */
   @Override
-  public void memberDeparted(final InternalDistributedMember id, final boolean crashed) {
+  public void memberDeparted(DistributionManager distributionManager,
+      final InternalDistributedMember id, final boolean crashed) {
     if (removeMember(id, true)) {
       synchronized (this) {
         if (this.departedMembers == null) {

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/ReplyProcessor21.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/ReplyProcessor21.java
@@ -472,15 +472,15 @@ public class ReplyProcessor21 implements MembershipListener {
         new Object[] {ex.getUnknownDSFID(), msg.getSender(), versionStr}), ex);
   }
 
-  public void memberJoined(InternalDistributedMember id) {
+  public void memberJoined(DistributionManager distributionManager, InternalDistributedMember id) {
     // Nothing to do - member wasn't sent the operation, anyway.
   }
 
-  public void quorumLost(Set<InternalDistributedMember> failures,
-      List<InternalDistributedMember> remaining) {}
+  public void quorumLost(DistributionManager distributionManager,
+      Set<InternalDistributedMember> failures, List<InternalDistributedMember> remaining) {}
 
-  public void memberSuspect(InternalDistributedMember id, InternalDistributedMember whoSuspected,
-      String reason) {
+  public void memberSuspect(DistributionManager distributionManager, InternalDistributedMember id,
+      InternalDistributedMember whoSuspected, String reason) {
     if (isSevereAlertProcessingEnabled()) {
       // if we're waiting for the member that initiated suspicion, we don't
       // want to be hasty about kicking it out of the distributed system
@@ -496,7 +496,8 @@ public class ReplyProcessor21 implements MembershipListener {
     }
   }
 
-  public void memberDeparted(final InternalDistributedMember id, final boolean crashed) {
+  public void memberDeparted(DistributionManager distributionManager,
+      final InternalDistributedMember id, final boolean crashed) {
     removeMember(id, true);
     checkIfDone();
   }
@@ -570,7 +571,7 @@ public class ReplyProcessor21 implements MembershipListener {
     for (int i = 0; i < this.members.length; i++) {
       if (this.members[i] != null) {
         if (!activeMembers.contains(this.members[i])) {
-          memberDeparted(this.members[i], false);
+          memberDeparted(getDistributionManager(), this.members[i], false);
         }
       }
     }
@@ -1084,7 +1085,7 @@ public class ReplyProcessor21 implements MembershipListener {
             logger.warn(LocalizedMessage.create(
                 LocalizedStrings.ReplyProcessor21_VIEW_NO_LONGER_HAS_0_AS_AN_ACTIVE_MEMBER_SO_WE_WILL_NO_LONGER_WAIT_FOR_IT,
                 this.members[i]));
-            memberDeparted(this.members[i], false);
+            memberDeparted(getDistributionManager(), this.members[i], false);
           } else {
             if (suspectMembers != null) {
               suspectMembers.add(this.members[i]);

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/StartupOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/StartupOperation.java
@@ -81,7 +81,7 @@ public class StartupOperation {
         InternalDistributedMember id = (InternalDistributedMember) it.next();
         this.dm.handleManagerDeparture(id, false,
             LocalizedStrings.StartupOperation_LEFT_THE_MEMBERSHIP_VIEW.toLocalizedString());
-        proc.memberDeparted(id, true);
+        proc.memberDeparted(this.dm, id, true);
       }
     }
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/direct/DirectChannel.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/direct/DirectChannel.java
@@ -719,7 +719,7 @@ public class DirectChannel {
       logger.warn(LocalizedMessage.create(
           LocalizedStrings.DirectChannel_VIEW_NO_LONGER_HAS_0_AS_AN_ACTIVE_MEMBER_SO_WE_WILL_NO_LONGER_WAIT_FOR_IT,
           c.getRemoteAddress()));
-      processor.memberDeparted(c.getRemoteAddress(), true);
+      processor.memberDeparted(getDM(), c.getRemoteAddress(), true);
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/locks/DLockGrantor.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/locks/DLockGrantor.java
@@ -3636,17 +3636,18 @@ public class DLockGrantor {
 
   /** Detects loss of the lock grantor and initiates grantor recovery. */
   private MembershipListener membershipListener = new MembershipListener() {
-    public void memberJoined(InternalDistributedMember id) {}
+    public void memberJoined(DistributionManager distributionManager,
+        InternalDistributedMember id) {}
 
-    public void quorumLost(Set<InternalDistributedMember> failures,
-        List<InternalDistributedMember> remaining) {}
+    public void quorumLost(DistributionManager distributionManager,
+        Set<InternalDistributedMember> failures, List<InternalDistributedMember> remaining) {}
 
-    public void memberSuspect(InternalDistributedMember id, InternalDistributedMember whoSuspected,
-        String reason) {}
+    public void memberSuspect(DistributionManager distributionManager, InternalDistributedMember id,
+        InternalDistributedMember whoSuspected, String reason) {}
 
-    public void memberDeparted(final InternalDistributedMember id, final boolean crashed) {
+    public void memberDeparted(DistributionManager distMgr, final InternalDistributedMember id,
+        final boolean crashed) {
       final DLockGrantor me = DLockGrantor.this;
-      final DistributionManager distMgr = me.dlock.getDistributionManager();
       // if the VM is being forcibly disconnected, we shouldn't release locks as it
       // will take longer than the time allowed by the InternalDistributedSystem
       // shutdown mechanism.

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RemoteGfManagerAgent.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RemoteGfManagerAgent.java
@@ -1355,7 +1355,8 @@ class RemoteGfManagerAgent implements GfManagerAgent {
      *
      * @see JoinLeaveListener#nodeJoined
      */
-    public void memberJoined(final InternalDistributedMember id) {
+    public void memberJoined(DistributionManager distributionManager,
+        final InternalDistributedMember id) {
       if (!isListening()) {
         return;
       }
@@ -1368,11 +1369,11 @@ class RemoteGfManagerAgent implements GfManagerAgent {
       }
     }
 
-    public void memberSuspect(InternalDistributedMember id, InternalDistributedMember whoSuspected,
-        String reason) {}
+    public void memberSuspect(DistributionManager distributionManager, InternalDistributedMember id,
+        InternalDistributedMember whoSuspected, String reason) {}
 
-    public void quorumLost(Set<InternalDistributedMember> failures,
-        List<InternalDistributedMember> remaining) {}
+    public void quorumLost(DistributionManager distributionManager,
+        Set<InternalDistributedMember> failures, List<InternalDistributedMember> remaining) {}
 
     /**
      * This method is invoked after a member has explicitly left the system. It may not get invoked
@@ -1381,7 +1382,8 @@ class RemoteGfManagerAgent implements GfManagerAgent {
      * @see JoinLeaveListener#nodeCrashed
      * @see JoinLeaveListener#nodeLeft
      */
-    public void memberDeparted(InternalDistributedMember id, boolean crashed) {
+    public void memberDeparted(DistributionManager distributionManager,
+        InternalDistributedMember id, boolean crashed) {
       synchronized (this) {
         if (!this.distributedMembers.remove(id)) {
           return;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
@@ -3399,14 +3399,14 @@ public class DistributedRegion extends LocalRegion implements InternalDistribute
     }
 
     @Override
-    public void quorumLost(Set<InternalDistributedMember> failures,
-        List<InternalDistributedMember> remaining) {
+    public void quorumLost(DistributionManager distributionManager,
+        Set<InternalDistributedMember> failures, List<InternalDistributedMember> remaining) {
       // do nothing
     }
 
     @Override
-    public void memberSuspect(InternalDistributedMember id, InternalDistributedMember whoSuspected,
-        String reason) {
+    public void memberSuspect(DistributionManager distributionManager, InternalDistributedMember id,
+        InternalDistributedMember whoSuspected, String reason) {
       // do nothing
     }
 
@@ -3418,7 +3418,8 @@ public class DistributedRegion extends LocalRegion implements InternalDistribute
     }
 
     @Override
-    public synchronized void memberJoined(InternalDistributedMember id) {
+    public synchronized void memberJoined(DistributionManager distributionManager,
+        InternalDistributedMember id) {
       if (this.destroyed) {
         return;
       }
@@ -3469,7 +3470,8 @@ public class DistributedRegion extends LocalRegion implements InternalDistribute
       }
     }
 
-    public synchronized void memberDeparted(InternalDistributedMember id, boolean crashed) {
+    public synchronized void memberDeparted(DistributionManager distributionManager,
+        InternalDistributedMember id, boolean crashed) {
       if (this.destroyed) {
         return;
       }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InitialImageFlowControl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InitialImageFlowControl.java
@@ -161,11 +161,11 @@ public class InitialImageFlowControl implements MembershipListener {
     return id;
   }
 
-  public void memberDeparted(InternalDistributedMember id, boolean crashed) {
+  public void memberDeparted(DistributionManager distributionManager, InternalDistributedMember id,
+      boolean crashed) {
     if (id.equals(target)) {
       abort();
     }
-
   }
 
   private void abort() {
@@ -177,15 +177,15 @@ public class InitialImageFlowControl implements MembershipListener {
     }
   }
 
-  public void memberJoined(InternalDistributedMember id) {
+  public void memberJoined(DistributionManager distributionManager, InternalDistributedMember id) {
     // Do nothing
   }
 
-  public void quorumLost(Set<InternalDistributedMember> failures,
-      List<InternalDistributedMember> remaining) {}
+  public void quorumLost(DistributionManager distributionManager,
+      Set<InternalDistributedMember> failures, List<InternalDistributedMember> remaining) {}
 
-  public void memberSuspect(InternalDistributedMember id, InternalDistributedMember whoSuspected,
-      String reason) {
+  public void memberSuspect(DistributionManager distributionManager, InternalDistributedMember id,
+      InternalDistributedMember whoSuspected, String reason) {
     // Do nothing
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PRHARedundancyProvider.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PRHARedundancyProvider.java
@@ -2131,7 +2131,8 @@ public class PRHARedundancyProvider {
       this.bucketToMonitor.getBucketAdvisor().removeMembershipListener(this);
     }
 
-    public void memberJoined(InternalDistributedMember id) {
+    public void memberJoined(DistributionManager distributionManager,
+        InternalDistributedMember id) {
       if (logger.isDebugEnabled()) {
         logger.debug("Observer for bucket {} member joined {}", this.bucketToMonitor, id);
       }
@@ -2142,10 +2143,11 @@ public class PRHARedundancyProvider {
       }
     }
 
-    public void memberSuspect(InternalDistributedMember id, InternalDistributedMember whoSuspected,
-        String reason) {}
+    public void memberSuspect(DistributionManager distributionManager, InternalDistributedMember id,
+        InternalDistributedMember whoSuspected, String reason) {}
 
-    public void memberDeparted(InternalDistributedMember id, boolean crashed) {
+    public void memberDeparted(DistributionManager distributionManager,
+        InternalDistributedMember id, boolean crashed) {
       if (logger.isDebugEnabled()) {
         logger.debug("Observer for bucket {} member departed {}", this.bucketToMonitor, id);
       }
@@ -2231,8 +2233,8 @@ public class PRHARedundancyProvider {
     }
 
     @Override
-    public void quorumLost(Set<InternalDistributedMember> failures,
-        List<InternalDistributedMember> remaining) {}
+    public void quorumLost(DistributionManager distributionManager,
+        Set<InternalDistributedMember> failures, List<InternalDistributedMember> remaining) {}
   }
 
   /**
@@ -2240,7 +2242,8 @@ public class PRHARedundancyProvider {
    *
    */
   protected class PRMembershipListener implements MembershipListener {
-    public void memberDeparted(final InternalDistributedMember id, final boolean crashed) {
+    public void memberDeparted(DistributionManager distributionManager,
+        final InternalDistributedMember id, final boolean crashed) {
       try {
         DistributedMember dmem = prRegion.getSystem().getDistributedMember();
         if (logger.isDebugEnabled()) {
@@ -2271,15 +2274,16 @@ public class PRHARedundancyProvider {
       }
     }
 
-    public void memberSuspect(InternalDistributedMember id, InternalDistributedMember whoSuspected,
-        String reason) {}
+    public void memberSuspect(DistributionManager distributionManager, InternalDistributedMember id,
+        InternalDistributedMember whoSuspected, String reason) {}
 
-    public void memberJoined(InternalDistributedMember id) {
+    public void memberJoined(DistributionManager distributionManager,
+        InternalDistributedMember id) {
       // no action required
     }
 
-    public void quorumLost(Set<InternalDistributedMember> failures,
-        List<InternalDistributedMember> remaining) {}
+    public void quorumLost(DistributionManager distributionManager,
+        Set<InternalDistributedMember> failures, List<InternalDistributedMember> remaining) {}
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
@@ -8960,7 +8960,8 @@ public class PartitionedRegion extends LocalRegion
     }
 
     @Override
-    public synchronized void memberJoined(InternalDistributedMember id) {
+    public synchronized void memberJoined(DistributionManager distributionManager,
+        InternalDistributedMember id) {
       // bug #44684 - this notification has been moved to a point AFTER the
       // other member has finished initializing its region
 
@@ -8969,15 +8970,16 @@ public class PartitionedRegion extends LocalRegion
     }
 
     @Override
-    public void quorumLost(Set<InternalDistributedMember> failures,
-        List<InternalDistributedMember> remaining) {}
+    public void quorumLost(DistributionManager distributionManager,
+        Set<InternalDistributedMember> failures, List<InternalDistributedMember> remaining) {}
 
     @Override
-    public void memberSuspect(InternalDistributedMember id, InternalDistributedMember whoSuspected,
-        String reason) {}
+    public void memberSuspect(DistributionManager distributionManager, InternalDistributedMember id,
+        InternalDistributedMember whoSuspected, String reason) {}
 
     @Override
-    public synchronized void memberDeparted(InternalDistributedMember id, boolean crashed) {
+    public synchronized void memberDeparted(DistributionManager distributionManager,
+        InternalDistributedMember id, boolean crashed) {
       if (PartitionedRegion.this.isInitialized() && hasListener()) {
         RegionEventImpl event =
             new RegionEventImpl(PartitionedRegion.this, Operation.REGION_CLOSE, null, true, id);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegionHelper.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegionHelper.java
@@ -936,19 +936,21 @@ public class PartitionedRegionHelper {
       this.cache = cache;
     }
 
-    public void memberJoined(InternalDistributedMember id) {
+    public void memberJoined(DistributionManager distributionManager,
+        InternalDistributedMember id) {
 
     }
 
-    public void memberDeparted(final InternalDistributedMember id, boolean crashed) {
+    public void memberDeparted(DistributionManager distributionManager,
+        final InternalDistributedMember id, boolean crashed) {
       PartitionedRegionHelper.cleanUpMetaDataOnNodeFailure(cache, id);
     }
 
-    public void memberSuspect(InternalDistributedMember id, InternalDistributedMember whoSuspected,
-        String reason) {}
+    public void memberSuspect(DistributionManager distributionManager, InternalDistributedMember id,
+        InternalDistributedMember whoSuspected, String reason) {}
 
-    public void quorumLost(Set<InternalDistributedMember> failures,
-        List<InternalDistributedMember> remaining) {}
+    public void quorumLost(DistributionManager distributionManager,
+        Set<InternalDistributedMember> failures, List<InternalDistributedMember> remaining) {}
 
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/RemoteOperationMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/RemoteOperationMessage.java
@@ -565,7 +565,8 @@ public abstract class RemoteOperationMessage extends DistributionMessage
     }
 
     @Override
-    public void memberDeparted(final InternalDistributedMember id, final boolean crashed) {
+    public void memberDeparted(DistributionManager distributionManager,
+        final InternalDistributedMember id, final boolean crashed) {
       if (id != null) {
         if (removeMember(id, true)) {
           this.prce = new ForceReattemptException(

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/SearchLoadAndWriteProcessor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/SearchLoadAndWriteProcessor.java
@@ -231,17 +231,18 @@ public class SearchLoadAndWriteProcessor implements MembershipListener {
     }
   }
 
-  public void memberJoined(InternalDistributedMember id) {
+  public void memberJoined(DistributionManager distributionManager, InternalDistributedMember id) {
     // Ignore - if they just joined, they don't have what we want
   }
 
-  public void memberSuspect(InternalDistributedMember id, InternalDistributedMember whoSuspected,
-      String reason) {}
+  public void memberSuspect(DistributionManager distributionManager, InternalDistributedMember id,
+      InternalDistributedMember whoSuspected, String reason) {}
 
-  public void quorumLost(Set<InternalDistributedMember> failures,
-      List<InternalDistributedMember> remaining) {}
+  public void quorumLost(DistributionManager distributionManager,
+      Set<InternalDistributedMember> failures, List<InternalDistributedMember> remaining) {}
 
-  public void memberDeparted(final InternalDistributedMember id, final boolean crashed) {
+  public void memberDeparted(DistributionManager distributionManager,
+      final InternalDistributedMember id, final boolean crashed) {
 
     synchronized (membersLock) {
       pendingResponders.remove(id);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/StateFlushOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/StateFlushOperation.java
@@ -755,13 +755,14 @@ public class StateFlushOperation {
     /** process the failure set from sending the message */
     public void messageNotSentTo(Set failures) {
       for (Iterator it = failures.iterator(); it.hasNext();) {
-        this.memberDeparted((InternalDistributedMember) it.next(), true);
+        this.memberDeparted(null, (InternalDistributedMember) it.next(), true);
       }
     }
 
     @Override
-    public void memberDeparted(final InternalDistributedMember id, final boolean crashed) {
-      super.memberDeparted(id, crashed);
+    public void memberDeparted(DistributionManager distributionManager,
+        final InternalDistributedMember id, final boolean crashed) {
+      super.memberDeparted(distributionManager, id, crashed);
     }
 
     @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXCommitMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXCommitMessage.java
@@ -549,7 +549,7 @@ public class TXCommitMessage extends PooledDistributionMessage
         txTracker.add(this);
       }
       if (!this.dm.getDistributionManagerIds().contains(getSender())) {
-        memberDeparted(getSender(), false /* don't care */);
+        memberDeparted(this.dm, getSender(), false /* don't care */);
       }
 
     } else {
@@ -1928,17 +1928,22 @@ public class TXCommitMessage extends PooledDistributionMessage
   }
 
   /********************* MembershipListener Implementation ***************************************/
-  public void memberJoined(InternalDistributedMember id) {
+  @Override
+  public void memberJoined(DistributionManager distributionManager, InternalDistributedMember id) {
     // do nothing
   }
 
-  public void memberSuspect(InternalDistributedMember id, InternalDistributedMember whoSuspected,
-      String reason) {}
+  @Override
+  public void memberSuspect(DistributionManager distributionManager, InternalDistributedMember id,
+      InternalDistributedMember whoSuspected, String reason) {}
 
-  public void quorumLost(Set<InternalDistributedMember> failures,
-      List<InternalDistributedMember> remaining) {}
+  @Override
+  public void quorumLost(DistributionManager distributionManager,
+      Set<InternalDistributedMember> failures, List<InternalDistributedMember> remaining) {}
 
-  public void memberDeparted(final InternalDistributedMember id, boolean crashed) {
+  @Override
+  public void memberDeparted(DistributionManager distributionManager,
+      final InternalDistributedMember id, boolean crashed) {
     if (!getSender().equals(id)) {
       return;
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXFarSideCMTracker.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXFarSideCMTracker.java
@@ -198,12 +198,14 @@ public class TXFarSideCMTracker {
     final Object lock = new Object();
     final MembershipListener memEar = new MembershipListener() {
       // MembershipListener implementation
-      public void memberJoined(InternalDistributedMember id) {}
+      public void memberJoined(DistributionManager distributionManager,
+          InternalDistributedMember id) {}
 
-      public void memberSuspect(InternalDistributedMember id,
-          InternalDistributedMember whoSuspected, String reason) {}
+      public void memberSuspect(DistributionManager distributionManager,
+          InternalDistributedMember id, InternalDistributedMember whoSuspected, String reason) {}
 
-      public void memberDeparted(InternalDistributedMember id, boolean crashed) {
+      public void memberDeparted(DistributionManager distributionManager,
+          InternalDistributedMember id, boolean crashed) {
         if (memberId.equals(id)) {
           synchronized (lock) {
             lock.notifyAll();
@@ -211,8 +213,8 @@ public class TXFarSideCMTracker {
         }
       }
 
-      public void quorumLost(Set<InternalDistributedMember> failures,
-          List<InternalDistributedMember> remaining) {}
+      public void quorumLost(DistributionManager distributionManager,
+          Set<InternalDistributedMember> failures, List<InternalDistributedMember> remaining) {}
     };
     try {
       Set memberSet = dm.addMembershipListenerAndGetDistributionManagerIds(memEar);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXManagerImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXManagerImpl.java
@@ -1062,7 +1062,8 @@ public class TXManagerImpl implements CacheTransactionManager, MembershipListene
     return this.localTxMap.size();
   }
 
-  public void memberDeparted(InternalDistributedMember id, boolean crashed) {
+  public void memberDeparted(DistributionManager distributionManager, InternalDistributedMember id,
+      boolean crashed) {
     synchronized (this.hostedTXStates) {
       Iterator<Map.Entry<TXId, TXStateProxy>> iterator = this.hostedTXStates.entrySet().iterator();
       while (iterator.hasNext()) {
@@ -1080,13 +1081,13 @@ public class TXManagerImpl implements CacheTransactionManager, MembershipListene
     expireClientTransactionsSentFromDepartedProxy(id);
   }
 
-  public void memberJoined(InternalDistributedMember id) {}
+  public void memberJoined(DistributionManager distributionManager, InternalDistributedMember id) {}
 
-  public void quorumLost(Set<InternalDistributedMember> failures,
-      List<InternalDistributedMember> remaining) {}
+  public void quorumLost(DistributionManager distributionManager,
+      Set<InternalDistributedMember> failures, List<InternalDistributedMember> remaining) {}
 
-  public void memberSuspect(InternalDistributedMember id, InternalDistributedMember whoSuspected,
-      String reason) {}
+  public void memberSuspect(DistributionManager distributionManager, InternalDistributedMember id,
+      InternalDistributedMember whoSuspected, String reason) {}
 
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/backup/BackupService.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/backup/BackupService.java
@@ -30,6 +30,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.cache.persistence.PersistentID;
+import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.distributed.internal.MembershipListener;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.DiskStoreBackup;
@@ -137,24 +138,26 @@ public class BackupService {
 
   private class BackupMembershipListener implements MembershipListener {
     @Override
-    public void memberDeparted(InternalDistributedMember id, boolean crashed) {
+    public void memberDeparted(DistributionManager distributionManager,
+        InternalDistributedMember id, boolean crashed) {
       cleanup();
     }
 
     @Override
-    public void memberJoined(InternalDistributedMember id) {
+    public void memberJoined(DistributionManager distributionManager,
+        InternalDistributedMember id) {
       // unused
     }
 
     @Override
-    public void quorumLost(Set<InternalDistributedMember> failures,
-        List<InternalDistributedMember> remaining) {
+    public void quorumLost(DistributionManager distributionManager,
+        Set<InternalDistributedMember> failures, List<InternalDistributedMember> remaining) {
       // unused
     }
 
     @Override
-    public void memberSuspect(InternalDistributedMember id, InternalDistributedMember whoSuspected,
-        String reason) {
+    public void memberSuspect(DistributionManager distributionManager, InternalDistributedMember id,
+        InternalDistributedMember whoSuspected, String reason) {
       // unused
     }
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/FunctionStreamingResultCollector.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/FunctionStreamingResultCollector.java
@@ -36,6 +36,7 @@ import org.apache.geode.cache.execute.FunctionInvocationTargetException;
 import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.DistributedSystemDisconnectedException;
+import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.distributed.internal.DistributionMessage;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.ReplyException;
@@ -376,7 +377,8 @@ public class FunctionStreamingResultCollector extends ReplyProcessor21 implement
   }
 
   @Override
-  public void memberDeparted(final InternalDistributedMember id, final boolean crashed) {
+  public void memberDeparted(DistributionManager distributionManager,
+      final InternalDistributedMember id, final boolean crashed) {
     if (id != null) {
       synchronized (this.members) {
         if (removeMember(id, true)) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/PRFunctionStreamingResultCollector.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/PRFunctionStreamingResultCollector.java
@@ -26,6 +26,7 @@ import org.apache.geode.cache.execute.FunctionException;
 import org.apache.geode.cache.execute.FunctionInvocationTargetException;
 import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.distributed.internal.DistributionMessage;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.ReplyException;
@@ -344,7 +345,8 @@ public class PRFunctionStreamingResultCollector extends FunctionStreamingResultC
   }
 
   @Override
-  public void memberDeparted(final InternalDistributedMember id, final boolean crashed) {
+  public void memberDeparted(DistributionManager distributionManager,
+      final InternalDistributedMember id, final boolean crashed) {
     FunctionInvocationTargetException fite;
     if (id != null) {
       synchronized (this.members) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/PartitionMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/PartitionMessage.java
@@ -757,7 +757,8 @@ public abstract class PartitionMessage extends DistributionMessage
     }
 
     @Override
-    public void memberDeparted(final InternalDistributedMember id, final boolean crashed) {
+    public void memberDeparted(DistributionManager distributionManager,
+        final InternalDistributedMember id, final boolean crashed) {
       if (id != null) {
         if (removeMember(id, true)) {
           this.prce = new ForceReattemptException(

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/PartitionedRegionRebalanceOp.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/PartitionedRegionRebalanceOp.java
@@ -610,7 +610,8 @@ public class PartitionedRegionRebalanceOp {
 
   private class MembershipChangeListener implements MembershipListener {
 
-    public void memberDeparted(InternalDistributedMember id, boolean crashed) {
+    public void memberDeparted(DistributionManager distributionManager,
+        InternalDistributedMember id, boolean crashed) {
       if (logger.isDebugEnabled()) {
         logger.debug(
             "PartitionedRegionRebalanceOP - membership changed, restarting rebalancing for region {}",
@@ -619,7 +620,8 @@ public class PartitionedRegionRebalanceOp {
       membershipChange = true;
     }
 
-    public void memberJoined(InternalDistributedMember id) {
+    public void memberJoined(DistributionManager distributionManager,
+        InternalDistributedMember id) {
       if (logger.isDebugEnabled()) {
         logger.debug(
             "PartitionedRegionRebalanceOP - membership changed, restarting rebalancing for region {}",
@@ -628,12 +630,12 @@ public class PartitionedRegionRebalanceOp {
       membershipChange = true;
     }
 
-    public void memberSuspect(InternalDistributedMember id, InternalDistributedMember whoSuspected,
-        String reason) {
+    public void memberSuspect(DistributionManager distributionManager, InternalDistributedMember id,
+        InternalDistributedMember whoSuspected, String reason) {
       // do nothing.
     }
 
-    public void quorumLost(Set<InternalDistributedMember> failures,
-        List<InternalDistributedMember> remaining) {}
+    public void quorumLost(DistributionManager distributionManager,
+        Set<InternalDistributedMember> failures, List<InternalDistributedMember> remaining) {}
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/StreamingPartitionOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/StreamingPartitionOperation.java
@@ -202,14 +202,15 @@ public abstract class StreamingPartitionOperation extends StreamingOperation {
     }
 
     @Override
-    public void memberDeparted(InternalDistributedMember id, boolean crashed) {
+    public void memberDeparted(DistributionManager distributionManager,
+        InternalDistributedMember id, boolean crashed) {
       if (id != null && waitingOnMember(id)) {
         this.failedMembers.add(id);
         this.memberDepartedMessage =
             LocalizedStrings.StreamingPartitionOperation_GOT_MEMBERDEPARTED_EVENT_FOR_0_CRASHED_1
                 .toLocalizedString(new Object[] {id, Boolean.valueOf(crashed)});
       }
-      super.memberDeparted(id, crashed);
+      super.memberDeparted(distributionManager, id, crashed);
     }
 
     /**

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/PersistenceAdvisorImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/PersistenceAdvisorImpl.java
@@ -1227,7 +1227,8 @@ public class PersistenceAdvisorImpl implements PersistenceAdvisor {
       }
     }
 
-    public void memberJoined(InternalDistributedMember id) {
+    public void memberJoined(DistributionManager distributionManager,
+        InternalDistributedMember id) {
       afterMembershipChange();
     }
 
@@ -1238,16 +1239,17 @@ public class PersistenceAdvisorImpl implements PersistenceAdvisor {
       }
     }
 
-    public void memberDeparted(InternalDistributedMember id, boolean crashed) {
+    public void memberDeparted(DistributionManager distributionManager,
+        InternalDistributedMember id, boolean crashed) {
       afterMembershipChange();
     }
 
-    public void memberSuspect(InternalDistributedMember id, InternalDistributedMember whoSuspected,
-        String reason) {}
+    public void memberSuspect(DistributionManager distributionManager, InternalDistributedMember id,
+        InternalDistributedMember whoSuspected, String reason) {}
 
     @Override
-    public void quorumLost(Set<InternalDistributedMember> failures,
-        List<InternalDistributedMember> remaining) {}
+    public void quorumLost(DistributionManager distributionManager,
+        Set<InternalDistributedMember> failures, List<InternalDistributedMember> remaining) {}
 
     public void memberOffline(InternalDistributedMember member, PersistentMemberID persistentID) {
       afterMembershipChange();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/PersistentMemberManager.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/PersistentMemberManager.java
@@ -242,12 +242,14 @@ public class PersistentMemberManager {
     }
 
     @Override
-    public void memberJoined(InternalDistributedMember id) {
+    public void memberJoined(DistributionManager distributionManager,
+        InternalDistributedMember id) {
 
     }
 
     @Override
-    public void memberDeparted(InternalDistributedMember id, boolean crashed) {
+    public void memberDeparted(DistributionManager distributionManager,
+        InternalDistributedMember id, boolean crashed) {
       if (id.equals(sender)) {
         cancelRevoke(pattern);
       }
@@ -255,12 +257,12 @@ public class PersistentMemberManager {
     }
 
     @Override
-    public void memberSuspect(InternalDistributedMember id, InternalDistributedMember whoSuspected,
-        String reason) {}
+    public void memberSuspect(DistributionManager distributionManager, InternalDistributedMember id,
+        InternalDistributedMember whoSuspected, String reason) {}
 
     @Override
-    public void quorumLost(Set<InternalDistributedMember> failures,
-        List<InternalDistributedMember> remaining) {}
+    public void quorumLost(DistributionManager distributionManager,
+        Set<InternalDistributedMember> failures, List<InternalDistributedMember> remaining) {}
 
     public void remove() {
       dm.removeAllMembershipListener(this);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/versions/RegionVersionVector.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/versions/RegionVersionVector.java
@@ -304,13 +304,12 @@ public abstract class RegionVersionVector<T extends VersionSource<?>>
   /** unlocks version generation for clear() operations */
   public void unlockForClear(InternalDistributedMember locker) {
     synchronized (this.clearLockSync) {
-      InternalDistributedSystem instance = InternalDistributedSystem.getAnyInstance();
-      if (instance != null && logger.isDebugEnabled()) {
+      if (logger.isDebugEnabled()) {
         logger.debug("Unlocking for clear, from member {} RVV {}", locker,
             System.identityHashCode(this));
       }
       if (this.lockOwner != null && !locker.equals(this.lockOwner)) {
-        if (instance != null && logger.isDebugEnabled()) {
+        if (logger.isDebugEnabled()) {
           logger.debug("current clear lock owner was {} not unlocking", lockOwner);
         }
         // this method is invoked by memberDeparted events and may not be for the current lock owner
@@ -1417,13 +1416,13 @@ public abstract class RegionVersionVector<T extends VersionSource<?>>
   }
 
 
-  public void memberJoined(InternalDistributedMember id) {}
+  public void memberJoined(DistributionManager distributionManager, InternalDistributedMember id) {}
 
-  public void memberSuspect(InternalDistributedMember id, InternalDistributedMember whoSuspected,
-      String reason) {}
+  public void memberSuspect(DistributionManager distributionManager, InternalDistributedMember id,
+      InternalDistributedMember whoSuspected, String reason) {}
 
-  public void quorumLost(Set<InternalDistributedMember> failures,
-      List<InternalDistributedMember> remaining) {}
+  public void quorumLost(DistributionManager distributionManager,
+      Set<InternalDistributedMember> failures, List<InternalDistributedMember> remaining) {}
 
   /*
    * (non-Javadoc) this ensures that the version generation lock is released
@@ -1431,12 +1430,12 @@ public abstract class RegionVersionVector<T extends VersionSource<?>>
    * @see org.apache.geode.distributed.internal.MembershipListener#memberDeparted(org.apache.geode.
    * distributed.internal.membership.InternalDistributedMember, boolean)
    */
-  public void memberDeparted(final InternalDistributedMember id, boolean crashed) {
+  public void memberDeparted(DistributionManager distributionManager,
+      final InternalDistributedMember id, boolean crashed) {
     // since unlockForClear uses synchronization we need to try to execute it in another
     // thread so that membership events aren't blocked
-    InternalDistributedSystem system = InternalDistributedSystem.getAnyInstance();
-    if (system != null) {
-      system.getDistributionManager().getWaitingThreadPool().execute(new Runnable() {
+    if (distributionManager != null) {
+      distributionManager.getWaitingThreadPool().execute(new Runnable() {
         public void run() {
           unlockForClear(id);
         }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/versions/VMRegionVersionVector.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/versions/VMRegionVersionVector.java
@@ -19,6 +19,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.LocalRegion;
 
@@ -75,16 +76,10 @@ public class VMRegionVersionVector extends RegionVersionVector<InternalDistribut
     return REGION_VERSION_VECTOR;
   }
 
-  /*
-   * (non-Javadoc)
-   *
-   * @see
-   * org.apache.geode.internal.cache.versions.RegionVersionVector#memberDeparted(org.apache.geode.
-   * distributed.internal.membership.InternalDistributedMember, boolean)
-   */
   @Override
-  public void memberDeparted(final InternalDistributedMember id, boolean crashed) {
-    super.memberDeparted(id, crashed);
+  public void memberDeparted(DistributionManager distributionManager,
+      final InternalDistributedMember id, boolean crashed) {
+    super.memberDeparted(distributionManager, id, crashed);
     removeOldMember(id);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/ManagementMembershipListener.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/ManagementMembershipListener.java
@@ -19,6 +19,7 @@ import java.util.Set;
 
 import org.apache.logging.log4j.Logger;
 
+import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.distributed.internal.MembershipListener;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.logging.LogService;
@@ -44,7 +45,8 @@ public class ManagementMembershipListener implements MembershipListener {
   }
 
   @Override
-  public void memberDeparted(InternalDistributedMember id, boolean crashed) {
+  public void memberDeparted(DistributionManager distributionManager, InternalDistributedMember id,
+      boolean crashed) {
     if (logger.isDebugEnabled()) {
       logger.debug("ManagementMembershipListener member departed.. {}", id.getId());
     }
@@ -59,7 +61,7 @@ public class ManagementMembershipListener implements MembershipListener {
   }
 
   @Override
-  public void memberJoined(InternalDistributedMember id) {
+  public void memberJoined(DistributionManager distributionManager, InternalDistributedMember id) {
 
     if (logger.isDebugEnabled()) {
       logger.debug("ManagementMembershipListener member joined .. {}", id.getId());
@@ -74,8 +76,8 @@ public class ManagementMembershipListener implements MembershipListener {
   }
 
   @Override
-  public void memberSuspect(InternalDistributedMember id, InternalDistributedMember whoSuspected,
-      String reason) {
+  public void memberSuspect(DistributionManager distributionManager, InternalDistributedMember id,
+      InternalDistributedMember whoSuspected, String reason) {
 
     if (logger.isDebugEnabled()) {
       logger.debug("ManagementMembershipListener member suspected .. {}", id.getId());
@@ -88,6 +90,6 @@ public class ManagementMembershipListener implements MembershipListener {
     }
   }
 
-  public void quorumLost(Set<InternalDistributedMember> failures,
-      List<InternalDistributedMember> remaining) {}
+  public void quorumLost(DistributionManager distributionManager,
+      Set<InternalDistributedMember> failures, List<InternalDistributedMember> remaining) {}
 }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/SystemManagementService.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/SystemManagementService.java
@@ -666,27 +666,27 @@ public class SystemManagementService extends BaseManagementService {
 
   public void memberJoined(InternalDistributedMember id) {
     for (ProxyListener listener : proxyListeners) {
-      listener.memberJoined(id);
+      listener.memberJoined(system.getDistributionManager(), id);
     }
   }
 
   public void memberDeparted(InternalDistributedMember id, boolean crashed) {
     for (ProxyListener listener : proxyListeners) {
-      listener.memberDeparted(id, crashed);
+      listener.memberDeparted(system.getDistributionManager(), id, crashed);
     }
   }
 
   public void memberSuspect(InternalDistributedMember id, InternalDistributedMember whoSuspected,
       String reason) {
     for (ProxyListener listener : proxyListeners) {
-      listener.memberSuspect(id, whoSuspected, reason);
+      listener.memberSuspect(system.getDistributionManager(), id, whoSuspected, reason);
     }
   }
 
   public void quorumLost(Set<InternalDistributedMember> failures,
       List<InternalDistributedMember> remaining) {
     for (ProxyListener listener : proxyListeners) {
-      listener.quorumLost(failures, remaining);
+      listener.quorumLost(system.getDistributionManager(), failures, remaining);
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/MBeanAggregator.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/MBeanAggregator.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import javax.management.Notification;
 import javax.management.ObjectName;
 
+import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.i18n.LogWriterI18n;
@@ -394,22 +395,23 @@ public class MBeanAggregator implements ProxyListener {
   }
 
   @Override
-  public void memberDeparted(InternalDistributedMember id, boolean crashed) {
+  public void memberDeparted(DistributionManager distributionManager, InternalDistributedMember id,
+      boolean crashed) {
     distributedSystemBridge.memberDeparted(id, crashed);
   }
 
   @Override
-  public void memberJoined(InternalDistributedMember id) {
+  public void memberJoined(DistributionManager distributionManager, InternalDistributedMember id) {
     distributedSystemBridge.memberJoined(id);
 
   }
 
-  public void quorumLost(Set<InternalDistributedMember> failures,
-      List<InternalDistributedMember> remaining) {}
+  public void quorumLost(DistributionManager distributionManager,
+      Set<InternalDistributedMember> failures, List<InternalDistributedMember> remaining) {}
 
   @Override
-  public void memberSuspect(InternalDistributedMember id, InternalDistributedMember whoSuspected,
-      String reason) {
+  public void memberSuspect(DistributionManager distributionManager, InternalDistributedMember id,
+      InternalDistributedMember whoSuspected, String reason) {
     distributedSystemBridge.memberSuspect(id, whoSuspected);
   }
 

--- a/geode-core/src/test/java/org/apache/geode/distributed/LocatorDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/LocatorDUnitTest.java
@@ -66,6 +66,7 @@ import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.distributed.internal.ClusterDistributionManager;
 import org.apache.geode.distributed.internal.DistributionException;
+import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.distributed.internal.HighPriorityAckedMessage;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.InternalLocator;
@@ -2177,17 +2178,19 @@ public class LocatorDUnitTest extends JUnit4DistributedTestCase {
     boolean quorumLostInvoked;
     List<String> suspectReasons = new ArrayList<>(50);
 
-    public void memberJoined(InternalDistributedMember id) {}
+    public void memberJoined(DistributionManager distributionManager,
+        InternalDistributedMember id) {}
 
-    public void memberDeparted(InternalDistributedMember id, boolean crashed) {}
+    public void memberDeparted(DistributionManager distributionManager,
+        InternalDistributedMember id, boolean crashed) {}
 
-    public void memberSuspect(InternalDistributedMember id, InternalDistributedMember whoSuspected,
-        String reason) {
+    public void memberSuspect(DistributionManager distributionManager, InternalDistributedMember id,
+        InternalDistributedMember whoSuspected, String reason) {
       suspectReasons.add(reason);
     }
 
-    public void quorumLost(Set<InternalDistributedMember> failures,
-        List<InternalDistributedMember> remaining) {
+    public void quorumLost(DistributionManager distributionManager,
+        Set<InternalDistributedMember> failures, List<InternalDistributedMember> remaining) {
       quorumLostInvoked = true;
       org.apache.geode.test.dunit.LogWriterUtils.getLogWriter()
           .info("quorumLost invoked in test code");

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/RemoteTransactionDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/RemoteTransactionDUnitTest.java
@@ -3204,8 +3204,8 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
 
     accessor.invoke(new SerializableCallable() {
       public Object call() throws Exception {
-        Region cust = getGemfireCache().getRegion(CUSTOMER);
-        TXManagerImpl mgr = getGemfireCache().getTxManager();
+        Region cust = getCache().getRegion(CUSTOMER);
+        TXManagerImpl mgr = getCache().getTxManager();
         mgr.begin();
         cust.put(new CustId(6), new Customer("customer6", "address6"));
         return null;
@@ -3214,14 +3214,14 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
     final InternalDistributedMember member =
         (InternalDistributedMember) accessor.invoke(new SerializableCallable() {
           public Object call() throws Exception {
-            return getGemfireCache().getMyId();
+            return getCache().getMyId();
           }
         });
     datastore.invoke(new SerializableCallable() {
       public Object call() throws Exception {
-        TXManagerImpl mgr = getGemfireCache().getTxManager();
+        TXManagerImpl mgr = getCache().getTxManager();
         assertEquals(1, mgr.hostedTransactionsInProgressForTest());
-        mgr.memberDeparted(member, true);
+        mgr.memberDeparted(getCache().getDistributionManager(), member, true);
         assertEquals(0, mgr.hostedTransactionsInProgressForTest());
         return null;
       }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/SearchLoadAndWriteProcessorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/SearchLoadAndWriteProcessorTest.java
@@ -126,7 +126,7 @@ public class SearchLoadAndWriteProcessorTest {
             .until(() -> processor.getSelectedNode() != null);
         departedMember = processor.getSelectedNode();
         // Simulate member departed event
-        processor.memberDeparted(departedMember, true);
+        processor.memberDeparted(dm, departedMember, true);
       }
     });
     t1.start();

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/versions/RegionVersionVectorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/versions/RegionVersionVectorTest.java
@@ -215,8 +215,8 @@ public class RegionVersionVectorTest {
     rv1.recordVersion(server3, 1);
     rv1.recordVersion(server4, 1);
     rv1.recordVersion(server5, 1);
-    rv1.memberDeparted(server2, false);
-    rv1.memberDeparted(server4, true);
+    rv1.memberDeparted(null, server2, false);
+    rv1.memberDeparted(null, server4, true);
     assertTrue(rv1.containsMember(server2));
     assertTrue(rv1.containsMember(server3));
     assertTrue(rv1.containsMember(server4));
@@ -228,7 +228,7 @@ public class RegionVersionVectorTest {
     rv1.removeOldMembers(retain);
     assertFalse(rv1.containsMember(server4));
 
-    rv1.memberDeparted(server3, false); // {server2, server3(departed), server5}
+    rv1.memberDeparted(null, server3, false); // {server2, server3(departed), server5}
 
     // Now test that departed members are transferred with GII. We simulate
     // a new server, server6, doing a GII from server1


### PR DESCRIPTION
The MembershipListener interface methods are now passed a DistributionManager.

This allowed memberDeparted in RegionVersionVector to no longer use getAnyInstance
to get the DistributionManager.

Also one of the getAnyInstance calls was not needed because it had to do with debug logging.
