### PR TITLE
[GEODE-4459] Remove singleton calls from all tests in org.apache.geode.pdx

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/pdx/ClientsWithVersioningRetryDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/pdx/ClientsWithVersioningRetryDUnitTest.java
@@ -269,7 +269,7 @@ public class ClientsWithVersioningRetryDUnitTest extends JUnit4CacheTestCase {
     vm1.invoke(new SerializableRunnable() {
       @Override
       public void run() {
-        GemFireCacheImpl cache = GemFireCacheImpl.getInstance();
+        GemFireCacheImpl cache = (GemFireCacheImpl) basicGetCache();
         assertTrue(cache == null || cache.isClosed());
       }
     });
@@ -382,7 +382,7 @@ public class ClientsWithVersioningRetryDUnitTest extends JUnit4CacheTestCase {
     vm0.invoke(new SerializableRunnable() {
       @Override
       public void run() {
-        GemFireCacheImpl cache = GemFireCacheImpl.getInstance();
+        GemFireCacheImpl cache = (GemFireCacheImpl) basicGetCache();
         assertTrue(cache == null || cache.isClosed());
       }
     });

--- a/geode-core/src/test/java/org/apache/geode/pdx/DistributedSystemIdDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/pdx/DistributedSystemIdDUnitTest.java
@@ -140,8 +140,7 @@ public class DistributedSystemIdDUnitTest extends JUnit4DistributedTestCase {
 
     SerializableCallable createSystem = new SerializableCallable() {
       public Object call() throws Exception {
-        ClusterDistributionManager dm = (ClusterDistributionManager) InternalDistributedSystem
-            .getAnyInstance().getDistributionManager();
+        ClusterDistributionManager dm = (ClusterDistributionManager) basicGetSystem().getDistributionManager();
         assertEquals(dsId, dm.getDistributedSystemId());
         return null;
       }

--- a/geode-core/src/test/java/org/apache/geode/pdx/DistributedSystemIdDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/pdx/DistributedSystemIdDUnitTest.java
@@ -140,7 +140,8 @@ public class DistributedSystemIdDUnitTest extends JUnit4DistributedTestCase {
 
     SerializableCallable createSystem = new SerializableCallable() {
       public Object call() throws Exception {
-        ClusterDistributionManager dm = (ClusterDistributionManager) basicGetSystem().getDistributionManager();
+        ClusterDistributionManager dm =
+            (ClusterDistributionManager) basicGetSystem().getDistributionManager();
         assertEquals(dsId, dm.getDistributedSystemId());
         return null;
       }

--- a/geode-core/src/test/java/org/apache/geode/pdx/PdxAttributesJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/pdx/PdxAttributesJUnitTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.geode.test.dunit.cache.internal.JUnit4CacheTestCase;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -62,7 +63,7 @@ import org.apache.geode.test.junit.categories.SerializationTest;
  *
  */
 @Category({IntegrationTest.class, SerializationTest.class})
-public class PdxAttributesJUnitTest {
+public class PdxAttributesJUnitTest extends JUnit4CacheTestCase {
 
   private File diskDir;
 
@@ -77,7 +78,7 @@ public class PdxAttributesJUnitTest {
 
   @After
   public void tearDown() throws Exception {
-    GemFireCacheImpl instance = GemFireCacheImpl.getInstance();
+    GemFireCacheImpl instance = (GemFireCacheImpl) basicGetCache();
     if (instance != null) {
       instance.close();
     }

--- a/geode-core/src/test/java/org/apache/geode/pdx/PdxAttributesJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/pdx/PdxAttributesJUnitTest.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.geode.test.dunit.cache.internal.JUnit4CacheTestCase;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -56,6 +55,7 @@ import org.apache.geode.pdx.internal.EnumId;
 import org.apache.geode.pdx.internal.EnumInfo;
 import org.apache.geode.pdx.internal.PdxType;
 import org.apache.geode.pdx.internal.PeerTypeRegistration;
+import org.apache.geode.test.dunit.cache.internal.JUnit4CacheTestCase;
 import org.apache.geode.test.junit.categories.IntegrationTest;
 import org.apache.geode.test.junit.categories.SerializationTest;
 

--- a/geode-core/src/test/java/org/apache/geode/pdx/PdxInstanceJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/pdx/PdxInstanceJUnitTest.java
@@ -25,6 +25,8 @@ import java.lang.reflect.InvocationTargetException;
 import java.math.BigInteger;
 import java.util.*;
 
+import org.apache.geode.cache.CacheClosedException;
+import org.apache.geode.test.dunit.cache.internal.JUnit4CacheTestCase;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -44,7 +46,7 @@ import org.apache.geode.test.junit.categories.SerializationTest;
  *
  */
 @Category({IntegrationTest.class, SerializationTest.class})
-public class PdxInstanceJUnitTest {
+public class PdxInstanceJUnitTest extends JUnit4CacheTestCase {
 
   private GemFireCacheImpl c;
   private int allFieldCount;
@@ -223,8 +225,10 @@ public class PdxInstanceJUnitTest {
     if (f instanceof PdxInstanceEnumInfo) {
       PdxInstanceEnumInfo e = (PdxInstanceEnumInfo) f;
       assertEquals("ONE", e.getName());
-      GemFireCacheImpl theCache = GemFireCacheImpl
-          .getForPdx("PDX registry is unavailable because the Cache has been closed.");
+      GemFireCacheImpl theCache = (GemFireCacheImpl) getCache();
+      if ( theCache == null) {
+        throw new CacheClosedException("PDX registry is unavailable because the Cache has been closed.");
+      }
       theCache.getPdxRegistry().flushCache();
       assertEquals(MyComplexEnum.ONE, e.getObject());
     } else {
@@ -240,8 +244,10 @@ public class PdxInstanceJUnitTest {
     if (f instanceof PdxInstanceEnumInfo) {
       PdxInstanceEnumInfo e = (PdxInstanceEnumInfo) f;
       assertEquals("ONE", e.getName());
-      GemFireCacheImpl theCache = GemFireCacheImpl
-          .getForPdx("PDX registry is unavailable because the Cache has been closed.");
+      GemFireCacheImpl theCache = (GemFireCacheImpl) getCache();
+      if ( theCache == null) {
+        throw new CacheClosedException("PDX registry is unavailable because the Cache has been closed.");
+      }
       theCache.getPdxRegistry().flushCache();
       assertEquals(MyEnum.ONE, e.getObject());
     } else {

--- a/geode-core/src/test/java/org/apache/geode/pdx/PdxInstanceJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/pdx/PdxInstanceJUnitTest.java
@@ -25,20 +25,20 @@ import java.lang.reflect.InvocationTargetException;
 import java.math.BigInteger;
 import java.util.*;
 
-import org.apache.geode.cache.CacheClosedException;
-import org.apache.geode.test.dunit.cache.internal.JUnit4CacheTestCase;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import org.apache.geode.DataSerializer;
+import org.apache.geode.cache.CacheClosedException;
 import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.internal.HeapDataOutputStream;
 import org.apache.geode.internal.Version;
 import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.pdx.internal.EnumInfo.PdxInstanceEnumInfo;
 import org.apache.geode.pdx.internal.PdxInstanceFactoryImpl;
+import org.apache.geode.test.dunit.cache.internal.JUnit4CacheTestCase;
 import org.apache.geode.test.junit.categories.IntegrationTest;
 import org.apache.geode.test.junit.categories.SerializationTest;
 
@@ -226,8 +226,9 @@ public class PdxInstanceJUnitTest extends JUnit4CacheTestCase {
       PdxInstanceEnumInfo e = (PdxInstanceEnumInfo) f;
       assertEquals("ONE", e.getName());
       GemFireCacheImpl theCache = (GemFireCacheImpl) getCache();
-      if ( theCache == null) {
-        throw new CacheClosedException("PDX registry is unavailable because the Cache has been closed.");
+      if (theCache == null) {
+        throw new CacheClosedException(
+            "PDX registry is unavailable because the Cache has been closed.");
       }
       theCache.getPdxRegistry().flushCache();
       assertEquals(MyComplexEnum.ONE, e.getObject());
@@ -245,8 +246,9 @@ public class PdxInstanceJUnitTest extends JUnit4CacheTestCase {
       PdxInstanceEnumInfo e = (PdxInstanceEnumInfo) f;
       assertEquals("ONE", e.getName());
       GemFireCacheImpl theCache = (GemFireCacheImpl) getCache();
-      if ( theCache == null) {
-        throw new CacheClosedException("PDX registry is unavailable because the Cache has been closed.");
+      if (theCache == null) {
+        throw new CacheClosedException(
+            "PDX registry is unavailable because the Cache has been closed.");
       }
       theCache.getPdxRegistry().flushCache();
       assertEquals(MyEnum.ONE, e.getObject());


### PR DESCRIPTION
Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.

Removed GemFireCacheImpl.getInstance, InternalDistributedSystem.getAnyInstance,
    GemFireCacheImpl.getForPdx from all tests in org.apache.geode.pdx