### PR TITLE
GEODE-4827: CQ should not be added to cq map on exception

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/internal/cache/FilterProfileNullCqBaseRegionJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/FilterProfileNullCqBaseRegionJUnitTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.cache.query.CqException;
+import org.apache.geode.cache.query.RegionNotFoundException;
+import org.apache.geode.cache.query.internal.CqStateImpl;
+import org.apache.geode.cache.query.internal.cq.CqService;
+import org.apache.geode.cache.query.internal.cq.ServerCQ;
+import org.apache.geode.test.junit.categories.UnitTest;
+
+@Category(UnitTest.class)
+public class FilterProfileNullCqBaseRegionJUnitTest {
+
+  private FilterProfile filterProfile;
+  private CqService mockCqService;
+  private GemFireCacheImpl mockCache;
+  private CqStateImpl cqState;
+  private ServerCQ serverCQ;
+
+  @Before
+  public void setUp() {
+    mockCache = mock(GemFireCacheImpl.class);
+    mockCqService = mock(CqService.class);
+    cqState = mock(CqStateImpl.class);
+    serverCQ = mock(ServerCQ.class);
+
+    when(mockCache.getCqService()).thenReturn(mockCqService);
+    doNothing().when(mockCqService).start();
+    when(mockCache.getCacheServers()).thenReturn(Collections.emptyList());
+    when(serverCQ.getState()).thenReturn(cqState);
+    when(serverCQ.getCqBaseRegion()).thenReturn(null);
+
+  }
+
+  @Test
+  public void whenCqBaseRegionIsNullThenTheCqShouldNotBeAddedToTheCqMap()
+      throws CqException, RegionNotFoundException {
+    doThrow(RegionNotFoundException.class).when(serverCQ).registerCq(eq(null), eq(null), anyInt());
+
+    filterProfile = new FilterProfile();
+    filterProfile.processRegisterCq("TestCq", serverCQ, true, mockCache);
+    assertEquals(0, filterProfile.getCqMap().size());
+    filterProfile.processCloseCq("TestCq");
+
+  }
+}


### PR DESCRIPTION
	* Log level set to info when FilterProfile gets an exception while registering CQ
	* Before, when there is an exception while registering cq like while cache closing the cq's base region is null
	* There is an exception which is logged in debug level but execution continues and adds the cq to the cp map with base region set to null
	* This results in a NullPointerException while closing cq as methods are executed on null region
	* Now the operation to put the cq into the cq map is inside a if check for null cq base region.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
