### PR TITLE
GEODE-4182: Add JdbcConnectorException

### DIFF
--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/JdbcAsyncWriter.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/JdbcAsyncWriter.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.connectors.jdbc;
 
+import java.sql.SQLException;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -68,7 +69,7 @@ public class JdbcAsyncWriter extends AbstractJdbcCallback implements AsyncEventL
           getSqlHandler().write(event.getRegion(), event.getOperation(), event.getKey(),
               getPdxInstance(event));
           changeSuccessfulEvents(1);
-        } catch (RuntimeException ex) {
+        } catch (SQLException | RuntimeException ex) {
           changeFailedEvents(1);
           logger.error("Exception processing event {}", event, ex);
         }

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/JdbcConnectorException.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/JdbcConnectorException.java
@@ -12,34 +12,17 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.geode.connectors.jdbc.internal;
+package org.apache.geode.connectors.jdbc;
 
-import java.sql.Connection;
-import java.sql.SQLException;
+/**
+ * An exception thrown when communication with an external JDBC data source fails and can be used
+ * to diagnose the cause of database communication failures.
+ *
+ * @since Geode 1.5
+ */
+public class JdbcConnectorException extends RuntimeException {
 
-import com.zaxxer.hikari.HikariDataSource;
-
-class HikariJdbcDataSource implements JdbcDataSource {
-
-  private final HikariDataSource delegate;
-
-  HikariJdbcDataSource(ConnectionConfiguration config) {
-    HikariDataSource ds = new HikariDataSource();
-    ds.setJdbcUrl(config.getUrl());
-    ds.setUsername(config.getUser());
-    ds.setPassword(config.getPassword());
-    ds.setDataSourceProperties(config.getConnectionProperties());
-    this.delegate = ds;
+  public JdbcConnectorException(Exception e) {
+    super(e);
   }
-
-  @Override
-  public Connection getConnection() throws SQLException {
-    return this.delegate.getConnection();
-  }
-
-  @Override
-  public void close() {
-    this.delegate.close();
-  }
-
 }

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/JdbcConnectorException.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/JdbcConnectorException.java
@@ -14,15 +14,22 @@
  */
 package org.apache.geode.connectors.jdbc;
 
+import org.apache.geode.cache.CacheRuntimeException;
+
 /**
  * An exception thrown when communication with an external JDBC data source fails and can be used
  * to diagnose the cause of database communication failures.
  *
  * @since Geode 1.5
  */
-public class JdbcConnectorException extends RuntimeException {
+public class JdbcConnectorException extends CacheRuntimeException {
+  private static final long serialVersionUID = 1L;
 
   public JdbcConnectorException(Exception e) {
     super(e);
+  }
+
+  public JdbcConnectorException(String message) {
+    super(message);
   }
 }

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/JdbcLoader.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/JdbcLoader.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.connectors.jdbc;
 
+import java.sql.SQLException;
+
 import org.apache.geode.annotations.Experimental;
 import org.apache.geode.cache.CacheLoader;
 import org.apache.geode.cache.CacheLoaderException;
@@ -49,6 +51,10 @@ public class JdbcLoader<K, V> extends AbstractJdbcCallback implements CacheLoade
     // The following cast to V is to keep the compiler happy
     // but is erased at runtime and no actual cast happens.
     checkInitialized((InternalCache) helper.getRegion().getRegionService());
-    return (V) getSqlHandler().read(helper.getRegion(), helper.getKey());
+    try {
+      return (V) getSqlHandler().read(helper.getRegion(), helper.getKey());
+    } catch (SQLException e) {
+      throw new JdbcConnectorException(e);
+    }
   }
 }

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/HikariJdbcDataSourceFactory.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/HikariJdbcDataSourceFactory.java
@@ -14,7 +14,7 @@
  */
 package org.apache.geode.connectors.jdbc.internal;
 
-public class HikariJdbcDataSourceFactory implements JdbcDataSourceFactory {
+class HikariJdbcDataSourceFactory implements JdbcDataSourceFactory {
   public JdbcDataSource create(ConnectionConfiguration configuration) {
     return new HikariJdbcDataSource(configuration);
   }

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/SqlHandler.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/SqlHandler.java
@@ -26,6 +26,7 @@ import java.util.List;
 import org.apache.geode.annotations.Experimental;
 import org.apache.geode.cache.Operation;
 import org.apache.geode.cache.Region;
+import org.apache.geode.connectors.jdbc.JdbcConnectorException;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.pdx.PdxInstance;
 import org.apache.geode.pdx.PdxInstanceFactory;
@@ -132,7 +133,7 @@ public class SqlHandler {
           }
         }
         if (resultSet.next()) {
-          throw new IllegalStateException(
+          throw new JdbcConnectorException(
               "Multiple rows returned for query: " + resultSet.getStatement().toString());
         }
         pdxInstance = factory.create();

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/SqlHandler.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/SqlHandler.java
@@ -29,7 +29,6 @@ import org.apache.geode.cache.Region;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.pdx.PdxInstance;
 import org.apache.geode.pdx.PdxInstanceFactory;
-import org.apache.geode.pdx.internal.PdxInstanceImpl;
 
 @Experimental
 public class SqlHandler {
@@ -52,15 +51,11 @@ public class SqlHandler {
     manager.close();
   }
 
-  Connection getConnection(ConnectionConfiguration config) {
-    try {
-      return manager.getDataSource(config).getConnection();
-    } catch (SQLException e) {
-      throw new IllegalStateException("Could not connect to " + config.getUrl(), e);
-    }
+  Connection getConnection(ConnectionConfiguration config) throws SQLException {
+    return manager.getDataSource(config).getConnection();
   }
 
-  public <K, V> PdxInstance read(Region<K, V> region, K key) {
+  public <K, V> PdxInstance read(Region<K, V> region, K key) throws SQLException {
     if (key == null) {
       throw new IllegalArgumentException("Key for query cannot be null");
     }
@@ -69,18 +64,16 @@ public class SqlHandler {
     ConnectionConfiguration connectionConfig =
         getConnectionConfig(regionMapping.getConnectionConfigName());
     String tableName = regionMapping.getRegionToTableName();
-    PdxInstance result = null;
+    PdxInstance result;
     try (Connection connection = getConnection(connectionConfig)) {
       List<ColumnValue> columnList =
           getColumnToValueList(connection, regionMapping, key, null, Operation.GET);
       try (PreparedStatement statement =
-          getPreparedStatement(connection, columnList, tableName, Operation.GET, 0)) {
+          getPreparedStatement(connection, columnList, tableName, Operation.GET)) {
         PdxInstanceFactory factory = getPdxInstanceFactory(region, regionMapping);
         String keyColumnName = getKeyColumnName(connection, tableName);
         result = executeReadStatement(statement, columnList, factory, regionMapping, keyColumnName);
       }
-    } catch (SQLException e) {
-      handleSQLException(e);
     }
     return result;
   }
@@ -122,32 +115,28 @@ public class SqlHandler {
   }
 
   PdxInstance executeReadStatement(PreparedStatement statement, List<ColumnValue> columnList,
-      PdxInstanceFactory factory, RegionMapping regionMapping, String keyColumnName) {
+      PdxInstanceFactory factory, RegionMapping regionMapping, String keyColumnName)
+      throws SQLException {
     PdxInstance pdxInstance = null;
-    try {
-      setValuesInStatement(statement, columnList);
-      try (ResultSet resultSet = statement.executeQuery()) {
-        if (resultSet.next()) {
-          ResultSetMetaData metaData = resultSet.getMetaData();
-          int ColumnsNumber = metaData.getColumnCount();
-          for (int i = 1; i <= ColumnsNumber; i++) {
-            Object columnValue = resultSet.getObject(i);
-            String columnName = metaData.getColumnName(i);
-            String fieldName = mapColumnNameToFieldName(columnName, regionMapping);
-            if (regionMapping.isPrimaryKeyInValue()
-                || !keyColumnName.equalsIgnoreCase(columnName)) {
-              factory.writeField(fieldName, columnValue, Object.class);
-            }
+    setValuesInStatement(statement, columnList);
+    try (ResultSet resultSet = statement.executeQuery()) {
+      if (resultSet.next()) {
+        ResultSetMetaData metaData = resultSet.getMetaData();
+        int ColumnsNumber = metaData.getColumnCount();
+        for (int i = 1; i <= ColumnsNumber; i++) {
+          Object columnValue = resultSet.getObject(i);
+          String columnName = metaData.getColumnName(i);
+          String fieldName = mapColumnNameToFieldName(columnName, regionMapping);
+          if (regionMapping.isPrimaryKeyInValue() || !keyColumnName.equalsIgnoreCase(columnName)) {
+            factory.writeField(fieldName, columnValue, Object.class);
           }
-          if (resultSet.next()) {
-            throw new IllegalStateException(
-                "Multiple rows returned for query: " + resultSet.getStatement().toString());
-          }
-          pdxInstance = factory.create();
         }
+        if (resultSet.next()) {
+          throw new IllegalStateException(
+              "Multiple rows returned for query: " + resultSet.getStatement().toString());
+        }
+        pdxInstance = factory.create();
       }
-    } catch (SQLException e) {
-      handleSQLException(e);
     }
     return pdxInstance;
   }
@@ -165,7 +154,8 @@ public class SqlHandler {
     return regionMapping.getFieldNameForColumn(columnName);
   }
 
-  public <K, V> void write(Region<K, V> region, Operation operation, K key, PdxInstance value) {
+  public <K, V> void write(Region<K, V> region, Operation operation, K key, PdxInstance value)
+      throws SQLException {
     if (value == null && operation != Operation.DESTROY) {
       throw new IllegalArgumentException("PdxInstance cannot be null for non-destroy operations");
     }
@@ -174,15 +164,18 @@ public class SqlHandler {
         getConnectionConfig(regionMapping.getConnectionConfigName());
 
     String tableName = regionMapping.getRegionToTableName();
-    int pdxTypeId = value == null ? 0 : ((PdxInstanceImpl) value).getPdxType().getTypeId();
 
     try (Connection connection = getConnection(connectionConfig)) {
       List<ColumnValue> columnList =
           getColumnToValueList(connection, regionMapping, key, value, operation);
       int updateCount = 0;
       try (PreparedStatement statement =
-          getPreparedStatement(connection, columnList, tableName, operation, pdxTypeId)) {
-        updateCount = executeWriteStatement(statement, columnList, operation, false);
+          getPreparedStatement(connection, columnList, tableName, operation)) {
+        updateCount = executeWriteStatement(statement, columnList);
+      } catch (SQLException e) {
+        if (operation.isDestroy()) {
+          throw e;
+        }
       }
 
       // Destroy action not guaranteed to modify any database rows
@@ -193,16 +186,14 @@ public class SqlHandler {
       if (updateCount <= 0) {
         Operation upsertOp = getOppositeOperation(operation);
         try (PreparedStatement upsertStatement =
-            getPreparedStatement(connection, columnList, tableName, upsertOp, pdxTypeId)) {
-          updateCount = executeWriteStatement(upsertStatement, columnList, upsertOp, true);
+            getPreparedStatement(connection, columnList, tableName, upsertOp)) {
+          updateCount = executeWriteStatement(upsertStatement, columnList);
         }
       }
 
       if (updateCount != 1) {
         throw new IllegalStateException("Unexpected updateCount " + updateCount);
       }
-    } catch (SQLException e) {
-      handleSQLException(e);
     }
   }
 
@@ -210,30 +201,16 @@ public class SqlHandler {
     return operation.isUpdate() ? Operation.CREATE : Operation.UPDATE;
   }
 
-  private int executeWriteStatement(PreparedStatement statement, List<ColumnValue> columnList,
-      Operation operation, boolean handleException) {
-    int updateCount = 0;
-    try {
-      setValuesInStatement(statement, columnList);
-      updateCount = statement.executeUpdate();
-    } catch (SQLException e) {
-      if (handleException || operation.isDestroy()) {
-        handleSQLException(e);
-      }
-    }
-    return updateCount;
+  private int executeWriteStatement(PreparedStatement statement, List<ColumnValue> columnList)
+      throws SQLException {
+    setValuesInStatement(statement, columnList);
+    return statement.executeUpdate();
   }
 
   private PreparedStatement getPreparedStatement(Connection connection,
-      List<ColumnValue> columnList, String tableName, Operation operation, int pdxTypeId) {
+      List<ColumnValue> columnList, String tableName, Operation operation) throws SQLException {
     String sqlStr = getSqlString(tableName, columnList, operation);
-    PreparedStatement statement = null;
-    try {
-      statement = connection.prepareStatement(sqlStr);
-    } catch (SQLException e) {
-      handleSQLException(e);
-    }
-    return statement;
+    return connection.prepareStatement(sqlStr);
   }
 
   private String getSqlString(String tableName, List<ColumnValue> columnList, Operation operation) {
@@ -278,9 +255,5 @@ public class SqlHandler {
       result.add(columnValue);
     }
     return result;
-  }
-
-  static void handleSQLException(SQLException e) {
-    throw new IllegalStateException("JDBC connector detected unexpected SQLException", e);
   }
 }

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/TableKeyColumnManager.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/TableKeyColumnManager.java
@@ -21,6 +21,8 @@ import java.sql.SQLException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import org.apache.geode.connectors.jdbc.JdbcConnectorException;
+
 /**
  * Given a tableName this manager will determine which column should correspond to the Geode Region
  * key. The current implementation uses a connection to lookup the SQL metadata for the table and
@@ -37,7 +39,7 @@ class TableKeyColumnManager {
   }
 
   private String computeKeyColumnName(Connection connection, String tableName) {
-    String key = null;
+    String key;
     try {
       DatabaseMetaData metaData = connection.getMetaData();
       try (ResultSet tables = metaData.getTables(null, null, "%", null)) {
@@ -45,7 +47,7 @@ class TableKeyColumnManager {
         key = getPrimaryKeyColumnNameFromMetaData(realTableName, metaData);
       }
     } catch (SQLException e) {
-      SqlHandler.handleSQLException(e);
+      throw new JdbcConnectorException(e);
     }
     return key;
   }

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/JdbcAsyncWriterTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/JdbcAsyncWriterTest.java
@@ -67,7 +67,7 @@ public class JdbcAsyncWriterTest {
   }
 
   @Test
-  public void writesAProvidedEvent() {
+  public void writesAProvidedEvent() throws Exception {
     writer.processEvents(Collections.singletonList(createMockEvent()));
 
     verify(sqlHandler, times(1)).write(any(), any(), any(), any());
@@ -76,7 +76,7 @@ public class JdbcAsyncWriterTest {
   }
 
   @Test
-  public void writesMultipleProvidedEvents() {
+  public void writesMultipleProvidedEvents() throws Exception {
     List<AsyncEvent> events = new ArrayList<>();
     events.add(createMockEvent());
     events.add(createMockEvent());

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/JdbcLoaderTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/JdbcLoaderTest.java
@@ -48,7 +48,7 @@ public class JdbcLoaderTest {
   }
 
   @Test
-  public void loadReadsFromSqlHandler() {
+  public void loadReadsFromSqlHandler() throws Exception {
     loader.load(loaderHelper);
 
     verify(sqlHandler, times(1)).read(any(), any());

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/JdbcWriterTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/JdbcWriterTest.java
@@ -62,7 +62,7 @@ public class JdbcWriterTest {
   }
 
   @Test
-  public void beforeUpdateWithPdxInstanceWritesToSqlHandler() {
+  public void beforeUpdateWithPdxInstanceWritesToSqlHandler() throws Exception {
     writer.beforeUpdate(entryEvent);
 
     verify(sqlHandler, times(1)).write(any(), any(), any(), eq(pdxInstance));
@@ -77,14 +77,14 @@ public class JdbcWriterTest {
   }
 
   @Test
-  public void beforeCreateWithPdxInstanceWritesToSqlHandler() {
+  public void beforeCreateWithPdxInstanceWritesToSqlHandler() throws Exception {
     writer.beforeCreate(entryEvent);
 
     verify(sqlHandler, times(1)).write(any(), any(), any(), eq(pdxInstance));
   }
 
   @Test
-  public void beforeDestroyWithPdxInstanceWritesToSqlHandler() {
+  public void beforeDestroyWithPdxInstanceWritesToSqlHandler() throws Exception {
     writer.beforeDestroy(entryEvent);
 
     verify(sqlHandler, times(1)).write(any(), any(), any(), eq(pdxInstance));

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/SqlHandlerTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/SqlHandlerTest.java
@@ -45,6 +45,7 @@ import org.junit.rules.ExpectedException;
 
 import org.apache.geode.cache.Operation;
 import org.apache.geode.cache.Region;
+import org.apache.geode.connectors.jdbc.JdbcConnectorException;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.pdx.PdxInstanceFactory;
 import org.apache.geode.pdx.internal.PdxInstanceImpl;
@@ -212,7 +213,7 @@ public class SqlHandlerTest {
     when(cache.createPdxInstanceFactory(anyString(), anyBoolean()))
         .thenReturn(mock(PdxInstanceFactory.class));
 
-    thrown.expect(IllegalStateException.class);
+    thrown.expect(JdbcConnectorException.class);
     handler.read(region, new Object());
   }
 

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/SqlHandlerTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/SqlHandlerTest.java
@@ -113,7 +113,7 @@ public class SqlHandlerTest {
   }
 
   @Test
-  public void readReturnsNullIfNoKeyProvided() {
+  public void readReturnsNullIfNoKeyProvided() throws Exception {
     thrown.expect(IllegalArgumentException.class);
     handler.read(region, null);
   }
@@ -158,7 +158,7 @@ public class SqlHandlerTest {
   public void throwsExceptionIfQueryFails() throws Exception {
     when(statement.executeQuery()).thenThrow(SQLException.class);
 
-    thrown.expect(IllegalStateException.class);
+    thrown.expect(SQLException.class);
     handler.read(region, new Object());
   }
 
@@ -209,7 +209,6 @@ public class SqlHandlerTest {
     when(result.getStatement()).thenReturn(mock(PreparedStatement.class));
     when(statement.executeQuery()).thenReturn(result);
 
-    // when(manager.getKeyColumnName(any(), anyString())).thenReturn("key");
     when(cache.createPdxInstanceFactory(anyString(), anyBoolean()))
         .thenReturn(mock(PdxInstanceFactory.class));
 
@@ -218,7 +217,7 @@ public class SqlHandlerTest {
   }
 
   @Test
-  public void writeThrowsExceptionIfValueIsNullAndNotDoingDestroy() {
+  public void writeThrowsExceptionIfValueIsNullAndNotDoingDestroy() throws Exception {
     thrown.expect(IllegalArgumentException.class);
     handler.write(region, Operation.UPDATE, new Object(), null);
   }
@@ -267,7 +266,7 @@ public class SqlHandlerTest {
   public void destroyThrowExceptionWhenFail() throws Exception {
     when(statement.executeUpdate()).thenThrow(SQLException.class);
 
-    thrown.expect(IllegalStateException.class);
+    thrown.expect(SQLException.class);
     handler.write(region, Operation.DESTROY, new Object(), value);
   }
 
@@ -351,7 +350,7 @@ public class SqlHandlerTest {
     when(insertStatement.executeUpdate()).thenThrow(SQLException.class);
     when(connection.prepareStatement(any())).thenReturn(statement).thenReturn(insertStatement);
 
-    thrown.expect(IllegalStateException.class);
+    thrown.expect(SQLException.class);
     handler.write(region, Operation.UPDATE, new Object(), value);
     verify(statement).close();
     verify(insertStatement).close();
@@ -466,7 +465,7 @@ public class SqlHandlerTest {
     doThrow(new SQLException("test exception")).when(dataSource).getConnection();
 
     assertThatThrownBy(() -> handler.getConnection(connectionConfig))
-        .isInstanceOf(IllegalStateException.class).hasMessage("Could not connect to fake:url");
+        .isInstanceOf(SQLException.class).hasMessage("test exception");
   }
 
 

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/TableKeyColumnManagerTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/TableKeyColumnManagerTest.java
@@ -31,6 +31,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import org.apache.geode.connectors.jdbc.JdbcConnectorException;
 import org.apache.geode.test.junit.categories.UnitTest;
 
 @Category(UnitTest.class)
@@ -74,7 +75,7 @@ public class TableKeyColumnManagerTest {
     when(connection.getMetaData()).thenThrow(SQLException.class);
 
     assertThatThrownBy(() -> tableKeyColumnManager.getKeyColumnName(connection, TABLE_NAME))
-        .isInstanceOf(IllegalStateException.class);
+        .isInstanceOf(JdbcConnectorException.class);
   }
 
   @Test


### PR DESCRIPTION
  * This runtime exception is used to warp failures in comminication with
    an exernal database when using a JDBC data source