### PR TITLE
GEODE-4266: Make JdbcConnectionException safely serializable to clients

### DIFF
--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/JdbcConnectorException.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/JdbcConnectorException.java
@@ -22,7 +22,9 @@ import org.apache.geode.cache.CacheRuntimeException;
 
 /**
  * An exception thrown when communication with an external JDBC data source fails and can be used
- * to diagnose the cause of database communication failures.
+ * to diagnose the cause of database communication failures. In cases where the cause of this
+ * exception is not safe to serialize to clients, the stack trace is included in the message of the
+ * exception and the cause is left empty.
  *
  * @since Geode 1.5
  */
@@ -37,8 +39,7 @@ public class JdbcConnectorException extends CacheRuntimeException {
    * @param e cause of this Exception
    * @return a new JdbcConnectorException containing either the causing exception, if it can be
    *         serialized/deserialized by Geode, or containing the causing exception stack trace in
-   *         its
-   *         message if not
+   *         its message if not
    */
   public static JdbcConnectorException createException(Exception e) {
     String message;

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/JdbcConnectorException.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/JdbcConnectorException.java
@@ -14,6 +14,10 @@
  */
 package org.apache.geode.connectors.jdbc;
 
+import java.sql.SQLException;
+
+import org.apache.commons.lang.exception.ExceptionUtils;
+
 import org.apache.geode.cache.CacheRuntimeException;
 
 /**
@@ -25,7 +29,51 @@ import org.apache.geode.cache.CacheRuntimeException;
 public class JdbcConnectorException extends CacheRuntimeException {
   private static final long serialVersionUID = 1L;
 
-  public JdbcConnectorException(Exception e) {
+  /**
+   * Create a new JdbcConnectorException by first checking to see if the causing exception is or
+   * contains an exception that potentially could not be deserialized by remote systems receiving
+   * the serialized exception.
+   *
+   * @param e cause of this Exception
+   * @return a new JdbcConnectorException containing either the causing exception, if it can be
+   *         serialized/deserialized by Geode, or containing the causing exception stack trace in
+   *         its
+   *         message if not
+   */
+  public static JdbcConnectorException createException(Exception e) {
+    String message;
+    if (containsNonSerializableException(e)) {
+      message = e.getMessage() + System.lineSeparator() + ExceptionUtils.getFullStackTrace(e);
+      return new JdbcConnectorException(message);
+    } else {
+      return new JdbcConnectorException(e);
+    }
+  }
+
+  /*
+   * SQLExceptions likely are instances of or contain exceptions from the underlying SQL driver
+   * and potentially cannot be deserialzed by other systems (e.g. client or locators) that do not
+   * possess the driver on their classpaths.
+   */
+  private static boolean containsNonSerializableException(Exception e) {
+    if (e == null) {
+      return false;
+    }
+
+    if (e instanceof SQLException) {
+      return true;
+    }
+
+    Throwable cause;
+    while ((cause = e.getCause()) != null) {
+      if (cause instanceof SQLException) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private JdbcConnectorException(Exception e) {
     super(e);
   }
 

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/JdbcLoader.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/JdbcLoader.java
@@ -54,7 +54,7 @@ public class JdbcLoader<K, V> extends AbstractJdbcCallback implements CacheLoade
     try {
       return (V) getSqlHandler().read(helper.getRegion(), helper.getKey());
     } catch (SQLException e) {
-      throw new JdbcConnectorException(e);
+      throw JdbcConnectorException.createException(e);
     }
   }
 }

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/JdbcWriter.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/JdbcWriter.java
@@ -78,7 +78,7 @@ public class JdbcWriter<K, V> extends AbstractJdbcCallback implements CacheWrite
       getSqlHandler().write(event.getRegion(), event.getOperation(), event.getKey(),
           getPdxNewValue(event));
     } catch (SQLException e) {
-      throw new JdbcConnectorException(e);
+      throw JdbcConnectorException.createException(e);
     }
   }
 

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/TableKeyColumnManager.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/TableKeyColumnManager.java
@@ -47,7 +47,7 @@ class TableKeyColumnManager {
         key = getPrimaryKeyColumnNameFromMetaData(realTableName, metaData);
       }
     } catch (SQLException e) {
-      throw new JdbcConnectorException(e);
+      throw JdbcConnectorException.createException(e);
     }
     return key;
   }

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/JdbcConnectorExceptionTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/JdbcConnectorExceptionTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.connectors.jdbc;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.sql.SQLException;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TestName;
+
+import org.apache.geode.test.junit.categories.UnitTest;
+
+@Category(UnitTest.class)
+public class JdbcConnectorExceptionTest {
+  @Rule
+  public TestName testName = new TestName();
+
+  @Test
+  public void returnsExceptionWithCauseForNonSqlException() {
+    Exception e = JdbcConnectorException.createException(new IllegalStateException());
+    assertThat(e.getCause()).isNotNull().isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  public void returnsExceptionWithNoCauseForSqlException() {
+    Exception sqlException = new SQLException();
+    Exception e = JdbcConnectorException.createException(sqlException);
+    assertThat(e.getCause()).isNull();
+    assertThat(e.getMessage())
+        .contains(this.getClass().getCanonicalName() + "." + testName.getMethodName());
+  }
+}


### PR DESCRIPTION
  * SQLExceptions that come from underlying sql drivers may not be availale
    on clients or locators and will not be deserializable. When these
    exceptions are contained in a JdbcConnectorException, the stack trace
    is instead converted to a string to ensure safe serialization