### PR TITLE
GEODE-4180: get rid of withTempWorkingDir in ClusterStartupRule

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/AlterCompressorDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/AlterCompressorDUnitTest.java
@@ -17,11 +17,12 @@ package org.apache.geode.management.internal.cli.commands;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.stream.IntStream;
 
-import org.junit.*;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
@@ -29,7 +30,11 @@ import org.w3c.dom.NodeList;
 
 import org.apache.geode.cache.Region;
 import org.apache.geode.distributed.internal.ClusterConfigurationService;
-import org.apache.geode.internal.cache.*;
+import org.apache.geode.internal.cache.CachedDeserializable;
+import org.apache.geode.internal.cache.CachedDeserializableFactory;
+import org.apache.geode.internal.cache.EntryEventImpl;
+import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.RegionEntry;
 import org.apache.geode.management.internal.configuration.domain.Configuration;
 import org.apache.geode.management.internal.configuration.utils.XmlUtils;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
@@ -182,11 +187,7 @@ public class AlterCompressorDUnitTest {
   private void startServers() throws Exception {
     // start server1 and server2 in parallel because they each has a replicate data store on disk
     Arrays.asList(1, 2).parallelStream().forEach(id -> {
-      try {
-        cluster.startServerVM(id, "dataStore", locator.getPort());
-      } catch (IOException e) {
-        throw new RuntimeException(e.getMessage(), e);
-      }
+      cluster.startServerVM(id, "dataStore", locator.getPort());
     });
 
     cluster.startServerVM(3, "accessor", locator.getPort());

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ConnectCommandDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ConnectCommandDUnitTest.java
@@ -17,8 +17,6 @@ package org.apache.geode.management.internal.cli.commands;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Properties;
-
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -41,7 +39,7 @@ public class ConnectCommandDUnitTest {
 
   @Test
   public void useCurrentGfshToConnectToOlderLocator() throws Exception {
-    MemberVM locator = cluster.startLocatorVM(0, new Properties(), VersionManager.GEODE_130);
+    MemberVM locator = cluster.startLocatorVM(0, VersionManager.GEODE_130);
 
     gfsh.executeAndAssertThat("connect --jmx-manager=localhost[" + locator.getJmxPort() + "]")
         .statusIsError().containsOutput("Cannot use a")

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateAsyncEventQueueCommandDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateAsyncEventQueueCommandDUnitTest.java
@@ -49,7 +49,7 @@ public class CreateAsyncEventQueueCommandDUnitTest {
 
   @Test
   public void createQueueWithInvalidClass() throws Exception {
-    server = lsRule.startServerAsJmxManager(0);
+    server = lsRule.startServerVM(0, x -> x.withJMXManager());
     gfsh.connectAndVerify(server.getJmxPort(), GfshCommandRule.PortType.jmxManager);
     IgnoredException.addIgnoredException("java.lang.ClassNotFoundException: xyz");
     gfsh.executeAndAssertThat(COMMAND + " --id=queue --listener=xyz").statusIsError()
@@ -59,7 +59,7 @@ public class CreateAsyncEventQueueCommandDUnitTest {
 
   @Test
   public void createQueueWithoutCC() throws Exception {
-    server = lsRule.startServerAsJmxManager(0);
+    server = lsRule.startServerVM(0, x -> x.withJMXManager());
     gfsh.connectAndVerify(server.getJmxPort(), GfshCommandRule.PortType.jmxManager);
     gfsh.executeAndAssertThat(VALID_COMMAND + " --id=queue").statusIsSuccess()
         .containsOutput("This change is not persisted in the cluster configuration")

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateDefinedIndexesCommandDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateDefinedIndexesCommandDUnitTest.java
@@ -17,8 +17,6 @@ package org.apache.geode.management.internal.cli.commands;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Properties;
-
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -28,7 +26,6 @@ import org.junit.rules.TestName;
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.query.QueryService;
-import org.apache.geode.distributed.ConfigurationProperties;
 import org.apache.geode.distributed.Locator;
 import org.apache.geode.distributed.internal.ClusterConfigurationService;
 import org.apache.geode.distributed.internal.InternalLocator;
@@ -57,12 +54,7 @@ public class CreateDefinedIndexesCommandDUnitTest {
     locator = clusterStartupRule.startLocatorVM(0);
     server1 = clusterStartupRule.startServerVM(1, locator.getPort());
     server2 = clusterStartupRule.startServerVM(2, locator.getPort());
-
-    Properties server3Properties = new Properties();
-    server3Properties.setProperty(ConfigurationProperties.LOCATORS,
-        "localhost[" + locator.getPort() + "]");
-    server3Properties.setProperty(ConfigurationProperties.GROUPS, "group1");
-    server3 = clusterStartupRule.startServerVM(3, server3Properties);
+    server3 = clusterStartupRule.startServerVM(3, "group1", locator.getPort());
 
     gfsh.connectAndVerify(locator);
     gfsh.executeAndAssertThat("clear defined indexes").statusIsSuccess()

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DiskStoreCommandsDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DiskStoreCommandsDUnitTest.java
@@ -137,9 +137,7 @@ public class DiskStoreCommandsDUnitTest {
 
   @Test
   public void testDescribeOfflineDiskStoreCommand() throws Exception {
-    Properties props = new Properties();
-    props.setProperty("groups", GROUP);
-    MemberVM server1 = rule.startServerAsJmxManager(0, props);
+    MemberVM server1 = rule.startServerVM(0, x -> x.withJMXManager().withProperty("groups", GROUP));
 
     gfsh.connectAndVerify(server1.getJmxPort(), GfshCommandRule.PortType.jmxManager);
 
@@ -165,9 +163,7 @@ public class DiskStoreCommandsDUnitTest {
 
   @Test
   public void testExportOfflineDiskStore() throws Exception {
-    Properties props = new Properties();
-    props.setProperty("groups", GROUP);
-    MemberVM server1 = rule.startServerAsJmxManager(0, props);
+    MemberVM server1 = rule.startServerVM(0, x -> x.withJMXManager().withProperty("groups", GROUP));
 
     gfsh.connectAndVerify(server1.getJmxPort(), GfshCommandRule.PortType.jmxManager);
 

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ExportLogsOnServerManagerDUnit.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ExportLogsOnServerManagerDUnit.java
@@ -61,7 +61,7 @@ public class ExportLogsOnServerManagerDUnit {
 
   @Test
   public void testExportWithPeerLocator() throws Exception {
-    MemberVM server0 = lsRule.startServerVM(0, x -> x.withEmbeddedLocator());
+    MemberVM server0 = lsRule.startServerVM(0, x -> x.withEmbeddedLocator().withJMXManager());
     lsRule.startServerVM(1, server0.getEmbeddedLocatorPort());
     gfshConnector.connect(server0.getEmbeddedLocatorPort(), GfshCommandRule.PortType.locator);
     gfshConnector.executeAndAssertThat("export logs").statusIsSuccess();

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ExportLogsOnServerManagerDUnit.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ExportLogsOnServerManagerDUnit.java
@@ -16,7 +16,6 @@
 package org.apache.geode.management.internal.cli.commands;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -38,14 +37,14 @@ import org.apache.geode.test.junit.rules.GfshCommandRule;
 public class ExportLogsOnServerManagerDUnit {
 
   @Rule
-  public ClusterStartupRule lsRule = new ClusterStartupRule().withTempWorkingDir().withLogFile();
+  public ClusterStartupRule lsRule = new ClusterStartupRule().withLogFile();
 
   @Rule
   public GfshCommandRule gfshConnector = new GfshCommandRule();
 
   @Test
   public void testExportWithOneServer() throws Exception {
-    MemberVM server0 = lsRule.startServerAsJmxManager(0);
+    MemberVM server0 = lsRule.startServerVM(0, x -> x.withJMXManager());
     gfshConnector.connect(server0.getJmxPort(), GfshCommandRule.PortType.jmxManager);
     gfshConnector.executeAndAssertThat("export logs").statusIsSuccess();
 
@@ -62,7 +61,7 @@ public class ExportLogsOnServerManagerDUnit {
 
   @Test
   public void testExportWithPeerLocator() throws Exception {
-    MemberVM server0 = lsRule.startServerAsEmbeddedLocator(0);
+    MemberVM server0 = lsRule.startServerVM(0, x -> x.withEmbeddedLocator());
     lsRule.startServerVM(1, server0.getEmbeddedLocatorPort());
     gfshConnector.connect(server0.getEmbeddedLocatorPort(), GfshCommandRule.PortType.locator);
     gfshConnector.executeAndAssertThat("export logs").statusIsSuccess();

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ExportLogsStatsDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ExportLogsStatsDUnitTest.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.management.internal.cli.commands;
 
+import static java.util.stream.Collectors.toSet;
 import static org.apache.geode.distributed.ConfigurationProperties.STATISTIC_ARCHIVE_FILE;
 import static org.apache.geode.management.internal.cli.commands.ExportLogsCommand.ONLY_DATE_FORMAT;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -87,7 +88,10 @@ public class ExportLogsStatsDUnitTest {
     Set<String> expectedFiles = Sets.newHashSet("locator-0/locator-0.log", "server-1/server-1.log",
         "server-1/statistics.gfs");
     assertThat(actualZipEnries).containsAll(expectedFiles);
-    assertThat(actualZipEnries).hasSize(4);
+    // remove pulse.log if present
+    actualZipEnries =
+        actualZipEnries.stream().filter(x -> !x.endsWith("pulse.log")).collect(toSet());
+    assertThat(actualZipEnries).hasSize(3);
   }
 
   @Test
@@ -99,7 +103,10 @@ public class ExportLogsStatsDUnitTest {
 
     Set<String> expectedFiles = Sets.newHashSet("locator-0/locator-0.log", "server-1/server-1.log");
     assertThat(actualZipEnries).containsAll(expectedFiles);
-    assertThat(actualZipEnries).hasSize(3);
+    // remove pulse.log if present
+    actualZipEnries =
+        actualZipEnries.stream().filter(x -> !x.endsWith("pulse.log")).collect(toSet());
+    assertThat(actualZipEnries).hasSize(2);
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ExportLogsStatsDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ExportLogsStatsDUnitTest.java
@@ -15,13 +15,9 @@
 
 package org.apache.geode.management.internal.cli.commands;
 
-import static org.apache.geode.distributed.ConfigurationProperties.HTTP_SERVICE_BIND_ADDRESS;
-import static org.apache.geode.distributed.ConfigurationProperties.HTTP_SERVICE_PORT;
-import static org.apache.geode.distributed.ConfigurationProperties.JMX_MANAGER_PORT;
 import static org.apache.geode.distributed.ConfigurationProperties.STATISTIC_ARCHIVE_FILE;
 import static org.apache.geode.management.internal.cli.commands.ExportLogsCommand.ONLY_DATE_FORMAT;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
@@ -42,7 +38,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import org.apache.geode.distributed.ConfigurationProperties;
-import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.management.cli.Result;
 import org.apache.geode.management.internal.cli.result.CommandResult;
 import org.apache.geode.management.internal.cli.util.CommandStringBuilder;
@@ -59,22 +54,13 @@ public class ExportLogsStatsDUnitTest {
   @ClassRule
   public static GfshCommandRule connector = new GfshCommandRule();
 
-  protected static int jmxPort, httpPort;
   protected static Set<String> expectedZipEntries = new HashSet<>();
   protected static MemberVM locator;
 
   @BeforeClass
   public static void beforeClass() {
-    int[] ports = AvailablePortHelper.getRandomAvailableTCPPorts(2);
-    httpPort = ports[0];
-    jmxPort = ports[1];
-    Properties locatorProperties = new Properties();
-    locatorProperties.setProperty(HTTP_SERVICE_BIND_ADDRESS, "localhost");
-    locatorProperties.setProperty(HTTP_SERVICE_PORT, httpPort + "");
-    locatorProperties.setProperty(JMX_MANAGER_PORT, jmxPort + "");
-
     // start the locator in vm0 and then connect to it over http
-    locator = lsRule.startLocatorVM(0, locatorProperties);
+    locator = lsRule.startLocatorVM(0);
 
     Properties serverProperties = new Properties();
     serverProperties.setProperty(ConfigurationProperties.STATISTIC_SAMPLING_ENABLED, "true");
@@ -101,7 +87,7 @@ public class ExportLogsStatsDUnitTest {
     Set<String> expectedFiles = Sets.newHashSet("locator-0/locator-0.log", "server-1/server-1.log",
         "server-1/statistics.gfs");
     assertThat(actualZipEnries).containsAll(expectedFiles);
-    assertEquals(actualZipEnries.size(), 4);
+    assertThat(actualZipEnries).hasSize(4);
   }
 
   @Test
@@ -113,7 +99,7 @@ public class ExportLogsStatsDUnitTest {
 
     Set<String> expectedFiles = Sets.newHashSet("locator-0/locator-0.log", "server-1/server-1.log");
     assertThat(actualZipEnries).containsAll(expectedFiles);
-    assertEquals(actualZipEnries.size(), 3);
+    assertThat(actualZipEnries).hasSize(3);
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ExportLogsStatsDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ExportLogsStatsDUnitTest.java
@@ -54,8 +54,7 @@ import org.apache.geode.test.junit.rules.GfshCommandRule;
 @Category(DistributedTest.class)
 public class ExportLogsStatsDUnitTest {
   @ClassRule
-  public static ClusterStartupRule lsRule =
-      new ClusterStartupRule().withTempWorkingDir().withLogFile();
+  public static ClusterStartupRule lsRule = new ClusterStartupRule().withLogFile();
 
   @ClassRule
   public static GfshCommandRule connector = new GfshCommandRule();
@@ -65,7 +64,7 @@ public class ExportLogsStatsDUnitTest {
   protected static MemberVM locator;
 
   @BeforeClass
-  public static void beforeClass() throws Exception {
+  public static void beforeClass() {
     int[] ports = AvailablePortHelper.getRandomAvailableTCPPorts(2);
     httpPort = ports[0];
     jmxPort = ports[1];
@@ -156,6 +155,7 @@ public class ExportLogsStatsDUnitTest {
   }
 
   private static Set<String> getZipEntries(String zipFilePath) throws IOException {
-    return new ZipFile(zipFilePath).stream().map(ZipEntry::getName).collect(Collectors.toSet());
+    return new ZipFile(zipFilePath).stream().map(ZipEntry::getName)
+        .filter(x -> !x.endsWith("views.log")).collect(Collectors.toSet());
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ExportLogsWithMemberGroupDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ExportLogsWithMemberGroupDUnitTest.java
@@ -46,8 +46,7 @@ import org.apache.geode.test.junit.rules.GfshCommandRule;
 @Category(DistributedTest.class)
 public class ExportLogsWithMemberGroupDUnitTest {
   @ClassRule
-  public static ClusterStartupRule lsRule =
-      new ClusterStartupRule().withTempWorkingDir().withLogFile();
+  public static ClusterStartupRule lsRule = new ClusterStartupRule().withLogFile();
 
   @ClassRule
   public static GfshCommandRule connector = new GfshCommandRule();
@@ -132,6 +131,7 @@ public class ExportLogsWithMemberGroupDUnitTest {
   }
 
   private static Set<String> getZipEntries(String zipFilePath) throws IOException {
-    return new ZipFile(zipFilePath).stream().map(ZipEntry::getName).collect(Collectors.toSet());
+    return new ZipFile(zipFilePath).stream().map(ZipEntry::getName)
+        .filter(x -> !x.endsWith("views.log")).collect(Collectors.toSet());
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/IndexCommandsShareConfigurationDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/IndexCommandsShareConfigurationDUnitTest.java
@@ -15,7 +15,6 @@
 package org.apache.geode.management.internal.cli.commands;
 
 import static org.apache.geode.distributed.ConfigurationProperties.ENABLE_CLUSTER_CONFIGURATION;
-import static org.apache.geode.distributed.ConfigurationProperties.GROUPS;
 import static org.apache.geode.distributed.ConfigurationProperties.HTTP_SERVICE_PORT;
 import static org.apache.geode.distributed.ConfigurationProperties.JMX_MANAGER;
 import static org.apache.geode.distributed.ConfigurationProperties.JMX_MANAGER_PORT;
@@ -84,13 +83,10 @@ public class IndexCommandsShareConfigurationDUnitTest {
     locatorProps.setProperty(JMX_MANAGER_PORT, String.valueOf(jmxPort));
     locatorProps.setProperty(HTTP_SERVICE_PORT, String.valueOf(httpPort));
 
-    locator = startupRule.startLocatorVM(0, locatorProps);
+    locator = startupRule.startLocatorVM(0, x -> x.withProperties(locatorProps));
 
     gfsh.connectAndVerify(locator.getJmxPort(), GfshCommandRule.PortType.jmxManager);
-
-    Properties props = new Properties();
-    props.setProperty(GROUPS, groupName);
-    serverVM = startupRule.startServerVM(1, props, locator.getPort());
+    serverVM = startupRule.startServerVM(1, groupName, locator.getPort());
     serverVM.invoke(() -> {
       InternalCache cache = ClusterStartupRule.getCache();
       Region parReg =
@@ -142,10 +138,7 @@ public class IndexCommandsShareConfigurationDUnitTest {
 
     // Restart the data member cache to make sure that the index is destroyed.
     startupRule.stopVM(1);
-
-    Properties props = new Properties();
-    props.setProperty(GROUPS, groupName);
-    serverVM = startupRule.startServerVM(1, props, locator.getPort());
+    serverVM = startupRule.startServerVM(1, groupName, locator.getPort());
 
     serverVM.invoke(() -> {
       InternalCache restartedCache = ClusterStartupRule.getCache();

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/util/MergeLogsDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/util/MergeLogsDUnitTest.java
@@ -56,11 +56,8 @@ public class MergeLogsDUnitTest {
     properties.setProperty(DistributionConfig.LOG_LEVEL_NAME, "info");
     locator = lsRule.startLocatorVM(0, properties);
 
-    properties.setProperty(DistributionConfig.LOCATORS_NAME,
-        "localhost[" + locator.getPort() + "]");
-
-    MemberVM server = lsRule.startServerVM(1, properties);
-    MemberVM server2 = lsRule.startServerVM(2, properties);
+    MemberVM server = lsRule.startServerVM(1, properties, locator.getPort());
+    MemberVM server2 = lsRule.startServerVM(2, properties, locator.getPort());
 
     locator.invoke(() -> LogService.getLogger().info(MESSAGE_1));
     server.invoke(() -> LogService.getLogger().info(MESSAGE_2));

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/util/MergeLogsDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/util/MergeLogsDUnitTest.java
@@ -17,12 +17,14 @@
 package org.apache.geode.management.internal.cli.util;
 
 import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Properties;
 
 import org.apache.commons.io.FileUtils;
@@ -70,7 +72,11 @@ public class MergeLogsDUnitTest {
 
   @Test
   public void testExportInProcess() throws Exception {
-    assertThat(MergeLogs.findLogFilesToMerge(lsRule.getWorkingDirRoot())).hasSize(6);
+    List<File> actualFiles = MergeLogs.findLogFilesToMerge(lsRule.getWorkingDirRoot());
+    // remove pulse.log if present
+    actualFiles =
+        actualFiles.stream().filter(x -> !x.getName().endsWith("pulse.log")).collect(toList());
+    assertThat(actualFiles).hasSize(5);
 
     File result = MergeLogs.mergeLogFile(lsRule.getWorkingDirRoot().getCanonicalPath());
     assertOnLogContents(result);
@@ -78,7 +84,11 @@ public class MergeLogsDUnitTest {
 
   @Test
   public void testExportInNewProcess() throws Throwable {
-    assertThat(MergeLogs.findLogFilesToMerge(lsRule.getWorkingDirRoot())).hasSize(6);
+    List<File> actualFiles = MergeLogs.findLogFilesToMerge(lsRule.getWorkingDirRoot());
+    // remove pulse.log if present
+    actualFiles =
+        actualFiles.stream().filter(x -> !x.getName().endsWith("pulse.log")).collect(toList());
+    assertThat(actualFiles).hasSize(5);
 
     MergeLogs.mergeLogsInNewProcess(lsRule.getWorkingDirRoot().toPath());
     File result = Arrays.stream(lsRule.getWorkingDirRoot().listFiles())

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/util/MergeLogsDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/util/MergeLogsDUnitTest.java
@@ -40,7 +40,7 @@ import org.apache.geode.test.junit.categories.DistributedTest;
 @Category(DistributedTest.class)
 public class MergeLogsDUnitTest {
   @Rule
-  public ClusterStartupRule lsRule = new ClusterStartupRule().withTempWorkingDir().withLogFile();
+  public ClusterStartupRule lsRule = new ClusterStartupRule().withLogFile();
   private MemberVM locator;
 
   private static final String MESSAGE_1 = "MergeLogsMessage1";
@@ -73,18 +73,18 @@ public class MergeLogsDUnitTest {
 
   @Test
   public void testExportInProcess() throws Exception {
-    assertThat(MergeLogs.findLogFilesToMerge(lsRule.getTempWorkingDir().getRoot())).hasSize(4);
+    assertThat(MergeLogs.findLogFilesToMerge(lsRule.getWorkingDirRoot())).hasSize(6);
 
-    File result = MergeLogs.mergeLogFile(lsRule.getTempWorkingDir().getRoot().getCanonicalPath());
+    File result = MergeLogs.mergeLogFile(lsRule.getWorkingDirRoot().getCanonicalPath());
     assertOnLogContents(result);
   }
 
   @Test
   public void testExportInNewProcess() throws Throwable {
-    assertThat(MergeLogs.findLogFilesToMerge(lsRule.getTempWorkingDir().getRoot())).hasSize(4);
+    assertThat(MergeLogs.findLogFilesToMerge(lsRule.getWorkingDirRoot())).hasSize(6);
 
-    MergeLogs.mergeLogsInNewProcess(lsRule.getTempWorkingDir().getRoot().toPath());
-    File result = Arrays.stream(lsRule.getTempWorkingDir().getRoot().listFiles())
+    MergeLogs.mergeLogsInNewProcess(lsRule.getWorkingDirRoot().toPath());
+    File result = Arrays.stream(lsRule.getWorkingDirRoot().listFiles())
         .filter((File f) -> f.getName().startsWith("merge")).findFirst().orElseThrow(() -> {
           throw new AssertionError("No merged log file found");
         });

--- a/geode-core/src/test/java/org/apache/geode/management/internal/configuration/ClusterConfigStartMemberDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/configuration/ClusterConfigStartMemberDUnitTest.java
@@ -19,7 +19,6 @@ import static org.apache.geode.distributed.ConfigurationProperties.CLUSTER_CONFI
 import static org.apache.geode.distributed.ConfigurationProperties.ENABLE_CLUSTER_CONFIGURATION;
 import static org.apache.geode.distributed.ConfigurationProperties.GROUPS;
 import static org.apache.geode.distributed.ConfigurationProperties.LOAD_CLUSTER_CONFIGURATION_FROM_DIR;
-import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 
 import java.io.File;
 import java.util.Properties;
@@ -44,9 +43,7 @@ public class ClusterConfigStartMemberDUnitTest extends ClusterConfigTestBase {
 
   @Test
   public void testStartLocator() throws Exception {
-    locatorProps.setProperty(LOCATORS, "localhost[" + locator.getPort() + "]");
-    MemberVM secondLocator = lsRule.startLocatorVM(1, locatorProps);
-
+    MemberVM secondLocator = lsRule.startLocatorVM(1, locator.getPort());
     REPLICATED_CONFIG_FROM_ZIP.verify(secondLocator);
   }
 

--- a/geode-core/src/test/java/org/apache/geode/management/internal/configuration/ClusterConfigWithSecurityDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/configuration/ClusterConfigWithSecurityDUnitTest.java
@@ -62,10 +62,8 @@ public class ClusterConfigWithSecurityDUnitTest {
   @Before
   public void before() throws Exception {
     clusterConfigZipPath = buildSecureClusterConfigZip();
-
-    locatorProps = new Properties();
-    locatorProps.setProperty(SECURITY_MANAGER, SimpleTestSecurityManager.class.getName());
-    locator0 = lsRule.startLocatorVM(0, locatorProps);
+    locator0 =
+        lsRule.startLocatorVM(0, x -> x.withSecurityManager(SimpleTestSecurityManager.class));
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/management/internal/security/MultiGfshDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/security/MultiGfshDUnitTest.java
@@ -14,12 +14,10 @@
  */
 package org.apache.geode.management.internal.security;
 
-import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_MANAGER;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
 import java.util.List;
-import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 import org.awaitility.Awaitility;
@@ -56,9 +54,8 @@ public class MultiGfshDUnitTest {
 
   @Before
   public void setup() throws Exception {
-    Properties properties = new Properties();
-    properties.put(SECURITY_MANAGER, SimpleTestSecurityManager.class.getName());
-    server = lsRule.startServerAsJmxManager(0, properties);
+    server = lsRule.startServerVM(0,
+        x -> x.withJMXManager().withSecurityManager(SimpleTestSecurityManager.class));
   }
 
   @Category(FlakyTest.class) // GEODE-1579

--- a/geode-core/src/test/java/org/apache/geode/test/dunit/rules/ClusterStartupRule.java
+++ b/geode-core/src/test/java/org/apache/geode/test/dunit/rules/ClusterStartupRule.java
@@ -17,32 +17,25 @@
 package org.apache.geode.test.dunit.rules;
 
 import static org.apache.geode.distributed.ConfigurationProperties.GROUPS;
-import static org.apache.geode.distributed.ConfigurationProperties.JMX_MANAGER_PORT;
-import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
-import static org.apache.geode.distributed.ConfigurationProperties.NAME;
 import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_CLIENT_AUTH_INIT;
 import static org.apache.geode.test.dunit.Host.getHost;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
+import java.util.function.UnaryOperator;
 
+import org.apache.commons.io.FileUtils;
 import org.junit.rules.ExternalResource;
-import org.junit.rules.TemporaryFolder;
 
-import org.apache.geode.cache.Region;
 import org.apache.geode.cache.client.ClientCache;
 import org.apache.geode.cache.client.ClientCacheFactory;
-import org.apache.geode.cache.client.ClientRegionShortcut;
 import org.apache.geode.cache.server.CacheServer;
 import org.apache.geode.distributed.internal.InternalLocator;
-import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.security.templates.UserPasswordAuthInit;
 import org.apache.geode.test.dunit.VM;
@@ -56,7 +49,6 @@ import org.apache.geode.test.junit.rules.MemberStarterRule;
 import org.apache.geode.test.junit.rules.Server;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 import org.apache.geode.test.junit.rules.VMProvider;
-import org.apache.geode.test.junit.rules.serializable.SerializableTemporaryFolder;
 
 
 /**
@@ -87,7 +79,6 @@ public class ClusterStartupRule extends ExternalResource implements Serializable
   private DistributedRestoreSystemProperties restoreSystemProperties =
       new DistributedRestoreSystemProperties();
 
-  private TemporaryFolder tempWorkingDir;
   private Map<Integer, VMProvider> occupiedVMs;
 
   private boolean logFile = false;
@@ -101,30 +92,6 @@ public class ClusterStartupRule extends ExternalResource implements Serializable
   }
 
   /**
-   * This will use a temporary folder to hold all the vm directories instead of using dunit folder.
-   * It will set each VM's working dir to its respective sub-directories.
-   *
-   * use this if you want to examine each member's file system without worrying about it's being
-   * contaminated with DUnitLauncher's log files that exists in each dunit/vm folder such as
-   * locatorxxxView.dat and locatorxxxviews.log and other random log files.
-   *
-   * If the product code is doing new File(".") or new File("relative-path.log"), it will still
-   * pointing to the a File under the old CWD. So avoid using relative path and always use absolute
-   * path or with a parent dir when creating new File object.
-   *
-   * But this will cause the VMs to be bounced after test is done, because it dynamically changes
-   * the user.dir system property, causing slow running tests. Use with discretion.
-   */
-  public ClusterStartupRule withTempWorkingDir() {
-    tempWorkingDir = new SerializableTemporaryFolder();
-    return this;
-  }
-
-  public boolean useTempWorkingDir() {
-    return tempWorkingDir != null;
-  }
-
-  /**
    * this will allow all the logs go into log files instead of going into the console output
    */
   public ClusterStartupRule withLogFile() {
@@ -135,9 +102,6 @@ public class ClusterStartupRule extends ExternalResource implements Serializable
   @Override
   protected void before() throws Throwable {
     restoreSystemProperties.before();
-    if (useTempWorkingDir()) {
-      tempWorkingDir.create();
-    }
     occupiedVMs = new HashMap<>();
   }
 
@@ -151,174 +115,92 @@ public class ClusterStartupRule extends ExternalResource implements Serializable
       // stop all the clientsVM before stop all the memberVM
       occupiedVMs.values().forEach(x -> x.stopVM(true));
 
-      if (useTempWorkingDir()) {
-        tempWorkingDir.delete();
-      }
+      // delete any file under root dir
+      Arrays.stream(getWorkingDirRoot().listFiles()).filter(File::isFile)
+          .forEach(FileUtils::deleteQuietly);
+
       restoreSystemProperties.after();
     }
   }
 
-  /**
-   * Starts a locator instance with the given configuration properties inside
-   * {@code getHost(0).getVM(index)}.
-   *
-   * @return VM locator vm
-   */
-  public MemberVM startLocatorVM(int index, Properties specifiedProperties, String version)
-      throws Exception {
-    Properties properties = new Properties();
-    properties.putAll(specifiedProperties);
+  public MemberVM startLocatorVM(int index, int... locatorPort) {
+    return startLocatorVM(index, x -> x.withConnectionToLocator(locatorPort));
+  }
 
-    String defaultName = "locator-" + index;
-    properties.putIfAbsent(NAME, defaultName);
-    String name = properties.getProperty(NAME);
+  public MemberVM startLocatorVM(int index, Properties properties, int... locatorPort) {
+    return startLocatorVM(index,
+        x -> x.withProperties(properties).withConnectionToLocator(locatorPort));
+  }
 
+  public MemberVM startLocatorVM(int index, String version) {
+    return startLocatorVM(index, version, x -> x);
+  }
+
+  public MemberVM startLocatorVM(int index,
+      SerializableFunction1<LocatorStarterRule> ruleOperator) {
+    return startLocatorVM(index, VersionManager.CURRENT_VERSION, ruleOperator);
+  }
+
+  public MemberVM startLocatorVM(int index, String version,
+      SerializableFunction1<LocatorStarterRule> ruleOperator) {
+    final String defaultName = "locator-" + index;
     VM locatorVM = getVM(index, version);
-    Locator locator = locatorVM.invoke(() -> {
+    Locator server = locatorVM.invoke(() -> {
       memberStarter = new LocatorStarterRule();
       LocatorStarterRule locatorStarter = (LocatorStarterRule) memberStarter;
-      if (useTempWorkingDir()) {
-        File workingDirFile = createWorkingDirForMember(name);
-        locatorStarter.withWorkingDir(workingDirFile);
-      }
       if (logFile) {
         locatorStarter.withLogFile();
       }
-      locatorStarter.withProperties(properties).withAutoStart();
+      ruleOperator.apply(locatorStarter);
+      locatorStarter.withName(defaultName);
+      locatorStarter.withAutoStart();
       locatorStarter.before();
       return locatorStarter;
     });
-    MemberVM memberVM = new MemberVM(locator, locatorVM, useTempWorkingDir());
+
+    MemberVM memberVM = new MemberVM(server, locatorVM);
     occupiedVMs.put(index, memberVM);
     return memberVM;
   }
 
-  public MemberVM startLocatorVM(int index, Properties specifiedProperties) throws Exception {
-    return startLocatorVM(index, specifiedProperties, VersionManager.CURRENT_VERSION);
+  public MemberVM startServerVM(int index, int... locatorPort) {
+    return startServerVM(index, x -> x.withConnectionToLocator(locatorPort));
   }
 
-  public MemberVM startLocatorVM(int index, int... locatorPort) throws Exception {
-    Properties properties = new Properties();
-    String locators = Arrays.stream(locatorPort).mapToObj(i -> "localhost[" + i + "]")
-        .collect(Collectors.joining(","));
-    properties.setProperty(LOCATORS, locators);
-    return startLocatorVM(index, properties);
+  public MemberVM startServerVM(int index, String group, int... locatorPort) {
+    return startServerVM(index,
+        x -> x.withConnectionToLocator(locatorPort).withProperty(GROUPS, group));
   }
 
-  public MemberVM startLocatorVM(int index) throws Exception {
-    return startLocatorVM(index, new Properties());
+  public MemberVM startServerVM(int index, Properties properties, int... locatorPort) {
+    return startServerVM(index,
+        x -> x.withProperties(properties).withConnectionToLocator(locatorPort));
   }
 
-  /**
-   * Starts a cache server with given properties
-   */
-  public MemberVM startServerVM(int index, Properties specifiedProperties, int locatorPort,
-      String version) throws IOException {
-    Properties properties = new Properties();
-    properties.putAll(specifiedProperties);
+  public MemberVM startServerVM(int index, SerializableFunction1<ServerStarterRule> ruleOperator) {
+    return startServerVM(index, VersionManager.CURRENT_VERSION, ruleOperator);
+  }
 
-    String defaultName = "server-" + index;
-    properties.putIfAbsent(NAME, defaultName);
-    String name = properties.getProperty(NAME);
-
+  public MemberVM startServerVM(int index, String version,
+      SerializableFunction1<ServerStarterRule> ruleOperator) {
+    final String defaultName = "server-" + index;
     VM serverVM = getVM(index, version);
     Server server = serverVM.invoke(() -> {
       memberStarter = new ServerStarterRule();
       ServerStarterRule serverStarter = (ServerStarterRule) memberStarter;
-      if (useTempWorkingDir()) {
-        File workingDirFile = createWorkingDirForMember(name);
-        serverStarter.withWorkingDir(workingDirFile);
-      }
       if (logFile) {
         serverStarter.withLogFile();
       }
-      serverStarter.withProperties(properties).withConnectionToLocator(locatorPort).withAutoStart();
+      ruleOperator.apply(serverStarter);
+      serverStarter.withName(defaultName);
+      serverStarter.withAutoStart();
       serverStarter.before();
       return serverStarter;
     });
 
-    MemberVM memberVM = new MemberVM(server, serverVM, useTempWorkingDir());
+    MemberVM memberVM = new MemberVM(server, serverVM);
     occupiedVMs.put(index, memberVM);
     return memberVM;
-  }
-
-  public MemberVM startServerVM(int index, Properties specifiedProperties, int locatorPort)
-      throws IOException {
-    return startServerVM(index, specifiedProperties, locatorPort, VersionManager.CURRENT_VERSION);
-  }
-
-  public MemberVM startServerVM(int index, String group, int locatorPort) throws IOException {
-    Properties properties = new Properties();
-    properties.put(GROUPS, group);
-    return startServerVM(index, properties, locatorPort);
-  }
-
-  public MemberVM startServerVM(int index, int locatorPort) throws IOException {
-    return startServerVM(index, new Properties(), locatorPort);
-  }
-
-  public MemberVM startServerVM(int index, Properties properties) throws IOException {
-    return startServerVM(index, properties, -1);
-  }
-
-  public MemberVM startServerVM(int index) throws IOException {
-    return startServerVM(index, new Properties(), -1);
-  }
-
-  /**
-   * Starts a cache server with given properties, plus an available port for a JMX manager
-   */
-  public MemberVM startServerAsJmxManager(int index, Properties properties) throws IOException {
-    properties.setProperty(JMX_MANAGER_PORT, AvailablePortHelper.getRandomAvailableTCPPort() + "");
-    return startServerVM(index, properties, -1);
-  }
-
-  public MemberVM startServerAsJmxManager(int index) throws IOException {
-    return startServerAsJmxManager(index, new Properties());
-  }
-
-  /**
-   * Starts a cache server with given properties. Additionally, start the server with a JMX manager
-   * and embedded locator.
-   */
-  public MemberVM startServerAsEmbeddedLocator(int index, Properties specifiedProperties,
-      String version) throws IOException {
-    Properties properties = new Properties();
-    properties.putAll(specifiedProperties);
-
-    String defaultName = "server-" + index;
-    properties.putIfAbsent(NAME, defaultName);
-    String name = properties.getProperty(NAME);
-
-    VM serverVM = getVM(index, version);
-    Server server = serverVM.invoke(() -> {
-      memberStarter = new ServerStarterRule();
-      ServerStarterRule serverStarter = (ServerStarterRule) memberStarter;
-      if (useTempWorkingDir()) {
-        File workingDirFile = createWorkingDirForMember(name);
-        serverStarter.withWorkingDir(workingDirFile);
-      }
-      if (logFile) {
-        serverStarter.withLogFile();
-      }
-      serverStarter.withEmbeddedLocator().withProperties(properties).withName(name).withJMXManager()
-          .withAutoStart();
-      serverStarter.before();
-      return serverStarter;
-    });
-
-    MemberVM memberVM = new MemberVM(server, serverVM, useTempWorkingDir());
-    occupiedVMs.put(index, memberVM);
-    return memberVM;
-  }
-
-  public MemberVM startServerAsEmbeddedLocator(int index, Properties properties)
-      throws IOException {
-    return startServerAsEmbeddedLocator(index, properties, VersionManager.CURRENT_VERSION);
-  }
-
-  public MemberVM startServerAsEmbeddedLocator(int index) throws IOException {
-    return startServerAsEmbeddedLocator(index, new Properties());
   }
 
   /**
@@ -420,14 +302,7 @@ public class ClusterStartupRule extends ExternalResource implements Serializable
     member.stopVM(cleanWorkingDir);
   }
 
-  public TemporaryFolder getTempWorkingDir() {
-    return tempWorkingDir;
-  }
-
   public File getWorkingDirRoot() {
-    if (useTempWorkingDir())
-      return tempWorkingDir.getRoot();
-
     // return the dunit folder
     return new File(DUnitLauncher.DUNIT_DIR);
   }
@@ -443,12 +318,6 @@ public class ClusterStartupRule extends ExternalResource implements Serializable
     }
   }
 
-  private File createWorkingDirForMember(String dirName) throws IOException {
-    File workingDir = new File(tempWorkingDir.getRoot(), dirName).getAbsoluteFile();
-    if (!workingDir.exists()) {
-      tempWorkingDir.newFolder(dirName);
-    }
-
-    return workingDir;
+  public interface SerializableFunction1<T> extends UnaryOperator<T>, Serializable {
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/test/dunit/rules/MemberVM.java
+++ b/geode-core/src/test/java/org/apache/geode/test/dunit/rules/MemberVM.java
@@ -29,16 +29,10 @@ import org.apache.geode.test.junit.rules.VMProvider;
 public class MemberVM extends VMProvider implements Member {
   protected Member member;
   protected VM vm;
-  protected boolean tempWorkingDir;
 
   public MemberVM(Member member, VM vm) {
-    this(member, vm, false);
-  }
-
-  public MemberVM(Member member, VM vm, boolean tempWorkingDir) {
     this.member = member;
     this.vm = vm;
-    this.tempWorkingDir = tempWorkingDir;
   }
 
   public boolean isLocator() {
@@ -55,8 +49,6 @@ public class MemberVM extends VMProvider implements Member {
 
   @Override
   public File getWorkingDir() {
-    if (tempWorkingDir)
-      return member.getWorkingDir();
     return vm.getWorkingDirectory();
   }
 
@@ -87,6 +79,7 @@ public class MemberVM extends VMProvider implements Member {
     return ((Server) member).getEmbeddedLocatorPort();
   }
 
+  @Override
   public void stopVM(boolean cleanWorkingDir) {
     super.stopVM(cleanWorkingDir);
 
@@ -94,18 +87,9 @@ public class MemberVM extends VMProvider implements Member {
       return;
     }
 
-    if (tempWorkingDir) {
-      /*
-       * this temporary workingDir will dynamically change the "user.dir". system property to point
-       * to a temporary folder. The Path API caches the first value of "user.dir" that it sees, and
-       * this can result in a stale cached value of "user.dir" which points to a directory that no
-       * longer exists.
-       */
-      vm.bounce();
-    } else
-      // if using the dunit/vm dir as the preset working dir, need to cleanup dir
-      // so that regions/indexes won't get persisted across tests
-      Arrays.stream(getWorkingDir().listFiles()).forEach(FileUtils::deleteQuietly);
+    // if using the dunit/vm dir as the preset working dir, need to cleanup dir
+    // so that regions/indexes won't get persisted across tests
+    Arrays.stream(getWorkingDir().listFiles()).forEach(FileUtils::deleteQuietly);
   }
 
   /**

--- a/geode-core/src/test/java/org/apache/geode/test/dunit/rules/tests/ClusterStartupRuleCanSpecifyOlderVersionsDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/test/dunit/rules/tests/ClusterStartupRuleCanSpecifyOlderVersionsDUnitTest.java
@@ -72,7 +72,8 @@ public class ClusterStartupRuleCanSpecifyOlderVersionsDUnitTest {
 
   @Test
   public void serverWithEmbeddedLocatorVersioningTest() throws Exception {
-    MemberVM locator = csRule.startServerVM(0, version, x -> x.withEmbeddedLocator());
+    MemberVM locator =
+        csRule.startServerVM(0, version, x -> x.withEmbeddedLocator().withJMXManager());
     String locatorVMVersion = locator.getVM().getVersion();
     String locatorActualVersion = locator.invoke(GemFireVersion::getGemFireVersion);
     assertThat(locatorVMVersion).isEqualTo(version);

--- a/geode-core/src/test/java/org/apache/geode/test/dunit/rules/tests/ClusterStartupRuleCanSpecifyOlderVersionsDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/test/dunit/rules/tests/ClusterStartupRuleCanSpecifyOlderVersionsDUnitTest.java
@@ -54,7 +54,7 @@ public class ClusterStartupRuleCanSpecifyOlderVersionsDUnitTest {
 
   @Test
   public void locatorVersioningTest() throws Exception {
-    MemberVM locator = csRule.startLocatorVM(0, new Properties(), version);
+    MemberVM locator = csRule.startLocatorVM(0, version);
     String locatorVMVersion = locator.getVM().getVersion();
     String locatorActualVersion = locator.invoke(GemFireVersion::getGemFireVersion);
     assertThat(locatorVMVersion).isEqualTo(version);
@@ -63,7 +63,7 @@ public class ClusterStartupRuleCanSpecifyOlderVersionsDUnitTest {
 
   @Test
   public void serverVersioningTest() throws Exception {
-    MemberVM locator = csRule.startLocatorVM(0, new Properties(), version);
+    MemberVM locator = csRule.startLocatorVM(0, version);
     String locatorVMVersion = locator.getVM().getVersion();
     String locatorActualVersion = locator.invoke(GemFireVersion::getGemFireVersion);
     assertThat(locatorVMVersion).isEqualTo(version);
@@ -72,7 +72,7 @@ public class ClusterStartupRuleCanSpecifyOlderVersionsDUnitTest {
 
   @Test
   public void serverWithEmbeddedLocatorVersioningTest() throws Exception {
-    MemberVM locator = csRule.startServerAsEmbeddedLocator(0, new Properties(), version);
+    MemberVM locator = csRule.startServerVM(0, version, x -> x.withEmbeddedLocator());
     String locatorVMVersion = locator.getVM().getVersion();
     String locatorActualVersion = locator.invoke(GemFireVersion::getGemFireVersion);
     assertThat(locatorVMVersion).isEqualTo(version);

--- a/geode-core/src/test/java/org/apache/geode/test/junit/rules/MemberStarterRule.java
+++ b/geode-core/src/test/java/org/apache/geode/test/junit/rules/MemberStarterRule.java
@@ -28,9 +28,11 @@ import static org.awaitility.Awaitility.await;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang.ArrayUtils;
 import org.junit.rules.TemporaryFolder;
@@ -159,14 +161,19 @@ public abstract class MemberStarterRule<T> extends SerializableExternalResource 
 
   public T withName(String name) {
     this.name = name;
-    properties.setProperty(NAME, name);
+    properties.putIfAbsent(NAME, name);
     return (T) this;
   }
 
-  public T withConnectionToLocator(int locatorPort) {
-    if (locatorPort > 0) {
-      properties.setProperty(LOCATORS, "localhost[" + locatorPort + "]");
+  public T withConnectionToLocator(int... locatorPorts) {
+    if (locatorPorts.length == 0) {
+      properties.setProperty(LOCATORS, "");
+      return (T) this;
     }
+
+    String locators = Arrays.stream(locatorPorts).mapToObj(i -> "localhost[" + i + "]")
+        .collect(Collectors.joining(","));
+    properties.setProperty(LOCATORS, locators);
     return (T) this;
   }
 

--- a/geode-core/src/test/java/org/apache/geode/test/junit/rules/MemberStarterRule.java
+++ b/geode-core/src/test/java/org/apache/geode/test/junit/rules/MemberStarterRule.java
@@ -167,10 +167,8 @@ public abstract class MemberStarterRule<T> extends SerializableExternalResource 
 
   public T withConnectionToLocator(int... locatorPorts) {
     if (locatorPorts.length == 0) {
-      properties.setProperty(LOCATORS, "");
       return (T) this;
     }
-
     String locators = Arrays.stream(locatorPorts).mapToObj(i -> "localhost[" + i + "]")
         .collect(Collectors.joining(","));
     properties.setProperty(LOCATORS, locators);

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexCommandsDUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexCommandsDUnitTest.java
@@ -26,7 +26,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 import junitparams.JUnitParamsRunner;
@@ -82,8 +81,7 @@ public class LuceneIndexCommandsDUnitTest implements Serializable {
 
   @Before
   public void before() throws Exception {
-    Properties props = new Properties();
-    serverVM = startupRule.startServerAsJmxManager(0, props);
+    serverVM = startupRule.startServerVM(0, x->x.withJMXManager());
     connect(serverVM);
   }
 

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexCommandsDUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexCommandsDUnitTest.java
@@ -81,7 +81,7 @@ public class LuceneIndexCommandsDUnitTest implements Serializable {
 
   @Before
   public void before() throws Exception {
-    serverVM = startupRule.startServerVM(0, x->x.withJMXManager());
+    serverVM = startupRule.startServerVM(0, x -> x.withJMXManager());
     connect(serverVM);
   }
 

--- a/geode-web/src/test/java/org/apache/geode/management/internal/cli/commands/AlterRuntimeCommandDUnitTest.java
+++ b/geode-web/src/test/java/org/apache/geode/management/internal/cli/commands/AlterRuntimeCommandDUnitTest.java
@@ -47,8 +47,7 @@ import org.apache.geode.test.junit.rules.GfshCommandRule;
 @RunWith(JUnitParamsRunner.class)
 public class AlterRuntimeCommandDUnitTest {
   @Rule
-  public ClusterStartupRule startupRule =
-      new ClusterStartupRule().withTempWorkingDir().withLogFile();
+  public ClusterStartupRule startupRule = new ClusterStartupRule().withLogFile();
 
   @Rule
   public GfshCommandRule gfsh = new GfshCommandRule();
@@ -78,9 +77,8 @@ public class AlterRuntimeCommandDUnitTest {
     IgnoredException.addIgnoredException(
         "java.lang.IllegalArgumentException: Could not set \"log-disk-space-limit\"");
 
-    Properties props = new Properties();
-    props.setProperty(LOG_LEVEL, "error");
-    MemberVM server0 = startupRule.startServerAsJmxManager(0, props);
+    MemberVM server0 =
+        startupRule.startServerVM(0, x -> x.withJMXManager().withProperty(LOG_LEVEL, "error"));
 
     if (connectOverHttp) {
       gfsh.connectAndVerify(server0.getHttpPort(), GfshCommandRule.PortType.http);

--- a/geode-web/src/test/java/org/apache/geode/management/internal/cli/commands/DescribeConfigCommandDUnitTest.java
+++ b/geode-web/src/test/java/org/apache/geode/management/internal/cli/commands/DescribeConfigCommandDUnitTest.java
@@ -42,8 +42,7 @@ import org.apache.geode.test.junit.rules.GfshCommandRule;
 @RunWith(JUnitParamsRunner.class)
 public class DescribeConfigCommandDUnitTest {
   @Rule
-  public ClusterStartupRule startupRule =
-      new ClusterStartupRule().withTempWorkingDir().withLogFile();
+  public ClusterStartupRule startupRule = new ClusterStartupRule().withLogFile();
 
   @Rule
   public GfshCommandRule gfsh = new GfshCommandRule();
@@ -58,7 +57,8 @@ public class DescribeConfigCommandDUnitTest {
     localProps.setProperty(STATISTIC_SAMPLING_ENABLED, "true");
     localProps.setProperty(ENABLE_TIME_STATISTICS, "true");
     localProps.setProperty(GROUPS, "G1");
-    MemberVM server0 = startupRule.startServerAsJmxManager(0, localProps);
+    MemberVM server0 =
+        startupRule.startServerVM(0, x -> x.withProperties(localProps).withJMXManager());
 
     if (connectOverHttp) {
       gfsh.connectAndVerify(server0.getHttpPort(), GfshCommandRule.PortType.http);

--- a/geode-web/src/test/java/org/apache/geode/management/internal/cli/commands/ExportConfigCommandDUnitTest.java
+++ b/geode-web/src/test/java/org/apache/geode/management/internal/cli/commands/ExportConfigCommandDUnitTest.java
@@ -41,8 +41,7 @@ import org.apache.geode.test.junit.rules.GfshCommandRule;
 @RunWith(JUnitParamsRunner.class)
 public class ExportConfigCommandDUnitTest {
   @Rule
-  public ClusterStartupRule startupRule =
-      new ClusterStartupRule().withTempWorkingDir().withLogFile();
+  public ClusterStartupRule startupRule = new ClusterStartupRule().withLogFile();
 
   @Rule
   public GfshCommandRule gfsh = new GfshCommandRule();
@@ -56,7 +55,8 @@ public class ExportConfigCommandDUnitTest {
     Properties props = new Properties();
     props.setProperty(GROUPS, "Group1");
 
-    MemberVM server0 = startupRule.startServerAsEmbeddedLocator(0, props);
+    MemberVM server0 =
+        startupRule.startServerVM(0, x -> x.withEmbeddedLocator().withProperty(GROUPS, "Group1"));
 
     if (connectOverHttp) {
       gfsh.connectAndVerify(server0.getHttpPort(), GfshCommandRule.PortType.http);

--- a/geode-web/src/test/java/org/apache/geode/management/internal/cli/commands/ExportConfigCommandDUnitTest.java
+++ b/geode-web/src/test/java/org/apache/geode/management/internal/cli/commands/ExportConfigCommandDUnitTest.java
@@ -21,11 +21,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.File;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Properties;
 import java.util.stream.Collectors;
 
 import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -50,24 +48,16 @@ public class ExportConfigCommandDUnitTest {
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   @Test
-  @Parameters({"true", "false"})
-  public void testExportConfig(final boolean connectOverHttp) throws Exception {
-    Properties props = new Properties();
-    props.setProperty(GROUPS, "Group1");
-
+  public void testExportConfig() throws Exception {
     MemberVM server0 =
         startupRule.startServerVM(0, x -> x.withEmbeddedLocator().withProperty(GROUPS, "Group1"));
 
-    if (connectOverHttp) {
-      gfsh.connectAndVerify(server0.getHttpPort(), GfshCommandRule.PortType.http);
-    } else {
-      gfsh.connectAndVerify(server0.getJmxPort(), GfshCommandRule.PortType.jmxManager);
-    }
+    gfsh.connectAndVerify(server0.getJmxPort(), GfshCommandRule.PortType.jmxManager);
+
 
     // start server1 and server2 in group2
-    props.setProperty(GROUPS, "Group2");
-    startupRule.startServerVM(1, props, server0.getEmbeddedLocatorPort());
-    startupRule.startServerVM(2, props, server0.getEmbeddedLocatorPort());
+    startupRule.startServerVM(1, "Group2", server0.getEmbeddedLocatorPort());
+    startupRule.startServerVM(2, "Group2", server0.getEmbeddedLocatorPort());
 
     // start server3 that has no group info
     startupRule.startServerVM(3, server0.getEmbeddedLocatorPort());

--- a/geode-web/src/test/java/org/apache/geode/management/internal/cli/commands/ExportConfigCommandDUnitTest.java
+++ b/geode-web/src/test/java/org/apache/geode/management/internal/cli/commands/ExportConfigCommandDUnitTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -48,12 +49,16 @@ public class ExportConfigCommandDUnitTest {
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   @Test
-  public void testExportConfig() throws Exception {
-    MemberVM server0 =
-        startupRule.startServerVM(0, x -> x.withEmbeddedLocator().withProperty(GROUPS, "Group1"));
+  @Parameters({"true", "false"})
+  public void testExportConfig(final boolean connectOverHttp) throws Exception {
+    MemberVM server0 = startupRule.startServerVM(0,
+        x -> x.withProperty(GROUPS, "Group1").withJMXManager().withEmbeddedLocator());
 
-    gfsh.connectAndVerify(server0.getJmxPort(), GfshCommandRule.PortType.jmxManager);
-
+    if (connectOverHttp) {
+      gfsh.connectAndVerify(server0.getHttpPort(), GfshCommandRule.PortType.http);
+    } else {
+      gfsh.connectAndVerify(server0.getJmxPort(), GfshCommandRule.PortType.jmxManager);
+    }
 
     // start server1 and server2 in group2
     startupRule.startServerVM(1, "Group2", server0.getEmbeddedLocatorPort());

--- a/geode-web/src/test/java/org/apache/geode/management/internal/cli/commands/ExportLogsStatsOverHttpDUnitTest.java
+++ b/geode-web/src/test/java/org/apache/geode/management/internal/cli/commands/ExportLogsStatsOverHttpDUnitTest.java
@@ -41,7 +41,7 @@ public class ExportLogsStatsOverHttpDUnitTest extends ExportLogsStatsDUnitTest {
   @Override
   public void connectIfNeeded() throws Exception {
     if (!connector.isConnected())
-      connector.connect(httpPort, GfshCommandRule.PortType.http);
+      connector.connect(locator.getHttpPort(), GfshCommandRule.PortType.http);
   }
 
   @Test


### PR DESCRIPTION
* get rid of withTempWorkingDir in ClusterStartupRule
* cleanup more ClusterStartupRule API to use lamda on MemberStartupRule

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
