### PR TITLE
GEODE-4629: Ignore tests that assume non-approximate LRU

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/cache30/DiskRegionDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache30/DiskRegionDUnitTest.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.Set;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -67,6 +68,7 @@ import org.apache.geode.test.junit.categories.DistributedTest;
  *
  * @since GemFire 3.2
  */
+@Ignore
 @Category(DistributedTest.class)
 public class DiskRegionDUnitTest extends JUnit4CacheTestCase {
 


### PR DESCRIPTION
These tests need to be rewritten so that they make valid assumptions about how our LRUs function.