### PR TITLE
[GEODE-4835] Add python3 to ci docker image.

### DIFF
--- a/ci/docker/Dockerfile
+++ b/ci/docker/Dockerfile
@@ -20,7 +20,7 @@ ENTRYPOINT []
 RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 RUN apt-key adv --keyserver hkp://pgp.mit.edu --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
 RUN apt-get update
-RUN apt-get install -y apt-transport-https ca-certificates aptitude lsb-release jq unzip vim htop golang cgroupfs-mount
+RUN apt-get install -y apt-transport-https ca-certificates aptitude lsb-release jq unzip vim htop golang cgroupfs-mount python3 python3-pip
 ADD docker.list /etc/apt/sources.list.d/
 RUN echo "deb http://packages.cloud.google.com/apt cloud-sdk-$(lsb_release -c -s) main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
 

--- a/ci/scripts/concourse_job_performance.sh
+++ b/ci/scripts/concourse_job_performance.sh
@@ -27,7 +27,6 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
 done
 SCRIPTDIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
-apt-get install -y python3 python3-pip
 pip3 install requests
 pip3 install ansicolors
 pip3 install sseclient-py


### PR DESCRIPTION
* install python3 and python3-pip.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ X ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ X ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ X ] Is your initial contribution a single, squashed commit?

- [ X ] Does `gradlew build` run cleanly?

- [ N/A ] Have you written or updated unit tests to verify your changes?

- [ N/A ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
