### PR TITLE
GEODE-3642 Add function execution on groups

### DIFF
--- a/geode-protobuf-messages/src/main/proto/v1/clientProtocol.proto
+++ b/geode-protobuf-messages/src/main/proto/v1/clientProtocol.proto
@@ -63,6 +63,9 @@ message Message {
 
         AuthenticationRequest authenticationRequest = 22;
         AuthenticationResponse authenticationResponse = 23;
+
+        ExecuteFunctionOnGroupRequest executeFunctionOnGroupRequest = 24;
+        ExecuteFunctionOnGroupResponse executeFunctionOnGroupResponse= 25;
     }
 }
 

--- a/geode-protobuf-messages/src/main/proto/v1/function_API.proto
+++ b/geode-protobuf-messages/src/main/proto/v1/function_API.proto
@@ -38,3 +38,13 @@ message ExecuteFunctionOnMemberResponse {
     repeated EncodedValue results = 1; // some functions don't return results.
 }
 
+message ExecuteFunctionOnGroupRequest {
+    string functionID = 1;
+    repeated string groupName = 2;
+    EncodedValue arguments = 3;
+}
+
+message ExecuteFunctionOnGroupResponse {
+    repeated EncodedValue results = 1; // some functions don't return results.
+}
+

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/operations/AbstractFunctionRequestOperationHandler.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/operations/AbstractFunctionRequestOperationHandler.java
@@ -26,6 +26,7 @@ import org.apache.geode.cache.execute.FunctionService;
 import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.internal.exception.InvalidExecutionContextException;
 import org.apache.geode.internal.i18n.LocalizedStrings;
+import org.apache.geode.internal.protocol.operations.ProtobufOperationHandler;
 import org.apache.geode.internal.protocol.protobuf.v1.BasicTypes;
 import org.apache.geode.internal.protocol.protobuf.v1.ClientProtocol;
 import org.apache.geode.internal.protocol.protobuf.v1.Failure;
@@ -36,10 +37,13 @@ import org.apache.geode.internal.protocol.protobuf.v1.serialization.exception.En
 import org.apache.geode.internal.security.SecurityService;
 import org.apache.geode.security.NotAuthorizedException;
 
