### PR TITLE
GEODE-4651: fix transactional destroy entry leak

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalRegion.java
@@ -94,6 +94,14 @@ public interface InternalRegion extends Region, HasCachePerfStats, RegionEntryCo
 
   void addExpiryTaskIfAbsent(RegionEntry entry);
 
+  /**
+   * Used by unit tests to get access to the EntryExpiryTask of the given key. Returns null if the
+   * entry exists but does not have an expiry task.
+   *
+   * @throws EntryNotFoundException if no entry exists key.
+   */
+  EntryExpiryTask getEntryExpiryTask(Object key);
+
   DistributionManager getDistributionManager();
 
   void generateAndSetVersionTag(InternalCacheEvent event, RegionEntry entry);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
@@ -8041,12 +8041,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
     }
   }
 
-  /**
-   * Used by unit tests to get access to the EntryExpiryTask of the given key. Returns null if the
-   * entry exists but does not have an expiry task.
-   *
-   * @throws EntryNotFoundException if no entry exists key.
-   */
+  @Override
   public EntryExpiryTask getEntryExpiryTask(Object key) {
     RegionEntry re = this.getRegionEntry(key);
     if (re == null) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/AbstractRegionEntry.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/AbstractRegionEntry.java
@@ -1468,9 +1468,11 @@ public abstract class AbstractRegionEntry implements HashRegionEntry<Object, Obj
     if (TXManagerImpl.decRefCount(this)) {
       if (isInUseByTransaction()) {
         setInUseByTransaction(false);
-        appendToEvictionList(evictionList);
-        if (region != null && region.isEntryExpiryPossible()) {
-          region.addExpiryTaskIfAbsent(this);
+        if (!isDestroyedOrRemoved()) {
+          appendToEvictionList(evictionList);
+          if (region != null && region.isEntryExpiryPossible()) {
+            region.addExpiryTaskIfAbsent(this);
+          }
         }
       }
     }


### PR DESCRIPTION
When the transaction marks a region entry as no
longer being used by the transaction, it no longer
added it back to the eviction list if the entry
is removed or destroyed.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
