### PR TITLE
GEODE-4968: Increasing the client timeout in Gemcached tests

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/memcached/ConnectionWithOneMinuteTimeoutFactory.java
+++ b/geode-core/src/test/java/org/apache/geode/memcached/ConnectionWithOneMinuteTimeoutFactory.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.memcached;
+
+import net.spy.memcached.DefaultConnectionFactory;
+
+public class ConnectionWithOneMinuteTimeoutFactory extends DefaultConnectionFactory {
+  @Override
+  public long getOperationTimeout() {
+    // timeout after a minute
+    return 60 * 1000;
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/memcached/DomainObjectsAsValuesJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/memcached/DomainObjectsAsValuesJUnitTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.*;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.util.Collections;
 import java.util.concurrent.Future;
 
 import net.spy.memcached.MemcachedClient;
@@ -109,8 +110,8 @@ public class DomainObjectsAsValuesJUnitTest {
 
   @Test
   public void testGetPutDomainObject() throws Exception {
-    MemcachedClient client =
-        new MemcachedClient(new InetSocketAddress(InetAddress.getLocalHost(), PORT));
+    MemcachedClient client = new MemcachedClient(new ConnectionWithOneMinuteTimeoutFactory(),
+        Collections.singletonList(new InetSocketAddress(InetAddress.getLocalHost(), PORT)));
     Customer c = new Customer("name0", "addr0");
     Customer c1 = new Customer("name1", "addr1");
     Future<Boolean> f = client.add("keyObj", 10, c);

--- a/geode-core/src/test/java/org/apache/geode/memcached/GemcachedDevelopmentJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/memcached/GemcachedDevelopmentJUnitTest.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -255,8 +256,9 @@ public class GemcachedDevelopmentJUnitTest {
   }
 
   protected MemcachedClient createMemcachedClient() throws IOException, UnknownHostException {
-    MemcachedClient client =
-        new MemcachedClient(new InetSocketAddress(InetAddress.getLocalHost(), PORT));
+    MemcachedClient client = new MemcachedClient(new ConnectionWithOneMinuteTimeoutFactory(),
+        Collections.singletonList(new InetSocketAddress(InetAddress.getLocalHost(), PORT)));
     return client;
   }
+
 }

--- a/geode-core/src/test/java/org/apache/geode/memcached/IntegrationJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/memcached/IntegrationJUnitTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.*;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.util.Collections;
 import java.util.Properties;
 import java.util.concurrent.Future;
 
@@ -43,8 +44,8 @@ public class IntegrationJUnitTest {
     CacheFactory cf = new CacheFactory(props);
     Cache cache = cf.create();
 
-    MemcachedClient client =
-        new MemcachedClient(new InetSocketAddress(InetAddress.getLocalHost(), port));
+    MemcachedClient client = new MemcachedClient(new ConnectionWithOneMinuteTimeoutFactory(),
+        Collections.singletonList(new InetSocketAddress(InetAddress.getLocalHost(), port)));
     Future<Boolean> f = client.add("key", 10, "myStringValue");
     assertTrue(f.get());
     Future<Boolean> f1 = client.add("key1", 10, "myStringValue1");
@@ -66,7 +67,8 @@ public class IntegrationJUnitTest {
     CacheFactory cf = new CacheFactory(props);
     Cache cache = cf.create();
 
-    MemcachedClient client = new MemcachedClient(new InetSocketAddress("127.0.0.1", port));
+    MemcachedClient client = new MemcachedClient(new ConnectionWithOneMinuteTimeoutFactory(),
+        Collections.singletonList(new InetSocketAddress("127.0.0.1", port)));
     Future<Boolean> f = client.add("key", 10, "myStringValue");
     assertTrue(f.get());
     Future<Boolean> f1 = client.add("key1", 10, "myStringValue1");


### PR DESCRIPTION
The Gemcached tests were using the default timeout of 2.5 seconds.
Changing that to 1 minute.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
