### PR TITLE
GEODE-4579: Removed singleton instance

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/util/FindRestEnabledServersFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/util/FindRestEnabledServersFunction.java
@@ -41,7 +41,7 @@ public class FindRestEnabledServersFunction implements InternalFunction {
   public void execute(FunctionContext context) {
     try {
       InternalCache cache = (InternalCache) context.getCache();
-      DistributionConfig config = InternalDistributedSystem.getAnyInstance().getConfig();
+      DistributionConfig config = cache.getInternalDistributedSystem().getConfig();
 
       String bindAddress = RestAgent.getBindAddressForHttpService(config);
 


### PR DESCRIPTION
	* Removed InternalDistributedSystem.getAnyInstance() call from FindRestEnabledServersFunction in the package org.apache.geode.internal.cache.execute.util

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
