### PR TITLE
GEODE-4575: remove getAnyInstance call in CacheCreation

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/AbstractGatewaySender.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/AbstractGatewaySender.java
@@ -255,11 +255,11 @@ public abstract class AbstractGatewaySender implements GatewaySender, Distributi
     // if dispatcherThreads is 1 then maxMemoryPerDispatcherQueue will be same as maximumQueueMemory
     // of sender
     this.maxMemoryPerDispatcherQueue = this.queueMemory / this.dispatcherThreads;
-    this.myDSId =
-        this.cache.getInternalDistributedSystem().getDistributionManager().getDistributedSystemId();
     this.serialNumber = DistributionAdvisor.createSerialNumber();
     this.isMetaQueue = attrs.isMetaQueue();
     if (!(this.cache instanceof CacheCreation)) {
+      this.myDSId = this.cache.getInternalDistributedSystem().getDistributionManager()
+          .getDistributedSystemId();
       this.stopper = new Stopper(cache.getCancelCriterion());
       this.senderAdvisor = GatewaySenderAdvisor.createGatewaySenderAdvisor(this);
       if (!this.isForInternalUse()) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheCreation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheCreation.java
@@ -1473,7 +1473,7 @@ public class CacheCreation implements InternalCache {
 
   @Override
   public InternalDistributedSystem getInternalDistributedSystem() {
-    return InternalDistributedSystem.getAnyInstance();
+    throw new UnsupportedOperationException(LocalizedStrings.SHOULDNT_INVOKE.toLocalizedString());
   }
 
   @Override


### PR DESCRIPTION
Changed getInternalDistributedSystem to throw an exception if it is called.
It appears that this method is never used on a CacheCreation but because this
class implements the InternalCache interface it has to have an implementation.
