### PR TITLE
GEODE-4689: Colocation complete listeners added

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/ColocationListener.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/ColocationListener.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache;
+
+/*
+ * Callbacks that get executed when the region colocation is completed
+ */
+public interface ColocationListener {
+  /*
+   * execute the call back after the region colocation has completed
+   */
+  default void afterColocationCompleted() {
+
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionRegionConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionRegionConfig.java
@@ -24,7 +24,6 @@ import java.util.*;
 import org.apache.geode.DataSerializer;
 import org.apache.geode.cache.EvictionAttributes;
 import org.apache.geode.cache.ExpirationAttributes;
-import org.apache.geode.cache.FixedPartitionAttributes;
 import org.apache.geode.cache.PartitionAttributes;
 import org.apache.geode.cache.Scope;
 import org.apache.geode.cache.partition.PartitionListener;
@@ -32,7 +31,6 @@ import org.apache.geode.distributed.internal.membership.InternalDistributedMembe
 import org.apache.geode.internal.ExternalizableDSFID;
 import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.internal.Version;
-import org.apache.geode.internal.cache.PartitionAttributesImpl;
 import org.apache.geode.internal.util.Versionable;
 import org.apache.geode.internal.util.VersionedArrayList;
 
@@ -343,8 +341,9 @@ public class PartitionRegionConfig extends ExternalizableDSFID implements Versio
     isDestroying = true;
   }
 
-  void setColocationComplete() {
+  void setColocationComplete(PartitionedRegion partitionedRegion) {
     this.isColocationComplete = true;
+    partitionedRegion.executeColocationCallbacks();
   }
 
   public boolean isGreaterNodeListVersion(final PartitionRegionConfig other) {

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionRegionConfigJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionRegionConfigJUnitTest.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.test.junit.categories.UnitTest;
+
+@Category(UnitTest.class)
+public class PartitionRegionConfigJUnitTest {
+  @Test
+  public void whenSetColocationCompleteThenAllColocationListenersMustBeExecuted() {
+    PartitionedRegion partitionedRegion = mock(PartitionedRegion.class);
+    PartitionRegionConfig partitionRegionConfig = new PartitionRegionConfig();
+    partitionRegionConfig.setColocationComplete(partitionedRegion);
+    verify(partitionedRegion, times(1)).executeColocationCallbacks();
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionedRegionCreationJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionedRegionCreationJUnitTest.java
@@ -17,6 +17,7 @@ package org.apache.geode.internal.cache;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 
 import java.util.ArrayList;
 import java.util.Iterator;

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneFileRegionColocationListener.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneFileRegionColocationListener.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache.lucene.internal;
+
+import org.apache.geode.internal.cache.ColocationListener;
+
+public class LuceneFileRegionColocationListener implements ColocationListener {
+  private final PartitionedRepositoryManager partitionedRepositoryManager;
+  private final Integer bucketID;
+
+  public LuceneFileRegionColocationListener(
+      PartitionedRepositoryManager partitionedRepositoryManager, Integer bucketID) {
+    this.partitionedRepositoryManager = partitionedRepositoryManager;
+    this.bucketID = bucketID;
+  }
+
+
+  @Override
+  public void afterColocationCompleted() {
+    this.partitionedRepositoryManager.computeRepository(this.bucketID);
+  }
+
+  // Current implementation will allow only one LuceneFileRegionColocationListener to be
+  // added to the PartitionRegion colocationListener set.
+  @Override
+  public int hashCode() {
+    return bucketID.hashCode();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return (obj instanceof LuceneFileRegionColocationListener
+        && ((LuceneFileRegionColocationListener) obj).bucketID == this.bucketID);
+  }
+}

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneServiceImpl.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneServiceImpl.java
@@ -242,11 +242,11 @@ public class LuceneServiceImpl implements InternalLuceneService {
   protected boolean createLuceneIndexOnDataRegion(final PartitionedRegion userRegion,
       final InternalLuceneIndex luceneIndex) {
     try {
-      PartitionedRepositoryManager repositoryManager =
-          (PartitionedRepositoryManager) luceneIndex.getRepositoryManager();
       if (userRegion.getDataStore() == null) {
         return true;
       }
+      PartitionedRepositoryManager repositoryManager =
+          (PartitionedRepositoryManager) luceneIndex.getRepositoryManager();
       Set<Integer> primaryBucketIds = userRegion.getDataStore().getAllLocalPrimaryBucketIds();
       Iterator primaryBucketIterator = primaryBucketIds.iterator();
       while (primaryBucketIterator.hasNext()) {

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/PartitionedRepositoryManager.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/PartitionedRepositoryManager.java
@@ -117,7 +117,7 @@ public class PartitionedRepositoryManager implements RepositoryManager {
       InternalLuceneIndex index, PartitionedRegion userRegion, IndexRepository oldRepository)
       throws IOException {
     return indexRepositoryFactory.computeIndexRepository(bucketId, serializer, index, userRegion,
-        oldRepository);
+        oldRepository, this);
   }
 
 

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/RawIndexRepositoryFactory.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/RawIndexRepositoryFactory.java
@@ -34,8 +34,8 @@ public class RawIndexRepositoryFactory extends IndexRepositoryFactory {
 
   @Override
   public IndexRepository computeIndexRepository(final Integer bucketId, LuceneSerializer serializer,
-      InternalLuceneIndex index, PartitionedRegion userRegion, IndexRepository oldRepository)
-      throws IOException {
+      InternalLuceneIndex index, PartitionedRegion userRegion, IndexRepository oldRepository,
+      PartitionedRepositoryManager partitionedRepositoryManager) throws IOException {
     final IndexRepository repo;
     if (oldRepository != null) {
       oldRepository.cleanup();

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/RawLuceneRepositoryManager.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/RawLuceneRepositoryManager.java
@@ -51,6 +51,6 @@ public class RawLuceneRepositoryManager extends PartitionedRepositoryManager {
       InternalLuceneIndex index, PartitionedRegion userRegion, IndexRepository oldRepository)
       throws IOException {
     return indexRepositoryFactory.computeIndexRepository(bucketId, serializer, index, userRegion,
-        oldRepository);
+        oldRepository, this);
   }
 }

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/test/IndexRepositorySpy.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/test/IndexRepositorySpy.java
@@ -50,10 +50,10 @@ public class IndexRepositorySpy extends IndexRepositoryFactory {
 
   @Override
   public IndexRepository computeIndexRepository(final Integer bucketId, LuceneSerializer serializer,
-      InternalLuceneIndex index, PartitionedRegion userRegion, IndexRepository oldRepository)
-      throws IOException {
-    final IndexRepository indexRepo =
-        super.computeIndexRepository(bucketId, serializer, index, userRegion, oldRepository);
+      InternalLuceneIndex index, PartitionedRegion userRegion, IndexRepository oldRepository,
+      PartitionedRepositoryManager partitionedRepositoryManager) throws IOException {
+    final IndexRepository indexRepo = super.computeIndexRepository(bucketId, serializer, index,
+        userRegion, oldRepository, partitionedRepositoryManager);
     if (indexRepo == null) {
       return null;
     }


### PR DESCRIPTION
	* PartitionRegion can now add a colocation listener to itself which is triggered when the colocation is completed.
	* Lucene indexRepositoryFactory adds colocation complete listener to the file region
	* when the colocation of the file region is completed the compute repository is called

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
