### PR TITLE
GEODE-4377: Don't catch encoding exceptions in OperationHandlers

### DIFF
--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/operations/ProtobufOperationHandler.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/operations/ProtobufOperationHandler.java
@@ -19,6 +19,8 @@ import org.apache.geode.internal.protocol.protobuf.v1.ClientProtocol;
 import org.apache.geode.internal.protocol.protobuf.v1.MessageExecutionContext;
 import org.apache.geode.internal.protocol.protobuf.v1.ProtobufSerializationService;
 import org.apache.geode.internal.protocol.protobuf.v1.Result;
+import org.apache.geode.internal.protocol.protobuf.v1.serialization.exception.DecodingException;
+import org.apache.geode.internal.protocol.protobuf.v1.serialization.exception.EncodingException;
 import org.apache.geode.internal.protocol.protobuf.v1.state.exception.ConnectionStateException;
 
 /**
@@ -38,6 +40,6 @@ public interface ProtobufOperationHandler<Req, Resp> {
    */
   Result<Resp, ClientProtocol.ErrorResponse> process(
       ProtobufSerializationService serializationService, Req request,
-      MessageExecutionContext messageExecutionContext)
-      throws InvalidExecutionContextException, ConnectionStateException;
+      MessageExecutionContext messageExecutionContext) throws InvalidExecutionContextException,
+      ConnectionStateException, EncodingException, DecodingException;
 }

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/ProtobufOpsProcessor.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/ProtobufOpsProcessor.java
@@ -20,6 +20,8 @@ import org.apache.geode.annotations.Experimental;
 import org.apache.geode.internal.exception.InvalidExecutionContextException;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.protocol.protobuf.v1.registry.ProtobufOperationContextRegistry;
+import org.apache.geode.internal.protocol.protobuf.v1.serialization.exception.DecodingException;
+import org.apache.geode.internal.protocol.protobuf.v1.serialization.exception.EncodingException;
 import org.apache.geode.internal.protocol.protobuf.v1.state.ProtobufConnectionTerminatingStateProcessor;
 import org.apache.geode.internal.protocol.protobuf.v1.state.exception.ConnectionStateException;
 import org.apache.geode.internal.protocol.protobuf.v1.state.exception.OperationNotAuthorizedException;
