### PR TITLE
GEODE-4815: Forced test locator members to be LOCATOR_DM_TYPES

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/internal/cache/wan/AsyncEventQueueTestBase.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/wan/AsyncEventQueueTestBase.java
@@ -93,6 +93,7 @@ import org.apache.geode.cache.wan.GatewaySender.OrderPolicy;
 import org.apache.geode.cache.wan.GatewaySenderFactory;
 import org.apache.geode.distributed.Locator;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
+import org.apache.geode.distributed.internal.InternalLocator;
 import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.internal.cache.ForceReattemptException;
 import org.apache.geode.internal.cache.GemFireCacheImpl;
@@ -183,7 +184,7 @@ public class AsyncEventQueueTestBase extends JUnit4DistributedTestCase {
     props.setProperty(LOCATORS, "localhost[" + port + "]");
     props.setProperty(START_LOCATOR,
         "localhost[" + port + "],server=true,peer=true,hostname-for-clients=localhost");
-    test.getSystem(props);
+    test.startLocatorDistributedSystem(props);
     return port;
   }
 
@@ -197,8 +198,18 @@ public class AsyncEventQueueTestBase extends JUnit4DistributedTestCase {
     props.setProperty(START_LOCATOR,
         "localhost[" + port + "],server=true,peer=true,hostname-for-clients=localhost");
     props.setProperty(REMOTE_LOCATORS, "localhost[" + remoteLocPort + "]");
-    test.getSystem(props);
+    test.startLocatorDistributedSystem(props);
     return port;
+  }
+
+  private void startLocatorDistributedSystem(Properties props) {
+    // Start start the locator with a LOCATOR_DM_TYPE and not a NORMAL_DM_TYPE
+    System.setProperty(InternalLocator.FORCE_LOCATOR_DM_TYPE, "true");
+    try {
+      getSystem(props);
+    } finally {
+      System.clearProperty(InternalLocator.FORCE_LOCATOR_DM_TYPE);
+    }
   }
 
   public static void createReplicatedRegionWithAsyncEventQueue(String regionName,

--- a/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/WANTestBase.java
+++ b/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/WANTestBase.java
@@ -285,20 +285,38 @@ public class WANTestBase extends JUnit4DistributedTestCase {
     String remoteLocator = remoteLocatorBuffer.toString();
     remoteLocator = remoteLocator.replace(" ", "");
     props.setProperty(REMOTE_LOCATORS, remoteLocator);
-    test.getSystem(props);
+    test.startLocatorDistributedSystem(props);
+  }
+
+  private void startLocator(int dsId, int locatorPort, int startLocatorPort, int remoteLocPort,
+      boolean startServerLocator) {
+    Properties props = getDistributedSystemProperties();
+    props.setProperty(MCAST_PORT, "0");
+    props.setProperty(DISTRIBUTED_SYSTEM_ID, "" + dsId);
+    props.setProperty(LOCATORS, "localhost[" + locatorPort + "]");
+    props.setProperty(START_LOCATOR, "localhost[" + startLocatorPort + "],server="
+        + startServerLocator + ",peer=true,hostname-for-clients=localhost");
+    if (remoteLocPort != -1) {
+      props.setProperty(REMOTE_LOCATORS, "localhost[" + remoteLocPort + "]");
+    }
+    startLocatorDistributedSystem(props);
+  }
+
+  private void startLocatorDistributedSystem(Properties props) {
+    // Start start the locator with a LOCATOR_DM_TYPE and not a NORMAL_DM_TYPE
+    System.setProperty(InternalLocator.FORCE_LOCATOR_DM_TYPE, "true");
+    try {
+      getSystem(props);
+    } finally {
+      System.clearProperty(InternalLocator.FORCE_LOCATOR_DM_TYPE);
+    }
   }
 
   public static Integer createFirstLocatorWithDSId(int dsId) {
     stopOldLocator();
     WANTestBase test = new WANTestBase();
     int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
-    Properties props = test.getDistributedSystemProperties();
-    props.setProperty(MCAST_PORT, "0");
-    props.setProperty(DISTRIBUTED_SYSTEM_ID, "" + dsId);
-    props.setProperty(LOCATORS, "localhost[" + port + "]");
-    props.setProperty(START_LOCATOR,
-        "localhost[" + port + "],server=true,peer=true,hostname-for-clients=localhost");
-    test.getSystem(props);
+    test.startLocator(dsId, port, port, -1, true);
     return port;
   }
 
@@ -306,13 +324,7 @@ public class WANTestBase extends JUnit4DistributedTestCase {
     stopOldLocator();
     WANTestBase test = new WANTestBase();
     int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
-    Properties props = test.getDistributedSystemProperties();
-    props.setProperty(MCAST_PORT, "0");
-    props.setProperty(DISTRIBUTED_SYSTEM_ID, "" + dsId);
-    props.setProperty(LOCATORS, "localhost[" + port + "]");
-    props.setProperty(START_LOCATOR,
-        "localhost[" + port + "],server=false,peer=true,hostname-for-clients=localhost");
-    test.getSystem(props);
+    test.startLocator(dsId, port, port, -1, false);
     return port;
   }
 
@@ -320,13 +332,7 @@ public class WANTestBase extends JUnit4DistributedTestCase {
     stopOldLocator();
     WANTestBase test = new WANTestBase();
     int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
-    Properties props = test.getDistributedSystemProperties();
-    props.setProperty(MCAST_PORT, "0");
-    props.setProperty(DISTRIBUTED_SYSTEM_ID, "" + dsId);
-    props.setProperty(LOCATORS, "localhost[" + locatorPort + "]");
-    props.setProperty(START_LOCATOR,
-        "localhost[" + port + "],server=true,peer=true,hostname-for-clients=localhost");
-    test.getSystem(props);
+    test.startLocator(dsId, locatorPort, port, -1, true);
     return port;
   }
 
@@ -334,13 +340,7 @@ public class WANTestBase extends JUnit4DistributedTestCase {
     stopOldLocator();
     WANTestBase test = new WANTestBase();
     int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
-    Properties props = test.getDistributedSystemProperties();
-    props.setProperty(MCAST_PORT, "0");
-    props.setProperty(DISTRIBUTED_SYSTEM_ID, "" + dsId);
-    props.setProperty(LOCATORS, "localhost[" + locatorPort + "]");
-    props.setProperty(START_LOCATOR,
-        "localhost[" + port + "],server=false,peer=true,hostname-for-clients=localhost");
-    test.getSystem(props);
+    test.startLocator(dsId, locatorPort, port, -1, false);
     return port;
   }
 
@@ -348,28 +348,13 @@ public class WANTestBase extends JUnit4DistributedTestCase {
     stopOldLocator();
     WANTestBase test = new WANTestBase();
     int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
-    Properties props = test.getDistributedSystemProperties();
-    props.setProperty(MCAST_PORT, "0");
-    props.setProperty(DISTRIBUTED_SYSTEM_ID, "" + dsId);
-    props.setProperty(LOCATORS, "localhost[" + port + "]");
-    props.setProperty(START_LOCATOR,
-        "localhost[" + port + "],server=true,peer=true,hostname-for-clients=localhost");
-    props.setProperty(REMOTE_LOCATORS, "localhost[" + remoteLocPort + "]");
-    test.getSystem(props);
+    test.startLocator(dsId, port, port, remoteLocPort, true);
     return port;
   }
 
   public static void bringBackLocatorOnOldPort(int dsId, int remoteLocPort, int oldPort) {
     WANTestBase test = new WANTestBase();
-    Properties props = test.getDistributedSystemProperties();
-    props.put(LOG_LEVEL, "fine");
-    props.setProperty(MCAST_PORT, "0");
-    props.setProperty(DISTRIBUTED_SYSTEM_ID, "" + dsId);
-    props.setProperty(LOCATORS, "localhost[" + oldPort + "]");
-    props.setProperty(START_LOCATOR,
-        "localhost[" + oldPort + "],server=true,peer=true,hostname-for-clients=localhost");
-    props.setProperty(REMOTE_LOCATORS, "localhost[" + remoteLocPort + "]");
-    test.getSystem(props);
+    test.startLocator(dsId, oldPort, oldPort, remoteLocPort, true);
   }
 
 
@@ -377,14 +362,7 @@ public class WANTestBase extends JUnit4DistributedTestCase {
     stopOldLocator();
     WANTestBase test = new WANTestBase();
     int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
-    Properties props = test.getDistributedSystemProperties();
-    props.setProperty(MCAST_PORT, "0");
-    props.setProperty(DISTRIBUTED_SYSTEM_ID, "" + dsId);
-    props.setProperty(LOCATORS, "localhost[" + port + "]");
-    props.setProperty(START_LOCATOR,
-        "localhost[" + port + "],server=false,peer=true,hostname-for-clients=localhost");
-    props.setProperty(REMOTE_LOCATORS, "localhost[" + remoteLocPort + "]");
-    test.getSystem(props);
+    test.startLocator(dsId, port, port, remoteLocPort, false);
     return port;
   }
 
@@ -392,14 +370,7 @@ public class WANTestBase extends JUnit4DistributedTestCase {
     stopOldLocator();
     WANTestBase test = new WANTestBase();
     int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
-    Properties props = test.getDistributedSystemProperties();
-    props.setProperty(MCAST_PORT, "0");
-    props.setProperty(DISTRIBUTED_SYSTEM_ID, "" + dsId);
-    props.setProperty(LOCATORS, "localhost[" + localPort + "]");
-    props.setProperty(START_LOCATOR,
-        "localhost[" + port + "],server=true,peer=true,hostname-for-clients=localhost");
-    props.setProperty(REMOTE_LOCATORS, "localhost[" + remoteLocPort + "]");
-    test.getSystem(props);
+    test.startLocator(dsId, localPort, port, remoteLocPort, true);
     return port;
   }
 
@@ -407,7 +378,6 @@ public class WANTestBase extends JUnit4DistributedTestCase {
       String hostnameForClients) throws IOException {
     stopOldLocator();
     WANTestBase test = new WANTestBase();
-    int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
     Properties props = test.getDistributedSystemProperties();
     props.setProperty(MCAST_PORT, "0");
     props.setProperty(DISTRIBUTED_SYSTEM_ID, "" + dsId);
@@ -422,14 +392,7 @@ public class WANTestBase extends JUnit4DistributedTestCase {
     stopOldLocator();
     WANTestBase test = new WANTestBase();
     int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
-    Properties props = test.getDistributedSystemProperties();
-    props.setProperty(MCAST_PORT, "0");
-    props.setProperty(DISTRIBUTED_SYSTEM_ID, "" + dsId);
-    props.setProperty(LOCATORS, "localhost[" + localPort + "]");
-    props.setProperty(START_LOCATOR,
-        "localhost[" + port + "],server=false,peer=true,hostname-for-clients=localhost");
-    props.setProperty(REMOTE_LOCATORS, "localhost[" + remoteLocPort + "]");
-    test.getSystem(props);
+    test.startLocator(dsId, localPort, port, remoteLocPort, false);
     return port;
   }
 


### PR DESCRIPTION
This change is to start locator members with LOCATOR_DM_TYPE using the InternalLocator.FORCE_LOCATOR_DM_TYPE system property. This is the same property that InternalLocator startLocator uses. This affects several DUnit tests.

I did some refactoring as part of this change.

AsyncEventQueueTestBase - changed to use system property
UpdateVersionDUnitTest - changed to use system property and  also a bunch of refactoring to reduce duplicate code
CacheClientNotifierDUnitTest - changed to make the locator member just a locator and not create regions also
Simple2CacheServerDUnitTest - same as CacheClientNotifierDUnitTest
WANTestBase - changed to use system property and also a bunch of refactoring to reduce duplicate code