### PR TITLE
GEODE-3523: Update locatorDiscoveryCallback after updating state

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/AutoConnectionSourceImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/AutoConnectionSourceImpl.java
@@ -319,14 +319,13 @@ public class AutoConnectionSourceImpl implements ConnectionSource {
 
     LocatorList newLocatorList = new LocatorList(newLocatorAddresses);
 
-    locators.set(newLocatorList);
+    LocatorList oldLocators = locators.getAndSet(newLocatorList);
     onlineLocators.set(new LocatorList(newOnlineLocators));
     pool.getStats().setLocatorCount(newLocatorAddresses.size());
 
     if (logger.isInfoEnabled()
         || !locatorCallback.getClass().equals(LocatorDiscoveryCallbackAdapter.class)) {
       List<InetSocketAddress> newLocators = newLocatorList.getLocators();
-      LocatorList oldLocators = (LocatorList) locators.get();
       ArrayList<InetSocketAddress> removedLocators =
           new ArrayList<InetSocketAddress>(oldLocators.getLocators());
       removedLocators.removeAll(newLocators);

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/AutoConnectionSourceImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/AutoConnectionSourceImpl.java
@@ -319,7 +319,12 @@ public class AutoConnectionSourceImpl implements ConnectionSource {
 
     LocatorList newLocatorList = new LocatorList(newLocatorAddresses);
 
-    if (logger.isInfoEnabled()) {
+    locators.set(newLocatorList);
+    onlineLocators.set(new LocatorList(newOnlineLocators));
+    pool.getStats().setLocatorCount(newLocatorAddresses.size());
+
+    if (logger.isInfoEnabled()
+        || !locatorCallback.getClass().equals(LocatorDiscoveryCallbackAdapter.class)) {
       List<InetSocketAddress> newLocators = newLocatorList.getLocators();
       LocatorList oldLocators = (LocatorList) locators.get();
       ArrayList<InetSocketAddress> removedLocators =
@@ -342,11 +347,6 @@ public class AutoConnectionSourceImpl implements ConnectionSource {
       }
     }
 
-
-
-    locators.set(newLocatorList);
-    onlineLocators.set(new LocatorList(newOnlineLocators));
-    pool.getStats().setLocatorCount(newLocatorAddresses.size());
   }
 
   /**


### PR DESCRIPTION
Some tests wait for this callback to be notified of new locators before
killing old locators. But The callback is called before the internal
state on the client is updated. So there was a race condition where the
test would know about the new locator, but the client code itself would
not use it yet.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
