### PR TITLE
GEODE-4671: Removing flags that aren't recognized by JDK 9

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/test/dunit/standalone/ProcessManager.java
+++ b/geode-core/src/test/java/org/apache/geode/test/dunit/standalone/ProcessManager.java
@@ -258,9 +258,6 @@ public class ProcessManager {
         + ConfigurationProperties.VALIDATE_SERIALIZABLE_OBJECTS + "=true");
     cmds.add("-ea");
     cmds.add("-XX:MetaspaceSize=512m");
-    cmds.add("-XX:+PrintGC");
-    cmds.add("-XX:+PrintGCDetails");
-    cmds.add("-XX:+PrintGCTimeStamps");
     cmds.add(agent);
     cmds.add(ChildVM.class.getName());
     String[] rst = new String[cmds.size()];


### PR DESCRIPTION
Removing debug flags from ProcessManager that aren't recognized by JDK
9.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
