### PR TITLE
GEODE-3540: unable to gfsh destroy gateway-sender

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
@@ -3880,6 +3880,9 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
         this.allGatewaySenders = Collections.unmodifiableSet(newSenders);
       }
     }
+    if (!(sender.getRemoteDSId() < 0)) {
+      this.system.handleResourceEvent(ResourceEvent.GATEWAYSENDER_REMOVE, sender);
+    }
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/management/JMXNotificationType.java
+++ b/geode-core/src/main/java/org/apache/geode/management/JMXNotificationType.java
@@ -159,6 +159,13 @@ public interface JMXNotificationType {
       DistributionConfig.GEMFIRE_PREFIX + "distributedsystem.gateway.sender.resumed";
 
   /**
+   * Notification type which indicates that a gateway sender is removed <BR>
+   * The value of this type string is <CODE>gemfire.distributedsystem.gateway.sender.removed</CODE>.
+   */
+  public static final String GATEWAY_SENDER_REMOVED =
+      DistributionConfig.GEMFIRE_PREFIX + "distributedsystem.gateway.sender.removed";
+
+  /**
    * Notification type which indicates that an async queue is created <BR>
    * The value of this type string is
    * <CODE>ggemfire.distributedsystem.asycn.event.queue.created</CODE>.

--- a/geode-core/src/main/java/org/apache/geode/management/internal/ManagementConstants.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/ManagementConstants.java
@@ -180,6 +180,7 @@ public interface ManagementConstants {
   String GATEWAY_SENDER_STOPPED_PREFIX = "GatewaySender Stopped in the VM ";
   String GATEWAY_SENDER_PAUSED_PREFIX = "GatewaySender Paused in the VM ";
   String GATEWAY_SENDER_RESUMED_PREFIX = "GatewaySender Resumed in the VM ";
+  String GATEWAY_SENDER_REMOVED_PREFIX = "GatewaySender Removed in the VM ";
 
   String GATEWAY_RECEIVER_CREATED_PREFIX = "GatewayReceiver Created in the VM ";
   String GATEWAY_RECEIVER_STARTED_PREFIX = "GatewayReceiver Started in the VM ";

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/ManagementAdapter.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/ManagementAdapter.java
@@ -963,6 +963,28 @@ public class ManagementAdapter {
     memberLevelNotifEmitter.sendNotification(notification);
   }
 
+  public void handleGatewaySenderRemoved(GatewaySender sender) throws ManagementException {
+    if (!isServiceInitialised("handleGatewaySenderRemoved")) {
+      return;
+    }
+    if ((sender.getRemoteDSId() < 0)) {
+      return;
+    }
+
+    GatewaySenderMBean bean =
+        (GatewaySenderMBean) service.getLocalGatewaySenderMXBean(sender.getId());
+    bean.stopMonitor();
+
+    ObjectName gatewaySenderName = MBeanJMXAdapter.getGatewaySenderMBeanName(
+        internalCache.getDistributedSystem().getDistributedMember(), sender.getId());
+    service.unregisterMBean(gatewaySenderName);
+
+    Notification notification = new Notification(JMXNotificationType.GATEWAY_SENDER_REMOVED,
+        memberSource, SequenceNumber.next(), System.currentTimeMillis(),
+        ManagementConstants.GATEWAY_SENDER_REMOVED_PREFIX + sender.getId());
+    memberLevelNotifEmitter.sendNotification(notification);
+  }
+
   public void handleCacheServiceCreation(CacheService cacheService) throws ManagementException {
     if (!isServiceInitialised("handleCacheServiceCreation")) {
       return;

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/ManagementListener.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/ManagementListener.java
@@ -157,6 +157,10 @@ public class ManagementListener implements ResourceEventsListener {
         GatewaySender resumedSender = (GatewaySender) resource;
         adapter.handleGatewaySenderResumed(resumedSender);
         break;
+      case GATEWAYSENDER_REMOVE:
+        GatewaySender removedSender = (GatewaySender) resource;
+        adapter.handleGatewaySenderRemoved(removedSender);
+        break;
       case LOCKSERVICE_CREATE:
         DLockService createdLockService = (DLockService) resource;
         adapter.handleLockServiceCreation(createdLockService);

--- a/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/wancommand/DestroyGatewaySenderCommandDUnitTest.java
+++ b/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/wancommand/DestroyGatewaySenderCommandDUnitTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.wan.wancommand;
+
+import static org.apache.geode.distributed.ConfigurationProperties.DISTRIBUTED_SYSTEM_ID;
+import static org.apache.geode.distributed.ConfigurationProperties.NAME;
+import static org.apache.geode.distributed.ConfigurationProperties.REMOTE_LOCATORS;
+
+import java.util.Properties;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.test.dunit.rules.ClusterStartupRule;
+import org.apache.geode.test.dunit.rules.MemberVM;
+import org.apache.geode.test.junit.categories.DistributedTest;
+import org.apache.geode.test.junit.rules.GfshCommandRule;
+
+@Category(DistributedTest.class)
+public class DestroyGatewaySenderCommandDUnitTest {
+
+  public static final String CREATE =
+      "create gateway-sender --id=sender --remote-distributed-system-id=2";
+  public static final String DESTROY = "destroy gateway-sender --id=sender";
+
+  @ClassRule
+  public static ClusterStartupRule clusterStartupRule = new ClusterStartupRule();
+
+  @Rule
+  public GfshCommandRule gfsh = new GfshCommandRule();
+
+  private static MemberVM locatorSite1;
+  private static MemberVM server1;
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    Properties props = new Properties();
+    props.setProperty(NAME, "happylocator");
+    props.setProperty(DISTRIBUTED_SYSTEM_ID, "" + 1);
+    locatorSite1 = clusterStartupRule.startLocatorVM(0, props);
+
+    props.setProperty(NAME, "happyserver1");
+    server1 = clusterStartupRule.startServerVM(1, props, locatorSite1.getPort());
+
+    props.setProperty(DISTRIBUTED_SYSTEM_ID, "" + 2);
+    props.setProperty(NAME, "happyremotelocator");
+    props.setProperty(REMOTE_LOCATORS, "localhost[" + locatorSite1.getPort() + "]");
+    clusterStartupRule.startLocatorVM(2, props);
+  }
+
+  @Before
+  public void before() throws Exception {
+    gfsh.connectAndVerify(locatorSite1);
+  }
+
+  @Test
+  public void testCreateDestroySerialGatewaySenderWithDefault() throws Exception {
+    gfsh.executeAndAssertThat(CREATE).statusIsSuccess().tableHasColumnWithExactValuesInAnyOrder(
+        "Status", "GatewaySender \"sender\" created on \"happyserver1\"");
+
+    locatorSite1.waitTilGatewaySendersAreReady(1);
+
+    // destroy gateway sender and verify AEQs cleaned up
+    gfsh.executeAndAssertThat(DESTROY).statusIsSuccess().tableHasColumnWithExactValuesInAnyOrder(
+        "Status", "GatewaySender \"sender\" destroyed on \"happyserver1\"");
+
+    locatorSite1.waitTilGatewaySendersAreReady(0);
+
+    gfsh.executeAndAssertThat("list gateways").statusIsError()
+        .containsOutput("GatewaySenders or GatewayReceivers are not available in cluster");
+  }
+
+  @Test
+  public void testCreateDestroyParallellGatewaySenderWithDefault() throws Exception {
+    gfsh.executeAndAssertThat(CREATE + " --parallel").statusIsSuccess()
+        .tableHasColumnWithExactValuesInAnyOrder("Status",
+            "GatewaySender \"sender\" created on \"happyserver1\"");
+
+    locatorSite1.waitTilGatewaySendersAreReady(1);
+
+    // destroy gateway sender and verify AEQs cleaned up
+    gfsh.executeAndAssertThat(DESTROY).statusIsSuccess().tableHasColumnWithExactValuesInAnyOrder(
+        "Status", "GatewaySender \"sender\" destroyed on \"happyserver1\"");
+
+    locatorSite1.waitTilGatewaySendersAreReady(0);
+
+    gfsh.executeAndAssertThat("list gateways").statusIsError()
+        .containsOutput("GatewaySenders or GatewayReceivers are not available in cluster");
+  }
+}


### PR DESCRIPTION
GatewaySender MX bean is unregistered when destroyed.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
