### PR TITLE
GEODE-4735: Move CliUtil "get member" commands to CacheMembers interf…

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/BeanUtilFuncs.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/BeanUtilFuncs.java
@@ -31,7 +31,7 @@ import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.management.GemFireProperties;
-import org.apache.geode.management.internal.cli.CliUtil;
+import org.apache.geode.management.internal.cli.CacheMembers;
 
 /**
  * Various Utility Functions to be used by MBeans
@@ -123,8 +123,8 @@ public class BeanUtilFuncs {
     DistributedMember memberFound = null;
 
     if (memberNameOrId != null) {
-      InternalCache cache = (InternalCache) CacheFactory.getAnyInstance();
-      Set<DistributedMember> memberSet = CliUtil.getAllMembers(cache);
+      CacheMembers cacheMembers = () -> (InternalCache) CacheFactory.getAnyInstance();
+      Set<DistributedMember> memberSet = cacheMembers.getAllMembers();
       for (DistributedMember member : memberSet) {
         if (memberNameOrId.equals(member.getId()) || memberNameOrId.equals(member.getName())) {
           memberFound = member;

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/CacheMembers.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/CacheMembers.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.management.internal.cli;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.geode.cache.Region;
+import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.distributed.internal.InternalDistributedSystem;
+import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.management.DistributedRegionMXBean;
+import org.apache.geode.management.ManagementService;
+import org.apache.geode.management.internal.MBeanJMXAdapter;
+import org.apache.geode.management.internal.cli.exceptions.EntityNotFoundException;
+import org.apache.geode.management.internal.cli.exceptions.UserErrorException;
+import org.apache.geode.management.internal.cli.i18n.CliStrings;
+
+/**
+ * A utility class to provide easy access to members, particularly in Gfsh commands and functions,
+ * provided cache access is already available. As an interface, an anonymous class can be
+ * instantiated via lambda, providing a {@link java.util.function.Supplier} for the
+ * {@link CacheMembers#getCache()} method.
+ */
+public interface CacheMembers {
+  InternalCache getCache();
+
+  /**
+   * Gets all members in the GemFire distributed system/cache, including locators
+   */
+  default Set<DistributedMember> getAllMembers() {
+    return getAllMembers(getCache());
+  }
+
+  default Set<DistributedMember> getAllMembers(final InternalCache cache) {
+    return getAllMembers(cache.getInternalDistributedSystem());
+  }
+
+  default Set<DistributedMember> getAllMembers(InternalDistributedSystem internalDS) {
+    return new HashSet<DistributedMember>(
+        internalDS.getDistributionManager().getDistributionManagerIds());
+  }
+
+  /**
+   * Get All members, excluding locators
+   */
+  default Set<DistributedMember> getAllNormalMembers(InternalCache cache) {
+    return new HashSet<DistributedMember>(cache.getInternalDistributedSystem()
+        .getDistributionManager().getNormalDistributionManagerIds());
+  }
+
+  /**
+   * this either returns a non-null member or throw an exception if member is not found.
+   */
+  default DistributedMember getMember(final String memberName) {
+    DistributedMember member = findMember(memberName);
+
+    if (member == null) {
+      throw new EntityNotFoundException(
+          CliStrings.format(CliStrings.MEMBER_NOT_FOUND_ERROR_MESSAGE, memberName));
+    }
+    return member;
+  }
+
+  /**
+   * if no members matches these names, a UserErrorException will be thrown
+   */
+  default Set<DistributedMember> getMembers(String[] groups, String[] members) {
+    Set<DistributedMember> matchingMembers = findMembers(groups, members);
+    if (matchingMembers.size() == 0) {
+      throw new EntityNotFoundException(CliStrings.NO_MEMBERS_FOUND_MESSAGE);
+    }
+    return matchingMembers;
+  }
+
+  /**
+   * if no members matches these names, a UserErrorException will be thrown
+   */
+  default Set<DistributedMember> getMembersIncludingLocators(String[] groups, String[] members) {
+    Set<DistributedMember> matchingMembers = findMembersIncludingLocators(groups, members);
+    if (matchingMembers.size() == 0) {
+      throw new EntityNotFoundException(CliStrings.NO_MEMBERS_FOUND_MESSAGE);
+    }
+    return matchingMembers;
+  }
+
+  /**
+   * this will return the member found or null if no member with that name
+   */
+  default DistributedMember findMember(final String memberName) {
+    return findMember(memberName, getCache());
+  }
+
+  default DistributedMember findMember(final String memberName, InternalCache cache) {
+    if (memberName == null) {
+      return null;
+    }
+
+    Set<DistributedMember> memberSet = getAllMembers(cache);
+    return memberSet.stream().filter(member -> memberName.equalsIgnoreCase(member.getId())
+        || memberName.equalsIgnoreCase(member.getName())).findFirst().orElse(null);
+  }
+
+  /**
+   * if no members matches these names, an empty set would return, this does not include locators
+   */
+  default Set<DistributedMember> findMembers(String[] groups, String[] members) {
+    return findMembers(groups, members, getCache());
+  }
+
+  default Set<DistributedMember> findMembers(String[] groups, String[] members,
+      InternalCache cache) {
+    Set<DistributedMember> allNormalMembers = getAllNormalMembers(cache);
+
+    return findMembers(allNormalMembers, groups, members);
+  }
+
+  default Set<DistributedMember> findMembers(Set<DistributedMember> membersToConsider,
+      String[] groups, String[] members) {
+    if (groups == null) {
+      groups = new String[] {};
+    }
+
+    if (members == null) {
+      members = new String[] {};
+    }
+
+    if ((members.length > 0) && (groups.length > 0)) {
+      throw new UserErrorException(CliStrings.PROVIDE_EITHER_MEMBER_OR_GROUP_MESSAGE);
+    }
+
+    if (members.length == 0 && groups.length == 0) {
+      return membersToConsider;
+    }
+
+    Set<DistributedMember> matchingMembers = new HashSet<>();
+    // it will either go into this loop or the following loop, not both.
+    for (String memberNameOrId : members) {
+      for (DistributedMember member : membersToConsider) {
+        if (memberNameOrId.equalsIgnoreCase(member.getId())
+            || memberNameOrId.equalsIgnoreCase(member.getName())) {
+          matchingMembers.add(member);
+        }
+      }
+    }
+
+    for (String group : groups) {
+      for (DistributedMember member : membersToConsider) {
+        if (member.getGroups().contains(group)) {
+          matchingMembers.add(member);
+        }
+      }
+    }
+    return matchingMembers;
+  }
+
+  /**
+   * if no members matches these names, an empty set would return
+   */
+  default Set<DistributedMember> findMembersIncludingLocators(String[] groups, String[] members) {
+    Set<DistributedMember> allMembers = getAllMembers(getCache());
+    return findMembers(allMembers, groups, members);
+  }
+
+  default Set<DistributedMember> findMembersForRegion(InternalCache cache, String regionPath) {
+    return CliUtil.getRegionAssociatedMembers(regionPath, cache, true);
+  }
+
+  default Set<DistributedMember> findAnyMembersForRegion(InternalCache cache, String regionPath) {
+    return getRegionAssociatedMembers(regionPath, cache, false);
+  }
+
+  default Set<DistributedMember> getRegionAssociatedMembers(String region,
+      final InternalCache cache, boolean returnAll) {
+    if (region == null || region.isEmpty()) {
+      return Collections.emptySet();
+    }
+
+    if (!region.startsWith(Region.SEPARATOR)) {
+      region = Region.SEPARATOR + region;
+    }
+
+    DistributedRegionMXBean regionMXBean =
+        ManagementService.getManagementService(cache).getDistributedRegionMXBean(region);
+
+    if (regionMXBean == null) {
+      return Collections.emptySet();
+    }
+
+    String[] regionAssociatedMemberNames = regionMXBean.getMembers();
+    Set<DistributedMember> matchedMembers = new HashSet<>();
+    Set<DistributedMember> allClusterMembers = new HashSet<>(cache.getMembers());
+    allClusterMembers.add(cache.getDistributedSystem().getDistributedMember());
+
+    for (DistributedMember member : allClusterMembers) {
+      for (String regionAssociatedMemberName : regionAssociatedMemberNames) {
+        String name = MBeanJMXAdapter.getMemberNameOrId(member);
+        if (name.equals(regionAssociatedMemberName)) {
+          matchedMembers.add(member);
+          if (!returnAll) {
+            return matchedMembers;
+          }
+        }
+      }
+    }
+    return matchedMembers;
+  }
+
+  default Set<DistributedMember> findMembersWithAsyncEventQueue(String queueId) {
+    InternalCache cache = getCache();
+    Set<DistributedMember> members = findMembers(null, null, cache);
+    return members.stream().filter(m -> CliUtil.getAsyncEventQueueIds(cache, m).contains(queueId))
+        .collect(Collectors.toSet());
+  }
+
+}

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/AlterRegionCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/AlterRegionCommand.java
@@ -96,7 +96,7 @@ public class AlterRegionCommand implements GfshCommand {
     InternalCache cache = getCache();
 
     if (groups != null) {
-      RegionCommandsUtils.validateGroups(cache, groups);
+      RegionCommandsUtils.validateGroups(getAllNormalMembers(cache), groups);
     }
 
     RegionFunctionArgs regionFunctionArgs = new RegionFunctionArgs();

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/AlterRuntimeConfigCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/AlterRuntimeConfigCommand.java
@@ -37,7 +37,6 @@ import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
 import org.apache.geode.management.internal.cli.AbstractCliAroundInterceptor;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.GfshParseResult;
 import org.apache.geode.management.internal.cli.functions.AlterRuntimeConfigFunction;
 import org.apache.geode.management.internal.cli.functions.CliFunctionResult;
@@ -96,7 +95,7 @@ public class AlterRuntimeConfigCommand implements GfshCommand {
 
     Map<String, String> runTimeDistributionConfigAttributes = new HashMap<>();
     Map<String, String> rumTimeCacheAttributes = new HashMap<>();
-    Set<DistributedMember> targetMembers = CliUtil.findMembers(group, memberNameOrId, getCache());
+    Set<DistributedMember> targetMembers = findMembers(group, memberNameOrId, getCache());
 
     if (targetMembers.isEmpty()) {
       return ResultBuilder.createUserErrorResult(CliStrings.NO_MEMBERS_FOUND_MESSAGE);
@@ -182,7 +181,7 @@ public class AlterRuntimeConfigCommand implements GfshCommand {
     allRunTimeAttributes.putAll(rumTimeCacheAttributes);
 
     ResultCollector<?, ?> rc =
-        CliUtil.executeFunction(alterRunTimeConfigFunction, allRunTimeAttributes, targetMembers);
+        executeFunction(alterRunTimeConfigFunction, allRunTimeAttributes, targetMembers);
     List<CliFunctionResult> results = CliFunctionResult.cleanResults((List<?>) rc.getResult());
     Set<String> successfulMembers = new TreeSet<>();
     Set<String> errorMessages = new TreeSet<>();

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ChangeLogLevelCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ChangeLogLevelCommand.java
@@ -36,7 +36,6 @@ import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
 import org.apache.geode.management.internal.cli.AbstractCliAroundInterceptor;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.GfshParseResult;
 import org.apache.geode.management.internal.cli.LogWrapper;
 import org.apache.geode.management.internal.cli.functions.ChangeLogLevelFunction;
@@ -71,7 +70,7 @@ public class ChangeLogLevelCommand implements GfshCommand {
       LogWriter logger = cache.getLogger();
 
       Set<DistributedMember> dsMembers = new HashSet<>();
-      Set<DistributedMember> ds = CliUtil.getAllMembers(cache);
+      Set<DistributedMember> ds = getAllMembers(cache);
 
       if (grps != null && grps.length > 0) {
         for (String grp : grps) {
@@ -135,7 +134,7 @@ public class ChangeLogLevelCommand implements GfshCommand {
 
           }
         } catch (Exception ex) {
-          LogWrapper.getInstance(CliUtil.getCacheIfExists(this::getCache))
+          LogWrapper.getInstance(getCacheIfExists())
               .warning("change log level command exception " + ex);
         }
       }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CloseDurableCQsCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CloseDurableCQsCommand.java
@@ -26,7 +26,6 @@ import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.domain.MemberResult;
 import org.apache.geode.management.internal.cli.functions.CloseDurableCqFunction;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
@@ -57,7 +56,7 @@ public class CloseDurableCQsCommand implements GfshCommand {
           optionContext = ConverterHint.MEMBERGROUP) final String[] group) {
     Result result;
     try {
-      Set<DistributedMember> targetMembers = CliUtil.findMembers(group, memberNameOrId, getCache());
+      Set<DistributedMember> targetMembers = findMembers(group, memberNameOrId, getCache());
 
       if (targetMembers.isEmpty()) {
         return ResultBuilder.createUserErrorResult(CliStrings.NO_MEMBERS_FOUND_MESSAGE);
@@ -68,7 +67,7 @@ public class CloseDurableCQsCommand implements GfshCommand {
       params[1] = cqName;
 
       final ResultCollector<?, ?> rc =
-          CliUtil.executeFunction(new CloseDurableCqFunction(), params, targetMembers);
+          executeFunction(new CloseDurableCqFunction(), params, targetMembers);
       final List<MemberResult> results = (List<MemberResult>) rc.getResult();
       String failureHeader =
           CliStrings.format(CliStrings.CLOSE_DURABLE_CQS__FAILURE__HEADER, cqName, durableClientId);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CloseDurableClientCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CloseDurableClientCommand.java
@@ -26,7 +26,6 @@ import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.domain.MemberResult;
 import org.apache.geode.management.internal.cli.functions.CloseDurableClientFunction;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
@@ -55,14 +54,14 @@ public class CloseDurableClientCommand implements GfshCommand {
     Result result;
     try {
 
-      Set<DistributedMember> targetMembers = CliUtil.findMembers(group, memberNameOrId, getCache());
+      Set<DistributedMember> targetMembers = findMembers(group, memberNameOrId, getCache());
 
       if (targetMembers.isEmpty()) {
         return ResultBuilder.createUserErrorResult(CliStrings.NO_MEMBERS_FOUND_MESSAGE);
       }
 
       final ResultCollector<?, ?> rc =
-          CliUtil.executeFunction(new CloseDurableClientFunction(), durableClientId, targetMembers);
+          executeFunction(new CloseDurableClientFunction(), durableClientId, targetMembers);
       final List<MemberResult> results = (List<MemberResult>) rc.getResult();
       String failureHeader =
           CliStrings.format(CliStrings.CLOSE_DURABLE_CLIENTS__FAILURE__HEADER, durableClientId);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CompactDiskStoreCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CompactDiskStoreCommand.java
@@ -37,7 +37,6 @@ import org.apache.geode.management.ManagementService;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.LogWrapper;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.CompositeResultData;
@@ -122,7 +121,7 @@ public class CompactDiskStoreCommand implements GfshCommand {
             }
             String notExecutedMembers = CompactRequest.getNotExecutedMembers();
             if (notExecutedMembers != null && !notExecutedMembers.isEmpty()) {
-              LogWrapper.getInstance(CliUtil.getCacheIfExists(this::getCache))
+              LogWrapper.getInstance(getCacheIfExists())
                   .info("compact disk-store \"" + diskStoreName
                       + "\" message was scheduled to be sent to but was not send to "
                       + notExecutedMembers);
@@ -159,7 +158,7 @@ public class CompactDiskStoreCommand implements GfshCommand {
         } // all members' if
       } // disk store exists' if
     } catch (RuntimeException e) {
-      LogWrapper.getInstance(CliUtil.getCacheIfExists(this::getCache)).info(e.getMessage(), e);
+      LogWrapper.getInstance(getCacheIfExists()).info(e.getMessage(), e);
       result = ResultBuilder.createGemFireErrorResult(
           CliStrings.format(CliStrings.COMPACT_DISK_STORE__ERROR_WHILE_COMPACTING_REASON_0,
               new Object[] {e.getMessage()}));

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CompactOfflineDiskStoreCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CompactOfflineDiskStoreCommand.java
@@ -31,7 +31,6 @@ import org.apache.geode.GemFireIOException;
 import org.apache.geode.internal.lang.StringUtils;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.GfshParser;
 import org.apache.geode.management.internal.cli.LogWrapper;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
@@ -54,7 +53,7 @@ public class CompactOfflineDiskStoreCommand implements GfshCommand {
       @CliOption(key = CliStrings.COMPACT_OFFLINE_DISK_STORE__J,
           help = CliStrings.COMPACT_OFFLINE_DISK_STORE__J__HELP) String[] jvmProps) {
     Result result;
-    LogWrapper logWrapper = LogWrapper.getInstance(CliUtil.getCacheIfExists(this::getCache));
+    LogWrapper logWrapper = LogWrapper.getInstance(getCacheIfExists());
 
     StringBuilder output = new StringBuilder();
     StringBuilder error = new StringBuilder();

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ConfigurePDXCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ConfigurePDXCommand.java
@@ -28,7 +28,6 @@ import org.apache.geode.internal.cache.xmlcache.CacheXml;
 import org.apache.geode.internal.cache.xmlcache.CacheXmlGenerator;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.InfoResultData;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
@@ -63,7 +62,7 @@ public class ConfigurePDXCommand implements GfshCommand {
           && (patterns != null && patterns.length > 0)) {
         return ResultBuilder.createUserErrorResult(CliStrings.CONFIGURE_PDX__ERROR__MESSAGE);
       }
-      if (!CliUtil.getAllNormalMembers(getCache()).isEmpty()) {
+      if (!getAllNormalMembers(getCache()).isEmpty()) {
         ird.addLine(CliStrings.CONFIGURE_PDX__NORMAL__MEMBERS__WARNING);
       }
       // Set persistent and the disk-store

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ConnectCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ConnectCommand.java
@@ -282,7 +282,7 @@ public class ConnectCommand implements GfshCommand {
 
       gfsh.setOperationInvoker(operationInvoker);
 
-      LogWrapper.getInstance(CliUtil.getCacheIfExists(this::getCache))
+      LogWrapper.getInstance(getCacheIfExists())
           .info(CliStrings.format(CliStrings.CONNECT__MSG__SUCCESS, operationInvoker.toString()));
       return ResultBuilder.createInfoResult(
           CliStrings.format(CliStrings.CONNECT__MSG__SUCCESS, operationInvoker.toString()));
@@ -358,7 +358,7 @@ public class ConnectCommand implements GfshCommand {
       gfsh.setOperationInvoker(operationInvoker);
       infoResultData.addLine(CliStrings.format(CliStrings.CONNECT__MSG__SUCCESS,
           jmxHostPortToConnect.toString(false)));
-      LogWrapper.getInstance(CliUtil.getCacheIfExists(this::getCache)).info(CliStrings
+      LogWrapper.getInstance(getCacheIfExists()).info(CliStrings
           .format(CliStrings.CONNECT__MSG__SUCCESS, jmxHostPortToConnect.toString(false)));
       return ResultBuilder.buildResult(infoResultData);
     } catch (SecurityException | AuthenticationFailedException e) {
@@ -497,7 +497,7 @@ public class ConnectCommand implements GfshCommand {
   }
 
   private Result handleException(Exception e, String errorMessage) {
-    LogWrapper.getInstance(CliUtil.getCacheIfExists(this::getCache)).severe(errorMessage, e);
+    LogWrapper.getInstance(getCacheIfExists()).severe(errorMessage, e);
     return ResultBuilder.createConnectionErrorResult(errorMessage);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CountDurableCQEventsCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CountDurableCQEventsCommand.java
@@ -26,7 +26,6 @@ import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.domain.SubscriptionQueueSizeResult;
 import org.apache.geode.management.internal.cli.functions.GetSubscriptionQueueSizeFunction;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
@@ -56,7 +55,7 @@ public class CountDurableCQEventsCommand implements GfshCommand {
 
     Result result;
     try {
-      Set<DistributedMember> targetMembers = CliUtil.findMembers(group, memberNameOrId, getCache());
+      Set<DistributedMember> targetMembers = findMembers(group, memberNameOrId, getCache());
 
       if (targetMembers.isEmpty()) {
         return ResultBuilder.createUserErrorResult(CliStrings.NO_MEMBERS_FOUND_MESSAGE);
@@ -66,7 +65,7 @@ public class CountDurableCQEventsCommand implements GfshCommand {
       params[0] = durableClientId;
       params[1] = cqName;
       final ResultCollector<?, ?> rc =
-          CliUtil.executeFunction(new GetSubscriptionQueueSizeFunction(), params, targetMembers);
+          executeFunction(new GetSubscriptionQueueSizeFunction(), params, targetMembers);
       final List<SubscriptionQueueSizeResult> funcResults =
           (List<SubscriptionQueueSizeResult>) rc.getResult();
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateRegionCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateRegionCommand.java
@@ -521,12 +521,12 @@ public class CreateRegionCommand implements GfshCommand {
     return attributes;
   }
 
-  private static boolean isClusterWideSameConfig(InternalCache cache, String regionPath) {
+  private boolean isClusterWideSameConfig(InternalCache cache, String regionPath) {
     ManagementService managementService = ManagementService.getExistingManagementService(cache);
 
     DistributedSystemMXBean dsMXBean = managementService.getDistributedSystemMXBean();
 
-    Set<DistributedMember> allMembers = CliUtil.getAllNormalMembers(cache);
+    Set<DistributedMember> allMembers = getAllNormalMembers(cache);
 
     RegionAttributesData regionAttributesToValidateAgainst = null;
     for (DistributedMember distributedMember : allMembers) {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DeployCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DeployCommand.java
@@ -85,7 +85,7 @@ public class DeployCommand implements GfshCommand {
     List<String> jarFullPaths = CommandExecutionContext.getFilePathFromShell();
 
     Set<DistributedMember> targetMembers;
-    targetMembers = CliUtil.findMembers(groups, null, getCache());
+    targetMembers = findMembers(groups, null, getCache());
 
     List results = new ArrayList();
     ManagementAgent agent = ((SystemManagementService) getManagementService()).getManagementAgent();

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeClientCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeClientCommand.java
@@ -34,7 +34,6 @@ import org.apache.geode.management.ClientHealthStatus;
 import org.apache.geode.management.ManagementService;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.LogWrapper;
 import org.apache.geode.management.internal.cli.functions.ContinuousQueryFunction;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
@@ -105,7 +104,7 @@ public class DescribeClientCommand implements GfshCommand {
           CliStrings.format(CliStrings.DESCRIBE_CLIENT__CLIENT__ID__NOT__FOUND__0, clientId));
     }
 
-    Set<DistributedMember> dsMembers = CliUtil.getAllMembers(cache);
+    Set<DistributedMember> dsMembers = getAllMembers(cache);
     String isDurable = null;
     List<String> primaryServers = new ArrayList<>();
     List<String> secondaryServers = new ArrayList<>();
@@ -113,12 +112,12 @@ public class DescribeClientCommand implements GfshCommand {
     if (dsMembers.size() > 0) {
       ContinuousQueryFunction continuousQueryFunction = new ContinuousQueryFunction();
       FunctionService.registerFunction(continuousQueryFunction);
-      List<?> resultList = (List<?>) CliUtil
-          .executeFunction(continuousQueryFunction, clientId, dsMembers).getResult();
+      List<?> resultList =
+          (List<?>) executeFunction(continuousQueryFunction, clientId, dsMembers).getResult();
       for (Object aResultList : resultList) {
         Object object = aResultList;
         if (object instanceof Throwable) {
-          LogWrapper.getInstance(CliUtil.getCacheIfExists(this::getCache)).warning(
+          LogWrapper.getInstance(getCacheIfExists()).warning(
               "Exception in Describe Client " + ((Throwable) object).getMessage(),
               ((Throwable) object));
           continue;
@@ -156,8 +155,7 @@ public class DescribeClientCommand implements GfshCommand {
       return ResultBuilder.createGemFireErrorResult(CliStrings.DESCRIBE_CLIENT_NO_MEMBERS);
     }
 
-    LogWrapper.getInstance(CliUtil.getCacheIfExists(this::getCache))
-        .info("describe client result " + result);
+    LogWrapper.getInstance(getCacheIfExists()).info("describe client result " + result);
     return result;
   }
 
@@ -208,7 +206,7 @@ public class DescribeClientCommand implements GfshCommand {
           String poolStatsStr = entry.getValue();
           String str[] = poolStatsStr.split(";");
 
-          LogWrapper logWrapper = LogWrapper.getInstance(CliUtil.getCacheIfExists(this::getCache));
+          LogWrapper logWrapper = LogWrapper.getInstance(getCacheIfExists());
           logWrapper.info("describe client clientHealthStatus min conn="
               + str[0].substring(str[0].indexOf("=") + 1));
           logWrapper.info("describe client clientHealthStatus max conn ="

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyIndexCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyIndexCommand.java
@@ -27,7 +27,6 @@ import org.apache.geode.internal.lang.StringUtils;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.domain.IndexInfo;
 import org.apache.geode.management.internal.cli.functions.CliFunctionResult;
 import org.apache.geode.management.internal.cli.functions.DestroyIndexFunction;
@@ -70,7 +69,7 @@ public class DestroyIndexCommand implements GfshCommand {
     }
     IndexInfo indexInfo = new IndexInfo(indexName, regionName);
     indexInfo.setIfExists(ifExists);
-    Set<DistributedMember> targetMembers = CliUtil.findMembers(group, memberNameOrID, getCache());
+    Set<DistributedMember> targetMembers = findMembers(group, memberNameOrID, getCache());
 
     if (targetMembers.isEmpty()) {
       return ResultBuilder.createUserErrorResult(CliStrings.NO_MEMBERS_FOUND_MESSAGE);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DisconnectCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DisconnectCommand.java
@@ -19,7 +19,6 @@ import org.springframework.shell.core.annotation.CliCommand;
 
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.LogWrapper;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.InfoResultData;
@@ -46,7 +45,7 @@ public class DisconnectCommand implements GfshCommand {
           operationInvoker.stop();
           infoResultData.addLine(CliStrings.format(CliStrings.DISCONNECT__MSG__DISCONNECTED,
               operationInvoker.toString()));
-          LogWrapper.getInstance(CliUtil.getCacheIfExists(this::getCache)).info(CliStrings
+          LogWrapper.getInstance(getCacheIfExists()).info(CliStrings
               .format(CliStrings.DISCONNECT__MSG__DISCONNECTED, operationInvoker.toString()));
           if (!gfshInstance.isHeadlessMode()) {
             gfshInstance.setPromptPath(gfshInstance.getEnvAppContextPath());

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DiskStoreCommandsUtils.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DiskStoreCommandsUtils.java
@@ -18,12 +18,8 @@ package org.apache.geode.management.internal.cli.commands;
 import java.io.File;
 import java.net.URL;
 import java.util.List;
-import java.util.Set;
 
-import org.apache.geode.distributed.DistributedMember;
-import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.logging.LogService;
-import org.apache.geode.management.internal.cli.CliUtil;
 
 class DiskStoreCommandsUtils {
   static void configureLogging(final List<String> commandList) {
@@ -51,10 +47,5 @@ class DiskStoreCommandsUtils {
       invalidDirectories = builder.toString();
     }
     return invalidDirectories;
-  }
-
-  static Set<DistributedMember> getNormalMembers(final InternalCache cache) {
-    // TODO determine what this does (as it is untested and unmockable!)
-    return CliUtil.getAllNormalMembers(cache);
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExportConfigCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExportConfigCommand.java
@@ -30,7 +30,6 @@ import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
 import org.apache.geode.management.internal.cli.AbstractCliAroundInterceptor;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.GfshParseResult;
 import org.apache.geode.management.internal.cli.functions.CliFunctionResult;
 import org.apache.geode.management.internal.cli.functions.ExportConfigFunction;
@@ -68,13 +67,12 @@ public class ExportConfigCommand implements GfshCommand {
           help = CliStrings.EXPORT_CONFIG__DIR__HELP) String dir) {
     InfoResultData infoData = ResultBuilder.createInfoResultData();
 
-    Set<DistributedMember> targetMembers = CliUtil.findMembers(group, member, getCache());
+    Set<DistributedMember> targetMembers = findMembers(group, member, getCache());
     if (targetMembers.isEmpty()) {
       return ResultBuilder.createUserErrorResult(CliStrings.NO_MEMBERS_FOUND_MESSAGE);
     }
 
-    ResultCollector<?, ?> rc =
-        CliUtil.executeFunction(this.exportConfigFunction, null, targetMembers);
+    ResultCollector<?, ?> rc = executeFunction(this.exportConfigFunction, null, targetMembers);
     List<CliFunctionResult> results = CliFunctionResult.cleanResults((List<?>) rc.getResult());
 
     for (CliFunctionResult result : results) {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExportImportClusterConfigurationCommands.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExportImportClusterConfigurationCommands.java
@@ -44,7 +44,6 @@ import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.Result;
 import org.apache.geode.management.internal.cli.AbstractCliAroundInterceptor;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.GfshParseResult;
 import org.apache.geode.management.internal.cli.functions.CliFunctionResult;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
@@ -145,7 +144,7 @@ public class ExportImportClusterConfigurationCommands implements GfshCommand {
 
     InternalCache cache = getCache();
 
-    Set<DistributedMember> servers = CliUtil.getAllNormalMembers(cache);
+    Set<DistributedMember> servers = getAllNormalMembers(cache);
 
     Set<String> regionsWithData = servers.stream().map(this::getRegionNamesOnServer)
         .flatMap(Collection::stream).collect(toSet());

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExportOfflineDiskStoreCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExportOfflineDiskStoreCommand.java
@@ -24,7 +24,6 @@ import org.apache.geode.SystemFailure;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.LogWrapper;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
@@ -61,7 +60,7 @@ public class ExportOfflineDiskStoreCommand implements GfshCommand {
       throw e;
     } catch (Throwable th) {
       SystemFailure.checkFailure();
-      LogWrapper.getInstance(CliUtil.getCacheIfExists(this::getCache)).warning(th.getMessage(), th);
+      LogWrapper.getInstance(getCacheIfExists()).warning(th.getMessage(), th);
       return ResultBuilder.createGemFireErrorResult(CliStrings
           .format(CliStrings.EXPORT_OFFLINE_DISK_STORE__ERROR, diskStoreName, th.toString()));
     }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/GCCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/GCCommand.java
@@ -29,7 +29,6 @@ import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.LogWrapper;
 import org.apache.geode.management.internal.cli.functions.GarbageCollectionFunction;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
@@ -69,7 +68,7 @@ public class GCCommand implements GfshCommand {
     } else {
       // gc on entire cluster
       // exclude locators
-      dsMembers = CliUtil.getAllNormalMembers(cache);
+      dsMembers = getAllNormalMembers(cache);
       result = executeAndBuildResult(resultTable, dsMembers);
 
     }
@@ -81,16 +80,15 @@ public class GCCommand implements GfshCommand {
 
     List<?> resultList;
     Function garbageCollectionFunction = new GarbageCollectionFunction();
-    resultList =
-        (List<?>) CliUtil.executeFunction(garbageCollectionFunction, null, dsMembers).getResult();
+    resultList = (List<?>) executeFunction(garbageCollectionFunction, null, dsMembers).getResult();
 
     for (Object object : resultList) {
       if (object instanceof Exception) {
-        LogWrapper.getInstance(CliUtil.getCacheIfExists(this::getCache))
+        LogWrapper.getInstance(getCacheIfExists())
             .fine("Exception in GC " + ((Throwable) object).getMessage(), ((Throwable) object));
         continue;
       } else if (object instanceof Throwable) {
-        LogWrapper.getInstance(CliUtil.getCacheIfExists(this::getCache))
+        LogWrapper.getInstance(getCacheIfExists())
             .fine("Exception in GC " + ((Throwable) object).getMessage(), ((Throwable) object));
         continue;
       }
@@ -106,8 +104,7 @@ public class GCCommand implements GfshCommand {
               resultMap.get("TimeSpentInGC"));
         }
       } else {
-        LogWrapper.getInstance(CliUtil.getCacheIfExists(this::getCache))
-            .fine("ResultMap was null ");
+        LogWrapper.getInstance(getCacheIfExists()).fine("ResultMap was null ");
       }
     }
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListAsyncEventQueuesCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListAsyncEventQueuesCommand.java
@@ -26,7 +26,6 @@ import org.apache.geode.SystemFailure;
 import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.domain.AsyncEventQueueDetails;
 import org.apache.geode.management.internal.cli.functions.CliFunctionResult;
 import org.apache.geode.management.internal.cli.functions.ListAsyncEventQueuesFunction;
@@ -46,14 +45,14 @@ public class ListAsyncEventQueuesCommand implements GfshCommand {
       TabularResultData tabularData = ResultBuilder.createTabularResultData();
       boolean accumulatedData = false;
 
-      Set<DistributedMember> targetMembers = CliUtil.getAllNormalMembers(getCache());
+      Set<DistributedMember> targetMembers = getAllNormalMembers(getCache());
 
       if (targetMembers.isEmpty()) {
         return ResultBuilder.createUserErrorResult(CliStrings.NO_MEMBERS_FOUND_MESSAGE);
       }
 
-      ResultCollector<?, ?> rc = CliUtil.executeFunction(new ListAsyncEventQueuesFunction(),
-          new Object[] {}, targetMembers);
+      ResultCollector<?, ?> rc =
+          executeFunction(new ListAsyncEventQueuesFunction(), new Object[] {}, targetMembers);
       List<CliFunctionResult> results = CliFunctionResult.cleanResults((List<?>) rc.getResult());
 
       for (CliFunctionResult result : results) {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListClientCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListClientCommand.java
@@ -29,7 +29,6 @@ import org.apache.geode.management.CacheServerMXBean;
 import org.apache.geode.management.ManagementService;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.LogWrapper;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.CompositeResultData;
@@ -111,8 +110,7 @@ public class ListClientCommand implements GfshCommand {
     }
     result = ResultBuilder.buildResult(compositeResultData);
 
-    LogWrapper.getInstance(CliUtil.getCacheIfExists(this::getCache))
-        .info("list client result " + result);
+    LogWrapper.getInstance(getCacheIfExists()).info("list client result " + result);
 
     return result;
   }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListDeployedCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListDeployedCommand.java
@@ -26,7 +26,6 @@ import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.functions.CliFunctionResult;
 import org.apache.geode.management.internal.cli.functions.ListDeployedFunction;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
@@ -55,14 +54,13 @@ public class ListDeployedCommand implements GfshCommand {
       TabularResultData tabularData = ResultBuilder.createTabularResultData();
       boolean accumulatedData = false;
 
-      Set<DistributedMember> targetMembers = CliUtil.findMembers(group, null, getCache());
+      Set<DistributedMember> targetMembers = findMembers(group, null, getCache());
 
       if (targetMembers.isEmpty()) {
         return ResultBuilder.createUserErrorResult(CliStrings.NO_MEMBERS_FOUND_MESSAGE);
       }
 
-      ResultCollector<?, ?> rc =
-          CliUtil.executeFunction(this.listDeployedFunction, null, targetMembers);
+      ResultCollector<?, ?> rc = executeFunction(this.listDeployedFunction, null, targetMembers);
       List<CliFunctionResult> results = CliFunctionResult.cleanResults((List<?>) rc.getResult());
 
       for (CliFunctionResult result : results) {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListDiskStoresCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListDiskStoresCommand.java
@@ -43,7 +43,7 @@ public class ListDiskStoresCommand implements GfshCommand {
   @ResourceOperation(resource = ResourcePermission.Resource.CLUSTER,
       operation = ResourcePermission.Operation.READ)
   public Result listDiskStores() {
-    Set<DistributedMember> dataMembers = DiskStoreCommandsUtils.getNormalMembers(getCache());
+    Set<DistributedMember> dataMembers = getAllNormalMembers(getCache());
 
     if (dataMembers.isEmpty()) {
       return ResultBuilder.createInfoResult(CliStrings.NO_CACHING_MEMBERS_FOUND_MESSAGE);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListDurableClientCQsCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListDurableClientCQsCommand.java
@@ -29,7 +29,6 @@ import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.domain.DurableCqNamesResult;
 import org.apache.geode.management.internal.cli.functions.ListDurableCqNamesFunction;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
@@ -60,14 +59,14 @@ public class ListDurableClientCQsCommand implements GfshCommand {
     try {
 
       boolean noResults = true;
-      Set<DistributedMember> targetMembers = CliUtil.findMembers(group, memberNameOrId, getCache());
+      Set<DistributedMember> targetMembers = findMembers(group, memberNameOrId, getCache());
 
       if (targetMembers.isEmpty()) {
         return ResultBuilder.createUserErrorResult(CliStrings.NO_MEMBERS_FOUND_MESSAGE);
       }
 
       final ResultCollector<?, ?> rc =
-          CliUtil.executeFunction(new ListDurableCqNamesFunction(), durableClientId, targetMembers);
+          executeFunction(new ListDurableCqNamesFunction(), durableClientId, targetMembers);
       final List<DurableCqNamesResult> results = (List<DurableCqNamesResult>) rc.getResult();
       Map<String, List<String>> memberCqNamesMap = new TreeMap<>();
       Map<String, List<String>> errorMessageNodes = new HashMap<>();

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListFunctionCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListFunctionCommand.java
@@ -28,7 +28,6 @@ import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.functions.CliFunctionResult;
 import org.apache.geode.management.internal.cli.functions.ListFunctionFunction;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
@@ -56,7 +55,7 @@ public class ListFunctionCommand implements GfshCommand {
     TabularResultData tabularData = ResultBuilder.createTabularResultData();
     boolean accumulatedData = false;
 
-    Set<DistributedMember> targetMembers = CliUtil.findMembers(groups, members, getCache());
+    Set<DistributedMember> targetMembers = findMembers(groups, members, getCache());
 
     if (targetMembers.isEmpty()) {
       return ResultBuilder.createUserErrorResult(CliStrings.NO_MEMBERS_FOUND_MESSAGE);
@@ -64,7 +63,7 @@ public class ListFunctionCommand implements GfshCommand {
 
     try {
       ResultCollector<?, ?> rc =
-          CliUtil.executeFunction(this.listFunctionFunction, new Object[] {matches}, targetMembers);
+          executeFunction(this.listFunctionFunction, new Object[] {matches}, targetMembers);
       List<CliFunctionResult> results = CliFunctionResult.cleanResults((List<?>) rc.getResult());
 
       for (CliFunctionResult result : results) {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListRegionCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListRegionCommand.java
@@ -32,7 +32,6 @@ import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.domain.RegionInformation;
 import org.apache.geode.management.internal.cli.functions.GetRegionsFunction;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
@@ -59,14 +58,14 @@ public class ListRegionCommand implements GfshCommand {
     try {
       Set<RegionInformation> regionInfoSet = new LinkedHashSet<>();
       ResultCollector<?, ?> rc;
-      Set<DistributedMember> targetMembers = CliUtil.findMembers(group, memberNameOrId, getCache());
+      Set<DistributedMember> targetMembers = findMembers(group, memberNameOrId, getCache());
 
       if (targetMembers.isEmpty()) {
         return ResultBuilder.createUserErrorResult(CliStrings.NO_MEMBERS_FOUND_MESSAGE);
       }
 
       TabularResultData resultData = ResultBuilder.createTabularResultData();
-      rc = CliUtil.executeFunction(getRegionsFunction, null, targetMembers);
+      rc = executeFunction(getRegionsFunction, null, targetMembers);
       ArrayList<?> resultList = (ArrayList<?>) rc.getResult();
 
       if (resultList != null) {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/LoadBalanceGatewaySenderCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/LoadBalanceGatewaySenderCommand.java
@@ -30,7 +30,6 @@ import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
 import org.apache.geode.management.internal.SystemManagementService;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.cli.result.TabularResultData;
@@ -57,7 +56,7 @@ public class LoadBalanceGatewaySenderCommand implements GfshCommand {
     SystemManagementService service =
         (SystemManagementService) ManagementService.getExistingManagementService(cache);
     TabularResultData resultData = ResultBuilder.createTabularResultData();
-    Set<DistributedMember> dsMembers = CliUtil.getAllNormalMembers(cache);
+    Set<DistributedMember> dsMembers = getAllNormalMembers(cache);
 
     if (dsMembers.isEmpty()) {
       result = ResultBuilder.createInfoResult(CliStrings.GATEWAY_MSG_MEMBERS_NOT_FOUND);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/NetstatCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/NetstatCommand.java
@@ -84,7 +84,7 @@ public class NetstatCommand implements GfshCommand {
       if (members != null) {
         Set<String> notFoundMembers = new HashSet<>();
         for (String memberIdOrName : members) {
-          Set<DistributedMember> membersToExecuteOn = CliUtil.getAllMembers(system);
+          Set<DistributedMember> membersToExecuteOn = getAllMembers(system);
           boolean memberFound = false;
           for (DistributedMember distributedMember : membersToExecuteOn) {
             String memberName = distributedMember.getName();
@@ -112,7 +112,7 @@ public class NetstatCommand implements GfshCommand {
           membersToExecuteOn = system.getGroupMembers(group);
         } else {
           // consider all members
-          membersToExecuteOn = CliUtil.getAllMembers(system);
+          membersToExecuteOn = getAllMembers(system);
         }
 
         for (DistributedMember distributedMember : membersToExecuteOn) {
@@ -136,7 +136,7 @@ public class NetstatCommand implements GfshCommand {
       if (!hostMemberMap.isEmpty()) {
         Set<DistributedMember> membersToExecuteOn = new HashSet<>(hostMemberMap.values());
         ResultCollector<?, ?> netstatResult =
-            CliUtil.executeFunction(NetstatFunction.INSTANCE, nfa, membersToExecuteOn);
+            executeFunction(NetstatFunction.INSTANCE, nfa, membersToExecuteOn);
         List<?> resultList = (List<?>) netstatResult.getResult();
         for (Object aResultList : resultList) {
           NetstatFunction.NetstatFunctionResult netstatFunctionResult =
@@ -171,13 +171,13 @@ public class NetstatCommand implements GfshCommand {
       }
       result = ResultBuilder.buildResult(resultData);
     } catch (IllegalArgumentException e) {
-      LogWrapper.getInstance(CliUtil.getCacheIfExists(this::getCache))
+      LogWrapper.getInstance(getCacheIfExists())
           .info(CliStrings.format(
               CliStrings.NETSTAT__MSG__ERROR_OCCURRED_WHILE_EXECUTING_NETSTAT_ON_0,
               new Object[] {Arrays.toString(members)}));
       result = ResultBuilder.createUserErrorResult(e.getMessage());
     } catch (RuntimeException e) {
-      LogWrapper.getInstance(CliUtil.getCacheIfExists(this::getCache))
+      LogWrapper.getInstance(getCacheIfExists())
           .info(CliStrings.format(
               CliStrings.NETSTAT__MSG__ERROR_OCCURRED_WHILE_EXECUTING_NETSTAT_ON_0,
               new Object[] {Arrays.toString(members)}), e);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/RebalanceCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/RebalanceCommand.java
@@ -50,7 +50,6 @@ import org.apache.geode.management.ManagementService;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.Result;
 import org.apache.geode.management.internal.MBeanJMXAdapter;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.LogWrapper;
 import org.apache.geode.management.internal.cli.functions.RebalanceFunction;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
@@ -94,8 +93,7 @@ public class RebalanceCommand implements GfshCommand {
     } catch (TimeoutException timeoutException) {
       result = ResultBuilder.createInfoResult(CliStrings.REBALANCE__MSG__REBALANCE_WILL_CONTINUE);
     }
-    LogWrapper.getInstance(CliUtil.getCacheIfExists(this::getCache))
-        .info("Rebalance returning result >>>" + result);
+    LogWrapper.getInstance(getCacheIfExists()).info("Rebalance returning result >>>" + result);
     return result;
   }
 
@@ -109,9 +107,9 @@ public class RebalanceCommand implements GfshCommand {
               CliStrings.format(CliStrings.REBALANCE__MSG__NO_EXECUTION, member.getId()),
               ((Exception) object).getMessage());
 
-          LogWrapper.getInstance(CliUtil.getCacheIfExists(this::getCache))
-              .info(CliStrings.REBALANCE__MSG__NO_EXECUTION + member.getId() + " exception="
-                  + ((Throwable) object).getMessage(), ((Throwable) object));
+          LogWrapper.getInstance(getCacheIfExists()).info(CliStrings.REBALANCE__MSG__NO_EXECUTION
+              + member.getId() + " exception=" + ((Throwable) object).getMessage(),
+              ((Throwable) object));
 
           toContinueForOtherMembers = true;
           break;
@@ -120,16 +118,16 @@ public class RebalanceCommand implements GfshCommand {
               CliStrings.format(CliStrings.REBALANCE__MSG__NO_EXECUTION, member.getId()),
               ((Throwable) object).getMessage());
 
-          LogWrapper.getInstance(CliUtil.getCacheIfExists(this::getCache))
-              .info(CliStrings.REBALANCE__MSG__NO_EXECUTION + member.getId() + " exception="
-                  + ((Throwable) object).getMessage(), ((Throwable) object));
+          LogWrapper.getInstance(getCacheIfExists()).info(CliStrings.REBALANCE__MSG__NO_EXECUTION
+              + member.getId() + " exception=" + ((Throwable) object).getMessage(),
+              ((Throwable) object));
 
           toContinueForOtherMembers = true;
           break;
         }
       }
     } else {
-      LogWrapper.getInstance(CliUtil.getCacheIfExists(this::getCache)).info(
+      LogWrapper.getInstance(getCacheIfExists()).info(
           "Rebalancing for member=" + member.getId() + ", resultList is either null or empty");
       rebalanceResultData.addSection().addData("Rebalancing for member=" + member.getId(),
           ", resultList is either null or empty");
@@ -250,9 +248,8 @@ public class RebalanceCommand implements GfshCommand {
               DistributedMember member = getAssociatedMembers(regionName, cache);
 
               if (member == null) {
-                LogWrapper.getInstance(CliUtil.getCacheIfExists(RebalanceCommand.this::getCache))
-                    .info(CliStrings.format(
-                        CliStrings.REBALANCE__MSG__NO_ASSOCIATED_DISTRIBUTED_MEMBER, regionName));
+                LogWrapper.getInstance(getCacheIfExists()).info(CliStrings.format(
+                    CliStrings.REBALANCE__MSG__NO_ASSOCIATED_DISTRIBUTED_MEMBER, regionName));
                 continue;
               }
 
@@ -275,7 +272,7 @@ public class RebalanceCommand implements GfshCommand {
                   resultList = (ArrayList) executeFunction(rebalanceFunction, functionArgs, member)
                       .getResult();
                 } catch (Exception ex) {
-                  LogWrapper.getInstance(CliUtil.getCacheIfExists(RebalanceCommand.this::getCache))
+                  LogWrapper.getInstance(getCacheIfExists())
                       .info(CliStrings.format(
                           CliStrings.REBALANCE__MSG__EXCEPTION_IN_REBALANCE_FOR_MEMBER_0_Exception_1,
                           member.getId(), ex.getMessage()), ex);
@@ -301,7 +298,7 @@ public class RebalanceCommand implements GfshCommand {
                   resultList = (ArrayList) executeFunction(rebalanceFunction, functionArgs, member)
                       .getResult();
                 } catch (Exception ex) {
-                  LogWrapper.getInstance(CliUtil.getCacheIfExists(RebalanceCommand.this::getCache))
+                  LogWrapper.getInstance(getCacheIfExists())
                       .info(CliStrings.format(
                           CliStrings.REBALANCE__MSG__EXCEPTION_IN_REBALANCE_FOR_MEMBER_0_Exception_1,
                           member.getId(), ex.getMessage()), ex);
@@ -350,19 +347,17 @@ public class RebalanceCommand implements GfshCommand {
             }
             index++;
           }
-          LogWrapper.getInstance(CliUtil.getCacheIfExists(RebalanceCommand.this::getCache))
-              .info("Rebalance returning result " + result);
+          LogWrapper.getInstance(getCacheIfExists()).info("Rebalance returning result " + result);
           return result;
         } else {
           result = executeRebalanceOnDS(cache, String.valueOf(simulate), excludeRegions);
-          LogWrapper.getInstance(CliUtil.getCacheIfExists(RebalanceCommand.this::getCache))
+          LogWrapper.getInstance(getCacheIfExists())
               .info("Starting Rebalance simulate false result >> " + result);
         }
       } catch (Exception e) {
         result = ResultBuilder.createGemFireErrorResult(e.getMessage());
       }
-      LogWrapper.getInstance(CliUtil.getCacheIfExists(RebalanceCommand.this::getCache))
-          .info("Rebalance returning result >>>" + result);
+      LogWrapper.getInstance(getCacheIfExists()).info("Rebalance returning result >>>" + result);
       return result;
     }
   }
@@ -378,7 +373,7 @@ public class RebalanceCommand implements GfshCommand {
     }
 
     String[] membersName = bean.getMembers();
-    Set<DistributedMember> dsMembers = CliUtil.getAllMembers(cache);
+    Set<DistributedMember> dsMembers = getAllMembers(cache);
     Iterator it = dsMembers.iterator();
 
     boolean matchFound = false;
@@ -616,7 +611,7 @@ public class RebalanceCommand implements GfshCommand {
     List<MemberPRInfo> listMemberPRInfo = new ArrayList<>();
     String[] listDSRegions =
         ManagementService.getManagementService(cache).getDistributedSystemMXBean().listRegions();
-    final Set<DistributedMember> dsMembers = CliUtil.getAllMembers(cache);
+    final Set<DistributedMember> dsMembers = getAllMembers(cache);
 
     for (String regionName : listDSRegions) {
       // check for excluded regions
@@ -687,7 +682,7 @@ public class RebalanceCommand implements GfshCommand {
   private boolean checkMemberPresence(DistributedMember dsMember, InternalCache cache) {
     // check if member's presence just before executing function
     // this is to avoid running a function on departed members #47248
-    Set<DistributedMember> dsMemberList = CliUtil.getAllNormalMembers(cache);
+    Set<DistributedMember> dsMemberList = getAllNormalMembers(cache);
     return dsMemberList.contains(dsMember);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/RegionCommandsUtils.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/RegionCommandsUtils.java
@@ -25,7 +25,6 @@ import java.util.TreeSet;
 import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.internal.cache.InternalCache;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 
 public class RegionCommandsUtils {
@@ -47,10 +46,9 @@ public class RegionCommandsUtils {
     PERSISTENT_OVERFLOW_SHORTCUTS.add(RegionShortcut.LOCAL_PERSISTENT_OVERFLOW);
   }
 
-  static void validateGroups(InternalCache cache, String[] groups) {
+  static void validateGroups(Set<DistributedMember> members, String[] groups) {
     if (groups != null && groups.length != 0) {
       Set<String> existingGroups = new HashSet<>();
-      Set<DistributedMember> members = CliUtil.getAllNormalMembers(cache);
       for (DistributedMember distributedMember : members) {
         List<String> memberGroups = distributedMember.getGroups();
         existingGroups.addAll(memberGroups);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ResumeGatewaySenderCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ResumeGatewaySenderCommand.java
@@ -30,7 +30,6 @@ import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
 import org.apache.geode.management.internal.SystemManagementService;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.cli.result.TabularResultData;
@@ -67,7 +66,7 @@ public class ResumeGatewaySenderCommand implements GfshCommand {
 
     TabularResultData resultData = ResultBuilder.createTabularResultData();
 
-    Set<DistributedMember> dsMembers = CliUtil.findMembers(onGroup, onMember, getCache());
+    Set<DistributedMember> dsMembers = findMembers(onGroup, onMember, getCache());
 
     if (dsMembers.isEmpty()) {
       return ResultBuilder.createUserErrorResult(CliStrings.NO_MEMBERS_FOUND_MESSAGE);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ShCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ShCommand.java
@@ -25,7 +25,6 @@ import org.springframework.shell.core.annotation.CliOption;
 import org.apache.geode.internal.lang.SystemUtils;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.LogWrapper;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.InfoResultData;
@@ -47,7 +46,7 @@ public class ShCommand implements GfshCommand {
           ResultBuilder.buildResult(executeCommand(Gfsh.getCurrentInstance(), command, useConsole));
     } catch (IllegalStateException | IOException e) {
       result = ResultBuilder.createUserErrorResult(e.getMessage());
-      LogWrapper.getInstance(CliUtil.getCacheIfExists(this::getCache))
+      LogWrapper.getInstance(getCacheIfExists())
           .warning("Unable to execute command \"" + command + "\". Reason:" + e.getMessage() + ".");
     }
     return result;

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ShowDeadlockCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ShowDeadlockCommand.java
@@ -30,7 +30,6 @@ import org.apache.geode.distributed.internal.deadlock.GemFireDeadlockDetector;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.InfoResultData;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
@@ -54,7 +53,7 @@ public class ShowDeadlockCommand implements GfshCommand {
       }
       InternalCache cache = getCache();
 
-      Set<DistributedMember> allMembers = CliUtil.getAllMembers(cache);
+      Set<DistributedMember> allMembers = getAllMembers(cache);
       GemFireDeadlockDetector gfeDeadLockDetector = new GemFireDeadlockDetector(allMembers);
       DependencyGraph dependencyGraph = gfeDeadLockDetector.find();
       Collection<Dependency> deadlock = dependencyGraph.findCycle();

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ShowMissingDiskStoreCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ShowMissingDiskStoreCommand.java
@@ -49,7 +49,7 @@ public class ShowMissingDiskStoreCommand implements GfshCommand {
   public Result showMissingDiskStore() {
 
     try {
-      Set<DistributedMember> dataMembers = DiskStoreCommandsUtils.getNormalMembers(getCache());
+      Set<DistributedMember> dataMembers = getAllMembers(getCache());
 
       if (dataMembers.isEmpty()) {
         return ResultBuilder.createInfoResult(CliStrings.NO_CACHING_MEMBERS_FOUND_MESSAGE);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ShutdownCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ShutdownCommand.java
@@ -39,7 +39,6 @@ import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.Result;
 import org.apache.geode.management.internal.cli.AbstractCliAroundInterceptor;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.GfshParseResult;
 import org.apache.geode.management.internal.cli.functions.ShutDownFunction;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
@@ -70,9 +69,9 @@ public class ShutdownCommand implements GfshCommand {
       // convert to milliseconds
       long timeout = userSpecifiedTimeout * 1000;
       InternalCache cache = getCache();
-      int numDataNodes = CliUtil.getAllNormalMembers(cache).size();
-      Set<DistributedMember> locators = CliUtil.getAllMembers(cache);
-      Set<DistributedMember> dataNodes = CliUtil.getAllNormalMembers(cache);
+      int numDataNodes = getAllNormalMembers(cache).size();
+      Set<DistributedMember> locators = getAllMembers(cache);
+      Set<DistributedMember> dataNodes = getAllNormalMembers(cache);
       locators.removeAll(dataNodes);
 
       if (!shutdownLocators && numDataNodes == 0) {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/SleepCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/SleepCommand.java
@@ -20,7 +20,6 @@ import org.springframework.shell.core.annotation.CliOption;
 
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.LogWrapper;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
@@ -31,8 +30,7 @@ public class SleepCommand implements GfshCommand {
   public Result sleep(@CliOption(key = {CliStrings.SLEEP__TIME}, unspecifiedDefaultValue = "3",
       help = CliStrings.SLEEP__TIME__HELP) double time) {
     try {
-      LogWrapper.getInstance(CliUtil.getCacheIfExists(this::getCache))
-          .fine("Sleeping for " + time + "seconds.");
+      LogWrapper.getInstance(getCacheIfExists()).fine("Sleeping for " + time + "seconds.");
       Thread.sleep(Math.round(time * 1000));
     } catch (InterruptedException ignored) {
     }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartGatewayReceiverCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartGatewayReceiverCommand.java
@@ -31,7 +31,6 @@ import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
 import org.apache.geode.management.internal.MBeanJMXAdapter;
 import org.apache.geode.management.internal.SystemManagementService;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.cli.result.TabularResultData;
@@ -63,7 +62,7 @@ public class StartGatewayReceiverCommand implements GfshCommand {
 
     TabularResultData resultData = ResultBuilder.createTabularResultData();
 
-    Set<DistributedMember> dsMembers = CliUtil.findMembers(onGroup, onMember, getCache());
+    Set<DistributedMember> dsMembers = findMembers(onGroup, onMember, getCache());
 
     if (dsMembers.isEmpty()) {
       return ResultBuilder.createUserErrorResult(CliStrings.NO_MEMBERS_FOUND_MESSAGE);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StatusClusterConfigServiceCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StatusClusterConfigServiceCommand.java
@@ -27,7 +27,6 @@ import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.Result;
 import org.apache.geode.management.cli.Result.Status;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.functions.CliFunctionResult;
 import org.apache.geode.management.internal.cli.functions.FetchSharedConfigurationStatusFunction;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
@@ -59,8 +58,7 @@ public class StatusClusterConfigServiceCommand implements GfshCommand {
 
   private TabularResultData getSharedConfigurationStatus(Set<DistributedMember> locators) {
     boolean isSharedConfigRunning = false;
-    ResultCollector<?, ?> rc =
-        CliUtil.executeFunction(fetchSharedConfigStatusFunction, null, locators);
+    ResultCollector<?, ?> rc = executeFunction(fetchSharedConfigStatusFunction, null, locators);
     List<CliFunctionResult> results = (List<CliFunctionResult>) rc.getResult();
     TabularResultData table = ResultBuilder.createTabularResultData();
     table.setHeader("Status of shared configuration on locators");

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StatusGatewayReceiverCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StatusGatewayReceiverCommand.java
@@ -31,7 +31,6 @@ import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
 import org.apache.geode.management.internal.MBeanJMXAdapter;
 import org.apache.geode.management.internal.SystemManagementService;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.CompositeResultData;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
@@ -68,7 +67,7 @@ public class StatusGatewayReceiverCommand implements GfshCommand {
         crd.addSection(CliStrings.SECTION_GATEWAY_RECEIVER_NOT_AVAILABLE)
             .addTable(CliStrings.TABLE_GATEWAY_RECEIVER);
 
-    Set<DistributedMember> dsMembers = CliUtil.findMembers(onGroup, onMember, getCache());
+    Set<DistributedMember> dsMembers = findMembers(onGroup, onMember, getCache());
 
     if (dsMembers.isEmpty()) {
       return ResultBuilder.createUserErrorResult(CliStrings.NO_MEMBERS_FOUND_MESSAGE);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StatusGatewaySenderCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StatusGatewaySenderCommand.java
@@ -30,7 +30,6 @@ import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
 import org.apache.geode.management.internal.SystemManagementService;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.CompositeResultData;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
@@ -75,7 +74,7 @@ public class StatusGatewaySenderCommand implements GfshCommand {
         crd.addSection(CliStrings.SECTION_GATEWAY_SENDER_NOT_AVAILABLE)
             .addTable(CliStrings.TABLE_GATEWAY_SENDER);
 
-    Set<DistributedMember> dsMembers = CliUtil.findMembers(onGroup, onMember, getCache());
+    Set<DistributedMember> dsMembers = findMembers(onGroup, onMember, getCache());
 
     if (dsMembers.isEmpty()) {
       return ResultBuilder.createUserErrorResult(CliStrings.NO_MEMBERS_FOUND_MESSAGE);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StopGatewayReceiverCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StopGatewayReceiverCommand.java
@@ -31,7 +31,6 @@ import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
 import org.apache.geode.management.internal.MBeanJMXAdapter;
 import org.apache.geode.management.internal.SystemManagementService;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.cli.result.TabularResultData;
@@ -62,7 +61,7 @@ public class StopGatewayReceiverCommand implements GfshCommand {
 
     TabularResultData resultData = ResultBuilder.createTabularResultData();
 
-    Set<DistributedMember> dsMembers = CliUtil.findMembers(onGroup, onMember, getCache());
+    Set<DistributedMember> dsMembers = findMembers(onGroup, onMember, getCache());
 
     if (dsMembers.isEmpty()) {
       return ResultBuilder.createUserErrorResult(CliStrings.NO_MEMBERS_FOUND_MESSAGE);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StopGatewaySenderCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StopGatewaySenderCommand.java
@@ -30,7 +30,6 @@ import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
 import org.apache.geode.management.internal.SystemManagementService;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.cli.result.TabularResultData;
@@ -68,7 +67,7 @@ public class StopGatewaySenderCommand implements GfshCommand {
 
     TabularResultData resultData = ResultBuilder.createTabularResultData();
 
-    Set<DistributedMember> dsMembers = CliUtil.findMembers(onGroup, onMember, getCache());
+    Set<DistributedMember> dsMembers = findMembers(onGroup, onMember, getCache());
 
     if (dsMembers.isEmpty()) {
       return ResultBuilder.createUserErrorResult(CliStrings.NO_MEMBERS_FOUND_MESSAGE);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/UndeployCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/UndeployCommand.java
@@ -27,7 +27,6 @@ import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.functions.CliFunctionResult;
 import org.apache.geode.management.internal.cli.functions.UndeployFunction;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
@@ -61,14 +60,14 @@ public class UndeployCommand implements GfshCommand {
       TabularResultData tabularData = ResultBuilder.createTabularResultData();
       boolean accumulatedData = false;
 
-      Set<DistributedMember> targetMembers = CliUtil.findMembers(groups, null, getCache());
+      Set<DistributedMember> targetMembers = findMembers(groups, null, getCache());
 
       if (targetMembers.isEmpty()) {
         return ResultBuilder.createUserErrorResult(CliStrings.NO_MEMBERS_FOUND_MESSAGE);
       }
 
       ResultCollector<?, ?> rc =
-          CliUtil.executeFunction(this.undeployFunction, new Object[] {jars}, targetMembers);
+          executeFunction(this.undeployFunction, new Object[] {jars}, targetMembers);
       List<CliFunctionResult> results = CliFunctionResult.cleanResults((List<?>) rc.getResult());
 
       for (CliFunctionResult result : results) {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/UpgradeOfflineDiskStoreCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/UpgradeOfflineDiskStoreCommand.java
@@ -31,7 +31,6 @@ import org.apache.geode.GemFireIOException;
 import org.apache.geode.internal.lang.StringUtils;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.GfshParser;
 import org.apache.geode.management.internal.cli.LogWrapper;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
@@ -55,7 +54,7 @@ public class UpgradeOfflineDiskStoreCommand implements GfshCommand {
           help = CliStrings.UPGRADE_OFFLINE_DISK_STORE__J__HELP) String[] jvmProps) {
 
     Result result;
-    LogWrapper logWrapper = LogWrapper.getInstance(CliUtil.getCacheIfExists(this::getCache));
+    LogWrapper logWrapper = LogWrapper.getInstance(getCacheIfExists());
 
     StringBuilder output = new StringBuilder();
     StringBuilder error = new StringBuilder();

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ShowLogCommandDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ShowLogCommandDUnitTest.java
@@ -39,7 +39,7 @@ import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.CliUtil;
+import org.apache.geode.management.internal.cli.CacheMembers;
 import org.apache.geode.management.internal.cli.result.CommandResult;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
@@ -163,10 +163,11 @@ public class ShowLogCommandDUnitTest implements Serializable {
   private static boolean allMembersAreConnected() {
     return manager.getVM().invoke(() -> {
       InternalCache cache = (InternalCache) CacheFactory.getAnyInstance();
+      CacheMembers cacheMembers = () -> cache;
       DistributedMember server1 =
-          CliUtil.getDistributedMemberByNameOrId(SERVER1_NAME, ClusterStartupRule.getCache());
+          cacheMembers.findMember(SERVER1_NAME, ClusterStartupRule.getCache());
       DistributedMember server2 =
-          CliUtil.getDistributedMemberByNameOrId(SERVER2_NAME, ClusterStartupRule.getCache());
+          cacheMembers.findMember(SERVER2_NAME, ClusterStartupRule.getCache());
 
       ShowLogCommand showLogCommand = new ShowLogCommand();
 

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexCommands.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexCommands.java
@@ -487,7 +487,7 @@ public class LuceneIndexCommands implements GfshCommand {
   protected ResultCollector<?, ?> executeFunctionOnAllMembers(Function function,
       final LuceneFunctionSerializable functionArguments)
       throws IllegalArgumentException, CommandResultException {
-    Set<DistributedMember> targetMembers = CliUtil.getAllNormalMembers(getCache());
+    Set<DistributedMember> targetMembers = getAllNormalMembers(getCache());
     return executeFunction(function, functionArguments, targetMembers);
   }
 


### PR DESCRIPTION
…ace.

* CacheMembers is instantiated anonymously in BeanUtilFuncs and several test classes.
* GfshCommand now extends CacheCommandContext.
* Move CliUtil.executeFunction to GfshCommand.  Invocations in ClusterConfigurationService and ClusterConfigurationLauncher have been in-lined.
* Rename CliUtilDUnitTest to reflect movement of covered methods.
* RegionCommandUtils.validateGroup signature changed.
* DiskStoreCommandsUtils.getNormalMembers replaced by corresponding CacheMembers method call.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [n/a - no change in functionality] Have you written or updated unit tests to verify your changes?

- [n/a - no additions] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
