### PR TITLE
GEODE-4642: Remove PowerMock any() method calls from non-mock invocations.

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/cache/query/internal/types/TypeUtilsJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/internal/types/TypeUtilsJUnitTest.java
@@ -418,13 +418,14 @@ public class TypeUtilsJUnitTest {
 
   @Test
   public void booleanCompareShouldThrowExceptionIfValuesAreNotInstancesOfBoolean() {
-    assertThatThrownBy(() -> TypeUtils.booleanCompare(true, new Object(), anyInt()))
+    Integer arbitraryInput = 10;
+    assertThatThrownBy(() -> TypeUtils.booleanCompare(true, new Object(), arbitraryInput))
         .isInstanceOf(TypeMismatchException.class)
         .hasMessageMatching("^Booleans can only be compared with booleans$");
-    assertThatThrownBy(() -> TypeUtils.booleanCompare(new Object(), false, anyInt()))
+    assertThatThrownBy(() -> TypeUtils.booleanCompare(new Object(), false, arbitraryInput))
         .isInstanceOf(TypeMismatchException.class)
         .hasMessageMatching("^Booleans can only be compared with booleans$");
-    assertThatThrownBy(() -> TypeUtils.booleanCompare(new Object(), new Object(), anyInt()))
+    assertThatThrownBy(() -> TypeUtils.booleanCompare(new Object(), new Object(), arbitraryInput))
         .isInstanceOf(TypeMismatchException.class)
         .hasMessageMatching("^Booleans can only be compared with booleans$");
   }


### PR DESCRIPTION
@jujoramos 
It appears to be an intermittent thing, but passing `anyInt()` or similar argument matchers to non-mock classes can result in a test failing.  See the Travis for a recent PR of mine
https://travis-ci.org/apache/geode/builds/339119584?utm_source=github_status&utm_medium=notification
or the JIRA
https://issues.apache.org/jira/browse/GEODE-4642

I also refactored this class, drive predominantly by IDE inspections.  For instance, it's beyond the scope of this class to make sure that `new Boolean` returns a `Boolean`.  Consequently, there was a lot of unnecessary parameter boxing and variable instantiation only to call `.getClass()`.

Inner classes should not be interspersed with methods.  Put them either at the beginning or the end of the class, whichever is more appropriate for readability.

----

I've left the refactor and the correction commits separate for ease of review, to be squashed at commit.

---


Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [n/a - testing issue] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
