### PR TITLE
GEODE-4585: remove getAnyInstance call

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/snapshot/ClientExporter.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/snapshot/ClientExporter.java
@@ -134,7 +134,7 @@ public class ClientExporter<K, V> implements Exporter<K, V> {
 
       Region<K, V> region = context.getCache().getRegion(args.getRegion());
       Exporter<K, V> exp = args.isPRSingleHop() ? new LocalExporter<K, V>()
-          : RegionSnapshotServiceImpl.<K, V>createExporter(region, args.options);
+          : RegionSnapshotServiceImpl.<K, V>createExporter(null, region, args.options);
 
       try {
         long count = exp.export(region, sink, args.getOptions());

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/snapshot/ClientExporter.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/snapshot/ClientExporter.java
@@ -30,6 +30,7 @@ import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.cache.execute.ResultSender;
 import org.apache.geode.cache.snapshot.SnapshotOptions;
 import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.execute.InternalFunction;
 import org.apache.geode.internal.cache.snapshot.RegionSnapshotServiceImpl.ExportSink;
 import org.apache.geode.internal.cache.snapshot.RegionSnapshotServiceImpl.Exporter;
@@ -133,8 +134,9 @@ public class ClientExporter<K, V> implements Exporter<K, V> {
       ExportSink sink = new ResultSenderSink(rs);
 
       Region<K, V> region = context.getCache().getRegion(args.getRegion());
+      InternalCache cache = (InternalCache) context.getCache();
       Exporter<K, V> exp = args.isPRSingleHop() ? new LocalExporter<K, V>()
-          : RegionSnapshotServiceImpl.<K, V>createExporter(null, region, args.options);
+          : RegionSnapshotServiceImpl.<K, V>createExporter(cache, region, args.options);
 
       try {
         long count = exp.export(region, sink, args.getOptions());

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/snapshot/RegionSnapshotServiceImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/snapshot/RegionSnapshotServiceImpl.java
@@ -47,13 +47,13 @@ import org.apache.geode.cache.snapshot.SnapshotOptions;
 import org.apache.geode.cache.snapshot.SnapshotOptions.SnapshotFormat;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.internal.DistributionConfig;
-import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.internal.DSCODE;
 import org.apache.geode.internal.InternalEntity;
 import org.apache.geode.internal.cache.CachePerfStats;
 import org.apache.geode.internal.cache.CachedDeserializable;
 import org.apache.geode.internal.cache.CachedDeserializableFactory;
 import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.LocalDataSet;
 import org.apache.geode.internal.cache.LocalRegion;
 import org.apache.geode.internal.cache.Token;
@@ -401,7 +401,7 @@ public class RegionSnapshotServiceImpl<K, V> implements RegionSnapshotService<K,
     if (pool != null) {
       return new ClientExporter<>(PoolManager.find(pool));
 
-    } else if (InternalDistributedSystem.getAnyInstance().isLoner()
+    } else if (((InternalRegion) region).getCache().getInternalDistributedSystem().isLoner()
         || region.getAttributes().getDataPolicy().equals(DataPolicy.NORMAL)
         || region.getAttributes().getDataPolicy().equals(DataPolicy.PRELOADED)
         || region instanceof LocalDataSet || (options.isParallelMode()

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/snapshot/RegionSnapshotServiceImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/snapshot/RegionSnapshotServiceImpl.java
@@ -341,7 +341,7 @@ public class RegionSnapshotServiceImpl<K, V> implements RegionSnapshotService<K,
     }
     directory.mkdirs();
     LocalRegion local = getLocalRegion(region);
-    Exporter<K, V> exp = createExporter(region, options);
+    Exporter<K, V> exp = createExporter(local.getCache(), region, options);
 
     if (getLoggerI18n().fineEnabled()) {
       getLoggerI18n().fine("Writing to snapshot " + snapshot.getAbsolutePath());
@@ -396,12 +396,13 @@ public class RegionSnapshotServiceImpl<K, V> implements RegionSnapshotService<K,
     return true;
   }
 
-  static <K, V> Exporter<K, V> createExporter(Region<?, ?> region, SnapshotOptions<K, V> options) {
+  static <K, V> Exporter<K, V> createExporter(InternalCache cache, Region<?, ?> region,
+      SnapshotOptions<K, V> options) {
     String pool = region.getAttributes().getPoolName();
     if (pool != null) {
       return new ClientExporter<>(PoolManager.find(pool));
 
-    } else if (((InternalRegion) region).getCache().getInternalDistributedSystem().isLoner()
+    } else if (cache.getInternalDistributedSystem().isLoner()
         || region.getAttributes().getDataPolicy().equals(DataPolicy.NORMAL)
         || region.getAttributes().getDataPolicy().equals(DataPolicy.PRELOADED)
         || region instanceof LocalDataSet || (options.isParallelMode()


### PR DESCRIPTION
The region is now used to obtain the InternalDistributedSystem
instead of calling getAnyInstance.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
