### PR TITLE
GEODE-4756: Restore the correct help string for the --group option

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListMembersCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListMembersCommand.java
@@ -40,7 +40,7 @@ public class ListMembersCommand implements GfshCommand {
       operation = ResourcePermission.Operation.READ)
   public Result listMember(@CliOption(key = {CliStrings.GROUP, CliStrings.GROUPS},
       optionContext = ConverterHint.MEMBERGROUP,
-      help = CliStrings.ALTER_REGION__GROUP__HELP) String[] groups) {
+      help = CliStrings.LIST_MEMBER__GROUP__HELP) String[] groups) {
 
     Set<DistributedMember> memberSet = new TreeSet<>();
     memberSet.addAll(this.findMembersIncludingLocators(groups, null));


### PR DESCRIPTION
Help string should be: Group name for which members will be displayed.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