-public abstract class AbstractFunctionRequestOperationHandler {
+public abstract class AbstractFunctionRequestOperationHandler<Req, Resp>
+    implements ProtobufOperationHandler<Req, Resp> {
 
 
-  public Result process(ProtobufSerializationService serializationService, AbstractMessage request,
+  @Override
+  public Result<Resp, ClientProtocol.ErrorResponse> process(
+      ProtobufSerializationService serializationService, Req request,
       MessageExecutionContext messageExecutionContext) throws InvalidExecutionContextException {
 
     final String functionID = getFunctionID(request);
@@ -111,19 +115,19 @@ public abstract class AbstractFunctionRequestOperationHandler {
   }
 
   protected abstract Set<?> parseFilter(ProtobufSerializationService serializationService,
-      AbstractMessage request) throws EncodingException;
+      Req request) throws EncodingException;
 
-  protected abstract String getFunctionID(AbstractMessage request);
+  protected abstract String getFunctionID(Req request);
 
   /** the result of this may be null, which is used by the security service to mean "no region" */
-  protected abstract String getRegionName(AbstractMessage request);
+  protected abstract String getRegionName(Req request);
 
   /** region, list of members, etc */
-  protected abstract Object getExecutionTarget(AbstractMessage request, String regionName,
+  protected abstract Object getExecutionTarget(Req request, String regionName,
       MessageExecutionContext executionContext) throws InvalidExecutionContextException;
 
   /** arguments for the function */
-  protected abstract Object getFunctionArguments(AbstractMessage request,
+  protected abstract Object getFunctionArguments(Req request,
       ProtobufSerializationService serializationService) throws EncodingException;
 
   protected abstract Execution getFunctionExecutionObject(Object executionTarget)

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/operations/AbstractFunctionRequestOperationHandler.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/operations/AbstractFunctionRequestOperationHandler.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.protocol.protobuf.v1.operations;
+
+import java.util.List;
+import java.util.Set;
+
+import com.google.protobuf.AbstractMessage;
+
+import org.apache.geode.cache.execute.Execution;
+import org.apache.geode.cache.execute.Function;
+import org.apache.geode.cache.execute.FunctionException;
+import org.apache.geode.cache.execute.FunctionService;
+import org.apache.geode.cache.execute.ResultCollector;
+import org.apache.geode.internal.exception.InvalidExecutionContextException;
+import org.apache.geode.internal.i18n.LocalizedStrings;
+import org.apache.geode.internal.protocol.protobuf.v1.BasicTypes;
+import org.apache.geode.internal.protocol.protobuf.v1.ClientProtocol;
+import org.apache.geode.internal.protocol.protobuf.v1.Failure;
+import org.apache.geode.internal.protocol.protobuf.v1.MessageExecutionContext;
+import org.apache.geode.internal.protocol.protobuf.v1.ProtobufSerializationService;
+import org.apache.geode.internal.protocol.protobuf.v1.Result;
+import org.apache.geode.internal.protocol.protobuf.v1.serialization.exception.EncodingException;
+import org.apache.geode.internal.security.SecurityService;
+import org.apache.geode.security.NotAuthorizedException;
+
+public abstract class AbstractFunctionRequestOperationHandler {
+
+
+  public Result process(ProtobufSerializationService serializationService, AbstractMessage request,
+      MessageExecutionContext messageExecutionContext) throws InvalidExecutionContextException {
+
+    final String functionID = getFunctionID(request);
+
+    final Function<?> function = FunctionService.getFunction(functionID);
+    if (function == null) {
+      return Failure.of(ClientProtocol.ErrorResponse.newBuilder()
+          .setError(BasicTypes.Error.newBuilder().setErrorCode(BasicTypes.ErrorCode.INVALID_REQUEST)
+              .setMessage(LocalizedStrings.ExecuteFunction_FUNCTION_NAMED_0_IS_NOT_REGISTERED
+                  .toLocalizedString(functionID))
+              .build())
+          .build());
+    }
+
+    final SecurityService securityService = messageExecutionContext.getCache().getSecurityService();
+    final String regionName = getRegionName(request);
+
+    try {
+      // check security for function.
+      function.getRequiredPermissions(regionName).forEach(securityService::authorize);
+    } catch (NotAuthorizedException ex) {
+      return Failure.of(ClientProtocol.ErrorResponse.newBuilder()
+          .setError(BasicTypes.Error.newBuilder()
+              .setMessage("Authorization failed for function \"" + functionID + "\"")
+              .setErrorCode(BasicTypes.ErrorCode.AUTHORIZATION_FAILED))
+          .build());
+    }
+
+    Object executionTarget = getExecutionTarget(request, regionName, messageExecutionContext);
+    if (executionTarget instanceof Failure) {
+      return (Failure) executionTarget;
+    }
+
+    try {
+      Execution execution = getFunctionExecutionObject(executionTarget);
+
+      Object arguments = getFunctionArguments(request, serializationService);
+
+      if (arguments != null) {
+        execution = execution.setArguments(arguments);
+      }
+
+      Set<?> parseFilter = parseFilter(serializationService, request);
+      if (parseFilter != null) {
+        execution = execution.withFilter(parseFilter);
+      }
+
+      final ResultCollector<Object, List<Object>> resultCollector = execution.execute(functionID);
+
+      if (function.hasResult()) {
+        List<Object> results = resultCollector.getResult();
+
+        return buildResultMessage(serializationService, results);
+      } else {
+        // This is fire and forget.
+        return buildResultMessage(serializationService);
+      }
+    } catch (FunctionException ex) {
+      return Failure.of(ClientProtocol.ErrorResponse.newBuilder()
+          .setError(BasicTypes.Error.newBuilder().setErrorCode(BasicTypes.ErrorCode.SERVER_ERROR)
+              .setMessage("Function execution failed: " + ex.toString()))
+          .build());
+    } catch (EncodingException ex) {
+      return Failure.of(ClientProtocol.ErrorResponse.newBuilder()
+          .setError(BasicTypes.Error.newBuilder().setErrorCode(BasicTypes.ErrorCode.SERVER_ERROR)
+              .setMessage("Encoding failed: " + ex.toString()))
+          .build());
+    }
+  }
+
+  protected abstract Set<?> parseFilter(ProtobufSerializationService serializationService,
+      AbstractMessage request) throws EncodingException;
+
+  protected abstract String getFunctionID(AbstractMessage request);
+
+  /** the result of this may be null, which is used by the security service to mean "no region" */
+  protected abstract String getRegionName(AbstractMessage request);
+
+  /** region, list of members, etc */
+  protected abstract Object getExecutionTarget(AbstractMessage request, String regionName,
+      MessageExecutionContext executionContext) throws InvalidExecutionContextException;
+
+  /** arguments for the function */
+  protected abstract Object getFunctionArguments(AbstractMessage request,
+      ProtobufSerializationService serializationService) throws EncodingException;
+
+  protected abstract Execution getFunctionExecutionObject(Object executionTarget)
+      throws InvalidExecutionContextException;
+
+  protected abstract Result buildResultMessage(ProtobufSerializationService serializationService)
+      throws EncodingException;
+
+  protected abstract Result buildResultMessage(ProtobufSerializationService serializationService,
+      List<Object> results) throws EncodingException;
+
+
+
+}

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/operations/ExecuteFunctionOnGroupRequestOperationHandler.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/operations/ExecuteFunctionOnGroupRequestOperationHandler.java
@@ -17,7 +17,6 @@ package org.apache.geode.internal.protocol.protobuf.v1.operations;
 import java.util.List;
 import java.util.Set;
 
-import com.google.protobuf.AbstractMessage;
 import com.google.protobuf.ProtocolStringList;
 
 import org.apache.geode.cache.execute.Execution;
@@ -36,9 +35,8 @@ import org.apache.geode.internal.protocol.protobuf.v1.Result;
 import org.apache.geode.internal.protocol.protobuf.v1.Success;
 import org.apache.geode.internal.protocol.protobuf.v1.serialization.exception.EncodingException;
 
-public class ExecuteFunctionOnGroupRequestOperationHandler
-    extends AbstractFunctionRequestOperationHandler implements
-    ProtobufOperationHandler<ExecuteFunctionOnGroupRequest, ExecuteFunctionOnGroupResponse> {
+public class ExecuteFunctionOnGroupRequestOperationHandler extends
+    AbstractFunctionRequestOperationHandler<ExecuteFunctionOnGroupRequest, ExecuteFunctionOnGroupResponse> {
 
 
   @Override
@@ -52,27 +50,26 @@ public class ExecuteFunctionOnGroupRequestOperationHandler
 
   @Override
   protected Set<?> parseFilter(ProtobufSerializationService serializationService,
-      AbstractMessage request) throws EncodingException {
+      ExecuteFunctionOnGroupRequest request) throws EncodingException {
     // filters are not allowed on functions not associated with regions
     return null;
   }
 
   @Override
-  protected String getFunctionID(AbstractMessage request) {
-    return ((ExecuteFunctionOnGroupRequest) request).getFunctionID();
+  protected String getFunctionID(ExecuteFunctionOnGroupRequest request) {
+    return (request).getFunctionID();
   }
 
   @Override
-  protected String getRegionName(AbstractMessage request) {
+  protected String getRegionName(ExecuteFunctionOnGroupRequest request) {
     // region name is not allowed in onMember invocation
     return null;
   }
 
   @Override
-  protected Object getExecutionTarget(AbstractMessage abstractRequest, String regionName,
+  protected Object getExecutionTarget(ExecuteFunctionOnGroupRequest request, String regionName,
       MessageExecutionContext executionContext) throws InvalidExecutionContextException {
 
-    ExecuteFunctionOnGroupRequest request = ((ExecuteFunctionOnGroupRequest) abstractRequest);
     ProtocolStringList groupList = request.getGroupNameList();
 
     // unfortunately FunctionServiceManager throws a FunctionException if there are no
@@ -100,9 +97,9 @@ public class ExecuteFunctionOnGroupRequestOperationHandler
   }
 
   @Override
-  protected Object getFunctionArguments(AbstractMessage request,
+  protected Object getFunctionArguments(ExecuteFunctionOnGroupRequest request,
       ProtobufSerializationService serializationService) throws EncodingException {
-    return serializationService.decode(((ExecuteFunctionOnGroupRequest) request).getArguments());
+    return serializationService.decode((request).getArguments());
   }
 
   @Override

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/operations/ExecuteFunctionOnMemberRequestOperationHandler.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/operations/ExecuteFunctionOnMemberRequestOperationHandler.java
@@ -18,7 +18,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import com.google.protobuf.AbstractMessage;
 import com.google.protobuf.ProtocolStringList;
 
 import org.apache.geode.cache.execute.Execution;
@@ -26,7 +25,6 @@ import org.apache.geode.cache.execute.FunctionService;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.internal.exception.InvalidExecutionContextException;
-import org.apache.geode.internal.protocol.operations.ProtobufOperationHandler;
 import org.apache.geode.internal.protocol.protobuf.v1.BasicTypes;
 import org.apache.geode.internal.protocol.protobuf.v1.ClientProtocol;
 import org.apache.geode.internal.protocol.protobuf.v1.Failure;
@@ -38,42 +36,40 @@ import org.apache.geode.internal.protocol.protobuf.v1.Result;
 import org.apache.geode.internal.protocol.protobuf.v1.Success;
 import org.apache.geode.internal.protocol.protobuf.v1.serialization.exception.EncodingException;
 
-public class ExecuteFunctionOnMemberRequestOperationHandler
-    extends AbstractFunctionRequestOperationHandler implements
-    ProtobufOperationHandler<ExecuteFunctionOnMemberRequest, ExecuteFunctionOnMemberResponse> {
+public class ExecuteFunctionOnMemberRequestOperationHandler extends
+    AbstractFunctionRequestOperationHandler<ExecuteFunctionOnMemberRequest, ExecuteFunctionOnMemberResponse> {
 
 
-  @Override
-  public Result<ExecuteFunctionOnMemberResponse, ClientProtocol.ErrorResponse> process(
-      ProtobufSerializationService serializationService, ExecuteFunctionOnMemberRequest request,
-      MessageExecutionContext messageExecutionContext) throws InvalidExecutionContextException {
-
-    return (Result<ExecuteFunctionOnMemberResponse, ClientProtocol.ErrorResponse>) super.process(
-        serializationService, request, messageExecutionContext);
-  }
+  // @Override
+  // public Result<ExecuteFunctionOnMemberResponse, ClientProtocol.ErrorResponse> process(
+  // ProtobufSerializationService serializationService, ExecuteFunctionOnMemberRequest request,
+  // MessageExecutionContext messageExecutionContext) throws InvalidExecutionContextException {
+  //
+  // return (Result<ExecuteFunctionOnMemberResponse, ClientProtocol.ErrorResponse>) super.process(
+  // serializationService, request, messageExecutionContext);
+  // }
 
   @Override
   protected Set<?> parseFilter(ProtobufSerializationService serializationService,
-      AbstractMessage request) throws EncodingException {
+      ExecuteFunctionOnMemberRequest request) throws EncodingException {
     // filters are not allowed on functions not associated with regions
     return null;
   }
 
   @Override
-  protected String getFunctionID(AbstractMessage request) {
-    return ((ExecuteFunctionOnMemberRequest) request).getFunctionID();
+  protected String getFunctionID(ExecuteFunctionOnMemberRequest request) {
+    return (request).getFunctionID();
   }
 
   @Override
-  protected String getRegionName(AbstractMessage request) {
+  protected String getRegionName(ExecuteFunctionOnMemberRequest request) {
     // region name is not allowed in onMember invocation
     return null;
   }
 
   @Override
-  protected Object getExecutionTarget(AbstractMessage abstractRequest, String regionName,
+  protected Object getExecutionTarget(ExecuteFunctionOnMemberRequest request, String regionName,
       MessageExecutionContext executionContext) throws InvalidExecutionContextException {
-    ExecuteFunctionOnMemberRequest request = (ExecuteFunctionOnMemberRequest) abstractRequest;
 
     ProtocolStringList memberNameList = request.getMemberNameList();
 
@@ -102,9 +98,9 @@ public class ExecuteFunctionOnMemberRequestOperationHandler
   }
 
   @Override
-  protected Object getFunctionArguments(AbstractMessage request,
+  protected Object getFunctionArguments(ExecuteFunctionOnMemberRequest request,
       ProtobufSerializationService serializationService) throws EncodingException {
-    return serializationService.decode(((ExecuteFunctionOnMemberRequest) request).getArguments());
+    return serializationService.decode((request).getArguments());
   }
 
   @Override

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/operations/ExecuteFunctionOnMemberRequestOperationHandler.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/operations/ExecuteFunctionOnMemberRequestOperationHandler.java
@@ -18,130 +18,120 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import com.google.protobuf.AbstractMessage;
 import com.google.protobuf.ProtocolStringList;
 
 import org.apache.geode.cache.execute.Execution;
-import org.apache.geode.cache.execute.Function;
-import org.apache.geode.cache.execute.FunctionException;
 import org.apache.geode.cache.execute.FunctionService;
-import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.internal.exception.InvalidExecutionContextException;
-import org.apache.geode.internal.i18n.LocalizedStrings;
 import org.apache.geode.internal.protocol.operations.ProtobufOperationHandler;
 import org.apache.geode.internal.protocol.protobuf.v1.BasicTypes;
 import org.apache.geode.internal.protocol.protobuf.v1.ClientProtocol;
 import org.apache.geode.internal.protocol.protobuf.v1.Failure;
-import org.apache.geode.internal.protocol.protobuf.v1.FunctionAPI;
+import org.apache.geode.internal.protocol.protobuf.v1.FunctionAPI.ExecuteFunctionOnMemberRequest;
+import org.apache.geode.internal.protocol.protobuf.v1.FunctionAPI.ExecuteFunctionOnMemberResponse;
 import org.apache.geode.internal.protocol.protobuf.v1.MessageExecutionContext;
 import org.apache.geode.internal.protocol.protobuf.v1.ProtobufSerializationService;
 import org.apache.geode.internal.protocol.protobuf.v1.Result;
 import org.apache.geode.internal.protocol.protobuf.v1.Success;
 import org.apache.geode.internal.protocol.protobuf.v1.serialization.exception.EncodingException;
-import org.apache.geode.internal.protocol.protobuf.v1.state.exception.ConnectionStateException;
-import org.apache.geode.internal.security.SecurityService;
-import org.apache.geode.security.NotAuthorizedException;
 
-public class ExecuteFunctionOnMemberRequestOperationHandler implements
-    ProtobufOperationHandler<FunctionAPI.ExecuteFunctionOnMemberRequest, FunctionAPI.ExecuteFunctionOnMemberResponse> {
+public class ExecuteFunctionOnMemberRequestOperationHandler
+    extends AbstractFunctionRequestOperationHandler implements
+    ProtobufOperationHandler<ExecuteFunctionOnMemberRequest, ExecuteFunctionOnMemberResponse> {
+
+
   @Override
-  public Result<FunctionAPI.ExecuteFunctionOnMemberResponse, ClientProtocol.ErrorResponse> process(
-      ProtobufSerializationService serializationService,
-      FunctionAPI.ExecuteFunctionOnMemberRequest request,
+  public Result<ExecuteFunctionOnMemberResponse, ClientProtocol.ErrorResponse> process(
+      ProtobufSerializationService serializationService, ExecuteFunctionOnMemberRequest request,
       MessageExecutionContext messageExecutionContext) throws InvalidExecutionContextException {
 
-    final String functionID = request.getFunctionID();
+    return (Result<ExecuteFunctionOnMemberResponse, ClientProtocol.ErrorResponse>) super.process(
+        serializationService, request, messageExecutionContext);
+  }
 
-    final Function<?> function = FunctionService.getFunction(functionID);
-    if (function == null) {
-      return Failure.of(ClientProtocol.ErrorResponse.newBuilder()
-          .setError(BasicTypes.Error.newBuilder().setErrorCode(BasicTypes.ErrorCode.INVALID_REQUEST)
-              .setMessage(LocalizedStrings.ExecuteFunction_FUNCTION_NAMED_0_IS_NOT_REGISTERED
-                  .toLocalizedString(functionID))
-              .build())
-          .build());
-    }
+  @Override
+  protected Set<?> parseFilter(ProtobufSerializationService serializationService,
+      AbstractMessage request) throws EncodingException {
+    // filters are not allowed on functions not associated with regions
+    return null;
+  }
 
-    final SecurityService securityService = messageExecutionContext.getCache().getSecurityService();
+  @Override
+  protected String getFunctionID(AbstractMessage request) {
+    return ((ExecuteFunctionOnMemberRequest) request).getFunctionID();
+  }
 
-    try {
-      // check security for function.
-      final String noRegion = null;
-      function.getRequiredPermissions(noRegion).forEach(securityService::authorize);
-    } catch (NotAuthorizedException ex) {
-      return Failure.of(ClientProtocol.ErrorResponse.newBuilder()
-          .setError(BasicTypes.Error.newBuilder()
-              .setMessage("Authorization failed for function \"" + functionID + "\"")
-              .setErrorCode(BasicTypes.ErrorCode.AUTHORIZATION_FAILED))
-          .build());
-    }
+  @Override
+  protected String getRegionName(AbstractMessage request) {
+    // region name is not allowed in onMember invocation
+    return null;
+  }
+
+  @Override
+  protected Object getExecutionTarget(AbstractMessage abstractRequest, String regionName,
+      MessageExecutionContext executionContext) throws InvalidExecutionContextException {
+    ExecuteFunctionOnMemberRequest request = (ExecuteFunctionOnMemberRequest) abstractRequest;
 
     ProtocolStringList memberNameList = request.getMemberNameList();
 
     Set<DistributedMember> memberIds = new HashSet<>(memberNameList.size());
-    DistributionManager distributionManager =
-        messageExecutionContext.getCache().getDistributionManager();
+    DistributionManager distributionManager = executionContext.getCache().getDistributionManager();
     for (String name : memberNameList) {
       DistributedMember member = distributionManager.getMemberWithName(name);
       if (member == null) {
         return Failure.of(ClientProtocol.ErrorResponse.newBuilder()
             .setError(BasicTypes.Error.newBuilder()
-                .setMessage("Member " + name + " not found to execute \"" + functionID + "\"")
+                .setMessage(
+                    "Member " + name + " not found to execute \"" + request.getFunctionID() + "\"")
                 .setErrorCode(BasicTypes.ErrorCode.NO_AVAILABLE_SERVER))
             .build());
       }
       memberIds.add(member);
     }
-
     if (memberIds.isEmpty()) {
       return Failure.of(ClientProtocol.ErrorResponse.newBuilder()
           .setError(BasicTypes.Error.newBuilder()
-              .setMessage("No members found to execute \"" + functionID + "\"")
+              .setMessage("No members found to execute \"" + request.getFunctionID() + "\"")
               .setErrorCode(BasicTypes.ErrorCode.NO_AVAILABLE_SERVER))
           .build());
     }
+    return memberIds;
+  }
 
-    try {
-      Execution execution;
-      if (memberIds.size() == 1) {
-        execution = FunctionService.onMember(memberIds.iterator().next());
-      } else {
-        execution = FunctionService.onMembers(memberIds);
-      }
+  @Override
+  protected Object getFunctionArguments(AbstractMessage request,
+      ProtobufSerializationService serializationService) throws EncodingException {
+    return serializationService.decode(((ExecuteFunctionOnMemberRequest) request).getArguments());
+  }
 
-      final Object arguments = serializationService.decode(request.getArguments());
-
-      if (arguments != null) {
-        execution = execution.setArguments(arguments);
-      }
-
-      final ResultCollector<Object, List<Object>> resultCollector = execution.execute(functionID);
-
-      if (function.hasResult()) {
-        List<Object> results = resultCollector.getResult();
-
-        final FunctionAPI.ExecuteFunctionOnMemberResponse.Builder responseMessage =
-            FunctionAPI.ExecuteFunctionOnMemberResponse.newBuilder();
-        for (Object result : results) {
-          responseMessage.addResults(serializationService.encode(result));
-        }
-        return Success.of(responseMessage.build());
-      } else {
-        // This is fire and forget.
-        return Success.of(FunctionAPI.ExecuteFunctionOnMemberResponse.newBuilder().build());
-      }
-    } catch (FunctionException ex) {
-      return Failure.of(ClientProtocol.ErrorResponse.newBuilder()
-          .setError(BasicTypes.Error.newBuilder().setErrorCode(BasicTypes.ErrorCode.SERVER_ERROR)
-              .setMessage("Function execution failed: " + ex.toString()))
-          .build());
-    } catch (EncodingException ex) {
-      return Failure.of(ClientProtocol.ErrorResponse.newBuilder()
-          .setError(BasicTypes.Error.newBuilder().setErrorCode(BasicTypes.ErrorCode.SERVER_ERROR)
-              .setMessage("Encoding failed: " + ex.toString()))
-          .build());
+  @Override
+  protected Execution getFunctionExecutionObject(Object executionTarget) {
+    Set<DistributedMember> memberIds = (Set<DistributedMember>) executionTarget;
+    if (memberIds.size() == 1) {
+      return FunctionService.onMember(memberIds.iterator().next());
+    } else {
+      return FunctionService.onMembers(memberIds);
     }
+  }
+
+  @Override
+  protected Result buildResultMessage(ProtobufSerializationService serializationService,
+      List<Object> results) throws EncodingException {
+    final ExecuteFunctionOnMemberResponse.Builder responseMessage =
+        ExecuteFunctionOnMemberResponse.newBuilder();
+    for (Object result : results) {
+      responseMessage.addResults(serializationService.encode(result));
+    }
+    return Success.of(responseMessage.build());
+  }
+
+  @Override
+  protected Result buildResultMessage(ProtobufSerializationService serializationService)
+      throws EncodingException {
+    return Success.of(ExecuteFunctionOnMemberResponse.newBuilder().build());
   }
 
 }

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/operations/ExecuteFunctionOnRegionRequestOperationHandler.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/operations/ExecuteFunctionOnRegionRequestOperationHandler.java
@@ -18,13 +18,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import com.google.protobuf.AbstractMessage;
-
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.execute.Execution;
 import org.apache.geode.cache.execute.FunctionService;
 import org.apache.geode.internal.exception.InvalidExecutionContextException;
-import org.apache.geode.internal.protocol.operations.ProtobufOperationHandler;
 import org.apache.geode.internal.protocol.protobuf.v1.BasicTypes;
 import org.apache.geode.internal.protocol.protobuf.v1.ClientProtocol;
 import org.apache.geode.internal.protocol.protobuf.v1.Failure;
@@ -36,23 +33,12 @@ import org.apache.geode.internal.protocol.protobuf.v1.Result;
 import org.apache.geode.internal.protocol.protobuf.v1.Success;
 import org.apache.geode.internal.protocol.protobuf.v1.serialization.exception.EncodingException;
 
-public class ExecuteFunctionOnRegionRequestOperationHandler
-    extends AbstractFunctionRequestOperationHandler implements
-    ProtobufOperationHandler<ExecuteFunctionOnRegionRequest, ExecuteFunctionOnRegionResponse> {
-
-  @Override
-  public Result<ExecuteFunctionOnRegionResponse, ClientProtocol.ErrorResponse> process(
-      ProtobufSerializationService serializationService, ExecuteFunctionOnRegionRequest request,
-      MessageExecutionContext messageExecutionContext) throws InvalidExecutionContextException {
-
-    return (Result<ExecuteFunctionOnRegionResponse, ClientProtocol.ErrorResponse>) super.process(
-        serializationService, request, messageExecutionContext);
-  }
+public class ExecuteFunctionOnRegionRequestOperationHandler extends
+    AbstractFunctionRequestOperationHandler<ExecuteFunctionOnRegionRequest, ExecuteFunctionOnRegionResponse> {
 
   protected Set<Object> parseFilter(ProtobufSerializationService serializationService,
-      AbstractMessage request) throws EncodingException {
-    List<BasicTypes.EncodedValue> encodedFilter =
-        ((ExecuteFunctionOnRegionRequest) request).getKeyFilterList();
+      ExecuteFunctionOnRegionRequest request) throws EncodingException {
+    List<BasicTypes.EncodedValue> encodedFilter = (request).getKeyFilterList();
     Set<Object> filter = new HashSet<>();
 
     for (BasicTypes.EncodedValue filterKey : encodedFilter) {
@@ -62,17 +48,17 @@ public class ExecuteFunctionOnRegionRequestOperationHandler
   }
 
   @Override
-  protected String getFunctionID(AbstractMessage request) {
-    return ((ExecuteFunctionOnRegionRequest) request).getFunctionID();
+  protected String getFunctionID(ExecuteFunctionOnRegionRequest request) {
+    return (request).getFunctionID();
   }
 
   @Override
-  protected String getRegionName(AbstractMessage request) {
-    return ((ExecuteFunctionOnRegionRequest) request).getRegion();
+  protected String getRegionName(ExecuteFunctionOnRegionRequest request) {
+    return (request).getRegion();
   }
 
   @Override
-  protected Object getExecutionTarget(AbstractMessage request, String regionName,
+  protected Object getExecutionTarget(ExecuteFunctionOnRegionRequest request, String regionName,
       MessageExecutionContext executionContext) throws InvalidExecutionContextException {
     final Region<Object, Object> region = executionContext.getCache().getRegion(regionName);
     if (region == null) {
@@ -85,9 +71,9 @@ public class ExecuteFunctionOnRegionRequestOperationHandler
   }
 
   @Override
-  protected Object getFunctionArguments(AbstractMessage request,
+  protected Object getFunctionArguments(ExecuteFunctionOnRegionRequest request,
       ProtobufSerializationService serializationService) throws EncodingException {
-    return serializationService.decode(((ExecuteFunctionOnRegionRequest) request).getArguments());
+    return serializationService.decode((request).getArguments());
   }
 
   @Override

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/registry/ProtobufOperationContextRegistry.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/registry/ProtobufOperationContextRegistry.java
@@ -21,6 +21,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.apache.geode.annotations.Experimental;
 import org.apache.geode.internal.protocol.protobuf.v1.ClientProtocol;
 import org.apache.geode.internal.protocol.protobuf.v1.ProtobufOperationContext;
+import org.apache.geode.internal.protocol.protobuf.v1.operations.ExecuteFunctionOnGroupRequestOperationHandler;
 import org.apache.geode.internal.protocol.protobuf.v1.operations.ExecuteFunctionOnMemberRequestOperationHandler;
 import org.apache.geode.internal.protocol.protobuf.v1.operations.ExecuteFunctionOnRegionRequestOperationHandler;
 import org.apache.geode.internal.protocol.protobuf.v1.operations.GetAllRequestOperationHandler;
@@ -125,6 +126,15 @@ public class ProtobufOperationContextRegistry {
             new ExecuteFunctionOnMemberRequestOperationHandler(),
             opsResp -> ClientProtocol.Message.newBuilder()
                 .setExecuteFunctionOnMemberResponse(opsResp),
+            // Resource permissions get handled per-function, since they have varying permission
+            // requirements.
+            new ResourcePermission(ResourcePermission.NULL, ResourcePermission.NULL)));
+
+    operationContexts.put(ClientProtocol.Message.MessageTypeCase.EXECUTEFUNCTIONONGROUPREQUEST,
+        new ProtobufOperationContext<>(ClientProtocol.Message::getExecuteFunctionOnGroupRequest,
+            new ExecuteFunctionOnGroupRequestOperationHandler(),
+            opsResp -> ClientProtocol.Message.newBuilder()
+                .setExecuteFunctionOnGroupResponse(opsResp),
             // Resource permissions get handled per-function, since they have varying permission
             // requirements.
             new ResourcePermission(ResourcePermission.NULL, ResourcePermission.NULL)));

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/ExecuteFunctionOnGroupIntegrationTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/ExecuteFunctionOnGroupIntegrationTest.java
@@ -1,0 +1,332 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.protocol.protobuf.v1;
+
+import static org.apache.geode.internal.protocol.protobuf.v1.ClientProtocol.Message.MessageTypeCase.EXECUTEFUNCTIONONGROUPRESPONSE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.net.Socket;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.awaitility.Awaitility;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.CacheFactory;
+import org.apache.geode.cache.DataPolicy;
+import org.apache.geode.cache.RegionFactory;
+import org.apache.geode.cache.execute.Function;
+import org.apache.geode.cache.execute.FunctionContext;
+import org.apache.geode.cache.execute.FunctionException;
+import org.apache.geode.cache.execute.FunctionService;
+import org.apache.geode.cache.server.CacheServer;
+import org.apache.geode.distributed.ConfigurationProperties;
+import org.apache.geode.internal.AvailablePortHelper;
+import org.apache.geode.management.internal.security.ResourceConstants;
+import org.apache.geode.security.ResourcePermission;
+import org.apache.geode.security.SecurityManager;
+import org.apache.geode.test.junit.categories.IntegrationTest;
+
+@Category(IntegrationTest.class)
+public class ExecuteFunctionOnGroupIntegrationTest {
+  private static final String TEST_REGION = "testRegion";
+  private static final String TEST_FUNCTION_ID = "testFunction";
+  private static final String SECURITY_PRINCIPAL = "principle";
+  private static final String COMPUTE_SERVERS = "computeServers";
+  private ProtobufSerializationService serializationService;
+  private Socket socket;
+  private Cache cache;
+  private SecurityManager securityManager;
+
+  @Rule
+  public RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
+
+  @Before
+  public void setUp() throws Exception {
+    CacheFactory cacheFactory = new CacheFactory(new Properties());
+    cacheFactory.set(ConfigurationProperties.MCAST_PORT, "0");
+    cacheFactory.set(ConfigurationProperties.ENABLE_CLUSTER_CONFIGURATION, "false");
+    cacheFactory.set(ConfigurationProperties.USE_CLUSTER_CONFIGURATION, "false");
+    cacheFactory.set(ConfigurationProperties.GROUPS, COMPUTE_SERVERS);
+
+    securityManager = mock(SecurityManager.class);
+    cacheFactory.setSecurityManager(securityManager);
+    when(securityManager.authenticate(any())).thenReturn(SECURITY_PRINCIPAL);
+    when(securityManager.authorize(eq(SECURITY_PRINCIPAL), any())).thenReturn(true);
+
+    cache = cacheFactory.create();
+
+    CacheServer cacheServer = cache.addCacheServer();
+    int cacheServerPort = AvailablePortHelper.getRandomAvailableTCPPort();
+    cacheServer.setPort(cacheServerPort);
+    cacheServer.start();
+
+    RegionFactory<Object, Object> regionFactory = cache.createRegionFactory();
+    regionFactory.setDataPolicy(DataPolicy.PARTITION);
+    regionFactory.create(TEST_REGION);
+
+
+    System.setProperty("geode.feature-protobuf-protocol", "true");
+
+    socket = new Socket("localhost", cacheServerPort);
+
+    Awaitility.await().atMost(5, TimeUnit.SECONDS).until(socket::isConnected);
+
+    MessageUtil.performAndVerifyHandshake(socket);
+
+    serializationService = new ProtobufSerializationService();
+  }
+
+  private static class TestFunction<T> implements Function<T> {
+    private final java.util.function.Function<FunctionContext<T>, Object> executeFunction;
+    // non-null iff function has been executed.
+    private final AtomicReference<FunctionContext> context = new AtomicReference<>();
+    private final boolean hasResult;
+
+    TestFunction() {
+      this.executeFunction = arg -> null;
+      this.hasResult = true;
+    }
+
+    TestFunction(java.util.function.Function<FunctionContext<T>, Object> executeFunction,
+        boolean hasResult) {
+      this.executeFunction = executeFunction;
+      this.hasResult = hasResult;
+    }
+
+    @Override
+    public String getId() {
+      return TEST_FUNCTION_ID;
+    }
+
+    @Override
+    public void execute(FunctionContext<T> context) {
+      this.context.set(context);
+      context.getResultSender().lastResult(executeFunction.apply(context));
+    }
+
+    @Override
+    public boolean hasResult() {
+      return hasResult;
+    }
+
+    @Override
+    public boolean isHA() {
+      // set for testing; we shouldn't need to test with isHA true because that's function service
+      // details.
+      return false;
+    }
+
+    FunctionContext getContext() {
+      return context.get();
+    }
+  }
+
+  @After
+  public void tearDown() {
+    cache.close();
+    try {
+      socket.close();
+    } catch (IOException ignore) {
+    }
+    FunctionService.unregisterFunction(TEST_FUNCTION_ID);
+  }
+
+  @Test
+  public void handlesNoResultFunction() throws IOException {
+    TestFunction<Object> testFunction = new TestFunction<>(context -> null, false);
+    FunctionService.registerFunction(testFunction);
+    final ClientProtocol.Message responseMessage = authenticateAndSendMessage();
+
+    assertNotNull(responseMessage);
+    assertEquals(EXECUTEFUNCTIONONGROUPRESPONSE, responseMessage.getMessageTypeCase());
+    final FunctionAPI.ExecuteFunctionOnGroupResponse executeFunctionOnGroupResponse =
+        responseMessage.getExecuteFunctionOnGroupResponse();
+
+    assertEquals(0, executeFunctionOnGroupResponse.getResultsCount());
+
+    Awaitility.await().atMost(5, TimeUnit.SECONDS).until(() -> testFunction.getContext() != null);
+  }
+
+  @Test
+  public void handlesResultFunction() throws Exception {
+    final TestFunction<Object> testFunction =
+        new TestFunction<>(functionContext -> Integer.valueOf(22), true);
+    FunctionService.registerFunction(testFunction);
+    final ClientProtocol.Message responseMessage = authenticateAndSendMessage();
+
+    final FunctionAPI.ExecuteFunctionOnGroupResponse executeFunctionOnGroupResponse =
+        getFunctionResponse(responseMessage);
+
+    assertEquals(1, executeFunctionOnGroupResponse.getResultsCount());
+
+    final Object responseValue =
+        serializationService.decode(executeFunctionOnGroupResponse.getResults(0));
+    assertTrue(responseValue instanceof Integer);
+    assertEquals(22, responseValue);
+  }
+
+  @Test
+  public void handlesException() throws IOException {
+    final TestFunction<Object> testFunction = new TestFunction<>(context -> {
+      throw new FunctionException();
+    }, true);
+    FunctionService.registerFunction(testFunction);
+
+    final ClientProtocol.Message message = authenticateAndSendMessage();
+
+    assertEquals(ClientProtocol.Message.MessageTypeCase.ERRORRESPONSE,
+        message.getMessageTypeCase());
+    final BasicTypes.Error error = message.getErrorResponse().getError();
+    assertEquals(BasicTypes.ErrorCode.SERVER_ERROR, error.getErrorCode());
+  }
+
+  @Test
+  public void handlesObjectThatCannotBeDecoded() throws IOException {
+    final TestFunction<Object> testFunction = new TestFunction<>(context -> {
+      return new Object();
+    }, true);
+    FunctionService.registerFunction(testFunction);
+
+    final ClientProtocol.Message message = authenticateAndSendMessage();
+
+
+    assertEquals(ClientProtocol.Message.MessageTypeCase.ERRORRESPONSE,
+        message.getMessageTypeCase());
+    final BasicTypes.Error error = message.getErrorResponse().getError();
+
+    assertEquals(BasicTypes.ErrorCode.SERVER_ERROR, error.getErrorCode());
+
+  }
+
+  @Test
+  public void handlesNullReturnValues() throws Exception {
+    final TestFunction<Object> testFunction = new TestFunction<>(functionContext -> null, true);
+    FunctionService.registerFunction(testFunction);
+    final ClientProtocol.Message responseMessage = authenticateAndSendMessage();
+
+    final FunctionAPI.ExecuteFunctionOnGroupResponse executeFunctionOnGroupResponse =
+        getFunctionResponse(responseMessage);
+
+    assertEquals(1, executeFunctionOnGroupResponse.getResultsCount());
+
+    final Object responseValue =
+        serializationService.decode(executeFunctionOnGroupResponse.getResults(0));
+    assertNull(responseValue);
+  }
+
+  @Test
+  public void argumentsArePassedToFunction() throws Exception {
+    final TestFunction<Object> testFunction =
+        new TestFunction<>(functionContext -> functionContext.getArguments(), true);
+    FunctionService.registerFunction(testFunction);
+    ClientProtocol.Message.Builder message = createRequestMessageBuilder(
+        FunctionAPI.ExecuteFunctionOnGroupRequest.newBuilder().setFunctionID(TEST_FUNCTION_ID)
+            .addGroupName(COMPUTE_SERVERS).setArguments(serializationService.encode("hello")));
+
+    authenticateWithServer();
+    final ClientProtocol.Message responseMessage = writeMessage(message.build());
+
+    FunctionAPI.ExecuteFunctionOnGroupResponse response = getFunctionResponse(responseMessage);
+
+    assertEquals("hello", serializationService.decode(response.getResults(0)));
+  }
+
+  @Test
+  public void permissionsAreRequiredToExecute() throws IOException {
+    final ResourcePermission requiredPermission = new ResourcePermission(
+        ResourcePermission.Resource.DATA, ResourcePermission.Operation.MANAGE);
+
+    final TestFunction<Object> testFunction = new TestFunction<Object>() {
+      @Override
+      public Collection<ResourcePermission> getRequiredPermissions(String regionName) {
+        return Arrays.asList(requiredPermission);
+      }
+    };
+    FunctionService.registerFunction(testFunction);
+
+    when(securityManager.authenticate(any())).thenReturn(SECURITY_PRINCIPAL);
+
+    when(securityManager.authorize(eq(SECURITY_PRINCIPAL), eq(requiredPermission)))
+        .thenReturn(false);
+
+    final ClientProtocol.Message message = authenticateAndSendMessage();
+    assertEquals("message=" + message, BasicTypes.ErrorCode.AUTHORIZATION_FAILED,
+        message.getErrorResponse().getError().getErrorCode());
+
+    verify(securityManager).authorize(eq(SECURITY_PRINCIPAL), eq(requiredPermission));
+  }
+
+  private FunctionAPI.ExecuteFunctionOnGroupResponse getFunctionResponse(
+      ClientProtocol.Message responseMessage) {
+    assertEquals(responseMessage.toString(),
+        ClientProtocol.Message.MessageTypeCase.EXECUTEFUNCTIONONGROUPRESPONSE,
+        responseMessage.getMessageTypeCase());
+    return responseMessage.getExecuteFunctionOnGroupResponse();
+  }
+
+  private void authenticateWithServer() throws IOException {
+    ClientProtocol.Message.Builder request = ClientProtocol.Message.newBuilder()
+        .setAuthenticationRequest(ConnectionAPI.AuthenticationRequest.newBuilder()
+            .putCredentials(ResourceConstants.USER_NAME, "someuser")
+            .putCredentials(ResourceConstants.PASSWORD, "somepassword"));
+
+    ClientProtocol.Message response = writeMessage(request.build());
+    assertEquals(response.toString(), true,
+        response.getAuthenticationResponse().getAuthenticated());
+  }
+
+
+  private ClientProtocol.Message authenticateAndSendMessage() throws IOException {
+    authenticateWithServer();
+
+    final ClientProtocol.Message request =
+        createRequestMessageBuilder(FunctionAPI.ExecuteFunctionOnGroupRequest.newBuilder()
+            .setFunctionID(TEST_FUNCTION_ID).addGroupName(COMPUTE_SERVERS)).build();
+
+    return writeMessage(request);
+  }
+
+
+  private ClientProtocol.Message.Builder createRequestMessageBuilder(
+      FunctionAPI.ExecuteFunctionOnGroupRequest.Builder functionRequest) {
+    return ClientProtocol.Message.newBuilder().setExecuteFunctionOnGroupRequest(functionRequest);
+  }
+
+  private ClientProtocol.Message writeMessage(ClientProtocol.Message request) throws IOException {
+    request.writeDelimitedTo(socket.getOutputStream());
+
+    return ClientProtocol.Message.parseDelimitedFrom(socket.getInputStream());
+  }
+
+}

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/operations/ExecuteFunctionOnGroupRequestOperationHandlerJUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/operations/ExecuteFunctionOnGroupRequestOperationHandlerJUnitTest.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.protocol.protobuf.v1.operations;
+
+import static org.apache.geode.internal.protocol.protobuf.v1.BasicTypes.ErrorCode.AUTHORIZATION_FAILED;
+import static org.apache.geode.internal.protocol.protobuf.v1.BasicTypes.ErrorCode.INVALID_REQUEST;
+import static org.apache.geode.internal.protocol.protobuf.v1.BasicTypes.ErrorCode.NO_AVAILABLE_SERVER;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.cache.execute.Function;
+import org.apache.geode.cache.execute.FunctionContext;
+import org.apache.geode.cache.execute.FunctionService;
+import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.distributed.DistributedSystemDisconnectedException;
+import org.apache.geode.distributed.internal.DistributionManager;
+import org.apache.geode.distributed.internal.InternalDistributedSystem;
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
+import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.protocol.protobuf.statistics.ProtobufClientStatistics;
+import org.apache.geode.internal.protocol.protobuf.v1.ClientProtocol;
+import org.apache.geode.internal.protocol.protobuf.v1.Failure;
+import org.apache.geode.internal.protocol.protobuf.v1.FunctionAPI;
+import org.apache.geode.internal.protocol.protobuf.v1.ProtobufSerializationService;
+import org.apache.geode.internal.protocol.protobuf.v1.Result;
+import org.apache.geode.internal.protocol.protobuf.v1.ServerMessageExecutionContext;
+import org.apache.geode.internal.security.SecurityService;
+import org.apache.geode.management.internal.security.ResourcePermissions;
+import org.apache.geode.security.NotAuthorizedException;
+import org.apache.geode.test.junit.categories.UnitTest;
+
+@Category(UnitTest.class)
+public class ExecuteFunctionOnGroupRequestOperationHandlerJUnitTest {
+  private static final String TEST_GROUP1 = "group1";
+  private static final String TEST_GROUP2 = "group2";
+  private static final String TEST_FUNCTION_ID = "testFunction";
+  public static final String NOT_A_GROUP = "notAGroup";
+  private InternalCache cacheStub;
+  private DistributionManager distributionManager;
+  private ExecuteFunctionOnGroupRequestOperationHandler operationHandler;
+  private ProtobufSerializationService serializationService;
+  private TestFunction function;
+  private InternalDistributedSystem distributedSystem;
+
+  private static class TestFunction implements Function {
+    // non-null iff function has been executed.
+    private AtomicReference<FunctionContext> context = new AtomicReference<>();
+
+    @Override
+    public String getId() {
+      return TEST_FUNCTION_ID;
+    }
+
+    @Override
+    public void execute(FunctionContext context) {
+      this.context.set(context);
+      context.getResultSender().lastResult("result");
+    }
+
+    FunctionContext getContext() {
+      return context.get();
+    }
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    cacheStub = mock(InternalCache.class);
+    serializationService = new ProtobufSerializationService();
+    when(cacheStub.getSecurityService()).thenReturn(mock(SecurityService.class));
+
+    distributionManager = mock(DistributionManager.class);
+    when(cacheStub.getDistributionManager()).thenReturn(distributionManager);
+
+    distributedSystem = mock(InternalDistributedSystem.class);
+    when(distributionManager.getSystem()).thenReturn(distributedSystem);
+
+    InternalDistributedMember localhost = new InternalDistributedMember("localhost", 0);
+    Set<DistributedMember> members = new HashSet<>();
+    members.add(localhost);
+    when(distributedSystem.getGroupMembers(TEST_GROUP1)).thenReturn(members);
+
+    operationHandler = new ExecuteFunctionOnGroupRequestOperationHandler();
+
+    function = new TestFunction();
+    FunctionService.registerFunction(function);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    FunctionService.unregisterFunction(TEST_FUNCTION_ID);
+  }
+
+  @Test
+  public void failsOnUnknownGroup() throws Exception {
+    final FunctionAPI.ExecuteFunctionOnGroupRequest request =
+        FunctionAPI.ExecuteFunctionOnGroupRequest.newBuilder().setFunctionID(TEST_FUNCTION_ID)
+            .addGroupName(NOT_A_GROUP).build();
+
+    final Result<FunctionAPI.ExecuteFunctionOnGroupResponse, ClientProtocol.ErrorResponse> result =
+        operationHandler.process(serializationService, request, mockedMessageExecutionContext());
+
+    assertTrue(result instanceof Failure);
+    assertEquals(NO_AVAILABLE_SERVER, result.getErrorMessage().getError().getErrorCode());
+  }
+
+  @Test
+  public void failsIfNoGroupSpecified() throws Exception {
+    final FunctionAPI.ExecuteFunctionOnGroupRequest request =
+        FunctionAPI.ExecuteFunctionOnGroupRequest.newBuilder().setFunctionID(TEST_FUNCTION_ID)
+            .build();
+
+    final Result<FunctionAPI.ExecuteFunctionOnGroupResponse, ClientProtocol.ErrorResponse> result =
+        operationHandler.process(serializationService, request, mockedMessageExecutionContext());
+
+    assertTrue(result instanceof Failure);
+    assertEquals(NO_AVAILABLE_SERVER, result.getErrorMessage().getError().getErrorCode());
+  }
+
+  @Test(expected = DistributedSystemDisconnectedException.class)
+  public void succeedsWithValidMembers() throws Exception {
+    when(distributionManager.getMemberWithName(any(String.class))).thenReturn(
+        new InternalDistributedMember("localhost", 0),
+        new InternalDistributedMember("localhost", 1), null);
+
+    final FunctionAPI.ExecuteFunctionOnGroupRequest request =
+        FunctionAPI.ExecuteFunctionOnGroupRequest.newBuilder().setFunctionID(TEST_FUNCTION_ID)
+            .addGroupName(TEST_GROUP1).addGroupName(TEST_GROUP2).build();
+
+    final Result<FunctionAPI.ExecuteFunctionOnGroupResponse, ClientProtocol.ErrorResponse> result =
+        operationHandler.process(serializationService, request, mockedMessageExecutionContext());
+
+    // unfortunately FunctionService fishes for a DistributedSystem and throws an exception
+    // if it can't find one. It uses a static method on InternalDistributedSystem, so no
+    // mocking is possible. If the test throws DistributedSystemDisconnectedException it
+    // means that the operation handler got to the point of trying get an execution
+    // context
+  }
+
+  @Test
+  public void requiresPermissions() throws Exception {
+    final SecurityService securityService = mock(SecurityService.class);
+    doThrow(new NotAuthorizedException("we should catch this")).when(securityService)
+        .authorize(ResourcePermissions.DATA_WRITE);
+    when(cacheStub.getSecurityService()).thenReturn(securityService);
+
+    final FunctionAPI.ExecuteFunctionOnGroupRequest request =
+        FunctionAPI.ExecuteFunctionOnGroupRequest.newBuilder().setFunctionID(TEST_FUNCTION_ID)
+            .addGroupName(TEST_GROUP1).build();
+
+    final Result<FunctionAPI.ExecuteFunctionOnGroupResponse, ClientProtocol.ErrorResponse> result =
+        operationHandler.process(serializationService, request, mockedMessageExecutionContext());
+
+    assertTrue(result instanceof Failure);
+
+    assertEquals(AUTHORIZATION_FAILED, result.getErrorMessage().getError().getErrorCode());
+
+  }
+
+  @Test
+  public void functionNotFound() throws Exception {
+    final FunctionAPI.ExecuteFunctionOnGroupRequest request =
+        FunctionAPI.ExecuteFunctionOnGroupRequest.newBuilder()
+            .setFunctionID("I am not a function, I am a human").addGroupName(TEST_GROUP1).build();
+
+    final Result<FunctionAPI.ExecuteFunctionOnGroupResponse, ClientProtocol.ErrorResponse> result =
+        operationHandler.process(serializationService, request, mockedMessageExecutionContext());
+
+    final ClientProtocol.ErrorResponse errorMessage = result.getErrorMessage();
+
+    assertEquals(INVALID_REQUEST, errorMessage.getError().getErrorCode());
+  }
+
+  private ServerMessageExecutionContext mockedMessageExecutionContext() {
+    return new ServerMessageExecutionContext(cacheStub, mock(ProtobufClientStatistics.class), null);
+  }
+}


### PR DESCRIPTION
I refactored the Function operation handlers, moving the common process() flow to an abstract superclass.  Then I added an OnGroups version of function execution.



Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
