### PR TITLE
GEODE-4725: PdxReadSerialized reset

### DIFF
--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneEventListener.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneEventListener.java
@@ -73,6 +73,7 @@ public class LuceneEventListener implements AsyncEventListener {
 
   protected boolean process(final List<AsyncEvent> events) {
     // Try to get a PDX instance if possible, rather than a deserialized object
+    boolean initialPdxReadSerializedFlag = DefaultQuery.getPdxReadSerialized();
     DefaultQuery.setPdxReadSerialized(true);
 
     Set<IndexRepository> affectedRepos = new HashSet<IndexRepository>();
@@ -111,7 +112,7 @@ public class LuceneEventListener implements AsyncEventListener {
     } catch (IOException e) {
       throw new InternalGemFireError("Unable to save to lucene index", e);
     } finally {
-      DefaultQuery.setPdxReadSerialized(false);
+      DefaultQuery.setPdxReadSerialized(initialPdxReadSerializedFlag);
     }
   }
 

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/LuceneEventListenerJUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/LuceneEventListenerJUnitTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.*;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -34,6 +35,7 @@ import org.apache.geode.cache.Region;
 import org.apache.geode.cache.asyncqueue.AsyncEvent;
 import org.apache.geode.cache.lucene.internal.repository.IndexRepository;
 import org.apache.geode.cache.lucene.internal.repository.RepositoryManager;
+import org.apache.geode.cache.query.internal.DefaultQuery;
 import org.apache.geode.internal.cache.BucketNotFoundException;
 import org.apache.geode.internal.cache.EntrySnapshot;
 import org.apache.geode.test.junit.categories.UnitTest;
@@ -47,6 +49,19 @@ public class LuceneEventListenerJUnitTest {
   @After
   public void clearExceptionListener() {
     LuceneEventListener.setExceptionObserver(null);
+  }
+
+  @Test
+  public void pdxReadSerializedFlagShouldBeResetBackToOriginalValueAfterProcessingEvents() {
+    boolean originalPdxReadSerialized = DefaultQuery.getPdxReadSerialized();
+    try {
+      DefaultQuery.setPdxReadSerialized(true);
+      LuceneEventListener luceneEventListener = new LuceneEventListener(null);
+      luceneEventListener.process(new LinkedList());
+      assertTrue(DefaultQuery.getPdxReadSerialized());
+    } finally {
+      DefaultQuery.setPdxReadSerialized(originalPdxReadSerialized);
+    }
   }
 
   @Test


### PR DESCRIPTION
	* In the lucene event listener's process events method the flag pdxReadSerialized is reset to the initial value then to rather change it to false.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
