### PR TITLE
GEODE-4573 set JTAPaused flag even if JTA is not yet bootstrapped whe…

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/IndexManager.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/IndexManager.java
@@ -429,11 +429,8 @@ public class IndexManager {
 
     } finally {
       DefaultQuery.setPdxReadSerialized(this.region.getCache(), oldReadSerialized);
+      ((TXManagerImpl) this.region.getCache().getCacheTransactionManager()).unpauseTransaction(tx);
 
-      if (tx != null) {
-        ((TXManagerImpl) this.region.getCache().getCacheTransactionManager())
-            .unpauseTransaction(tx);
-      }
     }
   }
 
@@ -1149,10 +1146,8 @@ public class IndexManager {
       }
     } finally {
       DefaultQuery.setPdxReadSerialized(this.region.getCache(), false);
-      if (tx != null) {
-        ((TXManagerImpl) this.region.getCache().getCacheTransactionManager())
-            .unpauseTransaction(tx);
-      }
+      ((TXManagerImpl) this.region.getCache().getCacheTransactionManager()).unpauseTransaction(tx);
+
       getCachePerfStats().endIndexUpdate(startPA);
     }
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
@@ -3856,9 +3856,7 @@ public class DistributedRegion extends LocalRegion implements InternalDistribute
         }
       }
     } finally {
-      if (tx != null) {
-        cache.getTXMgr().unpauseTransaction(tx);
-      }
+      cache.getTXMgr().unpauseTransaction(tx);
     }
     return tag;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
@@ -6432,6 +6432,11 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
     return txMgr.isTransactionPaused();
   }
 
+  private boolean isJTAPaused() {
+    TXManagerImpl txMgr = (TXManagerImpl) getCache().getCacheTransactionManager();
+    return txMgr.isJTAPaused();
+  }
+
   /**
    * @return true if a transaction is in process
    * @since GemFire tx
@@ -8324,7 +8329,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
               || jtaTransaction.getStatus() == Status.STATUS_NO_TRANSACTION) {
             return null;
           }
-          if (isTransactionPaused()) {
+          if (isTransactionPaused() || isJTAPaused()) {
             // Do not bootstrap JTA again, if the transaction has been paused.
             return null;
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXManagerImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXManagerImpl.java
@@ -89,6 +89,8 @@ public class TXManagerImpl implements CacheTransactionManager, MembershipListene
   // Thread specific context container
   private final ThreadLocal<TXStateProxy> txContext;
 
+  private final ThreadLocal<Boolean> pauseJTA;
+
   private static TXManagerImpl currentInstance = null;
 
   // The unique transaction ID for this Manager
@@ -186,6 +188,7 @@ public class TXManagerImpl implements CacheTransactionManager, MembershipListene
     this.cachePerfStats = cachePerfStats;
     this.hostedTXStates = new HashMap<>();
     this.txContext = new ThreadLocal<>();
+    this.pauseJTA = new ThreadLocal<Boolean>();
     this.isTXDistributed = new ThreadLocal<>();
     this.transactionTimeToLive = Integer
         .getInteger(DistributionConfig.GEMFIRE_PREFIX + "cacheServer.transactionTimeToLive", 180);
@@ -728,6 +731,11 @@ public class TXManagerImpl implements CacheTransactionManager, MembershipListene
       } else {
         setTXState(null);
       }
+    } else {
+      if (needToResumeBySameThread) {
+        // pausedJTA is set to true when JTA is not yet bootstrapped.
+        pauseJTA.set(true);
+      }
     }
     return result;
   }
@@ -781,11 +789,23 @@ public class TXManagerImpl implements CacheTransactionManager, MembershipListene
       setTXState(tx);
 
       tx.resume();
+    } else {
+      if (needToResumeBySameThread) {
+        pauseJTA.set(false);
+      }
     }
   }
 
   public boolean isTransactionPaused() {
     return txContext.get() == PAUSED;
+  }
+
+  public boolean isJTAPaused() {
+    Boolean jtaPaused = pauseJTA.get();
+    if (jtaPaused == null) {
+      return false;
+    }
+    return jtaPaused;
   }
 
   /**


### PR DESCRIPTION
…n pauseTransaction is executed.

* This will prevent discoverJTA to bootstrap a supposedly paused transaction.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
