### PR TITLE
GEODE-4669: Fall back on file controller if mbean controller fails

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/process/MBeanOrFileProcessController.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/process/MBeanOrFileProcessController.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.process;
+
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Process controller that attempts to use the MBeanProcessController but
+ * falls back on FileProcessController if that fails
+ */
+public class MBeanOrFileProcessController implements ProcessController {
+  private final ProcessController mbeanController;
+  private final ProcessController fileController;
+
+  public MBeanOrFileProcessController(ProcessControllerParameters parameters, int pid) {
+    mbeanController = new MBeanProcessController(parameters, pid);
+    fileController = new FileProcessController(parameters, pid);
+  }
+
+  @Override
+  public String status() throws UnableToControlProcessException, ConnectionFailedException,
+      IOException, MBeanInvocationFailedException, InterruptedException, TimeoutException {
+    try {
+      return mbeanController.status();
+    } catch (IOException | MBeanInvocationFailedException | ConnectionFailedException
+        | UnableToControlProcessException e) {
+      return fileController.status();
+    }
+  }
+
+  @Override
+  public void stop() throws UnableToControlProcessException, ConnectionFailedException, IOException,
+      MBeanInvocationFailedException {
+
+    try {
+      mbeanController.stop();
+    } catch (IOException | MBeanInvocationFailedException | ConnectionFailedException
+        | UnableToControlProcessException e) {
+      fileController.stop();
+    }
+
+  }
+
+  @Override
+  public int getProcessId() {
+    return mbeanController.getProcessId();
+  }
+
+  @Override
+  public void checkPidSupport() {}
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/process/ProcessControllerFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/process/ProcessControllerFactory.java
@@ -49,13 +49,11 @@ public class ProcessControllerFactory {
     notNull(parameters, "Invalid parameters '" + parameters + "' specified");
     isTrue(pid > 0, "Invalid pid '" + pid + "' specified");
 
-    if (isAttachAPIFound()) {
-      try {
-        return new MBeanProcessController(parameters, pid);
-      } catch (ExceptionInInitializerError ignore) {
-      }
+    if (!isAttachAPIFound()) {
+      return new FileProcessController(parameters, pid);
     }
-    return new FileProcessController(parameters, pid);
+
+    return new MBeanOrFileProcessController(parameters, pid);
   }
 
   public ProcessController createProcessController(final ProcessControllerParameters parameters,

--- a/geode-core/src/test/java/org/apache/geode/internal/process/ProcessControllerFactoryIntegrationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/process/ProcessControllerFactoryIntegrationTest.java
@@ -83,7 +83,7 @@ public class ProcessControllerFactoryIntegrationTest {
         factory.createProcessController(parameters, directory, pidFileName);
 
     // assert
-    assertThat(controller).isInstanceOf(MBeanProcessController.class);
+    assertThat(controller).isInstanceOf(MBeanOrFileProcessController.class);
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/internal/process/ProcessControllerFactoryTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/process/ProcessControllerFactoryTest.java
@@ -73,7 +73,7 @@ public class ProcessControllerFactoryTest {
     ProcessController controller = factory.createProcessController(parameters, pid);
 
     // assert
-    assertThat(controller).isInstanceOf(MBeanProcessController.class);
+    assertThat(controller).isInstanceOf(MBeanOrFileProcessController.class);
   }
 
   @Test


### PR DESCRIPTION
The MBeanProcessController has some logic to attach to a started locator
or server process and look for the location of JDK jars. Under JDK 9,
this logic does not work.

This fix allows us to fall back on the FileProcessController if the
mbean one fails, rather than silently hanging forever.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
