### PR TITLE
GEODE-4795: User Guide: Inequality queries return UNDEFINED entries

### DIFF
--- a/geode-docs/developing/query_additional/operators.html.md.erb
+++ b/geode-docs/developing/query_additional/operators.html.md.erb
@@ -27,17 +27,23 @@ Comparison operators compare two values and return the results, either TRUE or F
 
 The following are supported comparison operators:
 
-|          |                          |
+| Operator | Meaning                  |
 |----------|--------------------------|
-| =        | equal to                 |
-| &lt;&gt; | not equal to             |
-| !=       | not equal to             |
 | &lt;     | less than                |
 | &lt;=    | less than or equal to    |
 | &gt;     | greater than             |
 | &gt;=    | greater than or equal to |
+|          |                          |
+| =        | equal to                 |
+| !=       | not equal to             |
+| &lt;&gt; | not equal to             |
 
-The equal and not equal operators have lower precedence than the other comparison operators. They can be used with null. To perform equality or inequality comparisons with UNDEFINED, use the IS\_DEFINED and IS\_UNDEFINED preset query functions instead of these comparison operators.
+Regarding equality and inequality operators:
+
+- The equal and not equal operators have lower precedence than the other comparison operators.
+- The equal and not inequal operators can be used with null.
+- Inequality queries return results for which the search field is UNDEFINED.
+- To perform equality or inequality comparisons with UNDEFINED, use the IS\_DEFINED and IS\_UNDEFINED preset query functions instead of these comparison operators.
 
 ## <a id="operators__section_6A85A9DDA47E47009FDE1CC38D7BA66C" class="no-quick-link"></a>Logical Operators
 
@@ -45,7 +51,7 @@ The logical operators AND and OR allow you to create more complex expressions by
 
 ## <a id="operators__section_A970AE75B0D24E0B9E1B61BE2D9842D8" class="no-quick-link"></a>Unary Operators
 
-Unary operators operate on a single value or expression, and have lower precedence than comparison operators in expressions. <%=vars.product_name%> supports the unary operator NOT. NOT is the negation operator, which changes the value of the operand to its opposite. So if an expression evaluates to TRUE, NOT changes it to FALSE. The operand must be a boolean.
+Unary operators operate on a single value or expression, and have lower precedence than comparison operators in expressions. <%=vars.product_name%> supports the unary operator NOT. NOT is the negation operator, which changes the value of the operand to its opposite, so if an expression evaluates to TRUE, NOT changes it to FALSE. The operand must be a boolean.
 
 ## <a id="operators_arithmetic_OQL" class="no-quick-link"></a>Arithmetic Operators
 
@@ -57,20 +63,20 @@ and `getCause()` will state `ArithmeticException`.
 
 The following are supported arithmetic operators:
 
-|         |                          |
-|---------|--------------------------|
-| +       | addition                 |
-| -       | subtraction              |
-| *       | multiplication           |
-| /       | division                 |
-| %       | modulus                  |
-| MOD     | modulus                  |
+| Operator | Meaning                  |
+|----------|--------------------------|
+| +        | addition                 |
+| -        | subtraction              |
+| *        | multiplication           |
+| /        | division                 |
+| %        | modulus                  |
+| MOD      | modulus                  |
 
 ## <a id="operators__section_E78FB4FB3703471C8186A0E26D25F01F" class="no-quick-link"></a>Map and Index Operators
 
 Map and index operators access elements in key/value collections (such as maps and regions) and ordered collections (such as arrays, lists, and `String`s). The operator is represented by a set of square brackets (`[ ]`) immediately following the name of the collection. The mapping or indexing specification is provided inside these brackets.
 
-Array, list, and `String` elements are accessed using an index value. Indexing starts from zero for the first element, 1 for the second element and so on. If `myList` is an array, list, or String and `index` is an expression that evaluates to a non-negative integer, then `myList[index]` represents the (`index + 1`)th element of `myList`. The elements of a `String` are the list of characters that make up the string.
+Array, list, and `String` elements are accessed using an index value. Indexing starts from zero for the first element, 1 for the second element and so on. If `myList` is an array, list, or `String` and `index` is an expression that evaluates to a non-negative integer, then `myList[index]` represents the (`index + 1`)th element of `myList`. The elements of a `String` are the list of characters that make up the string.
 
 Map and region values are accessed by key using the same syntax. The key can be any `Object`. For a `Region`, the map operator performs a non-distributed `get` in the local cache only - with no use of `netSearch`. So `myRegion[keyExpression]` is the equivalent of `myRegion.getEntry(keyExpression).getValue`.
 


### PR DESCRIPTION
Added statement that inequality queries return UNDEFINED entries.
Did some reformatting while I was editing the page.