### PR TITLE
GEODE-4493: remove getAnyInstance calls from all tests in org.apache.geode.internal.cache.control

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/internal/cache/control/TestMemoryThresholdListener.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/control/TestMemoryThresholdListener.java
@@ -14,10 +14,12 @@
  */
 package org.apache.geode.internal.cache.control;
 
-import org.apache.geode.distributed.internal.InternalDistributedSystem;
+import org.apache.logging.log4j.Logger;
 
+import org.apache.geode.internal.logging.LogService;
 
 public class TestMemoryThresholdListener implements ResourceListener<MemoryEvent> {
+  private static final Logger logger = LogService.getLogger();
   private int normalCalls = 0;
   private int criticalThresholdCalls = 0;
   private int evictionThresholdCalls = 0;
@@ -118,8 +120,7 @@ public class TestMemoryThresholdListener implements ResourceListener<MemoryEvent
   @Override
   public void onEvent(MemoryEvent event) {
     if (this.logOnEventCalls) {
-      InternalDistributedSystem.getAnyInstance().getLogWriter()
-          .info("TestMemoryThresholdListener onEvent " + event);
+      logger.info("TestMemoryThresholdListener onEvent " + event);
     }
     synchronized (this) {
       if (event.getState().isNormal()) {


### PR DESCRIPTION
removed InternalDistributedSystem.getAnyInstance call
by using a static log4j logger