@@ -58,7 +60,7 @@ public class ProtobufOpsProcessor {
       // Don't move to a terminating state for authorization state failures
       logger.warn(e.getMessage());
       result = Failure.of(ProtobufResponseUtilities.makeErrorResponse(e));
-    } catch (ConnectionStateException e) {
+    } catch (EncodingException | DecodingException | ConnectionStateException e) {
       logger.warn(e.getMessage());
       messageExecutionContext
           .setConnectionStateProcessor(new ProtobufConnectionTerminatingStateProcessor());
@@ -71,7 +73,7 @@ public class ProtobufOpsProcessor {
 
   private Result processOperation(ClientProtocol.Message request, MessageExecutionContext context,
       ClientProtocol.Message.MessageTypeCase requestType, ProtobufOperationContext operationContext)
-      throws ConnectionStateException {
+      throws ConnectionStateException, EncodingException, DecodingException {
     try {
       return operationContext.getOperationHandler().process(serializationService,
           operationContext.getFromRequest().apply(request), context);

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/ProtobufSerializationService.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/ProtobufSerializationService.java
@@ -19,6 +19,7 @@ import com.google.protobuf.ByteString;
 import org.apache.geode.annotations.Experimental;
 import org.apache.geode.internal.protocol.protobuf.v1.serialization.JsonPdxConverter;
 import org.apache.geode.internal.protocol.protobuf.v1.serialization.SerializationService;
+import org.apache.geode.internal.protocol.protobuf.v1.serialization.exception.DecodingException;
 import org.apache.geode.internal.protocol.protobuf.v1.serialization.exception.EncodingException;
 import org.apache.geode.internal.protocol.protobuf.v1.utilities.exception.UnknownProtobufEncodingType;
 import org.apache.geode.pdx.PdxInstance;
@@ -98,7 +99,7 @@ public class ProtobufSerializationService implements SerializationService<BasicT
    * @throws EncodingException if the value cannot be decoded.
    */
   @Override
-  public Object decode(BasicTypes.EncodedValue encodedValue) throws EncodingException {
+  public Object decode(BasicTypes.EncodedValue encodedValue) throws DecodingException {
     switch (encodedValue.getValueCase()) {
       case BINARYRESULT:
         return encodedValue.getBinaryResult().toByteArray();
@@ -123,7 +124,7 @@ public class ProtobufSerializationService implements SerializationService<BasicT
       case VALUE_NOT_SET:
         return null;
       default:
-        throw new EncodingException(
+        throw new DecodingException(
             "Unknown Protobuf encoding type: " + encodedValue.getValueCase());
     }
   }

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/operations/ExecuteFunctionOnMemberRequestOperationHandler.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/operations/ExecuteFunctionOnMemberRequestOperationHandler.java
@@ -38,8 +38,8 @@ import org.apache.geode.internal.protocol.protobuf.v1.MessageExecutionContext;
 import org.apache.geode.internal.protocol.protobuf.v1.ProtobufSerializationService;
 import org.apache.geode.internal.protocol.protobuf.v1.Result;
 import org.apache.geode.internal.protocol.protobuf.v1.Success;
+import org.apache.geode.internal.protocol.protobuf.v1.serialization.exception.DecodingException;
 import org.apache.geode.internal.protocol.protobuf.v1.serialization.exception.EncodingException;
-import org.apache.geode.internal.protocol.protobuf.v1.state.exception.ConnectionStateException;
 import org.apache.geode.internal.security.SecurityService;
 import org.apache.geode.security.NotAuthorizedException;
 
@@ -49,7 +49,8 @@ public class ExecuteFunctionOnMemberRequestOperationHandler implements
   public Result<FunctionAPI.ExecuteFunctionOnMemberResponse, ClientProtocol.ErrorResponse> process(
       ProtobufSerializationService serializationService,
       FunctionAPI.ExecuteFunctionOnMemberRequest request,
-      MessageExecutionContext messageExecutionContext) throws InvalidExecutionContextException {
+      MessageExecutionContext messageExecutionContext)
+      throws InvalidExecutionContextException, EncodingException, DecodingException {
 
     final String functionID = request.getFunctionID();
 
@@ -135,11 +136,6 @@ public class ExecuteFunctionOnMemberRequestOperationHandler implements
       return Failure.of(ClientProtocol.ErrorResponse.newBuilder()
           .setError(BasicTypes.Error.newBuilder().setErrorCode(BasicTypes.ErrorCode.SERVER_ERROR)
               .setMessage("Function execution failed: " + ex.toString()))
-          .build());
-    } catch (EncodingException ex) {
-      return Failure.of(ClientProtocol.ErrorResponse.newBuilder()
-          .setError(BasicTypes.Error.newBuilder().setErrorCode(BasicTypes.ErrorCode.SERVER_ERROR)
-              .setMessage("Encoding failed: " + ex.toString()))
           .build());
     }
   }

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/operations/ExecuteFunctionOnRegionRequestOperationHandler.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/operations/ExecuteFunctionOnRegionRequestOperationHandler.java
@@ -35,6 +35,7 @@ import org.apache.geode.internal.protocol.protobuf.v1.MessageExecutionContext;
 import org.apache.geode.internal.protocol.protobuf.v1.ProtobufSerializationService;
 import org.apache.geode.internal.protocol.protobuf.v1.Result;
 import org.apache.geode.internal.protocol.protobuf.v1.Success;
+import org.apache.geode.internal.protocol.protobuf.v1.serialization.exception.DecodingException;
 import org.apache.geode.internal.protocol.protobuf.v1.serialization.exception.EncodingException;
 import org.apache.geode.internal.security.SecurityService;
 import org.apache.geode.security.NotAuthorizedException;
@@ -45,7 +46,8 @@ public class ExecuteFunctionOnRegionRequestOperationHandler implements
   public Result<FunctionAPI.ExecuteFunctionOnRegionResponse, ClientProtocol.ErrorResponse> process(
       ProtobufSerializationService serializationService,
       FunctionAPI.ExecuteFunctionOnRegionRequest request,
-      MessageExecutionContext messageExecutionContext) throws InvalidExecutionContextException {
+      MessageExecutionContext messageExecutionContext)
+      throws InvalidExecutionContextException, EncodingException, DecodingException {
 
     final String functionID = request.getFunctionID();
     final String regionName = request.getRegion();
@@ -112,16 +114,11 @@ public class ExecuteFunctionOnRegionRequestOperationHandler implements
           .setError(BasicTypes.Error.newBuilder().setErrorCode(BasicTypes.ErrorCode.SERVER_ERROR)
               .setMessage("Function execution failed: " + ex.toString()))
           .build());
-    } catch (EncodingException ex) {
-      return Failure.of(ClientProtocol.ErrorResponse.newBuilder()
-          .setError(BasicTypes.Error.newBuilder().setErrorCode(BasicTypes.ErrorCode.SERVER_ERROR)
-              .setMessage("Encoding failed: " + ex.toString()))
-          .build());
     }
   }
 
   private Set<Object> parseFilter(ProtobufSerializationService serializationService,
-      FunctionAPI.ExecuteFunctionOnRegionRequest request) throws EncodingException {
+      FunctionAPI.ExecuteFunctionOnRegionRequest request) throws DecodingException {
     List<BasicTypes.EncodedValue> encodedFilter = request.getKeyFilterList();
     Set<Object> filter = new HashSet<>();
 

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/operations/GetRegionNamesRequestOperationHandler.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/operations/GetRegionNamesRequestOperationHandler.java
@@ -26,6 +26,8 @@ import org.apache.geode.internal.protocol.protobuf.v1.ProtobufSerializationServi
 import org.apache.geode.internal.protocol.protobuf.v1.RegionAPI;
 import org.apache.geode.internal.protocol.protobuf.v1.Result;
 import org.apache.geode.internal.protocol.protobuf.v1.Success;
+import org.apache.geode.internal.protocol.protobuf.v1.serialization.exception.DecodingException;
+import org.apache.geode.internal.protocol.protobuf.v1.serialization.exception.EncodingException;
 import org.apache.geode.internal.protocol.protobuf.v1.utilities.ProtobufResponseUtilities;
 
 @Experimental

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/operations/GetRegionRequestOperationHandler.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/operations/GetRegionRequestOperationHandler.java
@@ -31,6 +31,8 @@ import org.apache.geode.internal.protocol.protobuf.v1.ProtobufSerializationServi
 import org.apache.geode.internal.protocol.protobuf.v1.RegionAPI;
 import org.apache.geode.internal.protocol.protobuf.v1.Result;
 import org.apache.geode.internal.protocol.protobuf.v1.Success;
+import org.apache.geode.internal.protocol.protobuf.v1.serialization.exception.DecodingException;
+import org.apache.geode.internal.protocol.protobuf.v1.serialization.exception.EncodingException;
 import org.apache.geode.internal.protocol.protobuf.v1.utilities.ProtobufResponseUtilities;
 import org.apache.geode.internal.protocol.protobuf.v1.utilities.ProtobufUtilities;
 

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/operations/GetRequestOperationHandler.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/operations/GetRequestOperationHandler.java
@@ -14,14 +14,12 @@
  */
 package org.apache.geode.internal.protocol.protobuf.v1.operations;
 
-import static org.apache.geode.internal.protocol.protobuf.v1.ProtobufErrorCode.INVALID_REQUEST;
 import static org.apache.geode.internal.protocol.protobuf.v1.ProtobufErrorCode.SERVER_ERROR;
 
 import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.annotations.Experimental;
 import org.apache.geode.cache.Region;
-import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.exception.InvalidExecutionContextException;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.protocol.operations.ProtobufOperationHandler;
@@ -33,6 +31,7 @@ import org.apache.geode.internal.protocol.protobuf.v1.ProtobufSerializationServi
 import org.apache.geode.internal.protocol.protobuf.v1.RegionAPI;
 import org.apache.geode.internal.protocol.protobuf.v1.Result;
 import org.apache.geode.internal.protocol.protobuf.v1.Success;
+import org.apache.geode.internal.protocol.protobuf.v1.serialization.exception.DecodingException;
 import org.apache.geode.internal.protocol.protobuf.v1.serialization.exception.EncodingException;
 import org.apache.geode.internal.protocol.protobuf.v1.utilities.ProtobufResponseUtilities;
 
@@ -44,7 +43,8 @@ public class GetRequestOperationHandler
   @Override
   public Result<RegionAPI.GetResponse, ClientProtocol.ErrorResponse> process(
       ProtobufSerializationService serializationService, RegionAPI.GetRequest request,
-      MessageExecutionContext messageExecutionContext) throws InvalidExecutionContextException {
+      MessageExecutionContext messageExecutionContext)
+      throws InvalidExecutionContextException, EncodingException, DecodingException {
     String regionName = request.getRegionName();
     Region region = messageExecutionContext.getCache().getRegion(regionName);
     if (region == null) {
@@ -55,7 +55,7 @@ public class GetRequestOperationHandler
     long startOperationTime = messageExecutionContext.getStatistics().startOperation();
 
     try {
-      ((InternalCache) messageExecutionContext.getCache()).setReadSerializedForCurrentThread(true);
+      messageExecutionContext.getCache().setReadSerializedForCurrentThread(true);
 
       Object decodedKey = serializationService.decode(request.getKey());
       Object resultValue = region.get(decodedKey);
@@ -66,12 +66,8 @@ public class GetRequestOperationHandler
 
       BasicTypes.EncodedValue encodedValue = serializationService.encode(resultValue);
       return Success.of(RegionAPI.GetResponse.newBuilder().setResult(encodedValue).build());
-    } catch (EncodingException ex) {
-      logger.error("Received Get request with unsupported encoding: {}", ex);
-      return Failure.of(
-          ProtobufResponseUtilities.makeErrorResponse(INVALID_REQUEST, "Encoding not supported."));
     } finally {
-      ((InternalCache) messageExecutionContext.getCache()).setReadSerializedForCurrentThread(false);
+      messageExecutionContext.getCache().setReadSerializedForCurrentThread(false);
       messageExecutionContext.getStatistics().endOperation(startOperationTime);
     }
   }

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/operations/GetServerOperationHandler.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/operations/GetServerOperationHandler.java
@@ -35,6 +35,8 @@ import org.apache.geode.internal.protocol.protobuf.v1.MessageExecutionContext;
 import org.apache.geode.internal.protocol.protobuf.v1.ProtobufSerializationService;
 import org.apache.geode.internal.protocol.protobuf.v1.Result;
 import org.apache.geode.internal.protocol.protobuf.v1.Success;
+import org.apache.geode.internal.protocol.protobuf.v1.serialization.exception.DecodingException;
+import org.apache.geode.internal.protocol.protobuf.v1.serialization.exception.EncodingException;
 import org.apache.geode.internal.protocol.protobuf.v1.state.ProtobufConnectionTerminatingStateProcessor;
 import org.apache.geode.internal.protocol.protobuf.v1.utilities.ProtobufResponseUtilities;
 

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/operations/PutRequestOperationHandler.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/operations/PutRequestOperationHandler.java
@@ -14,7 +14,6 @@
  */
 package org.apache.geode.internal.protocol.protobuf.v1.operations;
 
-import static org.apache.geode.internal.protocol.protobuf.v1.ProtobufErrorCode.INVALID_REQUEST;
 import static org.apache.geode.internal.protocol.protobuf.v1.ProtobufErrorCode.SERVER_ERROR;
 
 import org.apache.logging.log4j.Logger;
@@ -32,7 +31,9 @@ import org.apache.geode.internal.protocol.protobuf.v1.ProtobufSerializationServi
 import org.apache.geode.internal.protocol.protobuf.v1.RegionAPI;
 import org.apache.geode.internal.protocol.protobuf.v1.Result;
 import org.apache.geode.internal.protocol.protobuf.v1.Success;
+import org.apache.geode.internal.protocol.protobuf.v1.serialization.exception.DecodingException;
 import org.apache.geode.internal.protocol.protobuf.v1.serialization.exception.EncodingException;
+import org.apache.geode.internal.protocol.protobuf.v1.state.exception.ConnectionStateException;
 import org.apache.geode.internal.protocol.protobuf.v1.utilities.ProtobufResponseUtilities;
 
 @Experimental
@@ -43,7 +44,8 @@ public class PutRequestOperationHandler
   @Override
   public Result<RegionAPI.PutResponse, ClientProtocol.ErrorResponse> process(
       ProtobufSerializationService serializationService, RegionAPI.PutRequest request,
-      MessageExecutionContext messageExecutionContext) throws InvalidExecutionContextException {
+      MessageExecutionContext messageExecutionContext)
+      throws InvalidExecutionContextException, DecodingException {
     String regionName = request.getRegionName();
     Region region = messageExecutionContext.getCache().getRegion(regionName);
     if (region == null) {
@@ -65,10 +67,6 @@ public class PutRequestOperationHandler
         logger.error("Received Put request with invalid key type: {}", ex);
         return Failure.of(ProtobufResponseUtilities.makeErrorResponse(SERVER_ERROR, ex.toString()));
       }
-    } catch (EncodingException ex) {
-      logger.error("Got error when decoding Put request: {}", ex);
-      return Failure
-          .of(ProtobufResponseUtilities.makeErrorResponse(INVALID_REQUEST, ex.toString()));
     } finally {
       messageExecutionContext.getStatistics().endOperation(startTime);
     }

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/operations/RemoveRequestOperationHandler.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/operations/RemoveRequestOperationHandler.java
@@ -14,7 +14,6 @@
  */
 package org.apache.geode.internal.protocol.protobuf.v1.operations;
 
-import static org.apache.geode.internal.protocol.protobuf.v1.ProtobufErrorCode.INVALID_REQUEST;
 import static org.apache.geode.internal.protocol.protobuf.v1.ProtobufErrorCode.SERVER_ERROR;
 
 import org.apache.logging.log4j.LogManager;
@@ -31,6 +30,7 @@ import org.apache.geode.internal.protocol.protobuf.v1.ProtobufSerializationServi
 import org.apache.geode.internal.protocol.protobuf.v1.RegionAPI;
 import org.apache.geode.internal.protocol.protobuf.v1.Result;
 import org.apache.geode.internal.protocol.protobuf.v1.Success;
+import org.apache.geode.internal.protocol.protobuf.v1.serialization.exception.DecodingException;
 import org.apache.geode.internal.protocol.protobuf.v1.serialization.exception.EncodingException;
 import org.apache.geode.internal.protocol.protobuf.v1.utilities.ProtobufResponseUtilities;
 
@@ -42,7 +42,8 @@ public class RemoveRequestOperationHandler
   @Override
   public Result<RegionAPI.RemoveResponse, ClientProtocol.ErrorResponse> process(
       ProtobufSerializationService serializationService, RegionAPI.RemoveRequest request,
-      MessageExecutionContext messageExecutionContext) throws InvalidExecutionContextException {
+      MessageExecutionContext messageExecutionContext)
+      throws InvalidExecutionContextException, DecodingException {
 
     String regionName = request.getRegionName();
     Region region = messageExecutionContext.getCache().getRegion(regionName);
@@ -58,11 +59,6 @@ public class RemoveRequestOperationHandler
       region.remove(decodedKey);
 
       return Success.of(RegionAPI.RemoveResponse.newBuilder().build());
-    } catch (EncodingException ex) {
-      // can be thrown by encoding or decoding.
-      logger.error("Received Remove request with unsupported encoding: {}", ex);
-      return Failure.of(ProtobufResponseUtilities.makeErrorResponse(INVALID_REQUEST,
-          "Encoding not supported: " + ex.getMessage()));
     } finally {
       messageExecutionContext.getStatistics().endOperation(startTime);
     }

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/operations/security/AuthenticationRequestOperationHandler.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/operations/security/AuthenticationRequestOperationHandler.java
@@ -16,9 +16,7 @@ package org.apache.geode.internal.protocol.protobuf.v1.operations.security;
 
 import java.util.Properties;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
+import org.apache.geode.internal.exception.InvalidExecutionContextException;
 import org.apache.geode.internal.protocol.operations.ProtobufOperationHandler;
 import org.apache.geode.internal.protocol.protobuf.v1.ClientProtocol;
 import org.apache.geode.internal.protocol.protobuf.v1.ConnectionAPI;
@@ -26,6 +24,8 @@ import org.apache.geode.internal.protocol.protobuf.v1.MessageExecutionContext;
 import org.apache.geode.internal.protocol.protobuf.v1.ProtobufSerializationService;
 import org.apache.geode.internal.protocol.protobuf.v1.Result;
 import org.apache.geode.internal.protocol.protobuf.v1.Success;
+import org.apache.geode.internal.protocol.protobuf.v1.serialization.exception.DecodingException;
+import org.apache.geode.internal.protocol.protobuf.v1.serialization.exception.EncodingException;
 import org.apache.geode.internal.protocol.protobuf.v1.state.ProtobufConnectionAuthenticatingStateProcessor;
 import org.apache.geode.internal.protocol.protobuf.v1.state.ProtobufConnectionStateProcessor;
 import org.apache.geode.internal.protocol.protobuf.v1.state.ProtobufConnectionTerminatingStateProcessor;

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/serialization/JsonPdxConverter.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/serialization/JsonPdxConverter.java
@@ -15,6 +15,7 @@
 package org.apache.geode.internal.protocol.protobuf.v1.serialization;
 
 import org.apache.geode.annotations.Experimental;
+import org.apache.geode.internal.protocol.protobuf.v1.serialization.exception.DecodingException;
 import org.apache.geode.internal.protocol.protobuf.v1.serialization.exception.EncodingException;
 import org.apache.geode.pdx.JSONFormatter;
 import org.apache.geode.pdx.JSONFormatterException;
@@ -23,11 +24,11 @@ import org.apache.geode.pdx.PdxInstance;
 @Experimental
 public class JsonPdxConverter implements TypeConverter<String, PdxInstance> {
   @Override
-  public PdxInstance decode(String incoming) throws EncodingException {
+  public PdxInstance decode(String incoming) throws DecodingException {
     try {
       return JSONFormatter.fromJSON(incoming);
     } catch (JSONFormatterException ex) {
-      throw new EncodingException("Could not decode JSON-encoded object ", ex);
+      throw new DecodingException("Could not decode JSON-encoded object ", ex);
     }
   }
 

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/serialization/SerializationService.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/serialization/SerializationService.java
@@ -15,6 +15,7 @@
 package org.apache.geode.internal.protocol.protobuf.v1.serialization;
 
 import org.apache.geode.annotations.Experimental;
+import org.apache.geode.internal.protocol.protobuf.v1.serialization.exception.DecodingException;
 import org.apache.geode.internal.protocol.protobuf.v1.serialization.exception.EncodingException;
 
 /**
@@ -25,7 +26,7 @@ import org.apache.geode.internal.protocol.protobuf.v1.serialization.exception.En
  */
 @Experimental
 public interface SerializationService<T> {
-  Object decode(T encodedValue) throws EncodingException;
+  Object decode(T encodedValue) throws DecodingException;
 
   T encode(Object value) throws EncodingException;
 }

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/serialization/TypeConverter.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/serialization/TypeConverter.java
@@ -15,6 +15,7 @@
 package org.apache.geode.internal.protocol.protobuf.v1.serialization;
 
 import org.apache.geode.annotations.Experimental;
+import org.apache.geode.internal.protocol.protobuf.v1.serialization.exception.DecodingException;
 import org.apache.geode.internal.protocol.protobuf.v1.serialization.exception.EncodingException;
 
 /**
@@ -26,7 +27,7 @@ import org.apache.geode.internal.protocol.protobuf.v1.serialization.exception.En
  */
 @Experimental
 public interface TypeConverter<F, T> {
-  T decode(F incoming) throws EncodingException;
+  T decode(F incoming) throws DecodingException;
 
   F encode(T incoming) throws EncodingException;
 

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/serialization/exception/DecodingException.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/serialization/exception/DecodingException.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.protocol.protobuf.v1.serialization.exception;
+
+import org.apache.geode.annotations.Experimental;
+
+/**
+ * This indicates an encoding type that we don't know how to handle.
+ */
+@Experimental
+public class DecodingException extends Exception {
+  public DecodingException(String message) {
+    super(message);
+  }
+
+  public DecodingException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/serialization/exception/EncodingException.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/serialization/exception/EncodingException.java
@@ -17,7 +17,7 @@ package org.apache.geode.internal.protocol.protobuf.v1.serialization.exception;
 import org.apache.geode.annotations.Experimental;
 
 /**
- * This indicates an encoding type that we don't know how to handle.
+ * This indicates a Java object that we don't know how to handle.
  */
 @Experimental
 public class EncodingException extends Exception {

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/utilities/ProtobufResponseUtilities.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/utilities/ProtobufResponseUtilities.java
@@ -68,9 +68,9 @@ public abstract class ProtobufResponseUtilities {
     if (exception instanceof ConnectionStateException) {
       return makeErrorResponse((ConnectionStateException) exception);
     }
-    return ClientProtocol.ErrorResponse.newBuilder()
-        .setError(BasicTypes.Error.newBuilder().setErrorCode(BasicTypes.ErrorCode.SERVER_ERROR)
-            .setMessage(exception.getClass().getSimpleName() + exception.getMessage()))
+    return ClientProtocol.ErrorResponse
+        .newBuilder().setError(BasicTypes.Error.newBuilder()
+            .setErrorCode(BasicTypes.ErrorCode.SERVER_ERROR).setMessage(exception.toString()))
         .build();
   }
 

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/utilities/ProtobufResponseUtilities.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/utilities/ProtobufResponseUtilities.java
@@ -22,6 +22,8 @@ import org.apache.geode.internal.protocol.protobuf.v1.BasicTypes;
 import org.apache.geode.internal.protocol.protobuf.v1.ClientProtocol;
 import org.apache.geode.internal.protocol.protobuf.v1.ProtobufErrorCode;
 import org.apache.geode.internal.protocol.protobuf.v1.RegionAPI;
+import org.apache.geode.internal.protocol.protobuf.v1.serialization.exception.DecodingException;
+import org.apache.geode.internal.protocol.protobuf.v1.serialization.exception.EncodingException;
 import org.apache.geode.internal.protocol.protobuf.v1.state.exception.ConnectionStateException;
 
 
@@ -61,4 +63,15 @@ public abstract class ProtobufResponseUtilities {
   public static ClientProtocol.ErrorResponse makeErrorResponse(ConnectionStateException exception) {
     return makeErrorResponse(exception.getErrorCode(), exception.getMessage());
   }
+
+  public static ClientProtocol.ErrorResponse makeErrorResponse(Exception exception) {
+    if (exception instanceof ConnectionStateException) {
+      return makeErrorResponse((ConnectionStateException) exception);
+    }
+    return ClientProtocol.ErrorResponse.newBuilder()
+        .setError(BasicTypes.Error.newBuilder().setErrorCode(BasicTypes.ErrorCode.SERVER_ERROR)
+            .setMessage(exception.getClass().getSimpleName() + exception.getMessage()))
+        .build();
+  }
+
 }

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/ExecuteFunctionOnMemberIntegrationTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/ExecuteFunctionOnMemberIntegrationTest.java
@@ -26,12 +26,9 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.net.Socket;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.Properties;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -46,13 +43,11 @@ import org.junit.experimental.categories.Category;
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.DataPolicy;
-import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionFactory;
 import org.apache.geode.cache.execute.Function;
 import org.apache.geode.cache.execute.FunctionContext;
 import org.apache.geode.cache.execute.FunctionException;
 import org.apache.geode.cache.execute.FunctionService;
-import org.apache.geode.cache.execute.RegionFunctionContext;
 import org.apache.geode.cache.server.CacheServer;
 import org.apache.geode.distributed.ConfigurationProperties;
 import org.apache.geode.internal.AvailablePortHelper;

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/acceptance/CacheOperationsJUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/acceptance/CacheOperationsJUnitTest.java
@@ -319,8 +319,18 @@ public class CacheOperationsJUnitTest {
     RegionAPI.GetAllResponse getAllResponse = response.getGetAllResponse();
     assertEquals(3, getAllResponse.getEntriesCount());
     for (BasicTypes.Entry result : getAllResponse.getEntriesList()) {
-      String key = (String) serializationService.decode(result.getKey());
-      String value = (String) serializationService.decode(result.getValue());
+      String key = null;
+      try {
+        key = (String) serializationService.decode(result.getKey());
+      } catch (org.apache.geode.internal.protocol.protobuf.v1.serialization.exception.DecodingException e) {
+        e.printStackTrace();
+      }
+      String value = null;
+      try {
+        value = (String) serializationService.decode(result.getValue());
+      } catch (org.apache.geode.internal.protocol.protobuf.v1.serialization.exception.DecodingException e) {
+        e.printStackTrace();
+      }
       switch (key) {
         case TEST_MULTIOP_KEY1:
           assertEquals(TEST_MULTIOP_VALUE1, value);

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/operations/GetRequestOperationHandlerJUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/operations/GetRequestOperationHandlerJUnitTest.java
@@ -28,10 +28,13 @@ import org.apache.geode.internal.protocol.TestExecutionContext;
 import org.apache.geode.internal.protocol.protobuf.v1.BasicTypes;
 import org.apache.geode.internal.protocol.protobuf.v1.ClientProtocol;
 import org.apache.geode.internal.protocol.protobuf.v1.Failure;
+import org.apache.geode.internal.protocol.protobuf.v1.ProtobufOpsProcessor;
 import org.apache.geode.internal.protocol.protobuf.v1.ProtobufSerializationService;
 import org.apache.geode.internal.protocol.protobuf.v1.RegionAPI;
 import org.apache.geode.internal.protocol.protobuf.v1.Result;
 import org.apache.geode.internal.protocol.protobuf.v1.Success;
+import org.apache.geode.internal.protocol.protobuf.v1.registry.ProtobufOperationContextRegistry;
+import org.apache.geode.internal.protocol.protobuf.v1.serialization.exception.DecodingException;
 import org.apache.geode.internal.protocol.protobuf.v1.serialization.exception.EncodingException;
 import org.apache.geode.internal.protocol.protobuf.v1.utilities.ProtobufRequestUtilities;
 import org.apache.geode.test.junit.categories.UnitTest;
@@ -103,9 +106,9 @@ public class GetRequestOperationHandlerJUnitTest extends OperationHandlerJUnitTe
     Assert.assertTrue(response instanceof Success);
   }
 
-  @Test
-  public void processReturnsErrorWhenUnableToDecodeRequest() throws Exception {
-    EncodingException exception = new EncodingException("error finding codec for type");
+  @Test(expected = DecodingException.class)
+  public void processThrowsExceptionWhenUnableToDecodeRequest() throws Exception {
+    Exception exception = new DecodingException("error finding codec for type");
     ProtobufSerializationService serializationServiceStub =
         mock(ProtobufSerializationService.class);
     when(serializationServiceStub.decode(any())).thenThrow(exception);
@@ -115,14 +118,17 @@ public class GetRequestOperationHandlerJUnitTest extends OperationHandlerJUnitTe
     RegionAPI.GetRequest getRequest =
         ProtobufRequestUtilities.createGetRequest(TEST_REGION, encodedKey).getGetRequest();
 
-    Result response = operationHandler.process(serializationServiceStub, getRequest,
+    operationHandler.process(serializationServiceStub, getRequest,
         TestExecutionContext.getNoAuthCacheExecutionContext(cacheStub));
 
-    Assert.assertTrue(response instanceof Failure);
-    ClientProtocol.ErrorResponse errorMessage =
-        (ClientProtocol.ErrorResponse) response.getErrorMessage();
-    Assert.assertEquals(BasicTypes.ErrorCode.INVALID_REQUEST,
-        errorMessage.getError().getErrorCode());
+    // Result response = operationHandler.process(serializationServiceStub, getRequest,
+    // TestExecutionContext.getNoAuthCacheExecutionContext(cacheStub));
+
+    // Assert.assertTrue(response instanceof Failure);
+    // ClientProtocol.ErrorResponse errorMessage =
+    // (ClientProtocol.ErrorResponse) response.getErrorMessage();
+    // Assert.assertEquals(BasicTypes.ErrorCode.INVALID_REQUEST,
+    // errorMessage.getError().getErrorCode());
   }
 
   private RegionAPI.GetRequest generateTestRequest(boolean missingRegion, boolean missingKey,

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/operations/GetRequestOperationHandlerJUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/operations/GetRequestOperationHandlerJUnitTest.java
@@ -120,15 +120,6 @@ public class GetRequestOperationHandlerJUnitTest extends OperationHandlerJUnitTe
 
     operationHandler.process(serializationServiceStub, getRequest,
         TestExecutionContext.getNoAuthCacheExecutionContext(cacheStub));
-
-    // Result response = operationHandler.process(serializationServiceStub, getRequest,
-    // TestExecutionContext.getNoAuthCacheExecutionContext(cacheStub));
-
-    // Assert.assertTrue(response instanceof Failure);
-    // ClientProtocol.ErrorResponse errorMessage =
-    // (ClientProtocol.ErrorResponse) response.getErrorMessage();
-    // Assert.assertEquals(BasicTypes.ErrorCode.INVALID_REQUEST,
-    // errorMessage.getError().getErrorCode());
   }
 
   private RegionAPI.GetRequest generateTestRequest(boolean missingRegion, boolean missingKey,

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/utilities/ProtobufUtilitiesJUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/utilities/ProtobufUtilitiesJUnitTest.java
@@ -147,10 +147,18 @@ public class ProtobufUtilitiesJUnitTest {
   private <T> void createAndVerifyEncodedValue(T testObj) throws EncodingException {
     BasicTypes.EncodedValue encodedValue = protobufSerializationService.encode(testObj);
     if (testObj instanceof byte[]) {
-      assertArrayEquals((byte[]) testObj,
-          (byte[]) protobufSerializationService.decode(encodedValue));
+      try {
+        assertArrayEquals((byte[]) testObj,
+            (byte[]) protobufSerializationService.decode(encodedValue));
+      } catch (org.apache.geode.internal.protocol.protobuf.v1.serialization.exception.DecodingException e) {
+        e.printStackTrace();
+      }
     } else {
-      assertEquals(testObj, protobufSerializationService.decode(encodedValue));
+      try {
+        assertEquals(testObj, protobufSerializationService.decode(encodedValue));
+      } catch (org.apache.geode.internal.protocol.protobuf.v1.serialization.exception.DecodingException e) {
+        e.printStackTrace();
+      }
     }
   }
 }


### PR DESCRIPTION
This adds DecodingException and moves the handling of EncodingException
and this new exception to ProtobufOpsProcessor.



Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
