### PR TITLE
GEODE-4765: Add retries when retrieving cluster config

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
@@ -1041,7 +1041,10 @@ public class InternalLocator extends Locator implements ConnectListener {
         this.productUseLog.reopen();
       }
       this.productUseLog.monitorUse(newSystem);
-      startSharedConfigurationService();
+      if (isSharedConfigurationEnabled()) {
+        this.sharedConfig = new ClusterConfigurationService(newCache);
+        startSharedConfigurationService();
+      }
       if (!this.server.isAlive()) {
         logger.info("Locator restart: starting TcpServer");
         startTcpServer();

--- a/geode-core/src/test/java/org/apache/geode/management/internal/configuration/ClusterConfigLocatorRestartDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/configuration/ClusterConfigLocatorRestartDUnitTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.management.internal.configuration;
+
+import java.util.Properties;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.distributed.ConfigurationProperties;
+import org.apache.geode.distributed.internal.InternalDistributedSystem;
+import org.apache.geode.distributed.internal.membership.gms.MembershipManagerHelper;
+import org.apache.geode.internal.AvailablePortHelper;
+import org.apache.geode.test.dunit.rules.ClusterStartupRule;
+import org.apache.geode.test.dunit.rules.MemberVM;
+import org.apache.geode.test.junit.categories.DistributedTest;
+import org.apache.geode.test.junit.rules.GfshCommandRule;
+
+@Category(DistributedTest.class)
+public class ClusterConfigLocatorRestartDUnitTest {
+
+  private MemberVM locator1;
+  private MemberVM server1;
+  private MemberVM server2;
+
+  @Rule
+  public ClusterStartupRule rule = new ClusterStartupRule();
+
+  @Rule
+  public GfshCommandRule gfsh = new GfshCommandRule();
+
+  @Before
+  public void setup() throws Exception {
+    Properties props = new Properties();
+    props.setProperty(ConfigurationProperties.MAX_WAIT_TIME_RECONNECT, "5000");
+    // TODO: Need an actual port because reconnect doesn't work with an ephemeral port -
+    // i.e. if we use 0 initially. Fix this.
+    locator1 = rule.startLocatorVM(0, props, AvailablePortHelper.getRandomAvailableTCPPort());
+
+    server1 = rule.startServerVM(1, props, locator1.getPort());
+    server2 = rule.startServerVM(2, props, locator1.getPort());
+  }
+
+  @Test
+  public void serverRestartsAfterLocatorReconnects() throws Exception {
+    server2.invokeAsync(() -> MembershipManagerHelper
+        .crashDistributedSystem(InternalDistributedSystem.getConnectedInstance()));
+    locator1.invokeAsync(() -> MembershipManagerHelper
+        .crashDistributedSystem(InternalDistributedSystem.getConnectedInstance()));
+
+    // Wait some time to reconnect
+    Thread.sleep(10000);
+
+    rule.startServerVM(3, locator1.getPort());
+
+    gfsh.connectAndVerify(locator1);
+    gfsh.executeAndAssertThat("list members").statusIsSuccess().tableHasColumnOnlyWithValues("Name",
+        "locator-0", "server-1", "server-2", "server-3");
+  }
+
+}

--- a/geode-core/src/test/java/org/apache/geode/test/junit/rules/MemberStarterRule.java
+++ b/geode-core/src/test/java/org/apache/geode/test/junit/rules/MemberStarterRule.java
@@ -59,7 +59,7 @@ public abstract class MemberStarterRule<T> extends SerializableExternalResource 
 
   protected transient TemporaryFolder temporaryFolder;
   protected File workingDir;
-  protected int memberPort = -1;
+  protected int memberPort = 0;
   protected int jmxPort = -1;
   protected int httpPort = -1;
 

--- a/geode-core/src/test/java/org/apache/geode/test/junit/rules/MemberStarterRule.java
+++ b/geode-core/src/test/java/org/apache/geode/test/junit/rules/MemberStarterRule.java
@@ -59,7 +59,7 @@ public abstract class MemberStarterRule<T> extends SerializableExternalResource 
 
   protected transient TemporaryFolder temporaryFolder;
   protected File workingDir;
-  protected int memberPort = 0;
+  protected int memberPort = -1;
   protected int jmxPort = -1;
   protected int httpPort = -1;
 


### PR DESCRIPTION
- This helps when a locator is reconnecting to the distributed system and isn't
  fully ready yet.
- During reconnect, pass a fresh cache to the ClusterConfigurationService -
  this fixes the 'DLock destroyed' issue.
- Also fixes GEODE-4730

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
