### PR TITLE
GEODE-4785: Add test category annotation to Pulse tests

### DIFF
--- a/geode-assembly/src/test/java/org/apache/geode/tools/pulse/PulseConnectivityTest.java
+++ b/geode-assembly/src/test/java/org/apache/geode/tools/pulse/PulseConnectivityTest.java
@@ -32,13 +32,14 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import org.apache.geode.test.junit.categories.IntegrationTest;
+import org.apache.geode.test.junit.categories.PulseTest;
 import org.apache.geode.test.junit.rules.EmbeddedPulseRule;
 import org.apache.geode.test.junit.rules.HttpClientRule;
 import org.apache.geode.test.junit.rules.LocatorStarterRule;
 import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactory;
 import org.apache.geode.tools.pulse.internal.data.Cluster;
 
-@Category(IntegrationTest.class)
+@Category({IntegrationTest.class, PulseTest.class})
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
 public class PulseConnectivityTest {

--- a/geode-assembly/src/test/java/org/apache/geode/tools/pulse/PulseDataExportTest.java
+++ b/geode-assembly/src/test/java/org/apache/geode/tools/pulse/PulseDataExportTest.java
@@ -28,10 +28,11 @@ import org.junit.experimental.categories.Category;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.test.junit.categories.IntegrationTest;
+import org.apache.geode.test.junit.categories.PulseTest;
 import org.apache.geode.test.junit.rules.HttpClientRule;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category(IntegrationTest.class)
+@Category({IntegrationTest.class, PulseTest.class})
 public class PulseDataExportTest {
 
   @Rule

--- a/geode-assembly/src/test/java/org/apache/geode/tools/pulse/PulseJmxPasswordFileTest.java
+++ b/geode-assembly/src/test/java/org/apache/geode/tools/pulse/PulseJmxPasswordFileTest.java
@@ -29,11 +29,13 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
 
 import org.apache.geode.test.junit.categories.IntegrationTest;
+import org.apache.geode.test.junit.categories.PulseTest;
+import org.apache.geode.test.junit.categories.SecurityTest;
 import org.apache.geode.test.junit.rules.HttpClientRule;
 import org.apache.geode.test.junit.rules.LocatorStarterRule;
 
 
-@Category(IntegrationTest.class)
+@Category({IntegrationTest.class, SecurityTest.class, PulseTest.class})
 public class PulseJmxPasswordFileTest {
   @Rule
   public LocatorStarterRule locator = new LocatorStarterRule();

--- a/geode-assembly/src/test/java/org/apache/geode/tools/pulse/PulseSecurityIntegrationTest.java
+++ b/geode-assembly/src/test/java/org/apache/geode/tools/pulse/PulseSecurityIntegrationTest.java
@@ -26,11 +26,13 @@ import org.junit.experimental.categories.Category;
 import org.apache.geode.examples.SimpleSecurityManager;
 import org.apache.geode.management.ManagementService;
 import org.apache.geode.test.junit.categories.IntegrationTest;
+import org.apache.geode.test.junit.categories.PulseTest;
+import org.apache.geode.test.junit.categories.SecurityTest;
 import org.apache.geode.test.junit.rules.EmbeddedPulseRule;
 import org.apache.geode.test.junit.rules.LocatorStarterRule;
 import org.apache.geode.tools.pulse.internal.data.Cluster;
 
-@Category(IntegrationTest.class)
+@Category({IntegrationTest.class, SecurityTest.class, PulseTest.class})
 public class PulseSecurityIntegrationTest {
 
   @Rule

--- a/geode-assembly/src/test/java/org/apache/geode/tools/pulse/PulseSecurityTest.java
+++ b/geode-assembly/src/test/java/org/apache/geode/tools/pulse/PulseSecurityTest.java
@@ -27,13 +27,15 @@ import org.junit.experimental.categories.Category;
 import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.security.SimpleTestSecurityManager;
 import org.apache.geode.test.junit.categories.IntegrationTest;
+import org.apache.geode.test.junit.categories.PulseTest;
+import org.apache.geode.test.junit.categories.SecurityTest;
 import org.apache.geode.test.junit.rules.EmbeddedPulseRule;
 import org.apache.geode.test.junit.rules.HttpClientRule;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 import org.apache.geode.tools.pulse.internal.data.Cluster;
 
 
-@Category(IntegrationTest.class)
+@Category({IntegrationTest.class, SecurityTest.class, PulseTest.class})
 public class PulseSecurityTest {
 
   @ClassRule

--- a/geode-assembly/src/test/java/org/apache/geode/tools/pulse/PulseSecurityWithSSLTest.java
+++ b/geode-assembly/src/test/java/org/apache/geode/tools/pulse/PulseSecurityWithSSLTest.java
@@ -38,11 +38,13 @@ import org.junit.experimental.categories.Category;
 import org.apache.geode.security.SecurableCommunicationChannels;
 import org.apache.geode.security.SimpleTestSecurityManager;
 import org.apache.geode.test.junit.categories.IntegrationTest;
+import org.apache.geode.test.junit.categories.PulseTest;
+import org.apache.geode.test.junit.categories.SecurityTest;
 import org.apache.geode.test.junit.rules.HttpClientRule;
 import org.apache.geode.test.junit.rules.LocatorStarterRule;
 
 
-@Category(IntegrationTest.class)
+@Category({IntegrationTest.class, SecurityTest.class, PulseTest.class})
 public class PulseSecurityWithSSLTest {
 
   private static File jks =

--- a/geode-junit/src/main/java/org/apache/geode/test/junit/categories/PulseTest.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/junit/categories/PulseTest.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.test.junit.categories;
+
+/**
+ * Test Category that specifies a test involving Pulse.
+ */
+public interface PulseTest {
+}

--- a/geode-pulse/src/test/java/org/apache/geode/tools/pulse/controllers/PulseControllerJUnitTest.java
+++ b/geode-pulse/src/test/java/org/apache/geode/tools/pulse/controllers/PulseControllerJUnitTest.java
@@ -14,15 +14,17 @@
  */
 package org.apache.geode.tools.pulse.controllers;
 
-import static org.hamcrest.Matchers.*;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.powermock.api.mockito.PowerMockito.spy;
 import static org.powermock.api.mockito.PowerMockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.io.File;
 import java.security.Principal;
@@ -52,18 +54,19 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 import org.apache.geode.test.junit.categories.IntegrationTest;
+import org.apache.geode.test.junit.categories.PulseTest;
 import org.apache.geode.tools.pulse.internal.controllers.PulseController;
 import org.apache.geode.tools.pulse.internal.data.Cluster;
 import org.apache.geode.tools.pulse.internal.data.PulseConfig;
 import org.apache.geode.tools.pulse.internal.data.Repository;
 
-@Category(IntegrationTest.class)
+@Category({IntegrationTest.class, PulseTest.class})
 @PrepareForTest(Repository.class)
 @RunWith(PowerMockRunner.class)
 @PowerMockRunnerDelegate(SpringJUnit4ClassRunner.class)
 @WebAppConfiguration
 @ContextConfiguration("classpath*:mvc-dispatcher-servlet.xml")
-@PowerMockIgnore("*.IntegrationTest")
+@PowerMockIgnore({"*.IntegrationTest", "*.PulseTest"})
 public class PulseControllerJUnitTest {
 
   private static final String PRINCIPAL_USER = "test-user";


### PR DESCRIPTION
Created PulseTest interface for annotating tests.
Added the new Category annotation for Pulse Intergration tests.
Added the SecurityTest annotation for Pulse tests that included security
features.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
