### PR TITLE
GEODE-4404: Move BackupWriter creation

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/admin/BackupStatus.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/BackupStatus.java
@@ -14,6 +14,12 @@
  */
 package org.apache.geode.admin;
 
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.geode.cache.persistence.PersistentID;
+import org.apache.geode.distributed.DistributedMember;
+
 /**
  * The status of a backup operation, returned by
  * {@link AdminDistributedSystem#backupAllMembers(java.io.File,java.io.File)}.
@@ -23,5 +29,17 @@ package org.apache.geode.admin;
  *             "{@docRoot}/org/apache/geode/management/package-summary.html">management</a></code>
  *             package instead
  */
-public interface BackupStatus extends org.apache.geode.management.BackupStatus {
+public interface BackupStatus {
+  /**
+   * Returns a map of disk stores that were successfully backed up. The key is an online distributed
+   * member. The value is the set of disk stores on that distributed member.
+   */
+  Map<DistributedMember, Set<PersistentID>> getBackedUpDiskStores();
+
+  /**
+   * Returns the set of disk stores that were known to be offline at the time of the backup. These
+   * members were not backed up. If this set is not empty the backup may not contain a complete
+   * snapshot of any partitioned regions in the distributed system.
+   */
+  Set<PersistentID> getOfflineDiskStores();
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/SystemAdmin.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/SystemAdmin.java
@@ -619,9 +619,8 @@ public class SystemAdmin {
     InternalDistributedSystem ads = getAdminCnx();
 
     // Baseline directory should be null if it was not provided on the command line
-    BackupStatus status =
-        BackupUtil.backupAllMembers(ads.getDistributionManager(), new File(targetDir),
-            (SystemAdmin.baselineDir == null ? null : new File(SystemAdmin.baselineDir)));
+    BackupStatus status = BackupUtil.backupAllMembers(ads.getDistributionManager(), targetDir,
+        SystemAdmin.baselineDir);
 
     boolean incomplete = !status.getOfflineDiskStores().isEmpty();
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/backup/AbstractBackupWriterConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/backup/AbstractBackupWriterConfig.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.backup;
+
+import java.util.Properties;
+
+import org.apache.commons.lang.StringUtils;
+
+abstract class AbstractBackupWriterConfig {
+
+  static final String TIMESTAMP = "TIMESTAMP";
+  static final String TYPE = "TYPE";
+
+  private final Properties properties;
+
+  AbstractBackupWriterConfig(Properties properties) {
+    this.properties = properties;
+  }
+
+  String getTimestamp() {
+    String value = properties.getProperty(TIMESTAMP);
+    if (StringUtils.isBlank(value)) {
+      throw new IllegalStateException("Timestamp is missing");
+    }
+    return value;
+  }
+
+  String getBackupType() {
+    String value = properties.getProperty(TYPE);
+    if (StringUtils.isBlank(value)) {
+      throw new IllegalStateException("Type is missing");
+    }
+    return value;
+  }
+
+  Properties getProperties() {
+    return properties;
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/backup/BackupDataStoreHelper.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/backup/BackupDataStoreHelper.java
@@ -14,9 +14,9 @@
  */
 package org.apache.geode.internal.cache.backup;
 
-import java.io.File;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 
 import org.apache.geode.cache.persistence.PersistentID;
@@ -37,7 +37,7 @@ public class BackupDataStoreHelper {
 
   @SuppressWarnings("rawtypes")
   public static BackupDataStoreResult backupAllMembers(DistributionManager dm, Set recipients,
-      File targetDir, File baselineDir) {
+      Properties properties) {
     new FlushToDiskOperation(dm, dm.getId(), dm.getCache(), recipients, flushToDiskFactory).send();
 
     boolean abort = true;
@@ -45,7 +45,7 @@ public class BackupDataStoreHelper {
     Map<DistributedMember, Set<PersistentID>> existingDataStores;
     try {
       existingDataStores = new PrepareBackupOperation(dm, dm.getId(), dm.getCache(), recipients,
-          prepareBackupFactory, targetDir, baselineDir).send();
+          prepareBackupFactory, properties).send();
       abort = false;
     } finally {
       if (abort) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/backup/BackupService.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/backup/BackupService.java
@@ -14,7 +14,6 @@
  */
 package org.apache.geode.internal.cache.backup;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
@@ -40,7 +39,7 @@ import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.logging.LoggingThreadGroup;
 
 public class BackupService {
-  Logger logger = LogService.getLogger();
+  private static final Logger logger = LogService.getLogger();
 
   public static final String DATA_STORES_TEMPORARY_DIRECTORY = "backupTemp_";
   private final ExecutorService executor;
@@ -71,10 +70,10 @@ public class BackupService {
     return Executors.newSingleThreadExecutor(threadFactory);
   }
 
-  public HashSet<PersistentID> prepareBackup(InternalDistributedMember sender, File targetDir,
-      File baselineDir) throws IOException, InterruptedException {
+  public HashSet<PersistentID> prepareBackup(InternalDistributedMember sender, BackupWriter writer)
+      throws IOException, InterruptedException {
     validateRequestingAdmin(sender);
-    BackupTask backupTask = new BackupTask(cache, targetDir, baselineDir);
+    BackupTask backupTask = new BackupTask(cache, writer);
     if (!currentTask.compareAndSet(null, backupTask)) {
       throw new IOException("Another backup already in progress");
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/backup/BackupWriterFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/backup/BackupWriterFactory.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.backup;
+
+import static org.apache.geode.internal.cache.backup.AbstractBackupWriterConfig.TIMESTAMP;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Properties;
+
+public enum BackupWriterFactory {
+  FILE_SYSTEM("FileSystem") {
+    BackupWriter createWriter(Properties properties, String memberId) {
+      FileSystemBackupWriterConfig config = new FileSystemBackupWriterConfig(properties);
+      Path targetDir = Paths.get(config.getTargetDirectory())
+          .resolve(properties.getProperty(TIMESTAMP)).resolve(memberId);
+      String baselineDir = config.getBaselineDirectory();
+      FileSystemIncrementalBackupLocation incrementalBackupLocation = null;
+      if (baselineDir != null) {
+        File baseline = new File(baselineDir);
+        incrementalBackupLocation = new FileSystemIncrementalBackupLocation(baseline, memberId);
+      }
+      return new FileSystemBackupWriter(targetDir, incrementalBackupLocation);
+    }
+  };
+
+  private String type;
+
+  BackupWriterFactory(String type) {
+    this.type = type;
+  }
+
+  String getType() {
+    return type;
+  }
+
+  static BackupWriterFactory getFactoryForType(String type) {
+    for (BackupWriterFactory factory : BackupWriterFactory.values()) {
+      if (factory.type.equals(type)) {
+        return factory;
+      }
+    }
+    throw new IllegalArgumentException("No factory exists for type '" + type + "'");
+  }
+
+  abstract BackupWriter createWriter(Properties properties, String memberId);
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/backup/FileSystemBackupWriterConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/backup/FileSystemBackupWriterConfig.java
@@ -12,12 +12,29 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.geode.management;
+package org.apache.geode.internal.cache.backup;
 
-/**
- * The status of a backup operation.
- *
- * @since Geode 1.4
- */
-public interface BackupStatus extends org.apache.geode.admin.BackupStatus {
+import java.util.Properties;
+
+import org.apache.commons.lang.StringUtils;
+
+class FileSystemBackupWriterConfig extends AbstractBackupWriterConfig {
+  static final String TARGET_DIR = "TARGET_DIRECTORY";
+  static final String BASELINE_DIR = "BASELINE_DIRECTORY";
+
+  FileSystemBackupWriterConfig(Properties properties) {
+    super(properties);
+  }
+
+  public String getTargetDirectory() {
+    String value = getProperties().getProperty(TARGET_DIR);
+    if (StringUtils.isBlank(value)) {
+      throw new IllegalStateException("Target directory is missing");
+    }
+    return value;
+  }
+
+  public String getBaselineDirectory() {
+    return getProperties().getProperty(BASELINE_DIR);
+  }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/backup/PrepareBackup.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/backup/PrepareBackup.java
@@ -14,7 +14,6 @@
  */
 package org.apache.geode.internal.cache.backup;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.HashSet;
 
@@ -26,15 +25,12 @@ class PrepareBackup {
 
   private final InternalDistributedMember member;
   private final InternalCache cache;
-  private final File targetDir;
-  private final File baselineDir;
+  private final BackupWriter backupWriter;
 
-  PrepareBackup(InternalDistributedMember member, InternalCache cache, File targetDir,
-      File baselineDir) {
+  PrepareBackup(InternalDistributedMember member, InternalCache cache, BackupWriter backupWriter) {
     this.member = member;
     this.cache = cache;
-    this.targetDir = targetDir;
-    this.baselineDir = baselineDir;
+    this.backupWriter = backupWriter;
   }
 
   HashSet<PersistentID> run() throws IOException, InterruptedException {
@@ -42,7 +38,7 @@ class PrepareBackup {
     if (cache == null) {
       persistentIds = new HashSet<>();
     } else {
-      persistentIds = cache.getBackupService().prepareBackup(member, targetDir, baselineDir);
+      persistentIds = cache.getBackupService().prepareBackup(member, backupWriter);
     }
     return persistentIds;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/backup/PrepareBackupOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/backup/PrepareBackupOperation.java
@@ -14,8 +14,8 @@
  */
 package org.apache.geode.internal.cache.backup;
 
-import java.io.File;
 import java.io.IOException;
+import java.util.Properties;
 import java.util.Set;
 
 import org.apache.logging.log4j.Logger;
@@ -34,19 +34,17 @@ class PrepareBackupOperation extends BackupOperation {
   private final InternalCache cache;
   private final Set<InternalDistributedMember> recipients;
   private final PrepareBackupFactory prepareBackupFactory;
-  private final File targetDir;
-  private final File baselineDir;
+  private final Properties properties;
 
   PrepareBackupOperation(DistributionManager dm, InternalDistributedMember member,
       InternalCache cache, Set<InternalDistributedMember> recipients,
-      PrepareBackupFactory prepareBackupFactory, File targetDir, File baselineDir) {
+      PrepareBackupFactory prepareBackupFactory, Properties properties) {
     super(dm);
     this.member = member;
     this.cache = cache;
     this.recipients = recipients;
     this.prepareBackupFactory = prepareBackupFactory;
-    this.targetDir = targetDir;
-    this.baselineDir = baselineDir;
+    this.properties = properties;
   }
 
   @Override
@@ -57,14 +55,14 @@ class PrepareBackupOperation extends BackupOperation {
   @Override
   DistributionMessage createDistributionMessage(ReplyProcessor21 replyProcessor) {
     return prepareBackupFactory.createRequest(member, recipients, replyProcessor.getProcessorId(),
-        targetDir, baselineDir);
+        properties);
   }
 
   @Override
   void processLocally() {
     try {
       addToResults(member,
-          prepareBackupFactory.createPrepareBackup(member, cache, targetDir, baselineDir).run());
+          prepareBackupFactory.createPrepareBackup(member, cache, properties).run());
     } catch (IOException | InterruptedException e) {
       logger.fatal("Failed to PrepareBackup in " + member, e);
     }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/DistributedSystemBridge.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/DistributedSystemBridge.java
@@ -484,7 +484,9 @@ public class DistributedSystemBridge {
     properties.setProperty("TIMESTAMP", format.format(new Date()));
     properties.setProperty("TYPE", "FileSystem");
     properties.setProperty("TARGET_DIRECTORY", targetDirPath);
-    properties.setProperty("BASELINE_DIRECTORY", baselineDirPath);
+    if (baselineDirPath != null) {
+      properties.setProperty("BASELINE_DIRECTORY", baselineDirPath);
+    }
     BackupStatus result = BackupUtil.backupAllMembers(dm, properties);
     DiskBackupStatusImpl diskBackupStatus = new DiskBackupStatusImpl();
     diskBackupStatus.generateBackedUpDiskStores(result.getBackedUpDiskStores());

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/MemberMBeanBridge.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/MemberMBeanBridge.java
@@ -16,7 +16,6 @@ package org.apache.geode.management.internal.beans;
 
 import static org.apache.geode.internal.lang.SystemUtils.getLineSeparator;
 
-import java.io.File;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
@@ -29,7 +28,6 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -48,7 +46,6 @@ import org.apache.geode.StatisticsType;
 import org.apache.geode.cache.DiskStore;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.execute.FunctionService;
-import org.apache.geode.cache.persistence.PersistentID;
 import org.apache.geode.cache.wan.GatewayReceiver;
 import org.apache.geode.cache.wan.GatewaySender;
 import org.apache.geode.distributed.Locator;
@@ -98,10 +95,8 @@ import org.apache.geode.internal.statistics.platform.SolarisSystemStats;
 import org.apache.geode.internal.statistics.platform.WindowsSystemStats;
 import org.apache.geode.internal.stats50.VMStats50;
 import org.apache.geode.internal.tcp.ConnectionTable;
-import org.apache.geode.management.DiskBackupResult;
 import org.apache.geode.management.GemFireProperties;
 import org.apache.geode.management.JVMMetrics;
-import org.apache.geode.management.ManagementException;
 import org.apache.geode.management.OSMetrics;
 import org.apache.geode.management.cli.Result;
 import org.apache.geode.management.internal.ManagementConstants;
@@ -984,64 +979,6 @@ public class MemberMBeanBridge {
       t.setDaemon(false);
       t.start();
     }
-  }
-
-  /**
-   * backs up all the disk to the targeted directory
-   *
-   * @param targetDirPath path of the directory where back up is to be taken
-   * @return array of DiskBackup results which might get aggregated at Managing node Check the
-   *         validity of this mbean call. When does it make sense to backup a single member of a
-   *         gemfire system in isolation of the other members?
-   */
-  public DiskBackupResult[] backupMember(String targetDirPath) {
-    if (cache != null) {
-      Collection<DiskStore> diskStores = cache.listDiskStoresIncludingRegionOwned();
-      for (DiskStore store : diskStores) {
-        store.flush();
-      }
-    }
-
-    DiskBackupResult[] diskBackUpResult = null;
-    File targetDir = new File(targetDirPath);
-
-    if (cache == null) {
-      return null;
-
-    } else {
-      try {
-        boolean abort = true;
-        Set<PersistentID> existingDataStores;
-        Set<PersistentID> successfulDataStores;
-        try {
-          existingDataStores = cache.getBackupService().prepareBackup(
-              cache.getInternalDistributedSystem().getDistributedMember(), targetDir, null);
-          abort = false;
-        } finally {
-          if (abort) {
-            cache.getBackupService().abortBackup();
-            successfulDataStores = Collections.emptySet();
-          } else {
-            successfulDataStores = cache.getBackupService().doBackup();
-          }
-        }
-        diskBackUpResult = new DiskBackupResult[existingDataStores.size()];
-        int j = 0;
-
-        for (PersistentID id : existingDataStores) {
-          if (successfulDataStores.contains(id)) {
-            diskBackUpResult[j] = new DiskBackupResult(id.getDirectory(), false);
-          } else {
-            diskBackUpResult[j] = new DiskBackupResult(id.getDirectory(), true);
-          }
-          j++;
-        }
-
-      } catch (IOException | InterruptedException e) {
-        throw new ManagementException(e);
-      }
-    }
-    return diskBackUpResult;
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/BackupDiskStoreCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/BackupDiskStoreCommand.java
@@ -15,7 +15,6 @@
 
 package org.apache.geode.management.internal.cli.commands;
 
-import java.io.File;
 import java.util.Map;
 import java.util.Set;
 
@@ -61,9 +60,9 @@ public class BackupDiskStoreCommand implements GfshCommand {
       BackupStatus backupStatus;
 
       if (baselineDir != null && !baselineDir.isEmpty()) {
-        backupStatus = BackupUtil.backupAllMembers(dm, new File(targetDir), new File(baselineDir));
+        backupStatus = BackupUtil.backupAllMembers(dm, targetDir, baselineDir);
       } else {
-        backupStatus = BackupUtil.backupAllMembers(dm, new File(targetDir), null);
+        backupStatus = BackupUtil.backupAllMembers(dm, targetDir, null);
       }
 
       Map<DistributedMember, Set<PersistentID>> backedupMemberDiskstoreMap =

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/backup/AbstractBackupWriterConfigTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/backup/AbstractBackupWriterConfigTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.backup;
+
+import static org.apache.geode.internal.cache.backup.AbstractBackupWriterConfig.TIMESTAMP;
+import static org.apache.geode.internal.cache.backup.AbstractBackupWriterConfig.TYPE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Properties;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.test.junit.categories.UnitTest;
+
+@Category(UnitTest.class)
+public class AbstractBackupWriterConfigTest {
+
+  private Properties properties;
+  private String timestamp;
+  private String type;
+  private AbstractBackupWriterConfig config;
+
+  @Before
+  public void setUp() {
+    properties = new Properties();
+    timestamp = new SimpleDateFormat("yyyy-MM-dd-HH-mm-ss").format(new Date());
+    type = "FileSystem";
+    config = new AbstractBackupWriterConfig(properties) {};
+  }
+
+  @Test
+  public void getTimestampThrowsIfMissing() {
+    assertThatThrownBy(() -> config.getTimestamp()).isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  public void getTimestampThrowsIfBlank() {
+    properties.setProperty(TIMESTAMP, "");
+    assertThatThrownBy(() -> config.getTimestamp()).isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  public void getTimestampReturnsCorrectString() {
+    properties.setProperty(TIMESTAMP, timestamp);
+    assertThat(config.getTimestamp()).isEqualTo(timestamp);
+  }
+
+  @Test
+  public void getBackupTypeThrowsIfMissing() {
+    assertThatThrownBy(() -> config.getBackupType()).isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  public void getBackupTypeThrowsIfBlank() {
+    properties.setProperty(TYPE, "");
+    assertThatThrownBy(() -> config.getBackupType()).isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  public void getBackupTypeReturnsCorrectString() {
+    properties.setProperty(TYPE, type);
+    assertThat(config.getBackupType()).isEqualTo(type);
+  }
+
+  @Test
+  public void getProperties() {
+    assertThat(config.getProperties()).isSameAs(properties);
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/backup/BackupDistributedTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/backup/BackupDistributedTest.java
@@ -123,7 +123,6 @@ public class BackupDistributedTest extends PersistentPartitionedRegionTestBase {
     workingDirByVm.put(vm3, tempDir.newFolder());
 
     backupBaseDir = tempDir.newFolder("backupDir");
-
   }
 
   @Override
@@ -142,6 +141,15 @@ public class BackupDistributedTest extends PersistentPartitionedRegionTestBase {
     long lastModified1 = setBackupFiles(vm1);
 
     createData();
+
+    vm0.invoke(() -> {
+      assertThat(getCache().getDistributionManager().getNormalDistributionManagerIds()).hasSize(2);
+    });
+
+    vm2.invoke(() -> {
+      getCache();
+      assertThat(getCache().getDistributionManager().getNormalDistributionManagerIds()).hasSize(3);
+    });
 
     BackupStatus status = backupMember(vm2);
     assertThat(status.getBackedUpDiskStores()).hasSize(2);
@@ -692,8 +700,8 @@ public class BackupDistributedTest extends PersistentPartitionedRegionTestBase {
   private BackupStatus backupMember(final VM vm) {
     return vm.invoke("backup", () -> {
       try {
-        return BackupUtil.backupAllMembers(getSystem().getDistributionManager(), backupBaseDir,
-            null);
+        return BackupUtil.backupAllMembers(getCache().getDistributionManager(),
+            backupBaseDir.toString(), null);
       } catch (ManagementException e) {
         throw new RuntimeException(e);
       }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/backup/BackupIntegrationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/backup/BackupIntegrationTest.java
@@ -192,8 +192,8 @@ public class BackupIntegrationTest {
     }
 
     BackupService backup = cache.getBackupService();
-    backup.prepareBackup(cache.getInternalDistributedSystem().getDistributedMember(), backupDir,
-        null);
+    BackupWriter writer = getBackupWriter();
+    backup.prepareBackup(cache.getMyId(), writer);
     backup.doBackup();
 
     // Put another key to make sure we restore
@@ -241,11 +241,17 @@ public class BackupIntegrationTest {
     createDiskStore();
 
     BackupService backup = cache.getBackupService();
-    backup.prepareBackup(cache.getInternalDistributedSystem().getDistributedMember(), backupDir,
-        null);
+    BackupWriter writer = getBackupWriter();
+    backup.prepareBackup(cache.getMyId(), writer);
     backup.doBackup();
     assertEquals("No backup files should have been created", Collections.emptyList(),
         Arrays.asList(backupDir.list()));
+  }
+
+  private BackupWriter getBackupWriter() {
+    Properties backupProperties = BackupUtil.createBackupProperties(backupDir.toString(), null);
+    return BackupWriterFactory.FILE_SYSTEM.createWriter(backupProperties,
+        cache.getMyId().toString());
   }
 
   @Test
@@ -257,8 +263,7 @@ public class BackupIntegrationTest {
     region.put("A", "A");
 
     BackupService backup = cache.getBackupService();
-    backup.prepareBackup(cache.getInternalDistributedSystem().getDistributedMember(), backupDir,
-        null);
+    backup.prepareBackup(cache.getMyId(), getBackupWriter());
     backup.doBackup();
 
 
@@ -285,8 +290,7 @@ public class BackupIntegrationTest {
     }
 
     BackupService backupService = cache.getBackupService();
-    backupService.prepareBackup(cache.getInternalDistributedSystem().getDistributedMember(),
-        backupDir, null);
+    backupService.prepareBackup(cache.getMyId(), getBackupWriter());
     final Region theRegion = region;
     final DiskStore theDiskStore = ds;
     CompletableFuture.runAsync(() -> destroyAndCompact(theRegion, theDiskStore));
@@ -319,8 +323,7 @@ public class BackupIntegrationTest {
     createRegion();
 
     BackupService backupService = cache.getBackupService();
-    backupService.prepareBackup(cache.getInternalDistributedSystem().getDistributedMember(),
-        backupDir, null);
+    backupService.prepareBackup(cache.getMyId(), getBackupWriter());
     backupService.doBackup();
     Collection<File> fileCollection = FileUtils.listFiles(backupDir,
         new RegexFileFilter("BackupIntegrationTest.cache.xml"), DirectoryFileFilter.DIRECTORY);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/backup/BackupPrepareAndFinishMsgDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/backup/BackupPrepareAndFinishMsgDUnitTest.java
@@ -26,6 +26,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -143,9 +144,10 @@ public abstract class BackupPrepareAndFinishMsgDUnitTest extends CacheTestCase {
       throws InterruptedException, TimeoutException, ExecutionException {
     DistributionManager dm = GemFireCacheImpl.getInstance().getDistributionManager();
     Set recipients = dm.getOtherDistributionManagerIds();
+    Properties backupProperties = BackupUtil.createBackupProperties(diskDirs[0].toString(), null);
     Future<Void> future = null;
     new PrepareBackupOperation(dm, dm.getId(), dm.getCache(), recipients,
-        new PrepareBackupFactory(), diskDirs[0], null).send();
+        new PrepareBackupFactory(), backupProperties).send();
     ReentrantLock backupLock = ((LocalRegion) region).getDiskStore().getBackupLock();
     future = CompletableFuture.runAsync(function);
     Awaitility.await().atMost(5, TimeUnit.SECONDS)
@@ -158,8 +160,9 @@ public abstract class BackupPrepareAndFinishMsgDUnitTest extends CacheTestCase {
   private void doReadActionsAndVerifyCompletion() {
     DistributionManager dm = GemFireCacheImpl.getInstance().getDistributionManager();
     Set recipients = dm.getOtherDistributionManagerIds();
+    Properties backupProperties = BackupUtil.createBackupProperties(diskDirs[0].toString(), null);
     new PrepareBackupOperation(dm, dm.getId(), dm.getCache(), recipients,
-        new PrepareBackupFactory(), diskDirs[0], null).send();
+        new PrepareBackupFactory(), backupProperties).send();
     ReentrantLock backupLock = ((LocalRegion) region).getDiskStore().getBackupLock();
     List<CompletableFuture<?>> futureList = doReadActions();
     CompletableFuture.allOf(futureList.toArray(new CompletableFuture<?>[futureList.size()]));

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/backup/BackupServiceTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/backup/BackupServiceTest.java
@@ -20,7 +20,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -74,7 +73,7 @@ public class BackupServiceTest {
   public void startBackupThrowsExceptionWhenAnotherBackupInProgress() throws Exception {
     BackupTask backupTask = mock(BackupTask.class);
     backupService.currentTask.set(backupTask);
-    assertThatThrownBy(() -> backupService.prepareBackup(sender, new File(""), null))
+    assertThatThrownBy(() -> backupService.prepareBackup(sender, null))
         .isInstanceOf(IOException.class);
   }
 
@@ -85,7 +84,7 @@ public class BackupServiceTest {
 
   @Test
   public void prepareBackupReturnsEmptyPersistentIdsWhenBackupNotInProgress() throws Exception {
-    assertThat(backupService.prepareBackup(sender, new File(""), null).size()).isEqualTo(0);
+    assertThat(backupService.prepareBackup(sender, null).size()).isEqualTo(0);
   }
 
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/backup/BackupWriterFactoryTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/backup/BackupWriterFactoryTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.backup;
+
+import static org.apache.geode.internal.cache.backup.AbstractBackupWriterConfig.TIMESTAMP;
+import static org.apache.geode.internal.cache.backup.AbstractBackupWriterConfig.TYPE;
+import static org.apache.geode.internal.cache.backup.BackupWriterFactory.FILE_SYSTEM;
+import static org.apache.geode.internal.cache.backup.FileSystemBackupWriterConfig.BASELINE_DIR;
+import static org.apache.geode.internal.cache.backup.FileSystemBackupWriterConfig.TARGET_DIR;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Properties;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.test.junit.categories.UnitTest;
+
+@Category(UnitTest.class)
+public class BackupWriterFactoryTest {
+
+  @Test
+  public void returnsCorrectFactoryForName() {
+    assertThat(BackupWriterFactory.getFactoryForType("FileSystem")).isEqualTo(FILE_SYSTEM);
+  }
+
+  @Test
+  public void throwsExceptionWhenFactoryForInvalidNameGiven() {
+    assertThatThrownBy(() -> BackupWriterFactory.getFactoryForType("badName"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void getType() {
+    assertThat(FILE_SYSTEM.getType()).isEqualTo("FileSystem");
+  }
+
+  @Test
+  public void returnsCorrectWriterType() {
+    Properties properties = new Properties();
+    properties.setProperty(TYPE, FILE_SYSTEM.getType());
+    properties.setProperty(TIMESTAMP, "yyyy-MM-dd-HH-mm-ss");
+    properties.setProperty(TARGET_DIR, "targetDir");
+    properties.setProperty(BASELINE_DIR, "baselineDir");
+
+    assertThat(FILE_SYSTEM.createWriter(properties, "memberId"))
+        .isInstanceOf(FileSystemBackupWriter.class);
+  }
+
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/backup/FileSystemBackupWriterConfigTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/backup/FileSystemBackupWriterConfigTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.backup;
+
+import static org.apache.geode.internal.cache.backup.FileSystemBackupWriterConfig.BASELINE_DIR;
+import static org.apache.geode.internal.cache.backup.FileSystemBackupWriterConfig.TARGET_DIR;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Properties;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.test.junit.categories.UnitTest;
+
+@Category(UnitTest.class)
+public class FileSystemBackupWriterConfigTest {
+
+  private Properties properties;
+  private String targetDir;
+  private String baselineDir;
+  private FileSystemBackupWriterConfig config;
+
+  @Before
+  public void setUp() {
+    properties = new Properties();
+    config = new FileSystemBackupWriterConfig(properties);
+    targetDir = "relative/path";
+    baselineDir = "baseline/directory";
+  }
+
+  @Test
+  public void getTargetDirectoryThrowsIfMissing() {
+    assertThatThrownBy(() -> config.getTargetDirectory()).isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  public void getTargetDirectoryThrowsIfBlank() {
+    properties.setProperty(TARGET_DIR, "");
+    assertThatThrownBy(() -> config.getTargetDirectory()).isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  public void getTargetDirectoryReturnsCorrectString() {
+    properties.setProperty(TARGET_DIR, targetDir);
+    assertThat(config.getTargetDirectory()).isEqualTo(targetDir);
+  }
+
+  @Test
+  public void getBaselineDirectoryReturnsCorrectString() {
+    properties.setProperty(BASELINE_DIR, baselineDir);
+    assertThat(config.getBaselineDirectory()).isEqualTo(baselineDir);
+  }
+
+  @Test
+  public void getBaselineDirectoryIsOptional() {
+    assertThatCode(() -> config.getBaselineDirectory()).doesNotThrowAnyException();
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/backup/IncrementalBackupDistributedTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/backup/IncrementalBackupDistributedTest.java
@@ -60,7 +60,6 @@ import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.cache.persistence.PersistentID;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.DistributedSystem;
-import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.internal.ClassPathLoader;
 import org.apache.geode.internal.DeployedJar;
 import org.apache.geode.internal.cache.DiskStoreImpl;
@@ -207,51 +206,33 @@ public class IncrementalBackupDistributedTest extends JUnit4CacheTestCase {
     });
   }
 
-  /**
-   * Invokes {@link BackupUtil#backupAllMembers(DistributionManager, File, File)} on a member.
-   *
-   * @param vm a member of the distributed system
-   * @return the status of the backup.
-   */
   private BackupStatus baseline(VM vm) {
     return vm.invoke(() -> {
       try {
-        return BackupUtil.backupAllMembers(getSystem().getDistributionManager(), getBaselineDir(),
-            null);
+        return BackupUtil.backupAllMembers(getSystem().getDistributionManager(),
+            getBaselineDir().toString(), null);
       } catch (ManagementException e) {
         throw new RuntimeException(e);
       }
     });
   }
 
-  /**
-   * Invokes {@link BackupUtil#backupAllMembers(DistributionManager, File, File)} on a member.
-   *
-   * @param vm a member of the distributed system.
-   * @return a status of the backup operation.
-   */
   private BackupStatus incremental(VM vm) {
     return vm.invoke(() -> {
       try {
         return BackupUtil.backupAllMembers(getSystem().getDistributionManager(),
-            getIncrementalDir(), getBaselineBackupDir());
+            getIncrementalDir().toString(), getBaselineBackupDir().toString());
       } catch (ManagementException e) {
         throw new RuntimeException(e);
       }
     });
   }
 
-  /**
-   * Invokes {@link BackupUtil#backupAllMembers(DistributionManager, File, File)} on a member.
-   *
-   * @param vm a member of the distributed system.
-   * @return a status of the backup operation.
-   */
   private BackupStatus incremental2(VM vm) {
     return vm.invoke(() -> {
       try {
         return BackupUtil.backupAllMembers(getSystem().getDistributionManager(),
-            getIncremental2Dir(), getIncrementalBackupDir());
+            getIncremental2Dir().toString(), getIncrementalBackupDir().toString());
       } catch (ManagementException e) {
         throw new RuntimeException(e);
       }
@@ -960,7 +941,7 @@ public class IncrementalBackupDistributedTest extends JUnit4CacheTestCase {
       public Object call() {
         try {
           return BackupUtil.backupAllMembers(getSystem().getDistributionManager(),
-              getIncrementalDir(), this.baselineDir);
+              getIncrementalDir().toString(), this.baselineDir.toString());
 
         } catch (ManagementException e) {
           throw new RuntimeException(e);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/backup/PrepareBackupFactoryTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/backup/PrepareBackupFactoryTest.java
@@ -18,8 +18,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.io.File;
 import java.util.HashSet;
+import java.util.Properties;
 import java.util.Set;
 
 import org.junit.Before;
@@ -44,7 +44,6 @@ public class PrepareBackupFactoryTest {
   private Set<InternalDistributedMember> recipients;
   private InternalDistributedMember member;
   private InternalCache cache;
-  private File targetDir;
 
   @Before
   public void setUp() throws Exception {
@@ -53,8 +52,6 @@ public class PrepareBackupFactoryTest {
     sender = mock(InternalDistributedMember.class);
     member = mock(InternalDistributedMember.class);
     cache = mock(InternalCache.class);
-    targetDir = mock(File.class);
-
     recipients = new HashSet<>();
 
     when(dm.getSystem()).thenReturn(mock(InternalDistributedSystem.class));
@@ -71,13 +68,14 @@ public class PrepareBackupFactoryTest {
 
   @Test
   public void createRequestReturnsPrepareBackupRequest() throws Exception {
-    assertThat(prepareBackupFactory.createRequest(sender, recipients, 1, targetDir, null))
+    assertThat(prepareBackupFactory.createRequest(sender, recipients, 1, null))
         .isInstanceOf(PrepareBackupRequest.class);
   }
 
   @Test
   public void createPrepareBackupReturnsPrepareBackup() throws Exception {
-    assertThat(prepareBackupFactory.createPrepareBackup(member, cache, targetDir, null))
+    Properties properties = BackupUtil.createBackupProperties("targetDir", null);
+    assertThat(prepareBackupFactory.createPrepareBackup(member, cache, properties))
         .isInstanceOf(PrepareBackup.class);
   }
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/backup/PrepareBackupOperationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/backup/PrepareBackupOperationTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.when;
 import java.io.File;
 import java.io.IOException;
 import java.util.HashSet;
+import java.util.Properties;
 import java.util.Set;
 
 import org.junit.Before;
@@ -80,17 +81,20 @@ public class PrepareBackupOperationTest {
     member2 = mock(InternalDistributedMember.class, "member2");
     recipients = new HashSet<>();
 
+    Properties backupProperties =
+        BackupUtil.createBackupProperties(targetDir.toString(), baselineDir.toString());
+
     prepareBackupOperation = new PrepareBackupOperation(dm, sender, cache, recipients,
-        prepareBackupFactory, targetDir, baselineDir);
+        prepareBackupFactory, backupProperties);
 
     when(prepareBackupReplyProcessor.getProcessorId()).thenReturn(42);
 
     when(prepareBackupFactory.createReplyProcessor(eq(prepareBackupOperation), eq(dm),
         eq(recipients))).thenReturn(prepareBackupReplyProcessor);
-    when(prepareBackupFactory.createRequest(eq(sender), eq(recipients), eq(42), eq(targetDir),
-        eq(baselineDir))).thenReturn(prepareBackupRequest);
-    when(prepareBackupFactory.createPrepareBackup(eq(sender), eq(cache), eq(targetDir),
-        eq(baselineDir))).thenReturn(prepareBackup);
+    when(prepareBackupFactory.createRequest(eq(sender), eq(recipients), eq(42),
+        eq(backupProperties))).thenReturn(prepareBackupRequest);
+    when(prepareBackupFactory.createPrepareBackup(eq(sender), eq(cache), eq(backupProperties)))
+        .thenReturn(prepareBackup);
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/backup/PrepareBackupRequestTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/backup/PrepareBackupRequestTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 import java.io.File;
 import java.io.IOException;
 import java.util.HashSet;
+import java.util.Properties;
 import java.util.Set;
 
 import org.junit.Before;
@@ -52,6 +53,7 @@ public class PrepareBackupRequestTest {
   private PrepareBackup prepareBackup;
   private File targetDir;
   private File baselineDir;
+  private Properties backupProperties;
 
   @Before
   public void setUp() throws Exception {
@@ -67,24 +69,27 @@ public class PrepareBackupRequestTest {
     recipients = new HashSet<>();
     persistentIds = new HashSet<>();
 
+    backupProperties =
+        BackupUtil.createBackupProperties(targetDir.toString(), baselineDir.toString());
+
     when(dm.getCache()).thenReturn(cache);
     when(dm.getDistributionManagerId()).thenReturn(sender);
-    when(prepareBackupFactory.createPrepareBackup(eq(sender), eq(cache), eq(targetDir),
-        eq(baselineDir))).thenReturn(prepareBackup);
+    when(prepareBackupFactory.createPrepareBackup(eq(sender), eq(cache), eq(backupProperties)))
+        .thenReturn(prepareBackup);
     when(prepareBackupFactory.createBackupResponse(eq(sender), eq(persistentIds)))
         .thenReturn(mock(BackupResponse.class));
     when(prepareBackup.run()).thenReturn(persistentIds);
 
-    prepareBackupRequest = new PrepareBackupRequest(sender, recipients, msgId, prepareBackupFactory,
-        targetDir, baselineDir);
+    prepareBackupRequest =
+        new PrepareBackupRequest(sender, recipients, msgId, prepareBackupFactory, backupProperties);
   }
 
   @Test
   public void usesFactoryToCreatePrepareBackup() throws Exception {
     prepareBackupRequest.createResponse(dm);
 
-    verify(prepareBackupFactory, times(1)).createPrepareBackup(eq(sender), eq(cache), eq(targetDir),
-        eq(baselineDir));
+    verify(prepareBackupFactory, times(1)).createPrepareBackup(eq(sender), eq(cache),
+        eq(backupProperties));
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/PersistentPartitionedRegionTestBase.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/PersistentPartitionedRegionTestBase.java
@@ -615,8 +615,8 @@ public abstract class PersistentPartitionedRegionTestBase extends JUnit4CacheTes
   protected BackupStatus backup(final VM vm) {
     return vm.invoke("backup", () -> {
       try {
-        return BackupUtil.backupAllMembers(getSystem().getDistributionManager(), getBackupDir(),
-            null);
+        return BackupUtil.backupAllMembers(getSystem().getDistributionManager(),
+            getBackupDir().toString(), null);
       } catch (ManagementException e) {
         throw new RuntimeException(e);
       }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/beans/DistributedSystemBridgeJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/beans/DistributedSystemBridgeJUnitTest.java
@@ -73,7 +73,7 @@ public class DistributedSystemBridgeJUnitTest {
 
     InOrder inOrder = inOrder(dm, backupService);
     inOrder.verify(dm).putOutgoing(isA(PrepareBackupRequest.class));
-    inOrder.verify(backupService).prepareBackup(any(), any(), any());
+    inOrder.verify(backupService).prepareBackup(any(), any());
     inOrder.verify(dm).putOutgoing(isA(FinishBackupRequest.class));
     inOrder.verify(backupService).doBackup();
   }

--- a/geode-core/src/test/resources/org/apache/geode/codeAnalysis/excludedClasses.txt
+++ b/geode-core/src/test/resources/org/apache/geode/codeAnalysis/excludedClasses.txt
@@ -20,9 +20,10 @@ org/apache/geode/internal/cache/DiskStoreMonitor$DiskState
 org/apache/geode/internal/cache/InitialImageOperation$GIITestHook
 org/apache/geode/internal/cache/Oplog$OPLOG_TYPE
 org/apache/geode/internal/cache/UserSpecifiedDiskStoreAttributes
+org/apache/geode/internal/cache/backup/BackupWriterFactory
+org/apache/geode/internal/cache/backup/BackupWriterFactory$1
 org/apache/geode/internal/cache/client/protocol/exception/ServiceLoadingFailureException
 org/apache/geode/internal/cache/client/protocol/exception/ServiceVersionNotFoundException
-org/apache/geode/internal/cache/UserSpecifiedDiskStoreAttributes
 org/apache/geode/internal/cache/client/protocol/exception/ServiceLoadingFailureException
 org/apache/geode/internal/cache/client/protocol/exception/ServiceVersionNotFoundException
 org/apache/geode/internal/cache/tier/CommunicationMode

--- a/geode-core/src/test/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
+++ b/geode-core/src/test/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
@@ -1426,8 +1426,8 @@ fromData,14,2a2bb700042a2bb80005b50003b1
 toData,14,2a2bb700062ab400032bb80007b1
 
 org/apache/geode/internal/cache/backup/PrepareBackupRequest,2
-fromData,22,2a2bb700192a2bb8001ab500082a2bb8001ab50009b1
-toData,22,2a2bb7001b2ab400082bb8001c2ab400092bb8001cb1
+fromData,14,2a2bb700182a2bb80019b50008b1
+toData,14,2a2bb7001a2ab400082bb8001bb1
 
 org/apache/geode/internal/cache/compression/CompressedCachedDeserializable,2
 fromData,18,2a2ab600082bb8000fb900090200b50003b1


### PR DESCRIPTION
  * to faciliate future creation of backup plugins, the BackupWriter is created
    using generic information passed from gfsh