### PR TITLE
GEODE-4670: Removing unused reflection of JDK methods

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/shared/NativeCalls.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/shared/NativeCalls.java
@@ -80,30 +80,6 @@ public abstract class NativeCalls {
     return instance;
   }
 
-  @SuppressWarnings("unchecked")
-  protected static Map<String, String> getModifiableJavaEnv() {
-    final Map<String, String> env = System.getenv();
-    try {
-      final Field m = env.getClass().getDeclaredField("m");
-      m.setAccessible(true);
-      return (Map<String, String>) m.get(env);
-    } catch (Exception ex) {
-      return null;
-    }
-  }
-
-  @SuppressWarnings("unchecked")
-  protected static Map<String, String> getModifiableJavaEnvWIN() {
-    try {
-      final Field envField = Class.forName("java.lang.ProcessEnvironment")
-          .getDeclaredField("theCaseInsensitiveEnvironment");
-      envField.setAccessible(true);
-      return (Map<String, String>) envField.get(null);
-    } catch (Exception ex) {
-      return null;
-    }
-  }
-
   /**
    * Get the native kernel descriptor given the java Socket. This is a horribly implementation
    * dependent code checking various cases to get to the underlying kernel socket descriptor but
@@ -261,17 +237,6 @@ public abstract class NativeCalls {
    * @param name the name of the environment variable to be modified
    */
   public abstract String getEnvironment(String name);
-
-  /**
-   * Set the value of an environment variable. This modifies both the value in the process, and the
-   * cached static map maintained by JVM on the first call so further calls to
-   * {@link System#getenv(String)} will also return the modified value.
-   *
-   * @param name the name of the environment variable to be modified
-   * @param value the new value of the environment variable; a value of null clears the existing
-   *        value
-   */
-  public abstract void setEnvironment(String name, String value);
 
   /**
    * Get the process ID of the current process.
@@ -479,13 +444,10 @@ public abstract class NativeCalls {
    */
   public static class NativeCallsGeneric extends NativeCalls {
 
-    private static final Map<String, String> javaEnv;
-
     private static final boolean isWin;
 
     static {
       isWin = System.getProperty("os.name").indexOf("Windows") >= 0;
-      javaEnv = isWin ? getModifiableJavaEnvWIN() : getModifiableJavaEnv();
     }
 
     /**
@@ -502,21 +464,6 @@ public abstract class NativeCalls {
     @Override
     public String getEnvironment(final String name) {
       return System.getenv(name);
-    }
-
-    /**
-     * @see NativeCalls#setEnvironment(String, String)
-     */
-    @Override
-    public void setEnvironment(final String name, final String value) {
-      // just change the cached map in java env if possible
-      if (javaEnv != null) {
-        if (value != null) {
-          javaEnv.put(name, value);
-        } else {
-          javaEnv.remove(name);
-        }
-      }
     }
 
     /**


### PR DESCRIPTION
JDK9 logs a warning about doing reflection on these classes. The methods
doing the reflection are not being used.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
