### PR TITLE
GEODE-4467: Removed instances of singleton usage

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/cache/query/partitioned/PRBasicIndexCreationDeadlockDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/partitioned/PRBasicIndexCreationDeadlockDUnitTest.java
@@ -15,10 +15,10 @@
 package org.apache.geode.cache.query.partitioned;
 
 import static org.apache.geode.cache.query.Utils.createPortfoliosAndPositions;
-import static org.junit.Assert.*;
 
 import java.io.File;
 
+import org.apache.logging.log4j.Logger;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -30,13 +30,12 @@ import org.apache.geode.cache.query.internal.index.IndexUtils;
 import org.apache.geode.cache30.CacheSerializableRunnable;
 import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.cache.PartitionedRegionDUnitTestCase;
+import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.test.dunit.AsyncInvocation;
 import org.apache.geode.test.dunit.Host;
 import org.apache.geode.test.dunit.ThreadUtils;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.Wait;
-import org.apache.geode.test.dunit.cache.internal.JUnit4CacheTestCase;
-import org.apache.geode.test.dunit.internal.JUnit4DistributedTestCase;
 import org.apache.geode.test.junit.categories.DistributedTest;
 
 /**
@@ -46,12 +45,6 @@ import org.apache.geode.test.junit.categories.DistributedTest;
 public class PRBasicIndexCreationDeadlockDUnitTest extends PartitionedRegionDUnitTestCase
 
 {
-  /**
-   * constructor
-   *
-   * @param name
-   */
-
   public PRBasicIndexCreationDeadlockDUnitTest() {
     super();
   }
@@ -68,6 +61,8 @@ public class PRBasicIndexCreationDeadlockDUnitTest extends PartitionedRegionDUni
       vm.invoke(() -> PRQueryDUnitHelper.setCache(getCache()));
     }
   }
+
+  private static final Logger logger = LogService.getLogger();
 
   PRQueryDUnitHelper PRQHelp = new PRQueryDUnitHelper();
 
@@ -121,7 +116,7 @@ public class PRBasicIndexCreationDeadlockDUnitTest extends PartitionedRegionDUni
 
         @Override
         public void run2() throws CacheException {
-          GemFireCacheImpl.getInstance().close();
+          PRQueryDUnitHelper.getCache().close();
         }
       });
 
@@ -129,7 +124,7 @@ public class PRBasicIndexCreationDeadlockDUnitTest extends PartitionedRegionDUni
 
         @Override
         public void run2() throws CacheException {
-          GemFireCacheImpl.getInstance().close();
+          PRQueryDUnitHelper.getCache().close();
         }
       });
 
@@ -228,7 +223,7 @@ public class PRBasicIndexCreationDeadlockDUnitTest extends PartitionedRegionDUni
 
     @Override
     public synchronized void hook(int spot) throws RuntimeException {
-      GemFireCacheImpl.getInstance().getLogger().fine("IndexUtilTestHook is set");
+      logger.debug("IndexUtilTestHook is set");
       switch (spot) {
         case 0:
           hooked = true;

--- a/geode-core/src/test/java/org/apache/geode/cache/query/partitioned/PRColocatedEquiJoinDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/partitioned/PRColocatedEquiJoinDUnitTest.java
@@ -17,8 +17,11 @@
  */
 package org.apache.geode.cache.query.partitioned;
 
-import static org.apache.geode.cache.query.Utils.*;
-import static org.junit.Assert.*;
+import static org.apache.geode.cache.query.Utils.createNewPortfoliosAndPositions;
+import static org.apache.geode.cache.query.Utils.createPortfoliosAndPositions;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -36,7 +39,6 @@ import org.apache.geode.cache.AttributesFactory;
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.CacheClosedException;
 import org.apache.geode.cache.CacheException;
-import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.PartitionAttributes;
 import org.apache.geode.cache.PartitionAttributesFactory;
 import org.apache.geode.cache.Region;
@@ -54,7 +56,6 @@ import org.apache.geode.cache.query.QueryService;
 import org.apache.geode.cache.query.RegionNotFoundException;
 import org.apache.geode.cache.query.SelectResults;
 import org.apache.geode.cache.query.data.Portfolio;
-import org.apache.geode.cache.query.partitioned.PRQueryDUnitHelper.TestQueryFunction;
 import org.apache.geode.cache30.CacheSerializableRunnable;
 import org.apache.geode.distributed.ConfigurationProperties;
 import org.apache.geode.distributed.internal.ReplyException;
@@ -67,8 +68,6 @@ import org.apache.geode.test.dunit.IgnoredException;
 import org.apache.geode.test.dunit.LogWriterUtils;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.Wait;
-import org.apache.geode.test.dunit.cache.internal.JUnit4CacheTestCase;
-import org.apache.geode.test.dunit.internal.JUnit4DistributedTestCase;
 import org.apache.geode.test.junit.categories.DistributedTest;
 import org.apache.geode.test.junit.categories.FlakyTest;
 
@@ -1575,7 +1574,7 @@ public class PRColocatedEquiJoinDUnitTest extends PartitionedRegionDUnitTestCase
 
     @Override
     public void execute(FunctionContext context) {
-      Cache cache = CacheFactory.getAnyInstance();
+      Cache cache = context.getCache();
       QueryService queryService = cache.getQueryService();
       ArrayList allQueryResults = new ArrayList();
       String qstr = (String) context.getArguments();

--- a/geode-core/src/test/java/org/apache/geode/cache/query/partitioned/PRQueryDUnitHelper.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/partitioned/PRQueryDUnitHelper.java
@@ -14,7 +14,10 @@
  */
 package org.apache.geode.cache.query.partitioned;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.Serializable;
@@ -35,7 +38,6 @@ import org.apache.geode.cache.AttributesFactory;
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.CacheClosedException;
 import org.apache.geode.cache.CacheException;
-import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.DataPolicy;
 import org.apache.geode.cache.DiskStore;
 import org.apache.geode.cache.EntryExistsException;
@@ -2446,9 +2448,8 @@ public class PRQueryDUnitHelper implements Serializable {
 
     @Override
     public void execute(FunctionContext context) {
-      Cache cache = CacheFactory.getAnyInstance();
+      Cache cache = context.getCache();
       QueryService queryService = cache.getQueryService();
-      ArrayList allQueryResults = new ArrayList();
       String qstr = (String) context.getArguments();
       try {
         Query query = queryService.newQuery(qstr);


### PR DESCRIPTION
	* Removed CacheFactory.getAnyInstance() from PRQueryDUnitHelper and PRColocatedEquiJoinDUnitTest
	* Removed GemFireCacheImpl.getInstance() from PRBasicIndexCreationDeadlockDUnitTest

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
