### PR TITLE
GEODE-4735: get rid of Cache.getInstance call from CliUtils and GfshC…

### DIFF
--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/AlterConnectionCommand.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/AlterConnectionCommand.java
@@ -37,7 +37,7 @@ import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
 @Experimental
-public class AlterConnectionCommand implements GfshCommand {
+public class AlterConnectionCommand extends GfshCommand {
   static final String ALTER_JDBC_CONNECTION = "alter jdbc-connection";
   static final String ALTER_JDBC_CONNECTION__HELP =
       EXPERIMENTAL + "Alter properties for an existing jdbc connection.";

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/AlterMappingCommand.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/AlterMappingCommand.java
@@ -37,7 +37,7 @@ import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
 @Experimental
-public class AlterMappingCommand implements GfshCommand {
+public class AlterMappingCommand extends GfshCommand {
   static final String ALTER_MAPPING = "alter jdbc-mapping";
   static final String ALTER_MAPPING__HELP =
       EXPERIMENTAL + "Alter properties for an existing jdbc mapping.";

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/CreateConnectionCommand.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/CreateConnectionCommand.java
@@ -42,7 +42,7 @@ import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
 @Experimental
-public class CreateConnectionCommand implements GfshCommand {
+public class CreateConnectionCommand extends GfshCommand {
   private static final Logger logger = LogService.getLogger();
 
   static final String CREATE_CONNECTION = "create jdbc-connection";

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/CreateMappingCommand.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/CreateMappingCommand.java
@@ -37,7 +37,7 @@ import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
 @Experimental
-public class CreateMappingCommand implements GfshCommand {
+public class CreateMappingCommand extends GfshCommand {
   static final String CREATE_MAPPING = "create jdbc-mapping";
   static final String CREATE_MAPPING__HELP =
       EXPERIMENTAL + "Create a mapping for a region for use with a JDBC database connection.";

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/DescribeConnectionCommand.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/DescribeConnectionCommand.java
@@ -41,7 +41,7 @@ import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
 @Experimental
-public class DescribeConnectionCommand implements GfshCommand {
+public class DescribeConnectionCommand extends GfshCommand {
   static final String DESCRIBE_CONNECTION = "describe jdbc-connection";
   static final String DESCRIBE_CONNECTION__HELP =
       EXPERIMENTAL + "Describe the specified jdbc connection.";

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/DescribeMappingCommand.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/DescribeMappingCommand.java
@@ -41,7 +41,7 @@ import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
 @Experimental
-public class DescribeMappingCommand implements GfshCommand {
+public class DescribeMappingCommand extends GfshCommand {
   static final String DESCRIBE_MAPPING = "describe jdbc-mapping";
   static final String DESCRIBE_MAPPING__HELP =
       EXPERIMENTAL + "Describe the specified jdbc mapping.";

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyConnectionCommand.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyConnectionCommand.java
@@ -35,7 +35,7 @@ import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
 @Experimental
-public class DestroyConnectionCommand implements GfshCommand {
+public class DestroyConnectionCommand extends GfshCommand {
   static final String DESTROY_CONNECTION = "destroy jdbc-connection";
   static final String DESTROY_CONNECTION__HELP =
       EXPERIMENTAL + "Destroy/Remove the specified jdbc connection.";

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyMappingCommand.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyMappingCommand.java
@@ -35,7 +35,7 @@ import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
 @Experimental
-public class DestroyMappingCommand implements GfshCommand {
+public class DestroyMappingCommand extends GfshCommand {
   static final String DESTROY_MAPPING = "destroy jdbc-mapping";
   static final String DESTROY_MAPPING__HELP = EXPERIMENTAL + "Destroy the specified mapping.";
   static final String DESTROY_MAPPING__REGION_NAME = "region";

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/ListConnectionCommand.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/ListConnectionCommand.java
@@ -35,7 +35,7 @@ import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
 @Experimental
-public class ListConnectionCommand implements GfshCommand {
+public class ListConnectionCommand extends GfshCommand {
   static final String LIST_JDBC_CONNECTION = "list jdbc-connections";
   static final String LIST_JDBC_CONNECTION__HELP =
       EXPERIMENTAL + "Display jdbc connections for all members.";

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/ListMappingCommand.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/ListMappingCommand.java
@@ -35,7 +35,7 @@ import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
 @Experimental
-public class ListMappingCommand implements GfshCommand {
+public class ListMappingCommand extends GfshCommand {
   static final String LIST_MAPPING = "list jdbc-mappings";
   static final String LIST_MAPPING__HELP = EXPERIMENTAL + "Display jdbc mappings for all members.";
 

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/AlterConnectionCommandIntegrationTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/AlterConnectionCommandIntegrationTest.java
@@ -47,9 +47,12 @@ public class AlterConnectionCommandIntegrationTest {
 
     cache = (InternalCache) new CacheFactory().set("locators", "").set("mcast-port", "0")
         .set(ENABLE_CLUSTER_CONFIGURATION, "true").create();
-    (new CreateConnectionCommand()).createConnection(name, url, user, password, params);
+    CreateConnectionCommand create = new CreateConnectionCommand();
+    create.setCache(cache);
+    create.createConnection(name, url, user, password, params);
 
     alterConnectionCommand = new AlterConnectionCommand();
+    alterConnectionCommand.setCache(cache);
   }
 
   @After

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/AlterMappingCommandIntegrationTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/AlterMappingCommandIntegrationTest.java
@@ -48,10 +48,13 @@ public class AlterMappingCommandIntegrationTest {
 
     cache = (InternalCache) new CacheFactory().set("locators", "").set("mcast-port", "0")
         .set(ENABLE_CLUSTER_CONFIGURATION, "true").create();
-    new CreateMappingCommand().createMapping(regionName, connectionName, tableName, pdxClass,
-        keyInValue, fieldMappings);
+    CreateMappingCommand create = new CreateMappingCommand();
+    create.setCache(cache);
+    create.createMapping(regionName, connectionName, tableName, pdxClass, keyInValue,
+        fieldMappings);
 
     alterRegionMappingCommand = new AlterMappingCommand();
+    alterRegionMappingCommand.setCache(cache);
   }
 
   @After

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/CreateConnectionCommandIntegrationTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/CreateConnectionCommandIntegrationTest.java
@@ -53,6 +53,7 @@ public class CreateConnectionCommandIntegrationTest {
         .set(ENABLE_CLUSTER_CONFIGURATION, "true").create();
 
     createConnectionCommand = new CreateConnectionCommand();
+    createConnectionCommand.setCache(cache);
   }
 
   @After

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/CreateMappingCommandIntegrationTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/CreateMappingCommandIntegrationTest.java
@@ -56,6 +56,7 @@ public class CreateMappingCommandIntegrationTest {
         .set(ENABLE_CLUSTER_CONFIGURATION, "true").create();
 
     createRegionMappingCommand = new CreateMappingCommand();
+    createRegionMappingCommand.setCache(cache);
   }
 
   @After

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/DescribeConnectionCommandIntegrationTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/DescribeConnectionCommandIntegrationTest.java
@@ -62,6 +62,7 @@ public class DescribeConnectionCommandIntegrationTest {
     service = cache.getService(JdbcConnectorService.class);
 
     command = new DescribeConnectionCommand();
+    command.setCache(cache);
   }
 
   @After

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/DescribeMappingCommandIntegrationTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/DescribeMappingCommandIntegrationTest.java
@@ -62,6 +62,7 @@ public class DescribeMappingCommandIntegrationTest {
         .withPdxClassName("myPdxClass").withPrimaryKeyInValue(true)
         .withFieldToColumnMappings(fieldMappings).build();
     command = new DescribeMappingCommand();
+    command.setCache(cache);
   }
 
   @After

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyConnectionCommandIntegrationTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyConnectionCommandIntegrationTest.java
@@ -51,6 +51,7 @@ public class DestroyConnectionCommandIntegrationTest {
         .set(ENABLE_CLUSTER_CONFIGURATION, "true").create();
 
     command = new DestroyConnectionCommand();
+    command.setCache(cache);
   }
 
   @After

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyMappingCommandIntegrationTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyMappingCommandIntegrationTest.java
@@ -50,6 +50,7 @@ public class DestroyMappingCommandIntegrationTest {
         .set(ENABLE_CLUSTER_CONFIGURATION, "true").create();
 
     command = new DestroyMappingCommand();
+    command.setCache(cache);
   }
 
   @After

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/JdbcClusterConfigDistributedTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/JdbcClusterConfigDistributedTest.java
@@ -100,12 +100,14 @@ public class JdbcClusterConfigDistributedTest implements Serializable {
     cache = (InternalCache) new CacheFactory().set(LOCATORS, locators).create();
 
     locator.invoke(() -> {
-      Result result = new CreateConnectionCommand().createConnection(connectionName, connectionUrl,
-          null, null, null);
+      CreateConnectionCommand command = new CreateConnectionCommand();
+      command.setCache(CacheFactory.getAnyInstance());
+      Result result = command.createConnection(connectionName, connectionUrl, null, null, null);
       assertThat(result.getStatus()).isSameAs(Result.Status.OK);
-
-      result = new CreateMappingCommand().createMapping(regionName, connectionName, tableName,
-          pdxClass, keyInValue, fieldMappings);
+      CreateMappingCommand mappingCommand = new CreateMappingCommand();
+      mappingCommand.setCache(CacheFactory.getAnyInstance());
+      result = mappingCommand.createMapping(regionName, connectionName, tableName, pdxClass,
+          keyInValue, fieldMappings);
 
       assertThat(result.getStatus()).isSameAs(Result.Status.OK);
     });

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/ListConnectionCommandIntegrationTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/ListConnectionCommandIntegrationTest.java
@@ -61,6 +61,7 @@ public class ListConnectionCommandIntegrationTest {
     service = cache.getService(JdbcConnectorService.class);
 
     command = new ListConnectionCommand();
+    command.setCache(cache);
   }
 
   @After

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/ListMappingCommandIntegrationTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/ListMappingCommandIntegrationTest.java
@@ -61,6 +61,7 @@ public class ListMappingCommandIntegrationTest {
     service = cache.getService(JdbcConnectorService.class);
 
     command = new ListConnectionCommand();
+    command.setCache(cache);
   }
 
   @After

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/CliUtil.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/CliUtil.java
@@ -34,7 +34,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.zip.DataFormatException;
 import java.util.zip.Deflater;
@@ -43,7 +42,6 @@ import java.util.zip.Inflater;
 import org.apache.commons.lang.ArrayUtils;
 
 import org.apache.geode.cache.Cache;
-import org.apache.geode.cache.CacheClosedException;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.execute.Execution;
 import org.apache.geode.cache.execute.Function;
@@ -74,20 +72,6 @@ import org.apache.geode.management.internal.cli.shell.Gfsh;
  */
 public class CliUtil {
   public static final FileFilter JAR_FILE_FILTER = new CustomFileFilter(".jar");
-
-  /**
-   * Returns the InternalCache returned by the provided method.
-   * If the provided method would raise a CacheClosedException, returns null instead.
-   */
-  public static InternalCache getCacheIfExists(Supplier<InternalCache> getCacheMethod) {
-    InternalCache cache = null;
-    try {
-      cache = getCacheMethod.get();
-    } catch (CacheClosedException ignored) {
-    }
-    return cache;
-
-  }
 
   public static String cliDependenciesExist(boolean includeGfshDependencies) {
     // "Validate" each dependency by attempting to load an associated class

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/AlterAsyncEventQueueCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/AlterAsyncEventQueueCommand.java
@@ -51,7 +51,7 @@ import org.apache.geode.security.ResourcePermission;
  * this command currently only updates the cluster configuration. Requires server restart to pick up
  * the changes.
  */
-public class AlterAsyncEventQueueCommand implements GfshCommand {
+public class AlterAsyncEventQueueCommand extends GfshCommand {
 
   static final String COMMAND_NAME = "alter async-event-queue";
   static final String ID = "id";

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/AlterOfflineDiskStoreCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/AlterOfflineDiskStoreCommand.java
@@ -29,7 +29,7 @@ import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ErrorResultData;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 
-public class AlterOfflineDiskStoreCommand implements GfshCommand {
+public class AlterOfflineDiskStoreCommand extends GfshCommand {
   @CliCommand(value = CliStrings.ALTER_DISK_STORE, help = CliStrings.ALTER_DISK_STORE__HELP)
   @CliMetaData(shellOnly = true, relatedTopic = {CliStrings.TOPIC_GEODE_DISKSTORE})
   public Result alterOfflineDiskStore(

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/AlterRegionCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/AlterRegionCommand.java
@@ -40,7 +40,7 @@ import org.apache.geode.management.internal.configuration.domain.XmlEntity;
 import org.apache.geode.security.ResourcePermission.Operation;
 import org.apache.geode.security.ResourcePermission.Resource;
 
-public class AlterRegionCommand implements GfshCommand {
+public class AlterRegionCommand extends GfshCommand {
   @CliCommand(value = CliStrings.ALTER_REGION, help = CliStrings.ALTER_REGION__HELP)
   @CliMetaData(relatedTopic = CliStrings.TOPIC_GEODE_REGION)
   public Result alterRegion(

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/AlterRuntimeConfigCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/AlterRuntimeConfigCommand.java
@@ -47,7 +47,7 @@ import org.apache.geode.management.internal.configuration.domain.XmlEntity;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class AlterRuntimeConfigCommand implements GfshCommand {
+public class AlterRuntimeConfigCommand extends GfshCommand {
   private final AlterRuntimeConfigFunction alterRunTimeConfigFunction =
       new AlterRuntimeConfigFunction();
   private static Logger logger = LogService.getLogger();
@@ -96,7 +96,7 @@ public class AlterRuntimeConfigCommand implements GfshCommand {
 
     Map<String, String> runTimeDistributionConfigAttributes = new HashMap<>();
     Map<String, String> rumTimeCacheAttributes = new HashMap<>();
-    Set<DistributedMember> targetMembers = CliUtil.findMembers(group, memberNameOrId, getCache());
+    Set<DistributedMember> targetMembers = findMembers(group, memberNameOrId);
 
     if (targetMembers.isEmpty()) {
       return ResultBuilder.createUserErrorResult(CliStrings.NO_MEMBERS_FOUND_MESSAGE);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/BackupDiskStoreCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/BackupDiskStoreCommand.java
@@ -36,7 +36,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class BackupDiskStoreCommand implements GfshCommand {
+public class BackupDiskStoreCommand extends GfshCommand {
   /**
    * Internally, we also verify the resource operation permissions CLUSTER:WRITE:DISK if the region
    * is persistent

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ChangeLogLevelCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ChangeLogLevelCommand.java
@@ -36,7 +36,6 @@ import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
 import org.apache.geode.management.internal.cli.AbstractCliAroundInterceptor;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.GfshParseResult;
 import org.apache.geode.management.internal.cli.LogWrapper;
 import org.apache.geode.management.internal.cli.functions.ChangeLogLevelFunction;
@@ -47,7 +46,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class ChangeLogLevelCommand implements GfshCommand {
+public class ChangeLogLevelCommand extends GfshCommand {
   @CliCommand(value = CliStrings.CHANGE_LOGLEVEL, help = CliStrings.CHANGE_LOGLEVEL__HELP)
   @CliMetaData(relatedTopic = {CliStrings.TOPIC_LOGS},
       interceptor = "org.apache.geode.management.internal.cli.commands.ChangeLogLevelCommand$ChangeLogLevelCommandInterceptor")
@@ -67,11 +66,11 @@ public class ChangeLogLevelCommand implements GfshCommand {
             .createUserErrorResult(CliStrings.CHANGE_LOGLEVEL__MSG__SPECIFY_GRP_OR_MEMBER);
       }
 
-      InternalCache cache = GemFireCacheImpl.getInstance();
+      InternalCache cache = getCache();
       LogWriter logger = cache.getLogger();
 
       Set<DistributedMember> dsMembers = new HashSet<>();
-      Set<DistributedMember> ds = CliUtil.getAllMembers(cache);
+      Set<DistributedMember> ds = getAllMembers();
 
       if (grps != null && grps.length > 0) {
         for (String grp : grps) {
@@ -135,8 +134,7 @@ public class ChangeLogLevelCommand implements GfshCommand {
 
           }
         } catch (Exception ex) {
-          LogWrapper.getInstance(CliUtil.getCacheIfExists(this::getCache))
-              .warning("change log level command exception " + ex);
+          LogWrapper.getInstance(getCache()).warning("change log level command exception " + ex);
         }
       }
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ClearDefinedIndexesCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ClearDefinedIndexesCommand.java
@@ -25,7 +25,7 @@ import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class ClearDefinedIndexesCommand implements GfshCommand {
+public class ClearDefinedIndexesCommand extends GfshCommand {
   @CliCommand(value = CliStrings.CLEAR_DEFINED_INDEXES, help = CliStrings.CLEAR_DEFINED__HELP)
   @CliMetaData(relatedTopic = {CliStrings.TOPIC_GEODE_REGION, CliStrings.TOPIC_GEODE_DATA})
   @ResourceOperation(resource = ResourcePermission.Resource.CLUSTER,

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CloseDurableCQsCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CloseDurableCQsCommand.java
@@ -34,7 +34,7 @@ import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class CloseDurableCQsCommand implements GfshCommand {
+public class CloseDurableCQsCommand extends GfshCommand {
   DurableClientCommandsResultBuilder builder = new DurableClientCommandsResultBuilder();
 
   @CliCommand(value = CliStrings.CLOSE_DURABLE_CQS, help = CliStrings.CLOSE_DURABLE_CQS__HELP)
@@ -57,7 +57,7 @@ public class CloseDurableCQsCommand implements GfshCommand {
           optionContext = ConverterHint.MEMBERGROUP) final String[] group) {
     Result result;
     try {
-      Set<DistributedMember> targetMembers = CliUtil.findMembers(group, memberNameOrId, getCache());
+      Set<DistributedMember> targetMembers = findMembers(group, memberNameOrId);
 
       if (targetMembers.isEmpty()) {
         return ResultBuilder.createUserErrorResult(CliStrings.NO_MEMBERS_FOUND_MESSAGE);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CloseDurableClientCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CloseDurableClientCommand.java
@@ -34,7 +34,7 @@ import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class CloseDurableClientCommand implements GfshCommand {
+public class CloseDurableClientCommand extends GfshCommand {
   DurableClientCommandsResultBuilder builder = new DurableClientCommandsResultBuilder();
 
   @CliCommand(value = CliStrings.CLOSE_DURABLE_CLIENTS,
@@ -55,7 +55,7 @@ public class CloseDurableClientCommand implements GfshCommand {
     Result result;
     try {
 
-      Set<DistributedMember> targetMembers = CliUtil.findMembers(group, memberNameOrId, getCache());
+      Set<DistributedMember> targetMembers = findMembers(group, memberNameOrId);
 
       if (targetMembers.isEmpty()) {
         return ResultBuilder.createUserErrorResult(CliStrings.NO_MEMBERS_FOUND_MESSAGE);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CompactDiskStoreCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CompactDiskStoreCommand.java
@@ -37,7 +37,6 @@ import org.apache.geode.management.ManagementService;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.LogWrapper;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.CompositeResultData;
@@ -46,7 +45,7 @@ import org.apache.geode.management.internal.messages.CompactRequest;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class CompactDiskStoreCommand implements GfshCommand {
+public class CompactDiskStoreCommand extends GfshCommand {
   @CliCommand(value = CliStrings.COMPACT_DISK_STORE, help = CliStrings.COMPACT_DISK_STORE__HELP)
   @CliMetaData(relatedTopic = {CliStrings.TOPIC_GEODE_DISKSTORE})
   @ResourceOperation(resource = ResourcePermission.Resource.CLUSTER,
@@ -122,7 +121,7 @@ public class CompactDiskStoreCommand implements GfshCommand {
             }
             String notExecutedMembers = CompactRequest.getNotExecutedMembers();
             if (notExecutedMembers != null && !notExecutedMembers.isEmpty()) {
-              LogWrapper.getInstance(CliUtil.getCacheIfExists(this::getCache))
+              LogWrapper.getInstance(getCache())
                   .info("compact disk-store \"" + diskStoreName
                       + "\" message was scheduled to be sent to but was not send to "
                       + notExecutedMembers);
@@ -159,7 +158,7 @@ public class CompactDiskStoreCommand implements GfshCommand {
         } // all members' if
       } // disk store exists' if
     } catch (RuntimeException e) {
-      LogWrapper.getInstance(CliUtil.getCacheIfExists(this::getCache)).info(e.getMessage(), e);
+      LogWrapper.getInstance(getCache()).info(e.getMessage(), e);
       result = ResultBuilder.createGemFireErrorResult(
           CliStrings.format(CliStrings.COMPACT_DISK_STORE__ERROR_WHILE_COMPACTING_REASON_0,
               new Object[] {e.getMessage()}));

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CompactOfflineDiskStoreCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CompactOfflineDiskStoreCommand.java
@@ -31,7 +31,6 @@ import org.apache.geode.GemFireIOException;
 import org.apache.geode.internal.lang.StringUtils;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.GfshParser;
 import org.apache.geode.management.internal.cli.LogWrapper;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
@@ -39,7 +38,7 @@ import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.cli.shell.Gfsh;
 import org.apache.geode.management.internal.cli.util.DiskStoreCompacter;
 
-public class CompactOfflineDiskStoreCommand implements GfshCommand {
+public class CompactOfflineDiskStoreCommand extends GfshCommand {
   @CliCommand(value = CliStrings.COMPACT_OFFLINE_DISK_STORE,
       help = CliStrings.COMPACT_OFFLINE_DISK_STORE__HELP)
   @CliMetaData(shellOnly = true, relatedTopic = {CliStrings.TOPIC_GEODE_DISKSTORE})
@@ -54,7 +53,7 @@ public class CompactOfflineDiskStoreCommand implements GfshCommand {
       @CliOption(key = CliStrings.COMPACT_OFFLINE_DISK_STORE__J,
           help = CliStrings.COMPACT_OFFLINE_DISK_STORE__J__HELP) String[] jvmProps) {
     Result result;
-    LogWrapper logWrapper = LogWrapper.getInstance(CliUtil.getCacheIfExists(this::getCache));
+    LogWrapper logWrapper = LogWrapper.getInstance(getCache());
 
     StringBuilder output = new StringBuilder();
     StringBuilder error = new StringBuilder();

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ConfigurePDXCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ConfigurePDXCommand.java
@@ -28,7 +28,6 @@ import org.apache.geode.internal.cache.xmlcache.CacheXml;
 import org.apache.geode.internal.cache.xmlcache.CacheXmlGenerator;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.InfoResultData;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
@@ -37,7 +36,7 @@ import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.pdx.ReflectionBasedAutoSerializer;
 import org.apache.geode.security.ResourcePermission;
 
-public class ConfigurePDXCommand implements GfshCommand {
+public class ConfigurePDXCommand extends GfshCommand {
   @CliCommand(value = CliStrings.CONFIGURE_PDX, help = CliStrings.CONFIGURE_PDX__HELP)
   @CliMetaData(relatedTopic = CliStrings.TOPIC_GEODE_REGION)
   @ResourceOperation(resource = ResourcePermission.Resource.CLUSTER,
@@ -63,7 +62,7 @@ public class ConfigurePDXCommand implements GfshCommand {
           && (patterns != null && patterns.length > 0)) {
         return ResultBuilder.createUserErrorResult(CliStrings.CONFIGURE_PDX__ERROR__MESSAGE);
       }
-      if (!CliUtil.getAllNormalMembers(getCache()).isEmpty()) {
+      if (!getAllNormalMembers().isEmpty()) {
         ird.addLine(CliStrings.CONFIGURE_PDX__NORMAL__MEMBERS__WARNING);
       }
       // Set persistent and the disk-store

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ConnectCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ConnectCommand.java
@@ -70,7 +70,7 @@ import org.apache.geode.management.internal.security.ResourceConstants;
 import org.apache.geode.management.internal.web.shell.HttpOperationInvoker;
 import org.apache.geode.security.AuthenticationFailedException;
 
-public class ConnectCommand implements GfshCommand {
+public class ConnectCommand extends GfshCommand {
   // millis that connect --locator will wait for a response from the locator.
   static final int CONNECT_LOCATOR_TIMEOUT_MS = 60000; // see bug 45971
 
@@ -282,7 +282,7 @@ public class ConnectCommand implements GfshCommand {
 
       gfsh.setOperationInvoker(operationInvoker);
 
-      LogWrapper.getInstance(CliUtil.getCacheIfExists(this::getCache))
+      LogWrapper.getInstance(getCache())
           .info(CliStrings.format(CliStrings.CONNECT__MSG__SUCCESS, operationInvoker.toString()));
       return ResultBuilder.createInfoResult(
           CliStrings.format(CliStrings.CONNECT__MSG__SUCCESS, operationInvoker.toString()));
@@ -358,8 +358,8 @@ public class ConnectCommand implements GfshCommand {
       gfsh.setOperationInvoker(operationInvoker);
       infoResultData.addLine(CliStrings.format(CliStrings.CONNECT__MSG__SUCCESS,
           jmxHostPortToConnect.toString(false)));
-      LogWrapper.getInstance(CliUtil.getCacheIfExists(this::getCache)).info(CliStrings
-          .format(CliStrings.CONNECT__MSG__SUCCESS, jmxHostPortToConnect.toString(false)));
+      LogWrapper.getInstance(getCache()).info(CliStrings.format(CliStrings.CONNECT__MSG__SUCCESS,
+          jmxHostPortToConnect.toString(false)));
       return ResultBuilder.buildResult(infoResultData);
     } catch (SecurityException | AuthenticationFailedException e) {
       // if it's security exception, and we already sent in username and password, still returns the
@@ -497,7 +497,7 @@ public class ConnectCommand implements GfshCommand {
   }
 
   private Result handleException(Exception e, String errorMessage) {
-    LogWrapper.getInstance(CliUtil.getCacheIfExists(this::getCache)).severe(errorMessage, e);
+    LogWrapper.getInstance(getCache()).severe(errorMessage, e);
     return ResultBuilder.createConnectionErrorResult(errorMessage);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CountDurableCQEventsCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CountDurableCQEventsCommand.java
@@ -34,7 +34,7 @@ import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class CountDurableCQEventsCommand implements GfshCommand {
+public class CountDurableCQEventsCommand extends GfshCommand {
   DurableClientCommandsResultBuilder builder = new DurableClientCommandsResultBuilder();
 
   @CliCommand(value = CliStrings.COUNT_DURABLE_CQ_EVENTS,
@@ -56,7 +56,7 @@ public class CountDurableCQEventsCommand implements GfshCommand {
 
     Result result;
     try {
-      Set<DistributedMember> targetMembers = CliUtil.findMembers(group, memberNameOrId, getCache());
+      Set<DistributedMember> targetMembers = findMembers(group, memberNameOrId);
 
       if (targetMembers.isEmpty()) {
         return ResultBuilder.createUserErrorResult(CliStrings.NO_MEMBERS_FOUND_MESSAGE);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateAsyncEventQueueCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateAsyncEventQueueCommand.java
@@ -36,7 +36,7 @@ import org.apache.geode.management.internal.configuration.domain.XmlEntity;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class CreateAsyncEventQueueCommand implements GfshCommand {
+public class CreateAsyncEventQueueCommand extends GfshCommand {
   @CliCommand(value = CliStrings.CREATE_ASYNC_EVENT_QUEUE,
       help = CliStrings.CREATE_ASYNC_EVENT_QUEUE__HELP)
   @ResourceOperation(resource = ResourcePermission.Resource.CLUSTER,

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateDefinedIndexesCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateDefinedIndexesCommand.java
@@ -40,7 +40,7 @@ import org.apache.geode.management.internal.configuration.domain.XmlEntity;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class CreateDefinedIndexesCommand implements GfshCommand {
+public class CreateDefinedIndexesCommand extends GfshCommand {
   private static final CreateDefinedIndexesFunction createDefinedIndexesFunction =
       new CreateDefinedIndexesFunction();
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateDiskStoreCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateDiskStoreCommand.java
@@ -36,7 +36,7 @@ import org.apache.geode.management.internal.configuration.domain.XmlEntity;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class CreateDiskStoreCommand implements GfshCommand {
+public class CreateDiskStoreCommand extends GfshCommand {
   @CliCommand(value = CliStrings.CREATE_DISK_STORE, help = CliStrings.CREATE_DISK_STORE__HELP)
   @CliMetaData(relatedTopic = {CliStrings.TOPIC_GEODE_DISKSTORE})
   @ResourceOperation(resource = ResourcePermission.Resource.CLUSTER,

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateGatewayReceiverCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateGatewayReceiverCommand.java
@@ -38,7 +38,7 @@ import org.apache.geode.management.internal.configuration.domain.XmlEntity;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class CreateGatewayReceiverCommand implements GfshCommand {
+public class CreateGatewayReceiverCommand extends GfshCommand {
 
   @CliCommand(value = CliStrings.CREATE_GATEWAYRECEIVER,
       help = CliStrings.CREATE_GATEWAYRECEIVER__HELP)

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateGatewaySenderCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateGatewaySenderCommand.java
@@ -38,7 +38,7 @@ import org.apache.geode.management.internal.configuration.domain.XmlEntity;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class CreateGatewaySenderCommand implements GfshCommand {
+public class CreateGatewaySenderCommand extends GfshCommand {
   @CliCommand(value = CliStrings.CREATE_GATEWAYSENDER, help = CliStrings.CREATE_GATEWAYSENDER__HELP)
   @CliMetaData(relatedTopic = CliStrings.TOPIC_GEODE_WAN,
       interceptor = "org.apache.geode.management.internal.cli.commands.CreateGatewaySenderCommand$Interceptor")

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateIndexCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateIndexCommand.java
@@ -35,7 +35,7 @@ import org.apache.geode.management.internal.configuration.domain.XmlEntity;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class CreateIndexCommand implements GfshCommand {
+public class CreateIndexCommand extends GfshCommand {
   private static final CreateIndexFunction createIndexFunction = new CreateIndexFunction();
 
   @CliCommand(value = CliStrings.CREATE_INDEX, help = CliStrings.CREATE_INDEX__HELP)

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateJndiBindingCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateJndiBindingCommand.java
@@ -50,7 +50,7 @@ import org.apache.geode.management.internal.configuration.utils.XmlUtils;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class CreateJndiBindingCommand implements GfshCommand {
+public class CreateJndiBindingCommand extends GfshCommand {
   private static final Logger logger = LogService.getLogger();
 
   static final String CREATE_JNDIBINDING = "create jndi-binding";

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateRegionCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateRegionCommand.java
@@ -69,7 +69,7 @@ import org.apache.geode.management.internal.configuration.domain.XmlEntity;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class CreateRegionCommand implements GfshCommand {
+public class CreateRegionCommand extends GfshCommand {
   @CliCommand(value = CliStrings.CREATE_REGION, help = CliStrings.CREATE_REGION__HELP)
   @CliMetaData(relatedTopic = CliStrings.TOPIC_GEODE_REGION,
       interceptor = "org.apache.geode.management.internal.cli.commands.CreateRegionCommand$Interceptor")
@@ -488,7 +488,7 @@ public class CreateRegionCommand implements GfshCommand {
 
     if (attributes == null) {
       // find first member which has the region
-      Set<DistributedMember> regionAssociatedMembers = findMembersForRegion(cache, regionPath);
+      Set<DistributedMember> regionAssociatedMembers = findMembersForRegion(regionPath);
       if (regionAssociatedMembers != null && !regionAssociatedMembers.isEmpty()) {
         DistributedMember distributedMember = regionAssociatedMembers.iterator().next();
         ResultCollector<?, ?> resultCollector =
@@ -521,12 +521,12 @@ public class CreateRegionCommand implements GfshCommand {
     return attributes;
   }
 
-  private static boolean isClusterWideSameConfig(InternalCache cache, String regionPath) {
+  private boolean isClusterWideSameConfig(InternalCache cache, String regionPath) {
     ManagementService managementService = ManagementService.getExistingManagementService(cache);
 
     DistributedSystemMXBean dsMXBean = managementService.getDistributedSystemMXBean();
 
-    Set<DistributedMember> allMembers = CliUtil.getAllNormalMembers(cache);
+    Set<DistributedMember> allMembers = getAllNormalMembers();
 
     RegionAttributesData regionAttributesToValidateAgainst = null;
     for (DistributedMember distributedMember : allMembers) {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DebugCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DebugCommand.java
@@ -25,7 +25,7 @@ import org.apache.geode.management.internal.cli.result.ErrorResultData;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.cli.shell.Gfsh;
 
-public class DebugCommand implements GfshCommand {
+public class DebugCommand extends GfshCommand {
   @CliCommand(value = {CliStrings.DEBUG}, help = CliStrings.DEBUG__HELP)
   @CliMetaData(shellOnly = true,
       relatedTopic = {CliStrings.TOPIC_GFSH, CliStrings.TOPIC_GEODE_DEBUG_UTIL})

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DefineIndexCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DefineIndexCommand.java
@@ -29,7 +29,7 @@ import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class DefineIndexCommand implements GfshCommand {
+public class DefineIndexCommand extends GfshCommand {
   @CliCommand(value = CliStrings.DEFINE_INDEX, help = CliStrings.DEFINE_INDEX__HELP)
   @CliMetaData(relatedTopic = {CliStrings.TOPIC_GEODE_REGION, CliStrings.TOPIC_GEODE_DATA})
   // TODO : Add optionContext for indexName

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DeployCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DeployCommand.java
@@ -55,7 +55,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class DeployCommand implements GfshCommand {
+public class DeployCommand extends GfshCommand {
   private final DeployFunction deployFunction = new DeployFunction();
 
   /**
@@ -85,7 +85,7 @@ public class DeployCommand implements GfshCommand {
     List<String> jarFullPaths = CommandExecutionContext.getFilePathFromShell();
 
     Set<DistributedMember> targetMembers;
-    targetMembers = CliUtil.findMembers(groups, null, getCache());
+    targetMembers = findMembers(groups, null);
 
     List results = new ArrayList();
     ManagementAgent agent = ((SystemManagementService) getManagementService()).getManagementAgent();

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeClientCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeClientCommand.java
@@ -44,7 +44,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class DescribeClientCommand implements GfshCommand {
+public class DescribeClientCommand extends GfshCommand {
   @CliCommand(value = CliStrings.DESCRIBE_CLIENT, help = CliStrings.DESCRIBE_CLIENT__HELP)
   @CliMetaData(relatedTopic = {CliStrings.TOPIC_CLIENT})
   @ResourceOperation(resource = ResourcePermission.Resource.CLUSTER,
@@ -105,7 +105,7 @@ public class DescribeClientCommand implements GfshCommand {
           CliStrings.format(CliStrings.DESCRIBE_CLIENT__CLIENT__ID__NOT__FOUND__0, clientId));
     }
 
-    Set<DistributedMember> dsMembers = CliUtil.getAllMembers(cache);
+    Set<DistributedMember> dsMembers = getAllMembers();
     String isDurable = null;
     List<String> primaryServers = new ArrayList<>();
     List<String> secondaryServers = new ArrayList<>();
@@ -118,7 +118,7 @@ public class DescribeClientCommand implements GfshCommand {
       for (Object aResultList : resultList) {
         Object object = aResultList;
         if (object instanceof Throwable) {
-          LogWrapper.getInstance(CliUtil.getCacheIfExists(this::getCache)).warning(
+          LogWrapper.getInstance(getCache()).warning(
               "Exception in Describe Client " + ((Throwable) object).getMessage(),
               ((Throwable) object));
           continue;
@@ -156,8 +156,7 @@ public class DescribeClientCommand implements GfshCommand {
       return ResultBuilder.createGemFireErrorResult(CliStrings.DESCRIBE_CLIENT_NO_MEMBERS);
     }
 
-    LogWrapper.getInstance(CliUtil.getCacheIfExists(this::getCache))
-        .info("describe client result " + result);
+    LogWrapper.getInstance(getCache()).info("describe client result " + result);
     return result;
   }
 
@@ -208,7 +207,7 @@ public class DescribeClientCommand implements GfshCommand {
           String poolStatsStr = entry.getValue();
           String str[] = poolStatsStr.split(";");
 
-          LogWrapper logWrapper = LogWrapper.getInstance(CliUtil.getCacheIfExists(this::getCache));
+          LogWrapper logWrapper = LogWrapper.getInstance(getCache());
           logWrapper.info("describe client clientHealthStatus min conn="
               + str[0].substring(str[0].indexOf("=") + 1));
           logWrapper.info("describe client clientHealthStatus max conn ="

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeConfigCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeConfigCommand.java
@@ -40,7 +40,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class DescribeConfigCommand implements GfshCommand {
+public class DescribeConfigCommand extends GfshCommand {
   private final GetMemberConfigInformationFunction getMemberConfigFunction =
       new GetMemberConfigInformationFunction();
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeConnectionCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeConnectionCommand.java
@@ -26,7 +26,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.cli.shell.Gfsh;
 import org.apache.geode.management.internal.cli.shell.OperationInvoker;
 
-public class DescribeConnectionCommand implements GfshCommand {
+public class DescribeConnectionCommand extends GfshCommand {
   @CliCommand(value = {CliStrings.DESCRIBE_CONNECTION}, help = CliStrings.DESCRIBE_CONNECTION__HELP)
   @CliMetaData(shellOnly = true, relatedTopic = {CliStrings.TOPIC_GFSH, CliStrings.TOPIC_GEODE_JMX})
   public Result describeConnection() {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeDiskStoreCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeDiskStoreCommand.java
@@ -37,7 +37,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class DescribeDiskStoreCommand implements GfshCommand {
+public class DescribeDiskStoreCommand extends GfshCommand {
   @CliCommand(value = CliStrings.DESCRIBE_DISK_STORE, help = CliStrings.DESCRIBE_DISK_STORE__HELP)
   @CliMetaData(relatedTopic = {CliStrings.TOPIC_GEODE_DISKSTORE})
   @ResourceOperation(resource = ResourcePermission.Resource.CLUSTER,

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeMemberCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeMemberCommand.java
@@ -38,7 +38,7 @@ import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class DescribeMemberCommand implements GfshCommand {
+public class DescribeMemberCommand extends GfshCommand {
   private static final GetMemberInformationFunction getMemberInformation =
       new GetMemberInformationFunction();
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeOfflineDiskStoreCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeOfflineDiskStoreCommand.java
@@ -30,7 +30,7 @@ import org.apache.geode.management.cli.Result;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 
-public class DescribeOfflineDiskStoreCommand implements GfshCommand {
+public class DescribeOfflineDiskStoreCommand extends GfshCommand {
   @CliCommand(value = CliStrings.DESCRIBE_OFFLINE_DISK_STORE,
       help = CliStrings.DESCRIBE_OFFLINE_DISK_STORE__HELP)
   @CliMetaData(shellOnly = true, relatedTopic = {CliStrings.TOPIC_GEODE_DISKSTORE})

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeRegionCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeRegionCommand.java
@@ -45,7 +45,7 @@ import org.apache.geode.management.internal.cli.util.RegionAttributesNames;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class DescribeRegionCommand implements GfshCommand {
+public class DescribeRegionCommand extends GfshCommand {
   public static final Logger logger = LogService.getLogger();
 
   private static final GetRegionDescriptionFunction getRegionDescription =
@@ -103,7 +103,7 @@ public class DescribeRegionCommand implements GfshCommand {
   List<?> getFunctionResultFromMembers(String regionName) {
     InternalCache cache = getCache();
     ResultCollector<?, ?> rc =
-        executeFunction(getRegionDescription, regionName, getAllNormalMembers(cache));
+        executeFunction(getRegionDescription, regionName, getAllNormalMembers());
 
     return (List<?>) rc.getResult();
   }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyAsyncEventQueueCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyAsyncEventQueueCommand.java
@@ -35,7 +35,7 @@ import org.apache.geode.management.internal.configuration.domain.XmlEntity;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class DestroyAsyncEventQueueCommand implements GfshCommand {
+public class DestroyAsyncEventQueueCommand extends GfshCommand {
   public static final String DESTROY_ASYNC_EVENT_QUEUE = "destroy async-event-queue";
   public static final String DESTROY_ASYNC_EVENT_QUEUE__HELP = "destroy an Async Event Queue";
   public static final String DESTROY_ASYNC_EVENT_QUEUE__ID = "id";

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyDiskStoreCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyDiskStoreCommand.java
@@ -34,7 +34,7 @@ import org.apache.geode.management.internal.configuration.domain.XmlEntity;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class DestroyDiskStoreCommand implements GfshCommand {
+public class DestroyDiskStoreCommand extends GfshCommand {
   @CliCommand(value = CliStrings.DESTROY_DISK_STORE, help = CliStrings.DESTROY_DISK_STORE__HELP)
   @CliMetaData(relatedTopic = {CliStrings.TOPIC_GEODE_DISKSTORE})
   @ResourceOperation(resource = ResourcePermission.Resource.CLUSTER,

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyFunctionCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyFunctionCommand.java
@@ -41,7 +41,7 @@ import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class DestroyFunctionCommand implements GfshCommand {
+public class DestroyFunctionCommand extends GfshCommand {
   @CliCommand(value = CliStrings.DESTROY_FUNCTION, help = CliStrings.DESTROY_FUNCTION__HELP)
   @CliMetaData(relatedTopic = {CliStrings.TOPIC_GEODE_FUNCTION},
       interceptor = "org.apache.geode.management.internal.cli.commands.DestroyFunctionCommand$Interceptor")

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyGatewaySenderCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyGatewaySenderCommand.java
@@ -37,7 +37,7 @@ import org.apache.geode.management.internal.configuration.domain.XmlEntity;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class DestroyGatewaySenderCommand implements GfshCommand {
+public class DestroyGatewaySenderCommand extends GfshCommand {
   private static final Logger logger = LogService.getLogger();
 
   @CliCommand(value = CliStrings.DESTROY_GATEWAYSENDER,

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyIndexCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyIndexCommand.java
@@ -27,7 +27,6 @@ import org.apache.geode.internal.lang.StringUtils;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.domain.IndexInfo;
 import org.apache.geode.management.internal.cli.functions.CliFunctionResult;
 import org.apache.geode.management.internal.cli.functions.DestroyIndexFunction;
@@ -37,7 +36,7 @@ import org.apache.geode.management.internal.configuration.domain.XmlEntity;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class DestroyIndexCommand implements GfshCommand {
+public class DestroyIndexCommand extends GfshCommand {
   private static final DestroyIndexFunction destroyIndexFunction = new DestroyIndexFunction();
 
   @CliCommand(value = CliStrings.DESTROY_INDEX, help = CliStrings.DESTROY_INDEX__HELP)
@@ -70,7 +69,7 @@ public class DestroyIndexCommand implements GfshCommand {
     }
     IndexInfo indexInfo = new IndexInfo(indexName, regionName);
     indexInfo.setIfExists(ifExists);
-    Set<DistributedMember> targetMembers = CliUtil.findMembers(group, memberNameOrID, getCache());
+    Set<DistributedMember> targetMembers = findMembers(group, memberNameOrID);
 
     if (targetMembers.isEmpty()) {
       return ResultBuilder.createUserErrorResult(CliStrings.NO_MEMBERS_FOUND_MESSAGE);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyJndiBindingCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyJndiBindingCommand.java
@@ -43,7 +43,7 @@ import org.apache.geode.management.internal.configuration.utils.XmlUtils;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class DestroyJndiBindingCommand implements GfshCommand {
+public class DestroyJndiBindingCommand extends GfshCommand {
   static final String CREATE_JNDIBINDING = "destroy jndi-binding";
   static final String CREATE_JNDIBINDING__HELP =
       "Destroy a jndi binding that holds the configuration for the XA datasource.";

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyRegionCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyRegionCommand.java
@@ -34,7 +34,7 @@ import org.apache.geode.management.internal.configuration.domain.XmlEntity;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class DestroyRegionCommand implements GfshCommand {
+public class DestroyRegionCommand extends GfshCommand {
   @CliCommand(value = {CliStrings.DESTROY_REGION}, help = CliStrings.DESTROY_REGION__HELP)
   @CliMetaData(relatedTopic = CliStrings.TOPIC_GEODE_REGION)
   @ResourceOperation(resource = ResourcePermission.Resource.DATA,
@@ -48,7 +48,7 @@ public class DestroyRegionCommand implements GfshCommand {
 
     // this finds all the members that host this region. destroy will be called on each of these
     // members since the region might be a scope.LOCAL region
-    Set<DistributedMember> regionMembersList = findMembersForRegion(getCache(), regionPath);
+    Set<DistributedMember> regionMembersList = findMembersForRegion(regionPath);
 
     if (regionMembersList.size() == 0) {
       String message =

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DisconnectCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DisconnectCommand.java
@@ -19,7 +19,6 @@ import org.springframework.shell.core.annotation.CliCommand;
 
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.LogWrapper;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.InfoResultData;
@@ -27,7 +26,7 @@ import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.cli.shell.Gfsh;
 import org.apache.geode.management.internal.cli.shell.OperationInvoker;
 
-public class DisconnectCommand implements GfshCommand {
+public class DisconnectCommand extends GfshCommand {
   @CliCommand(value = {CliStrings.DISCONNECT}, help = CliStrings.DISCONNECT__HELP)
   @CliMetaData(shellOnly = true, relatedTopic = {CliStrings.TOPIC_GFSH, CliStrings.TOPIC_GEODE_JMX,
       CliStrings.TOPIC_GEODE_MANAGER})
@@ -46,7 +45,7 @@ public class DisconnectCommand implements GfshCommand {
           operationInvoker.stop();
           infoResultData.addLine(CliStrings.format(CliStrings.DISCONNECT__MSG__DISCONNECTED,
               operationInvoker.toString()));
-          LogWrapper.getInstance(CliUtil.getCacheIfExists(this::getCache)).info(CliStrings
+          LogWrapper.getInstance(getCache()).info(CliStrings
               .format(CliStrings.DISCONNECT__MSG__DISCONNECTED, operationInvoker.toString()));
           if (!gfshInstance.isHeadlessMode()) {
             gfshInstance.setPromptPath(gfshInstance.getEnvAppContextPath());

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/EchoCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/EchoCommand.java
@@ -28,7 +28,7 @@ import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.cli.shell.Gfsh;
 
-public class EchoCommand implements GfshCommand {
+public class EchoCommand extends GfshCommand {
   @CliCommand(value = {CliStrings.ECHO}, help = CliStrings.ECHO__HELP)
   @CliMetaData(shellOnly = true, relatedTopic = {CliStrings.TOPIC_GFSH})
   public Result echo(@CliOption(key = {CliStrings.ECHO__STR, ""}, specifiedDefaultValue = "",

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExecuteFunctionCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExecuteFunctionCommand.java
@@ -26,9 +26,6 @@ import org.apache.shiro.subject.Subject;
 import org.springframework.shell.core.annotation.CliCommand;
 import org.springframework.shell.core.annotation.CliOption;
 
-import org.apache.geode.cache.execute.Execution;
-import org.apache.geode.cache.execute.Function;
-import org.apache.geode.cache.execute.FunctionService;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
@@ -42,7 +39,7 @@ import org.apache.geode.management.internal.cli.result.CompositeResultData;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.cli.result.TabularResultData;
 
-public class ExecuteFunctionCommand implements GfshCommand {
+public class ExecuteFunctionCommand extends GfshCommand {
   @CliCommand(value = CliStrings.EXECUTE_FUNCTION, help = CliStrings.EXECUTE_FUNCTION__HELP)
   @CliMetaData(relatedTopic = {CliStrings.TOPIC_GEODE_FUNCTION},
       interceptor = "org.apache.geode.management.internal.cli.commands.ExecuteFunctionCommand$ExecuteFunctionCommandInterceptor")
@@ -77,7 +74,7 @@ public class ExecuteFunctionCommand implements GfshCommand {
       // find the members based on the groups or members
       dsMembers = findMembers(onGroups, onMembers);
     } else {
-      dsMembers = findMembersForRegion(getCache(), onRegion);
+      dsMembers = findMembersForRegion(onRegion);
     }
 
     if (dsMembers.size() == 0) {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExecuteScriptCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExecuteScriptCommand.java
@@ -27,7 +27,7 @@ import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.cli.shell.Gfsh;
 
-public class ExecuteScriptCommand implements GfshCommand {
+public class ExecuteScriptCommand extends GfshCommand {
   @CliCommand(value = {CliStrings.RUN}, help = CliStrings.RUN__HELP)
   @CliMetaData(shellOnly = true, relatedTopic = {CliStrings.TOPIC_GFSH})
   public Result executeScript(

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExitCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExitCommand.java
@@ -22,7 +22,7 @@ import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.shell.Gfsh;
 
-public class ExitCommand implements GfshCommand {
+public class ExitCommand extends GfshCommand {
   @CliCommand(value = {CliStrings.EXIT, "quit"}, help = CliStrings.EXIT__HELP)
   @CliMetaData(shellOnly = true, relatedTopic = {CliStrings.TOPIC_GFSH})
   public ExitShellRequest exit() {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExportConfigCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExportConfigCommand.java
@@ -41,7 +41,7 @@ import org.apache.geode.management.internal.cli.shell.Gfsh;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class ExportConfigCommand implements GfshCommand {
+public class ExportConfigCommand extends GfshCommand {
   private final ExportConfigFunction exportConfigFunction = new ExportConfigFunction();
 
   /**
@@ -68,7 +68,7 @@ public class ExportConfigCommand implements GfshCommand {
           help = CliStrings.EXPORT_CONFIG__DIR__HELP) String dir) {
     InfoResultData infoData = ResultBuilder.createInfoResultData();
 
-    Set<DistributedMember> targetMembers = CliUtil.findMembers(group, member, getCache());
+    Set<DistributedMember> targetMembers = findMembers(group, member);
     if (targetMembers.isEmpty()) {
       return ResultBuilder.createUserErrorResult(CliStrings.NO_MEMBERS_FOUND_MESSAGE);
     }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExportDataCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExportDataCommand.java
@@ -36,7 +36,7 @@ import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.security.ResourcePermission.Operation;
 import org.apache.geode.security.ResourcePermission.Resource;
 
-public class ExportDataCommand implements GfshCommand {
+public class ExportDataCommand extends GfshCommand {
   private final ExportDataFunction exportDataFunction = new ExportDataFunction();
 
   @CliCommand(value = CliStrings.EXPORT_DATA, help = CliStrings.EXPORT_DATA__HELP)

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExportImportClusterConfigurationCommands.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExportImportClusterConfigurationCommands.java
@@ -39,12 +39,10 @@ import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.internal.ClusterConfigurationService;
 import org.apache.geode.distributed.internal.InternalLocator;
-import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.Result;
 import org.apache.geode.management.internal.cli.AbstractCliAroundInterceptor;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.GfshParseResult;
 import org.apache.geode.management.internal.cli.functions.CliFunctionResult;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
@@ -66,7 +64,7 @@ import org.apache.geode.security.ResourcePermission.Resource;
  * Commands for the cluster configuration
  */
 @SuppressWarnings("unused")
-public class ExportImportClusterConfigurationCommands implements GfshCommand {
+public class ExportImportClusterConfigurationCommands extends GfshCommand {
 
   @CliCommand(value = {CliStrings.EXPORT_SHARED_CONFIG},
       help = CliStrings.EXPORT_SHARED_CONFIG__HELP)
@@ -143,9 +141,7 @@ public class ExportImportClusterConfigurationCommands implements GfshCommand {
       return ResultBuilder.buildResult(errorData);
     }
 
-    InternalCache cache = getCache();
-
-    Set<DistributedMember> servers = CliUtil.getAllNormalMembers(cache);
+    Set<DistributedMember> servers = getAllNormalMembers();
 
     Set<String> regionsWithData = servers.stream().map(this::getRegionNamesOnServer)
         .flatMap(Collection::stream).collect(toSet());

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExportLogsCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExportLogsCommand.java
@@ -49,7 +49,7 @@ import org.apache.geode.management.internal.configuration.utils.ZipUtils;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class ExportLogsCommand implements GfshCommand {
+public class ExportLogsCommand extends GfshCommand {
 
   private static final Logger logger = LogService.getLogger();
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExportOfflineDiskStoreCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExportOfflineDiskStoreCommand.java
@@ -24,12 +24,11 @@ import org.apache.geode.SystemFailure;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.LogWrapper;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 
-public class ExportOfflineDiskStoreCommand implements GfshCommand {
+public class ExportOfflineDiskStoreCommand extends GfshCommand {
   @CliCommand(value = CliStrings.EXPORT_OFFLINE_DISK_STORE,
       help = CliStrings.EXPORT_OFFLINE_DISK_STORE__HELP)
   @CliMetaData(shellOnly = true, relatedTopic = {CliStrings.TOPIC_GEODE_DISKSTORE})
@@ -61,7 +60,7 @@ public class ExportOfflineDiskStoreCommand implements GfshCommand {
       throw e;
     } catch (Throwable th) {
       SystemFailure.checkFailure();
-      LogWrapper.getInstance(CliUtil.getCacheIfExists(this::getCache)).warning(th.getMessage(), th);
+      LogWrapper.getInstance(getCache()).warning(th.getMessage(), th);
       return ResultBuilder.createGemFireErrorResult(CliStrings
           .format(CliStrings.EXPORT_OFFLINE_DISK_STORE__ERROR, diskStoreName, th.toString()));
     }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExportStackTraceCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExportStackTraceCommand.java
@@ -45,7 +45,7 @@ import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class ExportStackTraceCommand implements GfshCommand {
+public class ExportStackTraceCommand extends GfshCommand {
   public static final String STACK_TRACE_FOR_MEMBER = "*** Stack-trace for member ";
   private final GetStackTracesFunction getStackTracesFunction = new GetStackTracesFunction();
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/GCCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/GCCommand.java
@@ -39,7 +39,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class GCCommand implements GfshCommand {
+public class GCCommand extends GfshCommand {
   @CliCommand(value = CliStrings.GC, help = CliStrings.GC__HELP)
   @CliMetaData(relatedTopic = {CliStrings.TOPIC_GEODE_DEBUG_UTIL})
   @ResourceOperation(resource = ResourcePermission.Resource.CLUSTER,
@@ -69,7 +69,7 @@ public class GCCommand implements GfshCommand {
     } else {
       // gc on entire cluster
       // exclude locators
-      dsMembers = CliUtil.getAllNormalMembers(cache);
+      dsMembers = getAllNormalMembers();
       result = executeAndBuildResult(resultTable, dsMembers);
 
     }
@@ -86,11 +86,11 @@ public class GCCommand implements GfshCommand {
 
     for (Object object : resultList) {
       if (object instanceof Exception) {
-        LogWrapper.getInstance(CliUtil.getCacheIfExists(this::getCache))
+        LogWrapper.getInstance(getCache())
             .fine("Exception in GC " + ((Throwable) object).getMessage(), ((Throwable) object));
         continue;
       } else if (object instanceof Throwable) {
-        LogWrapper.getInstance(CliUtil.getCacheIfExists(this::getCache))
+        LogWrapper.getInstance(getCache())
             .fine("Exception in GC " + ((Throwable) object).getMessage(), ((Throwable) object));
         continue;
       }
@@ -106,8 +106,7 @@ public class GCCommand implements GfshCommand {
               resultMap.get("TimeSpentInGC"));
         }
       } else {
-        LogWrapper.getInstance(CliUtil.getCacheIfExists(this::getCache))
-            .fine("ResultMap was null ");
+        LogWrapper.getInstance(getCache()).fine("ResultMap was null ");
       }
     }
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/GetCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/GetCommand.java
@@ -38,7 +38,7 @@ import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.security.ResourcePermission.Operation;
 import org.apache.geode.security.ResourcePermission.Resource;
 
-public class GetCommand implements GfshCommand {
+public class GetCommand extends GfshCommand {
   @CliMetaData(relatedTopic = {CliStrings.TOPIC_GEODE_DATA, CliStrings.TOPIC_GEODE_REGION})
   @CliCommand(value = {CliStrings.GET}, help = CliStrings.GET__HELP)
   public Result get(
@@ -63,7 +63,7 @@ public class GetCommand implements GfshCommand {
     Region region = cache.getRegion(regionPath);
     DataCommandFunction getfn = new DataCommandFunction();
     if (region == null) {
-      Set<DistributedMember> memberList = findAnyMembersForRegion(getCache(), regionPath);
+      Set<DistributedMember> memberList = findAnyMembersForRegion(regionPath);
       if (CollectionUtils.isNotEmpty(memberList)) {
         DataCommandRequest request = new DataCommandRequest();
         request.setCommand(CliStrings.GET);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/GfshCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/GfshCommand.java
@@ -21,6 +21,7 @@ import java.util.Set;
 
 import org.springframework.shell.core.CommandMarker;
 
+import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.execute.Execution;
 import org.apache.geode.cache.execute.Function;
 import org.apache.geode.cache.execute.FunctionService;
@@ -50,8 +51,8 @@ import org.apache.geode.management.internal.configuration.domain.XmlEntity;
 public abstract class GfshCommand implements CommandMarker {
   private InternalCache cache;
 
-  public void setCache(InternalCache cache) {
-    this.cache = cache;
+  public void setCache(Cache cache) {
+    this.cache = (InternalCache) cache;
   }
 
   public InternalCache getCache() {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/GfshHelpCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/GfshHelpCommand.java
@@ -26,7 +26,7 @@ import org.apache.geode.management.internal.cli.CommandManagerAware;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 
-public class GfshHelpCommand implements GfshCommand, CommandManagerAware {
+public class GfshHelpCommand extends GfshCommand implements CommandManagerAware {
   private CommandManager commandManager = null;
 
   public void setCommandManager(CommandManager commandManager) {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/GfshHintCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/GfshHintCommand.java
@@ -26,7 +26,7 @@ import org.apache.geode.management.internal.cli.CommandManagerAware;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 
-public class GfshHintCommand implements GfshCommand, CommandManagerAware {
+public class GfshHintCommand extends GfshCommand implements CommandManagerAware {
   private CommandManager commandManager = null;
 
   public void setCommandManager(CommandManager commandManager) {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/HistoryCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/HistoryCommand.java
@@ -34,7 +34,7 @@ import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.cli.shell.Gfsh;
 import org.apache.geode.management.internal.cli.shell.jline.GfshHistory;
 
-public class HistoryCommand implements GfshCommand {
+public class HistoryCommand extends GfshCommand {
   @CliCommand(value = CliStrings.HISTORY, help = CliStrings.HISTORY__HELP)
   @CliMetaData(shellOnly = true, relatedTopic = {CliStrings.TOPIC_GFSH})
   public Result history(

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ImportDataCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ImportDataCommand.java
@@ -34,7 +34,7 @@ import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.security.ResourcePermission.Operation;
 import org.apache.geode.security.ResourcePermission.Resource;
 
-public class ImportDataCommand implements GfshCommand {
+public class ImportDataCommand extends GfshCommand {
   private final ImportDataFunction importDataFunction = new ImportDataFunction();
 
   @CliCommand(value = CliStrings.IMPORT_DATA, help = CliStrings.IMPORT_DATA__HELP)

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListAsyncEventQueuesCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListAsyncEventQueuesCommand.java
@@ -36,7 +36,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class ListAsyncEventQueuesCommand implements GfshCommand {
+public class ListAsyncEventQueuesCommand extends GfshCommand {
   @CliCommand(value = CliStrings.LIST_ASYNC_EVENT_QUEUES,
       help = CliStrings.LIST_ASYNC_EVENT_QUEUES__HELP)
   @ResourceOperation(resource = ResourcePermission.Resource.CLUSTER,
@@ -46,7 +46,7 @@ public class ListAsyncEventQueuesCommand implements GfshCommand {
       TabularResultData tabularData = ResultBuilder.createTabularResultData();
       boolean accumulatedData = false;
 
-      Set<DistributedMember> targetMembers = CliUtil.getAllNormalMembers(getCache());
+      Set<DistributedMember> targetMembers = getAllNormalMembers();
 
       if (targetMembers.isEmpty()) {
         return ResultBuilder.createUserErrorResult(CliStrings.NO_MEMBERS_FOUND_MESSAGE);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListClientCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListClientCommand.java
@@ -29,7 +29,6 @@ import org.apache.geode.management.CacheServerMXBean;
 import org.apache.geode.management.ManagementService;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.LogWrapper;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.CompositeResultData;
@@ -38,7 +37,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class ListClientCommand implements GfshCommand {
+public class ListClientCommand extends GfshCommand {
   @CliCommand(value = CliStrings.LIST_CLIENTS, help = CliStrings.LIST_CLIENT__HELP)
   @CliMetaData(relatedTopic = {CliStrings.TOPIC_CLIENT})
   @ResourceOperation(resource = ResourcePermission.Resource.CLUSTER,
@@ -111,8 +110,7 @@ public class ListClientCommand implements GfshCommand {
     }
     result = ResultBuilder.buildResult(compositeResultData);
 
-    LogWrapper.getInstance(CliUtil.getCacheIfExists(this::getCache))
-        .info("list client result " + result);
+    LogWrapper.getInstance(getCache()).info("list client result " + result);
 
     return result;
   }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListDeployedCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListDeployedCommand.java
@@ -35,7 +35,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class ListDeployedCommand implements GfshCommand {
+public class ListDeployedCommand extends GfshCommand {
   private final ListDeployedFunction listDeployedFunction = new ListDeployedFunction();
 
   /**
@@ -55,7 +55,7 @@ public class ListDeployedCommand implements GfshCommand {
       TabularResultData tabularData = ResultBuilder.createTabularResultData();
       boolean accumulatedData = false;
 
-      Set<DistributedMember> targetMembers = CliUtil.findMembers(group, null, getCache());
+      Set<DistributedMember> targetMembers = findMembers(group, null);
 
       if (targetMembers.isEmpty()) {
         return ResultBuilder.createUserErrorResult(CliStrings.NO_MEMBERS_FOUND_MESSAGE);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListDiskStoresCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListDiskStoresCommand.java
@@ -37,7 +37,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class ListDiskStoresCommand implements GfshCommand {
+public class ListDiskStoresCommand extends GfshCommand {
   @CliCommand(value = CliStrings.LIST_DISK_STORE, help = CliStrings.LIST_DISK_STORE__HELP)
   @CliMetaData(relatedTopic = {CliStrings.TOPIC_GEODE_DISKSTORE})
   @ResourceOperation(resource = ResourcePermission.Resource.CLUSTER,

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListDurableClientCQsCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListDurableClientCQsCommand.java
@@ -38,7 +38,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class ListDurableClientCQsCommand implements GfshCommand {
+public class ListDurableClientCQsCommand extends GfshCommand {
   DurableClientCommandsResultBuilder builder = new DurableClientCommandsResultBuilder();
 
   @CliCommand(value = CliStrings.LIST_DURABLE_CQS, help = CliStrings.LIST_DURABLE_CQS__HELP)
@@ -60,7 +60,7 @@ public class ListDurableClientCQsCommand implements GfshCommand {
     try {
 
       boolean noResults = true;
-      Set<DistributedMember> targetMembers = CliUtil.findMembers(group, memberNameOrId, getCache());
+      Set<DistributedMember> targetMembers = findMembers(group, memberNameOrId);
 
       if (targetMembers.isEmpty()) {
         return ResultBuilder.createUserErrorResult(CliStrings.NO_MEMBERS_FOUND_MESSAGE);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListFunctionCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListFunctionCommand.java
@@ -37,7 +37,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class ListFunctionCommand implements GfshCommand {
+public class ListFunctionCommand extends GfshCommand {
   private final ListFunctionFunction listFunctionFunction = new ListFunctionFunction();
 
   @CliCommand(value = CliStrings.LIST_FUNCTION, help = CliStrings.LIST_FUNCTION__HELP)
@@ -56,7 +56,7 @@ public class ListFunctionCommand implements GfshCommand {
     TabularResultData tabularData = ResultBuilder.createTabularResultData();
     boolean accumulatedData = false;
 
-    Set<DistributedMember> targetMembers = CliUtil.findMembers(groups, members, getCache());
+    Set<DistributedMember> targetMembers = findMembers(groups, members);
 
     if (targetMembers.isEmpty()) {
       return ResultBuilder.createUserErrorResult(CliStrings.NO_MEMBERS_FOUND_MESSAGE);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListGatewayCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListGatewayCommand.java
@@ -42,7 +42,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class ListGatewayCommand implements GfshCommand {
+public class ListGatewayCommand extends GfshCommand {
   @CliCommand(value = CliStrings.LIST_GATEWAY, help = CliStrings.LIST_GATEWAY__HELP)
   @CliMetaData(relatedTopic = CliStrings.TOPIC_GEODE_WAN)
   @ResourceOperation(resource = ResourcePermission.Resource.CLUSTER,

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListIndexCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListIndexCommand.java
@@ -38,7 +38,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class ListIndexCommand implements GfshCommand {
+public class ListIndexCommand extends GfshCommand {
   @CliCommand(value = CliStrings.LIST_INDEX, help = CliStrings.LIST_INDEX__HELP)
   @CliMetaData(relatedTopic = {CliStrings.TOPIC_GEODE_REGION, CliStrings.TOPIC_GEODE_DATA})
   @ResourceOperation(resource = ResourcePermission.Resource.CLUSTER,
@@ -89,7 +89,7 @@ public class ListIndexCommand implements GfshCommand {
   }
 
   List<IndexDetails> getIndexListing() {
-    final Execution functionExecutor = getMembersFunctionExecutor(getAllMembers(getCache()));
+    final Execution functionExecutor = getMembersFunctionExecutor(getAllMembers());
 
     if (functionExecutor instanceof AbstractExecution) {
       ((AbstractExecution) functionExecutor).setIgnoreDepartedMembers(true);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListJndiBindingCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListJndiBindingCommand.java
@@ -33,7 +33,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class ListJndiBindingCommand implements GfshCommand {
+public class ListJndiBindingCommand extends GfshCommand {
   private static final Logger logger = LogService.getLogger();
 
   private static final String LIST_JNDIBINDING = "list jndi-binding";

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListMembersCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListMembersCommand.java
@@ -33,7 +33,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class ListMembersCommand implements GfshCommand {
+public class ListMembersCommand extends GfshCommand {
   @CliCommand(value = {CliStrings.LIST_MEMBER}, help = CliStrings.LIST_MEMBER__HELP)
   @CliMetaData(relatedTopic = CliStrings.TOPIC_GEODE_SERVER)
   @ResourceOperation(resource = ResourcePermission.Resource.CLUSTER,

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListRegionCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListRegionCommand.java
@@ -41,7 +41,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class ListRegionCommand implements GfshCommand {
+public class ListRegionCommand extends GfshCommand {
   private static final GetRegionsFunction getRegionsFunction = new GetRegionsFunction();
 
   @CliCommand(value = {CliStrings.LIST_REGION}, help = CliStrings.LIST_REGION__HELP)
@@ -59,7 +59,7 @@ public class ListRegionCommand implements GfshCommand {
     try {
       Set<RegionInformation> regionInfoSet = new LinkedHashSet<>();
       ResultCollector<?, ?> rc;
-      Set<DistributedMember> targetMembers = CliUtil.findMembers(group, memberNameOrId, getCache());
+      Set<DistributedMember> targetMembers = findMembers(group, memberNameOrId);
 
       if (targetMembers.isEmpty()) {
         return ResultBuilder.createUserErrorResult(CliStrings.NO_MEMBERS_FOUND_MESSAGE);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/LoadBalanceGatewaySenderCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/LoadBalanceGatewaySenderCommand.java
@@ -30,14 +30,13 @@ import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
 import org.apache.geode.management.internal.SystemManagementService;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class LoadBalanceGatewaySenderCommand implements GfshCommand {
+public class LoadBalanceGatewaySenderCommand extends GfshCommand {
 
   @CliCommand(value = CliStrings.LOAD_BALANCE_GATEWAYSENDER,
       help = CliStrings.LOAD_BALANCE_GATEWAYSENDER__HELP)
@@ -57,7 +56,7 @@ public class LoadBalanceGatewaySenderCommand implements GfshCommand {
     SystemManagementService service =
         (SystemManagementService) ManagementService.getExistingManagementService(cache);
     TabularResultData resultData = ResultBuilder.createTabularResultData();
-    Set<DistributedMember> dsMembers = CliUtil.getAllNormalMembers(cache);
+    Set<DistributedMember> dsMembers = getAllNormalMembers();
 
     if (dsMembers.isEmpty()) {
       result = ResultBuilder.createInfoResult(CliStrings.GATEWAY_MSG_MEMBERS_NOT_FOUND);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/LocateEntryCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/LocateEntryCommand.java
@@ -35,7 +35,7 @@ import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.security.ResourcePermission.Operation;
 import org.apache.geode.security.ResourcePermission.Resource;
 
-public class LocateEntryCommand implements GfshCommand {
+public class LocateEntryCommand extends GfshCommand {
   @CliMetaData(relatedTopic = {CliStrings.TOPIC_GEODE_DATA, CliStrings.TOPIC_GEODE_REGION})
   @CliCommand(value = {CliStrings.LOCATE_ENTRY}, help = CliStrings.LOCATE_ENTRY__HELP)
   public Result locateEntry(
@@ -57,7 +57,7 @@ public class LocateEntryCommand implements GfshCommand {
     DataCommandResult dataResult;
 
     DataCommandFunction locateEntry = new DataCommandFunction();
-    Set<DistributedMember> memberList = findMembersForRegion(getCache(), regionPath);
+    Set<DistributedMember> memberList = findMembersForRegion(regionPath);
     if (CollectionUtils.isNotEmpty(memberList)) {
       DataCommandRequest request = new DataCommandRequest();
       request.setCommand(CliStrings.LOCATE_ENTRY);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/NetstatCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/NetstatCommand.java
@@ -47,7 +47,7 @@ import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class NetstatCommand implements GfshCommand {
+public class NetstatCommand extends GfshCommand {
   private static final String NETSTAT_FILE_REQUIRED_EXTENSION = ".txt";
 
   @CliCommand(value = CliStrings.NETSTAT, help = CliStrings.NETSTAT__HELP)
@@ -171,13 +171,13 @@ public class NetstatCommand implements GfshCommand {
       }
       result = ResultBuilder.buildResult(resultData);
     } catch (IllegalArgumentException e) {
-      LogWrapper.getInstance(CliUtil.getCacheIfExists(this::getCache))
+      LogWrapper.getInstance(getCache())
           .info(CliStrings.format(
               CliStrings.NETSTAT__MSG__ERROR_OCCURRED_WHILE_EXECUTING_NETSTAT_ON_0,
               new Object[] {Arrays.toString(members)}));
       result = ResultBuilder.createUserErrorResult(e.getMessage());
     } catch (RuntimeException e) {
-      LogWrapper.getInstance(CliUtil.getCacheIfExists(this::getCache))
+      LogWrapper.getInstance(getCache())
           .info(CliStrings.format(
               CliStrings.NETSTAT__MSG__ERROR_OCCURRED_WHILE_EXECUTING_NETSTAT_ON_0,
               new Object[] {Arrays.toString(members)}), e);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/PDXRenameCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/PDXRenameCommand.java
@@ -31,7 +31,7 @@ import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.pdx.internal.EnumInfo;
 import org.apache.geode.pdx.internal.PdxType;
 
-public class PDXRenameCommand implements GfshCommand {
+public class PDXRenameCommand extends GfshCommand {
   @CliCommand(value = CliStrings.PDX_RENAME, help = CliStrings.PDX_RENAME__HELP)
   @CliMetaData(shellOnly = true, relatedTopic = {CliStrings.TOPIC_GEODE_DISKSTORE})
   public Result pdxRename(@CliOption(key = CliStrings.PDX_RENAME_OLD, mandatory = true,

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/PauseGatewaySenderCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/PauseGatewaySenderCommand.java
@@ -36,7 +36,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class PauseGatewaySenderCommand implements GfshCommand {
+public class PauseGatewaySenderCommand extends GfshCommand {
 
   @CliCommand(value = CliStrings.PAUSE_GATEWAYSENDER, help = CliStrings.PAUSE_GATEWAYSENDER__HELP)
   @CliMetaData(relatedTopic = CliStrings.TOPIC_GEODE_WAN)

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/PutCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/PutCommand.java
@@ -37,7 +37,7 @@ import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.security.ResourcePermission.Operation;
 import org.apache.geode.security.ResourcePermission.Resource;
 
-public class PutCommand implements GfshCommand {
+public class PutCommand extends GfshCommand {
   @CliMetaData(relatedTopic = {CliStrings.TOPIC_GEODE_DATA, CliStrings.TOPIC_GEODE_REGION})
   @CliCommand(value = {CliStrings.PUT}, help = CliStrings.PUT__HELP)
   public Result put(
@@ -66,7 +66,7 @@ public class PutCommand implements GfshCommand {
     Region region = cache.getRegion(regionPath);
     DataCommandFunction putfn = new DataCommandFunction();
     if (region == null) {
-      Set<DistributedMember> memberList = findAnyMembersForRegion(getCache(), regionPath);
+      Set<DistributedMember> memberList = findAnyMembersForRegion(regionPath);
       if (CollectionUtils.isNotEmpty(memberList)) {
         DataCommandRequest request = new DataCommandRequest();
         request.setCommand(CliStrings.PUT);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/QueryCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/QueryCommand.java
@@ -50,7 +50,7 @@ import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.security.ResourcePermission.Operation;
 import org.apache.geode.security.ResourcePermission.Resource;
 
-public class QueryCommand implements GfshCommand {
+public class QueryCommand extends GfshCommand {
   private static final Logger logger = LogService.getLogger();
 
   @CliCommand(value = "query", help = CliStrings.QUERY__HELP)

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/RemoveCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/RemoveCommand.java
@@ -38,7 +38,7 @@ import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.security.ResourcePermission.Operation;
 import org.apache.geode.security.ResourcePermission.Resource;
 
-public class RemoveCommand implements GfshCommand {
+public class RemoveCommand extends GfshCommand {
   public static final String REGION_NOT_FOUND = "Region <%s> not found in any of the members";
 
   @CliMetaData(relatedTopic = {CliStrings.TOPIC_GEODE_DATA, CliStrings.TOPIC_GEODE_REGION})
@@ -69,7 +69,7 @@ public class RemoveCommand implements GfshCommand {
     DataCommandFunction removefn = new DataCommandFunction();
     DataCommandResult dataResult;
     if (region == null) {
-      Set<DistributedMember> memberList = findAnyMembersForRegion(getCache(), regionPath);
+      Set<DistributedMember> memberList = findAnyMembersForRegion(regionPath);
 
       if (CollectionUtils.isEmpty(memberList)) {
         return createUserErrorResult(String.format(REGION_NOT_FOUND, regionPath));

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ResumeGatewaySenderCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ResumeGatewaySenderCommand.java
@@ -30,14 +30,13 @@ import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
 import org.apache.geode.management.internal.SystemManagementService;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class ResumeGatewaySenderCommand implements GfshCommand {
+public class ResumeGatewaySenderCommand extends GfshCommand {
 
   @CliCommand(value = CliStrings.RESUME_GATEWAYSENDER, help = CliStrings.RESUME_GATEWAYSENDER__HELP)
   @CliMetaData(relatedTopic = CliStrings.TOPIC_GEODE_WAN)
@@ -67,7 +66,7 @@ public class ResumeGatewaySenderCommand implements GfshCommand {
 
     TabularResultData resultData = ResultBuilder.createTabularResultData();
 
-    Set<DistributedMember> dsMembers = CliUtil.findMembers(onGroup, onMember, getCache());
+    Set<DistributedMember> dsMembers = findMembers(onGroup, onMember);
 
     if (dsMembers.isEmpty()) {
       return ResultBuilder.createUserErrorResult(CliStrings.NO_MEMBERS_FOUND_MESSAGE);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/RevokeMissingDiskStoreCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/RevokeMissingDiskStoreCommand.java
@@ -28,7 +28,7 @@ import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class RevokeMissingDiskStoreCommand implements GfshCommand {
+public class RevokeMissingDiskStoreCommand extends GfshCommand {
   @CliCommand(value = CliStrings.REVOKE_MISSING_DISK_STORE,
       help = CliStrings.REVOKE_MISSING_DISK_STORE__HELP)
   @CliMetaData(relatedTopic = {CliStrings.TOPIC_GEODE_DISKSTORE})

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/SetVariableCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/SetVariableCommand.java
@@ -24,7 +24,7 @@ import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ErrorResultData;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 
-public class SetVariableCommand implements GfshCommand {
+public class SetVariableCommand extends GfshCommand {
   @CliCommand(value = {CliStrings.SET_VARIABLE}, help = CliStrings.SET_VARIABLE__HELP)
   @CliMetaData(shellOnly = true, relatedTopic = {CliStrings.TOPIC_GFSH})
   public Result setVariable(

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ShCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ShCommand.java
@@ -25,14 +25,13 @@ import org.springframework.shell.core.annotation.CliOption;
 import org.apache.geode.internal.lang.SystemUtils;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.LogWrapper;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.InfoResultData;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.cli.shell.Gfsh;
 
-public class ShCommand implements GfshCommand {
+public class ShCommand extends GfshCommand {
   @CliCommand(value = {CliStrings.SH}, help = CliStrings.SH__HELP)
   @CliMetaData(shellOnly = true, relatedTopic = {CliStrings.TOPIC_GFSH})
   public Result sh(
@@ -47,7 +46,7 @@ public class ShCommand implements GfshCommand {
           ResultBuilder.buildResult(executeCommand(Gfsh.getCurrentInstance(), command, useConsole));
     } catch (IllegalStateException | IOException e) {
       result = ResultBuilder.createUserErrorResult(e.getMessage());
-      LogWrapper.getInstance(CliUtil.getCacheIfExists(this::getCache))
+      LogWrapper.getInstance(getCache())
           .warning("Unable to execute command \"" + command + "\". Reason:" + e.getMessage() + ".");
     }
     return result;

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ShowDeadlockCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ShowDeadlockCommand.java
@@ -30,14 +30,13 @@ import org.apache.geode.distributed.internal.deadlock.GemFireDeadlockDetector;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.InfoResultData;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class ShowDeadlockCommand implements GfshCommand {
+public class ShowDeadlockCommand extends GfshCommand {
   @CliCommand(value = CliStrings.SHOW_DEADLOCK, help = CliStrings.SHOW_DEADLOCK__HELP)
   @CliMetaData(relatedTopic = {CliStrings.TOPIC_GEODE_DEBUG_UTIL})
   @ResourceOperation(resource = ResourcePermission.Resource.CLUSTER,
@@ -54,7 +53,7 @@ public class ShowDeadlockCommand implements GfshCommand {
       }
       InternalCache cache = getCache();
 
-      Set<DistributedMember> allMembers = CliUtil.getAllMembers(cache);
+      Set<DistributedMember> allMembers = getAllMembers();
       GemFireDeadlockDetector gfeDeadLockDetector = new GemFireDeadlockDetector(allMembers);
       DependencyGraph dependencyGraph = gfeDeadLockDetector.find();
       Collection<Dependency> deadlock = dependencyGraph.findCycle();

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ShowLogCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ShowLogCommand.java
@@ -36,7 +36,7 @@ import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class ShowLogCommand implements GfshCommand {
+public class ShowLogCommand extends GfshCommand {
   @CliCommand(value = CliStrings.SHOW_LOG, help = CliStrings.SHOW_LOG_HELP)
   @CliMetaData(relatedTopic = {CliStrings.TOPIC_GEODE_DEBUG_UTIL})
   @ResourceOperation(resource = ResourcePermission.Resource.CLUSTER,

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ShowMetricsCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ShowMetricsCommand.java
@@ -53,7 +53,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class ShowMetricsCommand implements GfshCommand {
+public class ShowMetricsCommand extends GfshCommand {
   enum Category {
     cache,
     cacheserver,

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ShowMissingDiskStoreCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ShowMissingDiskStoreCommand.java
@@ -40,7 +40,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class ShowMissingDiskStoreCommand implements GfshCommand {
+public class ShowMissingDiskStoreCommand extends GfshCommand {
   @CliCommand(value = CliStrings.SHOW_MISSING_DISK_STORE,
       help = CliStrings.SHOW_MISSING_DISK_STORE__HELP)
   @CliMetaData(relatedTopic = {CliStrings.TOPIC_GEODE_DISKSTORE})

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ShutdownCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ShutdownCommand.java
@@ -39,7 +39,6 @@ import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.Result;
 import org.apache.geode.management.internal.cli.AbstractCliAroundInterceptor;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.GfshParseResult;
 import org.apache.geode.management.internal.cli.functions.ShutDownFunction;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
@@ -47,7 +46,7 @@ import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class ShutdownCommand implements GfshCommand {
+public class ShutdownCommand extends GfshCommand {
   private static final String DEFAULT_TIME_OUT = "10";
   private static final Logger logger = LogService.getLogger();
 
@@ -70,9 +69,9 @@ public class ShutdownCommand implements GfshCommand {
       // convert to milliseconds
       long timeout = userSpecifiedTimeout * 1000;
       InternalCache cache = getCache();
-      int numDataNodes = CliUtil.getAllNormalMembers(cache).size();
-      Set<DistributedMember> locators = CliUtil.getAllMembers(cache);
-      Set<DistributedMember> dataNodes = CliUtil.getAllNormalMembers(cache);
+      int numDataNodes = getAllNormalMembers().size();
+      Set<DistributedMember> locators = getAllMembers();
+      Set<DistributedMember> dataNodes = getAllNormalMembers();
       locators.removeAll(dataNodes);
 
       if (!shutdownLocators && numDataNodes == 0) {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/SleepCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/SleepCommand.java
@@ -20,19 +20,17 @@ import org.springframework.shell.core.annotation.CliOption;
 
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.LogWrapper;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 
-public class SleepCommand implements GfshCommand {
+public class SleepCommand extends GfshCommand {
   @CliCommand(value = {CliStrings.SLEEP}, help = CliStrings.SLEEP__HELP)
   @CliMetaData(shellOnly = true, relatedTopic = {CliStrings.TOPIC_GFSH})
   public Result sleep(@CliOption(key = {CliStrings.SLEEP__TIME}, unspecifiedDefaultValue = "3",
       help = CliStrings.SLEEP__TIME__HELP) double time) {
     try {
-      LogWrapper.getInstance(CliUtil.getCacheIfExists(this::getCache))
-          .fine("Sleeping for " + time + "seconds.");
+      LogWrapper.getInstance(getCache()).fine("Sleeping for " + time + "seconds.");
       Thread.sleep(Math.round(time * 1000));
     } catch (InterruptedException ignored) {
     }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartGatewayReceiverCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartGatewayReceiverCommand.java
@@ -31,14 +31,13 @@ import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
 import org.apache.geode.management.internal.MBeanJMXAdapter;
 import org.apache.geode.management.internal.SystemManagementService;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class StartGatewayReceiverCommand implements GfshCommand {
+public class StartGatewayReceiverCommand extends GfshCommand {
 
   @CliCommand(value = CliStrings.START_GATEWAYRECEIVER,
       help = CliStrings.START_GATEWAYRECEIVER__HELP)
@@ -63,7 +62,7 @@ public class StartGatewayReceiverCommand implements GfshCommand {
 
     TabularResultData resultData = ResultBuilder.createTabularResultData();
 
-    Set<DistributedMember> dsMembers = CliUtil.findMembers(onGroup, onMember, getCache());
+    Set<DistributedMember> dsMembers = findMembers(onGroup, onMember);
 
     if (dsMembers.isEmpty()) {
       return ResultBuilder.createUserErrorResult(CliStrings.NO_MEMBERS_FOUND_MESSAGE);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartGatewaySenderCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartGatewaySenderCommand.java
@@ -46,7 +46,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class StartGatewaySenderCommand implements GfshCommand {
+public class StartGatewaySenderCommand extends GfshCommand {
 
   @CliCommand(value = CliStrings.START_GATEWAYSENDER, help = CliStrings.START_GATEWAYSENDER__HELP)
   @CliMetaData(relatedTopic = CliStrings.TOPIC_GEODE_WAN)

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartLocatorCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartLocatorCommand.java
@@ -55,7 +55,7 @@ import org.apache.geode.management.internal.cli.util.HostUtils;
 import org.apache.geode.management.internal.configuration.utils.ClusterConfigurationStatusRetriever;
 import org.apache.geode.security.AuthenticationFailedException;
 
-public class StartLocatorCommand implements GfshCommand {
+public class StartLocatorCommand extends GfshCommand {
   @CliCommand(value = CliStrings.START_LOCATOR, help = CliStrings.START_LOCATOR__HELP)
   @CliMetaData(shellOnly = true,
       relatedTopic = {CliStrings.TOPIC_GEODE_LOCATOR, CliStrings.TOPIC_GEODE_LIFECYCLE})

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartServerCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartServerCommand.java
@@ -46,7 +46,7 @@ import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.cli.shell.Gfsh;
 import org.apache.geode.management.internal.security.ResourceConstants;
 
-public class StartServerCommand implements GfshCommand {
+public class StartServerCommand extends GfshCommand {
   private static final String SERVER_TERM_NAME = "Server";
 
   @CliCommand(value = CliStrings.START_SERVER, help = CliStrings.START_SERVER__HELP)

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StatusClusterConfigServiceCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StatusClusterConfigServiceCommand.java
@@ -38,7 +38,7 @@ import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission.Operation;
 import org.apache.geode.security.ResourcePermission.Resource;
 
-public class StatusClusterConfigServiceCommand implements GfshCommand {
+public class StatusClusterConfigServiceCommand extends GfshCommand {
   private static final FetchSharedConfigurationStatusFunction fetchSharedConfigStatusFunction =
       new FetchSharedConfigurationStatusFunction();
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StatusGatewayReceiverCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StatusGatewayReceiverCommand.java
@@ -31,7 +31,6 @@ import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
 import org.apache.geode.management.internal.MBeanJMXAdapter;
 import org.apache.geode.management.internal.SystemManagementService;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.CompositeResultData;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
@@ -39,7 +38,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class StatusGatewayReceiverCommand implements GfshCommand {
+public class StatusGatewayReceiverCommand extends GfshCommand {
   @CliCommand(value = CliStrings.STATUS_GATEWAYRECEIVER,
       help = CliStrings.STATUS_GATEWAYRECEIVER__HELP)
   @CliMetaData(relatedTopic = CliStrings.TOPIC_GEODE_WAN)
@@ -68,7 +67,7 @@ public class StatusGatewayReceiverCommand implements GfshCommand {
         crd.addSection(CliStrings.SECTION_GATEWAY_RECEIVER_NOT_AVAILABLE)
             .addTable(CliStrings.TABLE_GATEWAY_RECEIVER);
 
-    Set<DistributedMember> dsMembers = CliUtil.findMembers(onGroup, onMember, getCache());
+    Set<DistributedMember> dsMembers = findMembers(onGroup, onMember);
 
     if (dsMembers.isEmpty()) {
       return ResultBuilder.createUserErrorResult(CliStrings.NO_MEMBERS_FOUND_MESSAGE);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StatusGatewaySenderCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StatusGatewaySenderCommand.java
@@ -30,7 +30,6 @@ import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
 import org.apache.geode.management.internal.SystemManagementService;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.CompositeResultData;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
@@ -38,7 +37,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class StatusGatewaySenderCommand implements GfshCommand {
+public class StatusGatewaySenderCommand extends GfshCommand {
   @CliCommand(value = CliStrings.STATUS_GATEWAYSENDER, help = CliStrings.STATUS_GATEWAYSENDER__HELP)
   @CliMetaData(relatedTopic = CliStrings.TOPIC_GEODE_WAN)
   @ResourceOperation(resource = ResourcePermission.Resource.CLUSTER,
@@ -75,7 +74,7 @@ public class StatusGatewaySenderCommand implements GfshCommand {
         crd.addSection(CliStrings.SECTION_GATEWAY_SENDER_NOT_AVAILABLE)
             .addTable(CliStrings.TABLE_GATEWAY_SENDER);
 
-    Set<DistributedMember> dsMembers = CliUtil.findMembers(onGroup, onMember, getCache());
+    Set<DistributedMember> dsMembers = findMembers(onGroup, onMember);
 
     if (dsMembers.isEmpty()) {
       return ResultBuilder.createUserErrorResult(CliStrings.NO_MEMBERS_FOUND_MESSAGE);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StopGatewayReceiverCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StopGatewayReceiverCommand.java
@@ -31,14 +31,13 @@ import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
 import org.apache.geode.management.internal.MBeanJMXAdapter;
 import org.apache.geode.management.internal.SystemManagementService;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class StopGatewayReceiverCommand implements GfshCommand {
+public class StopGatewayReceiverCommand extends GfshCommand {
   @CliCommand(value = CliStrings.STOP_GATEWAYRECEIVER, help = CliStrings.STOP_GATEWAYRECEIVER__HELP)
   @CliMetaData(relatedTopic = CliStrings.TOPIC_GEODE_WAN)
   @ResourceOperation(resource = ResourcePermission.Resource.CLUSTER,
@@ -62,7 +61,7 @@ public class StopGatewayReceiverCommand implements GfshCommand {
 
     TabularResultData resultData = ResultBuilder.createTabularResultData();
 
-    Set<DistributedMember> dsMembers = CliUtil.findMembers(onGroup, onMember, getCache());
+    Set<DistributedMember> dsMembers = findMembers(onGroup, onMember);
 
     if (dsMembers.isEmpty()) {
       return ResultBuilder.createUserErrorResult(CliStrings.NO_MEMBERS_FOUND_MESSAGE);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StopGatewaySenderCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StopGatewaySenderCommand.java
@@ -30,14 +30,13 @@ import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
 import org.apache.geode.management.internal.SystemManagementService;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class StopGatewaySenderCommand implements GfshCommand {
+public class StopGatewaySenderCommand extends GfshCommand {
 
   @CliCommand(value = CliStrings.STOP_GATEWAYSENDER, help = CliStrings.STOP_GATEWAYSENDER__HELP)
   @CliMetaData(relatedTopic = CliStrings.TOPIC_GEODE_WAN)
@@ -68,7 +67,7 @@ public class StopGatewaySenderCommand implements GfshCommand {
 
     TabularResultData resultData = ResultBuilder.createTabularResultData();
 
-    Set<DistributedMember> dsMembers = CliUtil.findMembers(onGroup, onMember, getCache());
+    Set<DistributedMember> dsMembers = findMembers(onGroup, onMember);
 
     if (dsMembers.isEmpty()) {
       return ResultBuilder.createUserErrorResult(CliStrings.NO_MEMBERS_FOUND_MESSAGE);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/UndeployCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/UndeployCommand.java
@@ -36,7 +36,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class UndeployCommand implements GfshCommand {
+public class UndeployCommand extends GfshCommand {
   private final UndeployFunction undeployFunction = new UndeployFunction();
 
   /**
@@ -61,7 +61,7 @@ public class UndeployCommand implements GfshCommand {
       TabularResultData tabularData = ResultBuilder.createTabularResultData();
       boolean accumulatedData = false;
 
-      Set<DistributedMember> targetMembers = CliUtil.findMembers(groups, null, getCache());
+      Set<DistributedMember> targetMembers = findMembers(groups, null);
 
       if (targetMembers.isEmpty()) {
         return ResultBuilder.createUserErrorResult(CliStrings.NO_MEMBERS_FOUND_MESSAGE);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/UpgradeOfflineDiskStoreCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/UpgradeOfflineDiskStoreCommand.java
@@ -31,7 +31,6 @@ import org.apache.geode.GemFireIOException;
 import org.apache.geode.internal.lang.StringUtils;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.GfshParser;
 import org.apache.geode.management.internal.cli.LogWrapper;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
@@ -39,7 +38,7 @@ import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.cli.shell.Gfsh;
 import org.apache.geode.management.internal.cli.util.DiskStoreUpgrader;
 
-public class UpgradeOfflineDiskStoreCommand implements GfshCommand {
+public class UpgradeOfflineDiskStoreCommand extends GfshCommand {
   @CliCommand(value = CliStrings.UPGRADE_OFFLINE_DISK_STORE,
       help = CliStrings.UPGRADE_OFFLINE_DISK_STORE__HELP)
   @CliMetaData(shellOnly = true, relatedTopic = {CliStrings.TOPIC_GEODE_DISKSTORE})
@@ -55,7 +54,7 @@ public class UpgradeOfflineDiskStoreCommand implements GfshCommand {
           help = CliStrings.UPGRADE_OFFLINE_DISK_STORE__J__HELP) String[] jvmProps) {
 
     Result result;
-    LogWrapper logWrapper = LogWrapper.getInstance(CliUtil.getCacheIfExists(this::getCache));
+    LogWrapper logWrapper = LogWrapper.getInstance(getCache());
 
     StringBuilder output = new StringBuilder();
     StringBuilder error = new StringBuilder();

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ValidateDiskStoreCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ValidateDiskStoreCommand.java
@@ -34,7 +34,7 @@ import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.cli.util.DiskStoreValidater;
 
-public class ValidateDiskStoreCommand implements GfshCommand {
+public class ValidateDiskStoreCommand extends GfshCommand {
   @CliCommand(value = CliStrings.VALIDATE_DISK_STORE, help = CliStrings.VALIDATE_DISK_STORE__HELP)
   @CliMetaData(shellOnly = true, relatedTopic = {CliStrings.TOPIC_GEODE_DISKSTORE})
   public Result validateDiskStore(

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/VersionCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/VersionCommand.java
@@ -24,7 +24,7 @@ import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.cli.shell.Gfsh;
 
-public class VersionCommand implements GfshCommand {
+public class VersionCommand extends GfshCommand {
   @CliCommand(value = {CliStrings.VERSION}, help = CliStrings.VERSION__HELP)
   @CliMetaData(shellOnly = true, relatedTopic = {CliStrings.TOPIC_GFSH})
   public Result version(@CliOption(key = {CliStrings.VERSION__FULL}, specifiedDefaultValue = "true",

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/lifecycle/StartJConsoleCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/lifecycle/StartJConsoleCommand.java
@@ -42,7 +42,7 @@ import org.apache.geode.management.internal.cli.shell.JmxOperationInvoker;
 import org.apache.geode.management.internal.cli.util.ConnectionEndpoint;
 import org.apache.geode.management.internal.cli.util.JdkTool;
 
-public class StartJConsoleCommand implements GfshCommand {
+public class StartJConsoleCommand extends GfshCommand {
 
   @CliCommand(value = CliStrings.START_JCONSOLE, help = CliStrings.START_JCONSOLE__HELP)
   @CliMetaData(shellOnly = true, relatedTopic = {CliStrings.TOPIC_GEODE_MANAGER,

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/lifecycle/StartJVisualVMCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/lifecycle/StartJVisualVMCommand.java
@@ -35,7 +35,7 @@ import org.apache.geode.management.internal.cli.result.InfoResultData;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.cli.util.JdkTool;
 
-public class StartJVisualVMCommand implements GfshCommand {
+public class StartJVisualVMCommand extends GfshCommand {
   @CliCommand(value = CliStrings.START_JVISUALVM, help = CliStrings.START_JVISUALVM__HELP)
   @CliMetaData(shellOnly = true, relatedTopic = {CliStrings.TOPIC_GEODE_MANAGER,
       CliStrings.TOPIC_GEODE_JMX, CliStrings.TOPIC_GEODE_M_AND_M})

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/lifecycle/StartPulseCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/lifecycle/StartPulseCommand.java
@@ -35,7 +35,7 @@ import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.cli.shell.OperationInvoker;
 
-public class StartPulseCommand implements GfshCommand {
+public class StartPulseCommand extends GfshCommand {
 
   @CliCommand(value = CliStrings.START_PULSE, help = CliStrings.START_PULSE__HELP)
   @CliMetaData(shellOnly = true, relatedTopic = {CliStrings.TOPIC_GEODE_MANAGER,

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/lifecycle/StartVsdCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/lifecycle/StartVsdCommand.java
@@ -41,7 +41,7 @@ import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.InfoResultData;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 
-public class StartVsdCommand implements GfshCommand {
+public class StartVsdCommand extends GfshCommand {
   @CliCommand(value = CliStrings.START_VSD, help = CliStrings.START_VSD__HELP)
   @CliMetaData(shellOnly = true,
       relatedTopic = {CliStrings.TOPIC_GEODE_M_AND_M, CliStrings.TOPIC_GEODE_STATISTICS})

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/lifecycle/StatusLocatorCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/lifecycle/StatusLocatorCommand.java
@@ -35,7 +35,7 @@ import org.apache.geode.management.internal.cli.result.InfoResultData;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.configuration.utils.ClusterConfigurationStatusRetriever;
 
-public class StatusLocatorCommand implements GfshCommand {
+public class StatusLocatorCommand extends GfshCommand {
   @CliCommand(value = CliStrings.STATUS_LOCATOR, help = CliStrings.STATUS_LOCATOR__HELP)
   @CliMetaData(shellOnly = true,
       relatedTopic = {CliStrings.TOPIC_GEODE_LOCATOR, CliStrings.TOPIC_GEODE_LIFECYCLE})

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/lifecycle/StatusServerCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/lifecycle/StatusServerCommand.java
@@ -32,7 +32,7 @@ import org.apache.geode.management.internal.cli.commands.GfshCommand;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 
-public class StatusServerCommand implements GfshCommand {
+public class StatusServerCommand extends GfshCommand {
 
   @CliCommand(value = CliStrings.STATUS_SERVER, help = CliStrings.STATUS_SERVER__HELP)
   @CliMetaData(shellOnly = true,

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/lifecycle/StopLocatorCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/lifecycle/StopLocatorCommand.java
@@ -35,7 +35,7 @@ import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.cli.shell.Gfsh;
 
-public class StopLocatorCommand implements GfshCommand {
+public class StopLocatorCommand extends GfshCommand {
   private static final long WAITING_FOR_STOP_TO_MAKE_PID_GO_AWAY_TIMEOUT_MILLIS = 30 * 1000;
 
   @CliCommand(value = CliStrings.STOP_LOCATOR, help = CliStrings.STOP_LOCATOR__HELP)

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/lifecycle/StopServerCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/lifecycle/StopServerCommand.java
@@ -34,7 +34,7 @@ import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.cli.shell.Gfsh;
 
-public class StopServerCommand implements GfshCommand {
+public class StopServerCommand extends GfshCommand {
   private static final long WAITING_FOR_STOP_TO_MAKE_PID_GO_AWAY_TIMEOUT_MILLIS = 30 * 1000;
 
   @CliCommand(value = CliStrings.STOP_SERVER, help = CliStrings.STOP_SERVER__HELP)

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/remote/OnlineCommandProcessor.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/remote/OnlineCommandProcessor.java
@@ -25,7 +25,7 @@ import org.springframework.shell.event.ParseResult;
 import org.springframework.util.StringUtils;
 
 import org.apache.geode.annotations.TestingOnly;
-import org.apache.geode.cache.Cache;
+import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.security.SecurityService;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.CommandProcessingException;
@@ -50,13 +50,13 @@ public class OnlineCommandProcessor {
   private final SecurityService securityService;
 
   public OnlineCommandProcessor(Properties cacheProperties, SecurityService securityService,
-      Cache cache) {
+      InternalCache cache) {
     this(cacheProperties, securityService, new CommandExecutor(), cache);
   }
 
   @TestingOnly
   public OnlineCommandProcessor(Properties cacheProperties, SecurityService securityService,
-      CommandExecutor commandExecutor, Cache cache) {
+      CommandExecutor commandExecutor, InternalCache cache) {
     this.gfshParser = new GfshParser(new CommandManager(cacheProperties, cache));
     this.executor = commandExecutor;
     this.securityService = securityService;

--- a/geode-core/src/main/java/org/apache/geode/redis/internal/RegionProvider.java
+++ b/geode-core/src/main/java/org/apache/geode/redis/internal/RegionProvider.java
@@ -399,6 +399,7 @@ public class RegionProvider implements Closeable {
     if (r != null)
       return r;
     do {
+      createRegionCmd.setCache(cache);
       Result result = createRegionCmd.createRegion(key, defaultRegionType, null, null, true, null,
           null, null, null, null, null, null, null, false, false, true, false, false, false, true,
           null, null, null, null, null, null, null, null, null, null, null, null, null, false, null,

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/extension/mock/MockExtensionCommands.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/extension/mock/MockExtensionCommands.java
@@ -26,7 +26,6 @@ import org.apache.geode.cache.Region;
 import org.apache.geode.cache.execute.Function;
 import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.distributed.DistributedMember;
-import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.management.cli.Result;
 import org.apache.geode.management.cli.Result.Status;
 import org.apache.geode.management.internal.cli.CliUtil;
@@ -44,7 +43,7 @@ import org.apache.geode.security.ResourcePermission.Resource;
  *
  * @since GemFire 8.1
  */
-public class MockExtensionCommands implements GfshCommand {
+public class MockExtensionCommands extends GfshCommand {
 
   public static final String OPTION_VALUE = "value";
 
@@ -172,8 +171,7 @@ public class MockExtensionCommands implements GfshCommand {
    */
   protected Result executeFunctionOnAllMembersTabulateResultPersist(final Function function,
       final boolean addXmlElement, final Object... args) {
-    final InternalCache cache = getCache();
-    final Set<DistributedMember> members = CliUtil.getAllNormalMembers(cache);
+    final Set<DistributedMember> members = getAllNormalMembers();
 
     @SuppressWarnings("unchecked")
     final ResultCollector<CliFunctionResult, List<CliFunctionResult>> resultCollector =

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/extension/mock/MockExtensionCommands.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/extension/mock/MockExtensionCommands.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.springframework.shell.core.CommandMarker;
 import org.springframework.shell.core.annotation.CliCommand;
 import org.springframework.shell.core.annotation.CliOption;
 
@@ -26,10 +27,13 @@ import org.apache.geode.cache.Region;
 import org.apache.geode.cache.execute.Function;
 import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.distributed.internal.ClusterConfigurationService;
+import org.apache.geode.distributed.internal.InternalLocator;
+import org.apache.geode.internal.cache.GemFireCacheImpl;
+import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.management.cli.Result;
 import org.apache.geode.management.cli.Result.Status;
 import org.apache.geode.management.internal.cli.CliUtil;
-import org.apache.geode.management.internal.cli.commands.GfshCommand;
 import org.apache.geode.management.internal.cli.functions.CliFunctionResult;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.cli.result.TabularResultData;
@@ -43,7 +47,7 @@ import org.apache.geode.security.ResourcePermission.Resource;
  *
  * @since GemFire 8.1
  */
-public class MockExtensionCommands extends GfshCommand {
+public class MockExtensionCommands implements CommandMarker {
 
   public static final String OPTION_VALUE = "value";
 
@@ -171,7 +175,8 @@ public class MockExtensionCommands extends GfshCommand {
    */
   protected Result executeFunctionOnAllMembersTabulateResultPersist(final Function function,
       final boolean addXmlElement, final Object... args) {
-    final Set<DistributedMember> members = getAllNormalMembers();
+    InternalCache cache = GemFireCacheImpl.getInstance();
+    final Set<DistributedMember> members = CliUtil.getAllNormalMembers(cache);
 
     @SuppressWarnings("unchecked")
     final ResultCollector<CliFunctionResult, List<CliFunctionResult>> resultCollector =
@@ -197,14 +202,13 @@ public class MockExtensionCommands extends GfshCommand {
 
     final Result result = ResultBuilder.buildResult(tabularResultData);
 
+    ClusterConfigurationService ccService = InternalLocator.getLocator().getSharedConfiguration();
     System.out.println("MockExtensionCommands: persisting xmlEntity=" + xmlEntity);
     if (null != xmlEntity.get()) {
       if (addXmlElement) {
-        persistClusterConfiguration(result,
-            () -> getSharedConfiguration().addXmlEntity(xmlEntity.get(), null));
+        ccService.addXmlEntity(xmlEntity.get(), null);
       } else {
-        persistClusterConfiguration(result,
-            () -> getSharedConfiguration().deleteXmlEntity(xmlEntity.get(), null));
+        ccService.deleteXmlEntity(xmlEntity.get(), null);
       }
     }
 

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/CommandManagerJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/CommandManagerJUnitTest.java
@@ -120,7 +120,6 @@ public class CommandManagerJUnitTest {
   public void testCommandManagerLoadPluginCommands() throws Exception {
     assertNotNull(commandManager);
 
-    // see META-INF/services/org.springframework.shell.core.CommandMarker service loader file.
     assertTrue("Should find listed plugin.",
         commandManager.getHelper().getCommands().contains("mock plugin command"));
     assertTrue("Should not find unlisted plugin.",

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DestroyRegionCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DestroyRegionCommandTest.java
@@ -95,7 +95,7 @@ public class DestroyRegionCommandTest {
 
   @Test
   public void whenNoRegionIsFoundOnAnyMembers() throws Exception {
-    doReturn(Collections.emptySet()).when(command).findMembersForRegion(any(), any());
+    doReturn(Collections.emptySet()).when(command).findMembersForRegion(any());
     parser.executeAndAssertThat(command, "destroy region --name=test").statusIsError()
         .containsOutput("Could not find a Region with Region path");
 
@@ -107,7 +107,7 @@ public class DestroyRegionCommandTest {
   public void multipleResultReturned_oneSucess_oneFailed() throws Exception {
     // mock this to pass the member search call
     doReturn(Collections.singleton(DistributedMember.class)).when(command)
-        .findMembersForRegion(any(), any());
+        .findMembersForRegion(any());
     when(result1.isSuccessful()).thenReturn(true);
     when(result1.getStatus()).thenReturn("result1 message");
     when(result1.getXmlEntity()).thenReturn(xmlEntity);
@@ -126,7 +126,7 @@ public class DestroyRegionCommandTest {
   public void multipleResultReturned_oneSuccess_oneException() throws Exception {
     // mock this to pass the member search call
     doReturn(Collections.singleton(DistributedMember.class)).when(command)
-        .findMembersForRegion(any(), any());
+        .findMembersForRegion(any());
     when(result1.isSuccessful()).thenReturn(true);
     when(result1.getStatus()).thenReturn("result1 message");
     when(result1.getXmlEntity()).thenReturn(xmlEntity);
@@ -146,7 +146,7 @@ public class DestroyRegionCommandTest {
   public void multipleResultReturned_all_failed() throws Exception {
     // mock this to pass the member search call
     doReturn(Collections.singleton(DistributedMember.class)).when(command)
-        .findMembersForRegion(any(), any());
+        .findMembersForRegion(any());
     when(result1.isSuccessful()).thenReturn(false);
     when(result1.getStatus()).thenReturn("result1 message");
 

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DiskStoreCommandsJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DiskStoreCommandsJUnitTest.java
@@ -386,7 +386,7 @@ public class DiskStoreCommandsJUnitTest {
     }
 
     @Override
-    public Set<DistributedMember> getAllMembers(final InternalCache cache) {
+    public Set<DistributedMember> getAllMembers() {
       assertSame(getCache(), cache);
       return Collections.singleton(this.distributedMember);
     }
@@ -423,7 +423,7 @@ public class DiskStoreCommandsJUnitTest {
     }
 
     @Override
-    public Set<DistributedMember> getAllMembers(final InternalCache cache) {
+    public Set<DistributedMember> getAllMembers() {
       assertSame(getCache(), cache);
       return Collections.singleton(this.distributedMember);
     }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ListIndexCommandJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ListIndexCommandJUnitTest.java
@@ -209,7 +209,7 @@ public class ListIndexCommandJUnitTest {
     }
 
     @Override
-    public Set<DistributedMember> getAllMembers(final InternalCache cache) {
+    public Set<DistributedMember> getAllMembers() {
       assertSame(getCache(), cache);
       return Collections.emptySet();
     }

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexCommands.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexCommands.java
@@ -67,7 +67,7 @@ import org.apache.geode.security.ResourcePermission.Resource;
  * @see LuceneListIndexFunction
  */
 @SuppressWarnings("unused")
-public class LuceneIndexCommands implements GfshCommand {
+public class LuceneIndexCommands extends GfshCommand {
   private static final LuceneCreateIndexFunction createIndexFunction =
       new LuceneCreateIndexFunction();
   private static final LuceneDescribeIndexFunction describeIndexFunction =
@@ -91,7 +91,7 @@ public class LuceneIndexCommands implements GfshCommand {
 
   @SuppressWarnings("unchecked")
   protected List<LuceneIndexDetails> getIndexListing() {
-    final Execution functionExecutor = getMembersFunctionExecutor(getAllMembers(getCache()));
+    final Execution functionExecutor = getMembersFunctionExecutor(getAllMembers());
 
     if (functionExecutor instanceof AbstractExecution) {
       ((AbstractExecution) functionExecutor).setIgnoreDepartedMembers(true);
@@ -317,8 +317,8 @@ public class LuceneIndexCommands implements GfshCommand {
     // the index has been created, but not the region
     XmlEntity xmlEntity = null;
     InternalCache cache = getCache();
-    Set<DistributedMember> regionMembers = findMembersForRegion(cache, regionPath);
-    Set<DistributedMember> normalMembers = getAllNormalMembers(cache);
+    Set<DistributedMember> regionMembers = findMembersForRegion(regionPath);
+    Set<DistributedMember> normalMembers = getAllNormalMembers();
     LuceneDestroyIndexInfo indexInfo = new LuceneDestroyIndexInfo(indexName, regionPath);
     ResultCollector<?, ?> rc;
     if (regionMembers.isEmpty()) {
@@ -485,9 +485,8 @@ public class LuceneIndexCommands implements GfshCommand {
   }
 
   protected ResultCollector<?, ?> executeFunctionOnAllMembers(Function function,
-      final LuceneFunctionSerializable functionArguments)
-      throws IllegalArgumentException, CommandResultException {
-    Set<DistributedMember> targetMembers = CliUtil.getAllNormalMembers(getCache());
+      final LuceneFunctionSerializable functionArguments) throws IllegalArgumentException {
+    Set<DistributedMember> targetMembers = getAllNormalMembers();
     return executeFunction(function, functionArguments, targetMembers);
   }
 

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexCommandsJUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexCommandsJUnitTest.java
@@ -14,7 +14,6 @@
  */
 package org.apache.geode.cache.lucene.internal.cli;
 
-import static junit.framework.TestCase.assertSame;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.any;
@@ -448,8 +447,8 @@ public class LuceneIndexCommandsJUnitTest {
         isA(LuceneDestroyIndexFunction.class), any(LuceneDestroyIndexInfo.class), any(Set.class));
     doReturn(cliFunctionResults).when(mockResultCollector).getResult();
 
-    doReturn(Collections.emptySet()).when(commands).getAllNormalMembers(any());
-    doReturn(Collections.emptySet()).when(commands).findMembersForRegion(any(), any());
+    doReturn(Collections.emptySet()).when(commands).getAllNormalMembers();
+    doReturn(Collections.emptySet()).when(commands).findMembersForRegion(any());
 
     CommandResult result = (CommandResult) commands.destroyIndex(indexName, regionPath);
     verifyDestroyIndexCommandResult(result, cliFunctionResults, expectedStatus);
@@ -485,8 +484,8 @@ public class LuceneIndexCommandsJUnitTest {
         isA(LuceneDestroyIndexFunction.class), any(LuceneDestroyIndexInfo.class), any(Set.class));
     doReturn(cliFunctionResults).when(mockResultCollector).getResult();
 
-    doReturn(members).when(commands).getAllNormalMembers(any());
-    doReturn(members).when(commands).findMembersForRegion(any(), any());
+    doReturn(members).when(commands).getAllNormalMembers();
+    doReturn(members).when(commands).findMembersForRegion(any());
 
     CommandResult result = (CommandResult) commands.destroyIndex(indexName, regionPath);
     verifyDestroyIndexCommandResult(result, cliFunctionResults, expectedStatus);
@@ -517,8 +516,8 @@ public class LuceneIndexCommandsJUnitTest {
         isA(LuceneDestroyIndexFunction.class), any(LuceneDestroyIndexInfo.class), any(Set.class));
     doReturn(cliFunctionResults).when(mockResultCollector).getResult();
 
-    doReturn(Collections.emptySet()).when(commands).getAllNormalMembers(any());
-    doReturn(Collections.emptySet()).when(commands).findMembersForRegion(any(), any());
+    doReturn(Collections.emptySet()).when(commands).getAllNormalMembers();
+    doReturn(Collections.emptySet()).when(commands).findMembersForRegion(any());
 
     CommandResult result = (CommandResult) commands.destroyIndex(indexName, regionPath);
     verifyDestroyIndexCommandResult(result, cliFunctionResults, expectedStatus);
@@ -554,8 +553,8 @@ public class LuceneIndexCommandsJUnitTest {
         isA(LuceneDestroyIndexFunction.class), any(LuceneDestroyIndexInfo.class), any(Set.class));
     doReturn(cliFunctionResults).when(mockResultCollector).getResult();
 
-    doReturn(Collections.emptySet()).when(commands).getAllNormalMembers(any());
-    doReturn(Collections.emptySet()).when(commands).findMembersForRegion(any(), any());
+    doReturn(Collections.emptySet()).when(commands).getAllNormalMembers();
+    doReturn(Collections.emptySet()).when(commands).findMembersForRegion(any());
 
     CommandResult result = (CommandResult) commands.destroyIndex(indexName, regionPath);
     verifyDestroyIndexCommandResult(result, cliFunctionResults, expectedStatus);
@@ -665,8 +664,7 @@ public class LuceneIndexCommandsJUnitTest {
     }
 
     @Override
-    public Set<DistributedMember> getAllMembers(final InternalCache cache) {
-      assertSame(getCache(), cache);
+    public Set<DistributedMember> getAllMembers() {
       return Collections.emptySet();
     }
 


### PR DESCRIPTION
…ommand

* all functions in CliUtils take cache as a parameter if needs one.
* InternalCache is injected to the command when the command is initialized.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
