### PR TITLE
GEODE-4769: optional early serialization of EntryEvent key and new value

### DIFF
--- a/extensions/geode-modules-session/src/test/java/org/apache/geode/modules/session/installer/InstallerJUnitTest.java
+++ b/extensions/geode-modules-session/src/test/java/org/apache/geode/modules/session/installer/InstallerJUnitTest.java
@@ -29,10 +29,8 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
 
 import org.apache.geode.test.junit.categories.IntegrationTest;
-import org.apache.geode.test.junit.categories.SessionTest;
 
-
-@Category({IntegrationTest.class, SessionTest.class})
+@Category(IntegrationTest.class)
 public class InstallerJUnitTest {
 
   @Rule

--- a/extensions/geode-modules-session/src/test/java/org/apache/geode/modules/session/internal/filter/SessionReplicationIntegrationJUnitTest.java
+++ b/extensions/geode-modules-session/src/test/java/org/apache/geode/modules/session/internal/filter/SessionReplicationIntegrationJUnitTest.java
@@ -56,13 +56,12 @@ import org.apache.geode.modules.session.filter.SessionCachingFilter;
 import org.apache.geode.modules.session.junit.PerTestClassLoaderRunner;
 import org.apache.geode.test.junit.categories.FlakyTest;
 import org.apache.geode.test.junit.categories.IntegrationTest;
-import org.apache.geode.test.junit.categories.SessionTest;
 
 /**
  * In-container testing using Jetty. This allows us to test context listener events as well as
  * dispatching actions.
  */
-@Category({IntegrationTest.class, SessionTest.class})
+@Category(IntegrationTest.class)
 @RunWith(PerTestClassLoaderRunner.class)
 @SuppressWarnings("unchecked")
 public class SessionReplicationIntegrationJUnitTest {
@@ -312,10 +311,9 @@ public class SessionReplicationIntegrationJUnitTest {
   /**
    * Test setting an attribute to null deletes it
    */
-  @Category(FlakyTest.class) // GEODE-1015: uses Jetty HttpTester, uses static
-                             // vars with class
-  // loader isolation, TODO: rewrite test with JUnit 4 rules including
-  // TemporaryFolder
+  @Category(FlakyTest.class) // GEODE-1015: uses Jetty HttpTester, uses static vars with class
+                             // loader isolation, TODO: rewrite test with JUnit 4 rules including
+                             // TemporaryFolder
   @Test
   public void testSetAttributeNullDeletesIt() throws Exception {
     Callback c_1 = (request, response) -> request.getSession().setAttribute("foo", "bar");
@@ -398,10 +396,9 @@ public class SessionReplicationIntegrationJUnitTest {
   /**
    * Test that invalidating a session destroys it as well as the backend object.
    */
-  @Category(FlakyTest.class) // GEODE-1015: uses Jetty HttpTester, uses static
-                             // vars with class
-  // loader isolation, TODO: rewrite test with JUnit 4 rules including
-  // TemporaryFolder
+  @Category(FlakyTest.class) // GEODE-1015: uses Jetty HttpTester, uses static vars with class
+                             // loader isolation, TODO: rewrite test with JUnit 4 rules including
+                             // TemporaryFolder
   @Test
   public void testInvalidateSession1() throws Exception {
     Callback c_1 = (request, response) -> request.getSession().setAttribute("foo", "bar");
@@ -471,10 +468,9 @@ public class SessionReplicationIntegrationJUnitTest {
   /**
    * Test that invalidating a session throws an exception on subsequent access.
    */
-  @Category(FlakyTest.class) // GEODE-1015: uses Jetty HttpTester, uses static
-                             // vars with class
-  // loader isolation, TODO: rewrite test with JUnit 4 rules including
-  // TemporaryFolder
+  @Category(FlakyTest.class) // GEODE-1015: uses Jetty HttpTester, uses static vars with class
+                             // loader isolation, TODO: rewrite test with JUnit 4 rules including
+                             // TemporaryFolder
   @Test
   public void testInvalidateSession3() throws Exception {
     Callback c_1 = (request, response) -> {
@@ -969,10 +965,9 @@ public class SessionReplicationIntegrationJUnitTest {
   /**
    * Test that request forward dispatching works
    */
-  @Category(FlakyTest.class) // GEODE-1015: uses Jetty HttpTester, uses static
-                             // vars with class
-  // loader isolation, TODO: rewrite test with JUnit 4 rules including
-  // TemporaryFolder
+  @Category(FlakyTest.class) // GEODE-1015: uses Jetty HttpTester, uses static vars with class
+                             // loader isolation, TODO: rewrite test with JUnit 4 rules including
+                             // TemporaryFolder
   @Test
   public void testDispatchingForward1() throws Exception {
     Callback c_1 = (request, response) -> {

--- a/extensions/geode-modules-session/src/test/java/org/apache/geode/modules/session/internal/filter/SessionReplicationJUnitTest.java
+++ b/extensions/geode-modules-session/src/test/java/org/apache/geode/modules/session/internal/filter/SessionReplicationJUnitTest.java
@@ -23,12 +23,11 @@ import org.junit.experimental.categories.Category;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.modules.session.filter.SessionCachingFilter;
 import org.apache.geode.test.junit.categories.IntegrationTest;
-import org.apache.geode.test.junit.categories.SessionTest;
 
 /**
  * This runs all tests with a local cache disabled
  */
-@Category({IntegrationTest.class, SessionTest.class})
+@Category(IntegrationTest.class)
 public class SessionReplicationJUnitTest extends CommonTests {
 
   @Before

--- a/extensions/geode-modules-session/src/test/java/org/apache/geode/modules/session/internal/filter/SessionReplicationLocalCacheJUnitTest.java
+++ b/extensions/geode-modules-session/src/test/java/org/apache/geode/modules/session/internal/filter/SessionReplicationLocalCacheJUnitTest.java
@@ -23,12 +23,11 @@ import org.junit.experimental.categories.Category;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.modules.session.filter.SessionCachingFilter;
 import org.apache.geode.test.junit.categories.IntegrationTest;
-import org.apache.geode.test.junit.categories.SessionTest;
 
 /**
  * This runs all tests with a local cache enabled
  */
-@Category({IntegrationTest.class, SessionTest.class})
+@Category(IntegrationTest.class)
 public class SessionReplicationLocalCacheJUnitTest extends CommonTests {
 
   @Before

--- a/extensions/geode-modules-tomcat7/src/test/java/org/apache/geode/modules/session/Tomcat7SessionsJUnitTest.java
+++ b/extensions/geode-modules-tomcat7/src/test/java/org/apache/geode/modules/session/Tomcat7SessionsJUnitTest.java
@@ -26,9 +26,8 @@ import org.junit.experimental.categories.Category;
 
 import org.apache.geode.modules.session.catalina.Tomcat7DeltaSessionManager;
 import org.apache.geode.test.junit.categories.IntegrationTest;
-import org.apache.geode.test.junit.categories.SessionTest;
 
-@Category({IntegrationTest.class, SessionTest.class})
+@Category(IntegrationTest.class)
 public class Tomcat7SessionsJUnitTest extends TestSessionsBase {
 
   // Set up the session manager we need

--- a/extensions/geode-modules-tomcat8/src/test/java/org/apache/geode/modules/session/Tomcat8SessionsClientServerDUnitTest.java
+++ b/extensions/geode-modules-tomcat8/src/test/java/org/apache/geode/modules/session/Tomcat8SessionsClientServerDUnitTest.java
@@ -14,9 +14,9 @@
  */
 package org.apache.geode.modules.session;
 
-import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
-import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
+import static org.apache.geode.distributed.ConfigurationProperties.*;
 
+import java.util.List;
 import java.util.Properties;
 
 import org.junit.experimental.categories.Category;
@@ -24,6 +24,8 @@ import org.junit.experimental.categories.Category;
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.client.ClientCacheFactory;
+import org.apache.geode.cache.client.PoolFactory;
+import org.apache.geode.cache.client.PoolManager;
 import org.apache.geode.cache.server.CacheServer;
 import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.internal.cache.GemFireCacheImpl;
@@ -32,9 +34,9 @@ import org.apache.geode.modules.session.catalina.DeltaSessionManager;
 import org.apache.geode.modules.session.catalina.Tomcat8DeltaSessionManager;
 import org.apache.geode.test.dunit.Host;
 import org.apache.geode.test.junit.categories.DistributedTest;
-import org.apache.geode.test.junit.categories.SessionTest;
+import org.apache.geode.test.junit.categories.UnitTest;
 
-@Category({DistributedTest.class, SessionTest.class})
+@Category(DistributedTest.class)
 public class Tomcat8SessionsClientServerDUnitTest extends TestSessionsTomcat8Base {
 
   // Set up the session manager we need

--- a/extensions/geode-modules-tomcat8/src/test/java/org/apache/geode/modules/session/Tomcat8SessionsDUnitTest.java
+++ b/extensions/geode-modules-tomcat8/src/test/java/org/apache/geode/modules/session/Tomcat8SessionsDUnitTest.java
@@ -14,10 +14,11 @@
  */
 package org.apache.geode.modules.session;
 
-import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
-import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
+import static org.apache.geode.distributed.ConfigurationProperties.*;
 
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
 import org.apache.geode.internal.AvailablePortHelper;
@@ -25,9 +26,9 @@ import org.apache.geode.modules.session.catalina.DeltaSessionManager;
 import org.apache.geode.modules.session.catalina.PeerToPeerCacheLifecycleListener;
 import org.apache.geode.modules.session.catalina.Tomcat8DeltaSessionManager;
 import org.apache.geode.test.junit.categories.DistributedTest;
-import org.apache.geode.test.junit.categories.SessionTest;
+import org.apache.geode.test.junit.categories.UnitTest;
 
-@Category({DistributedTest.class, SessionTest.class})
+@Category(DistributedTest.class)
 public class Tomcat8SessionsDUnitTest extends TestSessionsTomcat8Base {
 
   // Set up the session manager we need

--- a/extensions/geode-modules/src/test/java/org/apache/geode/modules/session/Tomcat6SessionsJUnitTest.java
+++ b/extensions/geode-modules/src/test/java/org/apache/geode/modules/session/Tomcat6SessionsJUnitTest.java
@@ -19,9 +19,9 @@ import org.junit.experimental.categories.Category;
 
 import org.apache.geode.modules.session.catalina.Tomcat6DeltaSessionManager;
 import org.apache.geode.test.junit.categories.IntegrationTest;
-import org.apache.geode.test.junit.categories.SessionTest;
+import org.apache.geode.test.junit.categories.UnitTest;
 
-@Category({IntegrationTest.class, SessionTest.class})
+@Category(IntegrationTest.class)
 public class Tomcat6SessionsJUnitTest extends TestSessionsBase {
 
   // Set up the session manager we need

--- a/extensions/geode-modules/src/test/java/org/apache/geode/modules/util/ClassLoaderObjectInputStreamTest.java
+++ b/extensions/geode-modules/src/test/java/org/apache/geode/modules/util/ClassLoaderObjectInputStreamTest.java
@@ -14,8 +14,7 @@
  */
 package org.apache.geode.modules.util;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.*;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -38,6 +37,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TestName;
 
+import org.apache.geode.internal.ClassPathLoader;
 import org.apache.geode.test.junit.categories.UnitTest;
 
 @Category(UnitTest.class)

--- a/extensions/geode-modules/src/test/java/org/apache/geode/modules/util/ModuleFunctionsSecurityTest.java
+++ b/extensions/geode-modules/src/test/java/org/apache/geode/modules/util/ModuleFunctionsSecurityTest.java
@@ -30,12 +30,11 @@ import org.apache.geode.cache.execute.FunctionService;
 import org.apache.geode.examples.SimpleSecurityManager;
 import org.apache.geode.test.junit.categories.IntegrationTest;
 import org.apache.geode.test.junit.categories.SecurityTest;
-import org.apache.geode.test.junit.categories.SessionTest;
 import org.apache.geode.test.junit.rules.ConnectionConfiguration;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({IntegrationTest.class, SecurityTest.class, SessionTest.class})
+@Category({IntegrationTest.class, SecurityTest.class})
 public class ModuleFunctionsSecurityTest {
 
   private static final String RESULT_HEADER = "Function Execution Result";

--- a/geode-assembly/src/test/java/org/apache/geode/management/internal/cli/commands/PutCommandWithJsonTest.java
+++ b/geode-assembly/src/test/java/org/apache/geode/management/internal/cli/commands/PutCommandWithJsonTest.java
@@ -12,7 +12,6 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package org.apache.geode.management.internal.cli.commands;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -33,17 +32,18 @@ import org.apache.geode.test.junit.rules.gfsh.GfshScript;
 
 @Category(AcceptanceTest.class)
 public class PutCommandWithJsonTest {
+
   private File jarToDeploy;
+
   @Rule
   public GfshRule gfsh = new GfshRule();
-
 
   @Before
   public void setup() throws IOException {
     jarToDeploy = new File(gfsh.getTemporaryFolder().getRoot(), "ourJar.jar");
 
     String classContents =
-        "public class Customer {private String name; public void setName(String name){this.name=name;}}";
+        "public class Customer implements java.io.Serializable {private String name; public void setName(String name){this.name=name;}}";
     JarBuilder jarBuilder = new JarBuilder();
     jarBuilder.buildJar(jarToDeploy, classContents);
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegionMap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegionMap.java
@@ -115,6 +115,8 @@ public abstract class AbstractRegionMap
   // the region that owns this map
   private RegionMapOwner owner;
 
+  private final EntryEventSerialization entryEventSerialization = new EntryEventSerialization();
+
   protected AbstractRegionMap(InternalRegionArguments internalRegionArgs) {
     // do nothing
   }
@@ -2200,7 +2202,11 @@ public abstract class AbstractRegionMap
       final boolean ifOld, Object expectedOldValue, // only non-null if ifOld
       boolean requireOldValue, final boolean overwriteDestroyed)
       throws CacheWriterException, TimeoutException {
+
     final LocalRegion owner = _getOwner();
+
+    entryEventSerialization.serializeNewValueIfNeeded(owner, event);
+
     boolean clearOccured = false;
     if (owner == null) {
       // "fix" for bug 32440

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/EntryEventImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/EntryEventImpl.java
@@ -863,7 +863,7 @@ public class EntryEventImpl implements InternalEntryEvent, InternalCacheEvent,
   }
 
   @Unretained
-  protected Object basicGetNewValue() {
+  public Object basicGetNewValue() {
     generateNewValueFromBytesIfNeeded();
     Object result = this.newValue;
     if (!this.offHeapOk && isOffHeapReference(result)) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/EntryEventSerialization.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/EntryEventSerialization.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache;
+
+import static org.apache.geode.internal.lang.SystemPropertyHelper.EARLY_ENTRY_EVENT_SERIALIZATION;
+import static org.apache.geode.internal.lang.SystemPropertyHelper.getProductBooleanProperty;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+import org.apache.geode.pdx.internal.InternalPdxInstance;
+
+class EntryEventSerialization {
+
+  private final boolean enabled =
+      getProductBooleanProperty(EARLY_ENTRY_EVENT_SERIALIZATION).orElse(false);
+
+  void serializeNewValueIfNeeded(final InternalRegion region, final InternalEntryEvent event) {
+    if (enabled) {
+      doWork(region, event);
+    }
+  }
+
+  private void doWork(final InternalRegion region, final InternalEntryEvent event) {
+    if (region.getScope().isLocal()) {
+      return;
+    }
+    if (region instanceof HARegion) {
+      return;
+    }
+    if (region instanceof BucketRegionQueue) {
+      return;
+    }
+    if (event.getCachedSerializedNewValue() != null) {
+      return;
+    }
+
+    Object newValue = event.basicGetNewValue();
+    if (newValue == null) {
+      return;
+    }
+    if (newValue instanceof byte[]) {
+      return;
+    }
+    if (Token.isToken(newValue)) {
+      return;
+    }
+
+    event.setCachedSerializedNewValue(toBytes(newValue));
+  }
+
+  private byte[] toBytes(Object newValue) {
+    byte[] newValueBytes;
+    if (newValue instanceof InternalPdxInstance) {
+      newValueBytes = toBytes((InternalPdxInstance) newValue);
+    } else if (newValue instanceof CachedDeserializable) {
+      newValueBytes = toBytes((CachedDeserializable) newValue);
+    } else {
+      newValueBytes = EntryEventImpl.serialize(newValue);
+    }
+    return newValueBytes;
+  }
+
+  private byte[] toBytes(final InternalPdxInstance pdxInstance) {
+    try {
+      return pdxInstance.toBytes();
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  private byte[] toBytes(final CachedDeserializable cachedDeserializable) {
+    return cachedDeserializable.getSerializedValue();
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionRegionConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionRegionConfig.java
@@ -12,14 +12,16 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
-/*
- * Created on Dec 1, 2005
- */
 package org.apache.geode.internal.cache;
 
-import java.io.*;
-import java.util.*;
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 
 import org.apache.geode.DataSerializer;
 import org.apache.geode.cache.EvictionAttributes;
@@ -40,12 +42,11 @@ import org.apache.geode.internal.util.VersionedArrayList;
  */
 public class PartitionRegionConfig extends ExternalizableDSFID implements Versionable {
 
-  /** PRId. */
-  int prId;
+  private int prId;
 
-  PartitionAttributesImpl pAttrs;
+  private PartitionAttributesImpl pAttrs;
 
-  Scope scope = null;
+  private Scope scope = null;
 
   /** Nodes participating in this PartitionedRegion */
   private VersionedArrayList nodes = null;
@@ -90,44 +91,13 @@ public class PartitionRegionConfig extends ExternalizableDSFID implements Versio
 
   private Set<String> gatewaySenderIds = Collections.emptySet();
 
-  public Set<String> getGatewaySenderIds() {
-    return gatewaySenderIds;
-  }
-
   /**
    * Default constructor for DataSerializer
    */
-  public PartitionRegionConfig() {}
-
-  /**
-   * Constructor.
-   */
-  PartitionRegionConfig(int prId, String path, PartitionAttributes prAtt, Scope sc) {
-    this.prId = prId;
-    this.pAttrs = (PartitionAttributesImpl) prAtt;
-    this.scope = sc;
-    this.isDestroying = false;
-    this.nodes = new VersionedArrayList();
-    if (prAtt.getPartitionResolver() != null) {
-      this.partitionResolver = prAtt.getPartitionResolver().getClass().getName();
-    }
-    this.colocatedWith = prAtt.getColocatedWith();
-    this.isColocationComplete = colocatedWith == null;
-    this.fullPath = path;
-    this.firstDataStoreCreated = prAtt.getLocalMaxMemory() > 0;
-    this.elderFPAs = new LinkedHashSet<FixedPartitionAttributesImpl>();
-    PartitionListener[] prListeners = prAtt.getPartitionListeners();
-    if (prListeners != null && prListeners.length != 0) {
-      for (int i = 0; i < prListeners.length; i++) {
-        PartitionListener listener = prListeners[i];
-        this.partitionListenerClassNames.add(listener.getClass().getName());
-      }
-    }
+  public PartitionRegionConfig() {
+    // nothing
   }
 
-  /**
-   * Constructor.
-   */
   PartitionRegionConfig(int prId, String path, PartitionAttributes prAtt, Scope sc,
       EvictionAttributes ea, final ExpirationAttributes regionIdleTimeout,
       final ExpirationAttributes regionTimeToLive, final ExpirationAttributes entryIdleTimeout,
@@ -160,6 +130,10 @@ public class PartitionRegionConfig extends ExternalizableDSFID implements Versio
       }
     }
     this.gatewaySenderIds = gatewaySenderIds;
+  }
+
+  public Set<String> getGatewaySenderIds() {
+    return gatewaySenderIds;
   }
 
   /**
@@ -350,18 +324,22 @@ public class PartitionRegionConfig extends ExternalizableDSFID implements Versio
     return this.nodes.isNewerThan(other.nodes);
   }
 
+  @Override
   public Comparable getVersion() {
     return this.nodes.getVersion();
   }
 
+  @Override
   public boolean isNewerThan(Versionable other) {
     return this.nodes.isNewerThan(other);
   }
 
+  @Override
   public boolean isSame(Versionable other) {
     return this.nodes.isSame(other);
   }
 
+  @Override
   public boolean isOlderThan(Versionable other) {
     return this.nodes.isOlderThan(other);
   }
@@ -421,7 +399,6 @@ public class PartitionRegionConfig extends ExternalizableDSFID implements Versio
   }
 
   public boolean hasSameDataStoreMembers(PartitionRegionConfig prConfig) {
-
     for (Node node : getNodes()) {
       if (!prConfig.containsMember(node.getMemberId())
           && ((node.getPRType() == Node.ACCESSOR_DATASTORE)
@@ -441,13 +418,11 @@ public class PartitionRegionConfig extends ExternalizableDSFID implements Versio
 
   @Override
   public Version[] getSerializationVersions() {
-    // TODO Auto-generated method stub
     return null;
   }
 
   public void setDatastoreCreated(EvictionAttributes evictionAttributes) {
     this.firstDataStoreCreated = true;
     this.ea = evictionAttributes;
-
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXCommitMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXCommitMessage.java
@@ -1543,10 +1543,12 @@ public class TXCommitMessage extends PooledDistributionMessage
         if (!this.op.isDestroy()) {
           this.didDestroy = in.readBoolean();
           if (!this.op.isInvalidate()) {
-            boolean isToken = in.readBoolean();
-            if (isToken) {
+            boolean isTokenOrByteArray = in.readBoolean();
+            if (isTokenOrByteArray) {
+              // token or byte[]
               this.value = DataSerializer.readObject(in);
             } else {
+              // CachedDeserializable, Object, or PDX
               this.value = CachedDeserializableFactory.create(DataSerializer.readByteArray(in),
                   GemFireCacheImpl.getInstance());
             }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/Token.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/Token.java
@@ -12,7 +12,6 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package org.apache.geode.internal.cache;
 
 import java.io.DataInput;
@@ -29,9 +28,9 @@ import org.apache.geode.internal.Version;
 /**
  * Internal tokens used as region values. These tokens are never seen from the public API.
  *
+ * <p>
  * These classes are Serializable and implement readResolve to support canonicalization in the face
  * of copysharing.
- *
  */
 public abstract class Token {
 
@@ -108,6 +107,10 @@ public abstract class Token {
     return o == DESTROYED;
   }
 
+  public static boolean isToken(Object o) {
+    return o instanceof Token;
+  }
+
   /**
    * Singleton token indicating an Invalid Entry.
    */
@@ -125,12 +128,15 @@ public abstract class Token {
       return INVALID;
     }
 
+    @Override
     public int getDSFID() {
       return TOKEN_INVALID;
     }
 
+    @Override
     public void toData(DataOutput out) throws IOException {}
 
+    @Override
     public void fromData(DataInput in) throws IOException, ClassNotFoundException {}
 
     public boolean isSerializedValue(byte[] value) {
@@ -141,7 +147,6 @@ public abstract class Token {
 
     @Override
     public Version[] getSerializationVersions() {
-      // TODO Auto-generated method stub
       return null;
     }
   }
@@ -180,17 +185,19 @@ public abstract class Token {
       return DESTROYED;
     }
 
+    @Override
     public int getDSFID() {
       return TOKEN_DESTROYED;
     }
 
+    @Override
     public void toData(DataOutput out) throws IOException {}
 
+    @Override
     public void fromData(DataInput in) throws IOException, ClassNotFoundException {}
 
     @Override
     public Version[] getSerializationVersions() {
-      // TODO Auto-generated method stub
       return null;
     }
   }
@@ -209,17 +216,19 @@ public abstract class Token {
       return TOMBSTONE;
     }
 
+    @Override
     public int getDSFID() {
       return TOKEN_TOMBSTONE;
     }
 
+    @Override
     public void toData(DataOutput out) throws IOException {}
 
+    @Override
     public void fromData(DataInput in) throws IOException, ClassNotFoundException {}
 
     @Override
     public Version[] getSerializationVersions() {
-      // TODO Auto-generated method stub
       return null;
     }
   }
@@ -238,17 +247,19 @@ public abstract class Token {
       return REMOVED_PHASE1;
     }
 
+    @Override
     public int getDSFID() {
       return TOKEN_REMOVED;
     }
 
+    @Override
     public void toData(DataOutput out) throws IOException {}
 
+    @Override
     public void fromData(DataInput in) throws IOException, ClassNotFoundException {}
 
     @Override
     public Version[] getSerializationVersions() {
-      // TODO Auto-generated method stub
       return null;
     }
   }
@@ -267,17 +278,19 @@ public abstract class Token {
       return REMOVED_PHASE2;
     }
 
+    @Override
     public int getDSFID() {
       return TOKEN_REMOVED2;
     }
 
+    @Override
     public void toData(DataOutput out) throws IOException {}
 
+    @Override
     public void fromData(DataInput in) throws IOException, ClassNotFoundException {}
 
     @Override
     public Version[] getSerializationVersions() {
-      // TODO Auto-generated method stub
       return null;
     }
   }
@@ -315,17 +328,19 @@ public abstract class Token {
       return END_OF_STREAM;
     }
 
+    @Override
     public int getDSFID() {
       return END_OF_STREAM_TOKEN;
     }
 
+    @Override
     public void fromData(DataInput in) throws IOException, ClassNotFoundException {}
 
+    @Override
     public void toData(DataOutput out) throws IOException {}
 
     @Override
     public Version[] getSerializationVersions() {
-      // TODO Auto-generated method stub
       return null;
     }
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/lang/SystemPropertyHelper.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/lang/SystemPropertyHelper.java
@@ -22,11 +22,10 @@ import java.util.Optional;
  *
  * @since Geode 1.4.0
  */
-
 public class SystemPropertyHelper {
-  private static final String GEODE_PREFIX = "geode.";
-  private static final String GEMFIRE_PREFIX = "gemfire.";
 
+  public static final String GEODE_PREFIX = "geode.";
+  public static final String GEMFIRE_PREFIX = "gemfire.";
 
   /**
    * When set to "true" enables asynchronous eviction algorithm (defaults to true). For more details
@@ -57,6 +56,8 @@ public class SystemPropertyHelper {
   public static final String EVICTION_SCAN_THRESHOLD_PERCENT = "EvictionScanThresholdPercent";
 
   public static final String EVICTION_SEARCH_MAX_ENTRIES = "lru.maxSearchEntries";
+
+  public static final String EARLY_ENTRY_EVENT_SERIALIZATION = "earlyEntryEventSerialization";
 
   /**
    * This method will try to look up "geode." and "gemfire." versions of the system property. It

--- a/geode-core/src/main/java/org/apache/geode/pdx/internal/InternalPdxInstance.java
+++ b/geode-core/src/main/java/org/apache/geode/pdx/internal/InternalPdxInstance.java
@@ -12,20 +12,9 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.geode.internal.cache;
+package org.apache.geode.pdx.internal;
 
-import org.apache.geode.cache.EntryEvent;
+import org.apache.geode.pdx.PdxInstance;
 
-/**
- * All of the API methods not exposed to User in EntryEvent.
- */
-public interface InternalEntryEvent extends EntryEvent {
-
-  void setRegionEntry(RegionEntry re);
-
-  Object basicGetNewValue();
-
-  void setCachedSerializedNewValue(byte[] v);
-
-  byte[] getCachedSerializedNewValue();
+public interface InternalPdxInstance extends PdxInstance, ConvertableToBytes {
 }

--- a/geode-core/src/main/java/org/apache/geode/pdx/internal/PdxInstanceImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/pdx/internal/PdxInstanceImpl.java
@@ -42,7 +42,6 @@ import org.apache.geode.internal.tcp.ByteBufferInputStream;
 import org.apache.geode.internal.tcp.ByteBufferInputStream.ByteSource;
 import org.apache.geode.internal.tcp.ByteBufferInputStream.ByteSourceFactory;
 import org.apache.geode.pdx.JSONFormatter;
-import org.apache.geode.pdx.PdxInstance;
 import org.apache.geode.pdx.PdxSerializationException;
 import org.apache.geode.pdx.WritablePdxInstance;
 
@@ -55,8 +54,7 @@ import org.apache.geode.pdx.WritablePdxInstance;
  * We do not use this normal java io serialization when serializing this class in GemFire because
  * Sendable takes precedence over Serializable.
  */
-public class PdxInstanceImpl extends PdxReaderImpl
-    implements PdxInstance, Sendable, ConvertableToBytes {
+public class PdxInstanceImpl extends PdxReaderImpl implements InternalPdxInstance, Sendable {
 
   private static final long serialVersionUID = -1669268527103938431L;
 
@@ -135,6 +133,7 @@ public class PdxInstanceImpl extends PdxReaderImpl
     }
   }
 
+  @Override
   public Object getField(String fieldName) {
     return getUnmodifiableReader(fieldName).readField(fieldName);
   }
@@ -155,7 +154,7 @@ public class PdxInstanceImpl extends PdxReaderImpl
     return writer;
   }
 
-  // Sendable implementation
+  @Override
   public void sendTo(DataOutput out) throws IOException {
     PdxReaderImpl ur = getUnmodifiableReader();
     if (ur.getPdxType().getHasDeletedField()) {
@@ -169,6 +168,7 @@ public class PdxInstanceImpl extends PdxReaderImpl
     }
   }
 
+  @Override
   public byte[] toBytes() {
     PdxReaderImpl ur = getUnmodifiableReader();
     if (ur.getPdxType().getHasDeletedField()) {
@@ -474,6 +474,7 @@ public class PdxInstanceImpl extends PdxReaderImpl
     return result.toString();
   }
 
+  @Override
   public List<String> getFieldNames() {
     return getPdxType().getFieldNames();
   }
@@ -488,6 +489,7 @@ public class PdxInstanceImpl extends PdxReaderImpl
     this.cachedObjectForm = null;
   }
 
+  @Override
   public WritablePdxInstance createWriter() {
     if (isEnum()) {
       throw new IllegalStateException("PdxInstances that are an enum can not be modified.");
@@ -617,10 +619,12 @@ public class PdxInstanceImpl extends PdxReaderImpl
     super.basicSendTo(bb);
   }
 
+  @Override
   public String getClassName() {
     return getPdxType().getClassName();
   }
 
+  @Override
   public boolean isEnum() {
     return false;
   }

--- a/geode-core/src/test/java/org/apache/geode/cache/query/Bug32947ValueConstraintJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/Bug32947ValueConstraintJUnitTest.java
@@ -26,8 +26,16 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import org.apache.geode.cache.*;
-import org.apache.geode.cache.query.data.*;
+import org.apache.geode.cache.AttributesFactory;
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.CacheFactory;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionAttributes;
+import org.apache.geode.cache.query.data.Address;
+import org.apache.geode.cache.query.data.Data;
+import org.apache.geode.cache.query.data.Employee;
+import org.apache.geode.cache.query.data.Manager;
+import org.apache.geode.cache.query.data.Portfolio;
 import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.test.junit.categories.IntegrationTest;
 import org.apache.geode.test.junit.categories.OQLQueryTest;
@@ -38,8 +46,8 @@ import org.apache.geode.test.junit.categories.OQLQueryTest;
 @Category({IntegrationTest.class, OQLQueryTest.class})
 public class Bug32947ValueConstraintJUnitTest {
 
-  DistributedSystem distributedSystem = null;
-  Cache cache = null;
+  private DistributedSystem distributedSystem;
+  private Cache cache;
 
   @Before
   public void setUp() throws java.lang.Exception {
@@ -57,8 +65,6 @@ public class Bug32947ValueConstraintJUnitTest {
 
   @Test
   public void testBug32947ValueConstraints() throws Exception {
-
-    boolean flag = false;
     AttributesFactory factory = new AttributesFactory();
     factory.setValueConstraint(Portfolio.class);
     RegionAttributes regionAttributes = factory.create();
@@ -67,13 +73,8 @@ public class Bug32947ValueConstraintJUnitTest {
     portolioRegion.put("key1", new Portfolio(1));
     try {
       portolioRegion.put("key2", new Data());
-    } catch (ClassCastException e) {
-      flag = true;
-    }
-
-    if (!flag) {
       fail("Expected ClassCastException after put as valueConstraint is set to Portfolio.class");
-      return;
+    } catch (ClassCastException expected) {
     }
 
     Set address1 = new HashSet();
@@ -96,23 +97,13 @@ public class Bug32947ValueConstraintJUnitTest {
     regionAttributes = factory.create();
     Region employeeRegion = cache.createRegion("employees", regionAttributes);
 
-    employeeRegion.put("key1", manager); // This is perfectly valid, as Manager is Derived from
-                                         // Employee
-
-    flag = false;
+    // This is perfectly valid, as Manager is Derived from Employee
+    employeeRegion.put("key1", manager);
 
     try {
       managerRegion.put("key1", employee);
-    } catch (ClassCastException e) {
-      flag = true;
-    }
-
-    if (!flag) {
       fail("Expected ClassCastException after put as valueConstraint is set to Manager.class");
-      return;
+    } catch (ClassCastException expected) {
     }
-
-    // Test passed successfully.
-
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/cache/query/PdxStringQueryJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/PdxStringQueryJUnitTest.java
@@ -15,9 +15,16 @@
 package org.apache.geode.cache.query;
 
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
-import java.util.*;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 import org.junit.After;
 import org.junit.Before;
@@ -43,22 +50,19 @@ import org.apache.geode.pdx.internal.PdxString;
 import org.apache.geode.test.junit.categories.IntegrationTest;
 import org.apache.geode.test.junit.categories.OQLQueryTest;
 
-/**
- *
- *
- */
 @Category({IntegrationTest.class, OQLQueryTest.class})
 public class PdxStringQueryJUnitTest {
-  private InternalCache cache;
-  private Region region;
-  private String regName = "exampleRegion";
-  QueryService queryService;
-  QueryObserver observer;
 
   private static final int NO_INDEX = 0;
   private static final int INDEX_TYPE_COMPACTRANGE = 0;
   private static final int INDEX_TYPE_PRIMARYKEY = 2;
   private static final int INDEX_TYPE_RANGE = 1;
+
+  private InternalCache cache;
+  private Region region;
+  private String regName = "exampleRegion";
+  private QueryService queryService;
+  private QueryObserver observer;
 
   @Before
   public void setUp() {
@@ -258,7 +262,7 @@ public class PdxStringQueryJUnitTest {
     region.clear();
   }
 
-  public void putPdxInstances() throws Exception {
+  private void putPdxInstances() throws Exception {
     PdxInstanceFactory pf = PdxInstanceFactoryImpl.newCreator("Portfolio", false, this.cache);
     pf.writeInt("ID", 111);
     pf.writeString("status", "active");
@@ -288,7 +292,7 @@ public class PdxStringQueryJUnitTest {
     region.put("VMW", pi);
   }
 
-  public void putPdxInstancesWithREUpdateInProgress() throws Exception {
+  private void putPdxInstancesWithREUpdateInProgress() throws Exception {
     PdxInstanceFactory pf = PdxInstanceFactoryImpl.newCreator("Portfolio", false, this.cache);
     pf.writeInt("ID", 111);
     pf.writeString("status", "active");
@@ -320,7 +324,7 @@ public class PdxStringQueryJUnitTest {
     makeREUpdateInProgress();
   }
 
-  public void makeREUpdateInProgress() {
+  private void makeREUpdateInProgress() {
     Iterator entryItr = region.entrySet().iterator();
     while (entryItr.hasNext()) {
       Region.Entry nonTxEntry = (Region.Entry) entryItr.next();
@@ -330,7 +334,7 @@ public class PdxStringQueryJUnitTest {
     }
   }
 
-  public void putHeterogeneousObjects() throws Exception {
+  private void putHeterogeneousObjects() throws Exception {
     PdxInstanceFactory pf = PdxInstanceFactoryImpl.newCreator("Portfolio", false, this.cache);
     pf.writeInt("ID", 111);
     pf.writeString("secId", "IBM");
@@ -612,7 +616,6 @@ public class PdxStringQueryJUnitTest {
       validateResult(secIdsList, iter.next());
     }
     cache.setPdxReadSerializedOverride(false);
-
   }
 
   private void validateStringResult(Object str1, Object str2) {
@@ -635,7 +638,8 @@ public class PdxStringQueryJUnitTest {
     assertTrue(list.contains(str2));
   }
 
-  public static class TestObject {
+  private static class TestObject implements Serializable {
+
     private int ID;
     private String secId;
     private String status;
@@ -685,6 +689,5 @@ public class PdxStringQueryJUnitTest {
     public void setStatus(String status) {
       this.status = status;
     }
-
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/cache/query/data/Address.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/data/Address.java
@@ -12,21 +12,12 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-/*
- * Address.java
- *
- * Created on March 2, 2005, 12:23 PM
- */
-
 package org.apache.geode.cache.query.data;
 
-import java.util.*;
+import java.io.Serializable;
+import java.util.Set;
 
-
-/**
- *
- */
-public class Address {
+public class Address implements Serializable {
   public String zipCode;
   public String city;
 
@@ -45,5 +36,4 @@ public class Address {
     this.street = street;
     this.phoneNo = phoneNo;
   }
-
-}// end of class
+}

--- a/geode-core/src/test/java/org/apache/geode/cache/query/data/Data.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/data/Data.java
@@ -12,25 +12,19 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
-/*
- * Data.java
- *
- * Created on March 10, 2005, 7:32 PM
- */
-
 package org.apache.geode.cache.query.data;
 
-/**
- *
- */
-public class Data {
+import java.io.Serializable;
+
+public class Data implements Serializable {
 
   /** Creates a new instance of Data */
-  public Data() {}
+  public Data() {
+    // nothing
+  }
 
   public void voidMethod() {
-
+    // nothing
   }
 
   public boolean booleanMethod() {

--- a/geode-core/src/test/java/org/apache/geode/cache/query/data/Employee.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/data/Employee.java
@@ -12,29 +12,20 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-/*
- * Employee.java
- *
- * Created on March 2, 2005, 12:29 PM
- */
-
 package org.apache.geode.cache.query.data;
 
-import java.util.*;
+import java.io.Serializable;
+import java.util.HashSet;
+import java.util.Set;
 
-/**
- *
- */
-public class Employee {
+public class Employee implements Serializable {
   private String name;
   private int age;
   private int empId;
   private Set addresses;
   private String title;
   private int salary;
-  private PhoneNo phoneNo = null;
-
-  // private Set subordinates;
+  private PhoneNo phoneNo;
 
   public String name() {
     return name;
@@ -80,5 +71,4 @@ public class Employee {
     ph.add(this.phoneNo);
     return ph;
   }
-
-}// end of employee class
+}

--- a/geode-core/src/test/java/org/apache/geode/cache/query/data/Keywords.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/data/Keywords.java
@@ -12,16 +12,11 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-/*
- * Keywords.java
- *
- * Created on March 10, 2005, 7:01 PM
- */
 package org.apache.geode.cache.query.data;
 
-/**
- */
-public class Keywords {
+import java.io.Serializable;
+
+public class Keywords implements Serializable {
 
   // "select", "distinct", "from", "where", "true", "false","undefined",
   // "element", "not", "and", "or"};

--- a/geode-core/src/test/java/org/apache/geode/cache/query/data/Manager.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/data/Manager.java
@@ -12,17 +12,10 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-/*
- * Manager.java
- *
- * Created on April 7, 2005, 6:05 PM
- */
 package org.apache.geode.cache.query.data;
 
 import java.util.Set;
 
-/**
- */
 public class Manager extends Employee {
 
   public int manager_id;

--- a/geode-core/src/test/java/org/apache/geode/cache/query/data/PhoneNo.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/data/PhoneNo.java
@@ -12,18 +12,11 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-/*
- * PhoneNo.java
- *
- * Created on September 29, 2005, 3:40 PM
- */
-
 package org.apache.geode.cache.query.data;
 
-/**
- *
- */
-public class PhoneNo {
+import java.io.Serializable;
+
+public class PhoneNo implements Serializable {
   public int phoneNo1;
   public int phoneNo2;
   public int phoneNo3;

--- a/geode-core/src/test/java/org/apache/geode/cache/query/data/Portfolio.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/data/Portfolio.java
@@ -12,12 +12,6 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
-/******
- * THIS FILE IS ENCODED IN UTF-8 IN ORDER TO TEST UNICODE IN FIELD NAMES. THE ENCODING MUST BE
- * SPECIFIED AS UTF-8 WHEN COMPILED
- *******/
-
 package org.apache.geode.cache.query.data;
 
 import java.io.DataInput;
@@ -28,16 +22,16 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import org.apache.commons.lang.StringUtils;
 
 import org.apache.geode.DataSerializable;
 import org.apache.geode.DataSerializer;
 import org.apache.geode.internal.Assert;
 
-
+/**
+ * THIS FILE IS ENCODED IN UTF-8 IN ORDER TO TEST UNICODE IN FIELD NAMES. THE ENCODING MUST BE
+ * SPECIFIED AS UTF-8 WHEN COMPILED
+ */
 public class Portfolio implements Serializable, DataSerializable {
 
   public static AtomicInteger instanceCount = new AtomicInteger(0);

--- a/geode-core/src/test/java/org/apache/geode/cache/query/data/Street.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/data/Street.java
@@ -12,18 +12,11 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-/*
- * Street.java
- *
- * Created on September 30, 2005, 1:26 PM
- */
-
 package org.apache.geode.cache.query.data;
 
-/**
- *
- */
-public class Street {
+import java.io.Serializable;
+
+public class Street implements Serializable {
   public String street;
   public String lane;
 

--- a/geode-core/src/test/java/org/apache/geode/cache/query/data/TradingLine.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/data/TradingLine.java
@@ -14,10 +14,11 @@
  */
 package org.apache.geode.cache.query.data;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
-public class TradingLine {
+public class TradingLine implements Serializable {
 
   private Map<String, String> alternateReferences;
 

--- a/geode-core/src/test/java/org/apache/geode/cache/query/functional/INOperatorJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/functional/INOperatorJUnitTest.java
@@ -12,16 +12,13 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-/*
- * InOperatorTest.java
- *
- * Created on March 24, 2005, 5:08 PM
- */
 package org.apache.geode.cache.query.functional;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
@@ -44,12 +41,8 @@ import org.apache.geode.cache.query.SelectResults;
 import org.apache.geode.test.junit.categories.IntegrationTest;
 import org.apache.geode.test.junit.categories.OQLQueryTest;
 
-/**
- *
- */
 @Category({IntegrationTest.class, OQLQueryTest.class})
 public class INOperatorJUnitTest {
-
 
   @Before
   public void setUp() throws Exception {
@@ -80,7 +73,7 @@ public class INOperatorJUnitTest {
   @Ignore
   @Test
   public void testInDecompositionWithFunctionalIndex() throws Exception {
-
+    // TODO: this test was never implemented?
   }
 
   @Test
@@ -108,13 +101,13 @@ public class INOperatorJUnitTest {
     expectedResults = new HashSet();
     expectedResults.add(new Integer(6));
     expectedResults.add(new Integer(10));
-    assertEquals(expectedResults, results.asSet());
+    assertThat(results.asSet()).isEqualTo(expectedResults);
 
     q = qs.newQuery("SELECT e.value FROM /pos.entrySet e WHERE e.key IN $1");
     keys = new Object[] {"42"};
     results = (SelectResults) q.execute(new Object[] {keys});
     expectedResults = new HashSet();
-    assertEquals(expectedResults, results.asSet());
+    assertThat(results.asSet()).isEqualTo(expectedResults);
 
     for (int i = 0; i < 1000; i++) {
       region.put(String.valueOf(i), new Integer(i));
@@ -127,35 +120,30 @@ public class INOperatorJUnitTest {
     expectedResults.add(new Integer(6));
     expectedResults.add(new Integer(10));
     expectedResults.add(new Integer(45));
-    assertEquals(expectedResults, results.asSet());
+    assertThat(results.asSet()).isEqualTo(expectedResults);
 
     q = qs.newQuery("SELECT e.key, e.value FROM /pos.entrySet e WHERE e.key IN $1");
     keys = new Object[] {"5", "6", "10", "45"};
     results = (SelectResults) q.execute(new Object[] {keys});
-    assertEquals(4, results.size());
+    assertThat(results).hasSize(4);
 
     region.destroyRegion();
   }
 
-
   @Test
   public void testIntSet() throws Exception {
-
     Query q = CacheUtils.getQueryService().newQuery("2 IN SET(1,2,3)");
 
     Object result = q.execute();
-    if (!result.equals(Boolean.TRUE))
-      fail("Failed for IN operator");
+    assertThat(result).isEqualTo(TRUE);
   }
 
   @Test
   public void testStringSet() throws Exception {
-
     Query q = CacheUtils.getQueryService().newQuery("'a' IN SET('x','y','z')");
 
     Object result = q.execute();
-    if (!result.equals(Boolean.FALSE))
-      fail("Failed for StringSet with IN operator");
+    assertThat(result).isEqualTo(FALSE);
   }
 
   @Test
@@ -165,8 +153,7 @@ public class INOperatorJUnitTest {
     params[0] = num;
     Query q = CacheUtils.getQueryService().newQuery("$1 IN SET(1,2,3)");
     Object result = q.execute(params);
-    if (!result.equals(Boolean.TRUE))
-      fail("Failed for ShortNum with IN operator");
+    assertThat(result).isEqualTo(TRUE);
   }
 
   @Test
@@ -185,8 +172,7 @@ public class INOperatorJUnitTest {
 
     Query q = CacheUtils.getQueryService().newQuery("$3 IN $2");
     Object result = q.execute(params);
-    if (!result.equals(Boolean.TRUE))
-      fail("Failed for Collection with IN operator");
+    assertThat(result).isEqualTo(TRUE);
   }
 
   @Test
@@ -201,8 +187,7 @@ public class INOperatorJUnitTest {
     params[1] = H1;
     Query q = CacheUtils.getQueryService().newQuery("$1 IN $2");
     Object result = q.execute(params);
-    if (!result.equals(Boolean.TRUE))
-      fail("Failed for String set with IN operator");
+    assertThat(result).isEqualTo(TRUE);
   }
 
   @Test
@@ -218,40 +203,33 @@ public class INOperatorJUnitTest {
     params[2] = AL1;
     Query q = CacheUtils.getQueryService().newQuery("$1 IN $3");
     Object result = q.execute(params);
-    if (!result.equals(Boolean.TRUE))
-      fail("Failed for ArrayList with IN operator");
+    assertThat(result).isEqualTo(TRUE);
   }
 
   @Test
   public void testNULL() throws Exception {
     Query q = CacheUtils.getQueryService().newQuery(" null IN SET('x','y','z')");
     Object result = q.execute();
-    if (!result.equals(Boolean.FALSE))
-      fail("Failed for NULL in IN operator Test");
+    assertThat(result).isEqualTo(FALSE);
 
     q = CacheUtils.getQueryService().newQuery(" null IN SET(null)");
     result = q.execute();
-    if (!result.equals(Boolean.TRUE))
-      fail("Failed for NULL in IN operator Test");
-
+    assertThat(result).isEqualTo(TRUE);
   }
 
   @Test
   public void testUNDEFINED() throws Exception {
     Query q = CacheUtils.getQueryService().newQuery(" UNDEFINED IN SET(1,2,3)");
     Object result = q.execute();
-    if (!result.equals(Boolean.FALSE))
-      fail("Failed for UNDEFINED with IN operator");
+    assertThat(result).isEqualTo(FALSE);
 
     q = CacheUtils.getQueryService().newQuery(" UNDEFINED IN SET(UNDEFINED)");
     result = q.execute();
-    if (!result.equals(QueryService.UNDEFINED))
-      fail("Failed for UNDEFINED with IN operator");
+    assertThat(result).isEqualTo(QueryService.UNDEFINED);
 
     q = CacheUtils.getQueryService().newQuery(" UNDEFINED IN SET(UNDEFINED,UNDEFINED)");
     result = q.execute();
-    if (!result.equals(QueryService.UNDEFINED))
-      fail("Failed for UNDEFINED with IN operator");
+    assertThat(result).isEqualTo(QueryService.UNDEFINED);
   }
 
   @Test
@@ -262,10 +240,8 @@ public class INOperatorJUnitTest {
     for (int i = 1; i < params.length; i++) {
       params[0] = params[i];
       Object result = q.execute(params);
-      if (!result.equals(Boolean.TRUE))
-        fail("Failed for Mix set with IN operator");
+      assertThat(result).isEqualTo(TRUE);
     }
-
   }
 
   @Test
@@ -293,13 +269,13 @@ public class INOperatorJUnitTest {
     expectedResults = new HashSet();
     expectedResults.add(new Integer(6));
     expectedResults.add(new Integer(10));
-    assertEquals(expectedResults, results.asSet());
+    assertThat(results.asSet()).isEqualTo(expectedResults);
 
     q = qs.newQuery("SELECT e.value FROM /pos.entrySet e WHERE e.key IN $1");
     keys = new Object[] {"42"};
     results = (SelectResults) q.execute(new Object[] {keys});
     expectedResults = new HashSet();
-    assertEquals(expectedResults, results.asSet());
+    assertThat(results.asSet()).isEqualTo(expectedResults);
 
     for (int i = 0; i < 1000; i++) {
       region.put(String.valueOf(i), new Integer(i));
@@ -312,20 +288,17 @@ public class INOperatorJUnitTest {
     expectedResults.add(new Integer(6));
     expectedResults.add(new Integer(10));
     expectedResults.add(new Integer(45));
-    assertEquals(expectedResults, results.asSet());
+    assertThat(results.asSet()).isEqualTo(expectedResults);
 
     q = qs.newQuery("SELECT e.key, e.value FROM /pos.entrySet e WHERE e.key IN $1");
     keys = new Object[] {"5", "6", "10", "45"};
     results = (SelectResults) q.execute(new Object[] {keys});
-    assertEquals(4, results.size());
+    assertThat(results).hasSize(4);
   }
-
 
   /**
    * Tests optimization of compiled in where we no longer evaluate on every iteration The set is
    * saved off into the query context and reused Each query should have it's own query context
-   *
-   * @throws Exception
    */
   @Test
   public void testCacheEvalCollnWithIn() throws Exception {
@@ -352,7 +325,7 @@ public class INOperatorJUnitTest {
     Query q = qs.newQuery(
         "<trace>select r from /receipts r, r.items i where i.productId = 8 and r.customerId in (select c.id from /customers c where c.profile = 'PremiumIndividual')");
     SelectResults results = (SelectResults) q.execute();
-    assertEquals("Not the same size", 500, results.size());
+    assertThat(results).hasSize(500);
 
     for (int i = 1000; i < 1100; i++) {
       customersRegion.put(i, new Customer(i, i % 2 == 0 ? "PremiumIndividual" : "AverageJoe"));
@@ -362,14 +335,12 @@ public class INOperatorJUnitTest {
       }
     }
     results = (SelectResults) q.execute();
-    assertEquals("Not the same size after new inserts", 550, results.size());
+    assertThat(results).hasSize(550);
   }
 
   /**
    * Tests optimization of compiled in where we no longer evaluate on every iteration The set is
    * saved off into the query context and reused Each query should have it's own query context
-   *
-   * @throws Exception
    */
   @Test
   public void testCacheEvalCollnWithInWithMultipleNestedIn() throws Exception {
@@ -396,7 +367,7 @@ public class INOperatorJUnitTest {
     Query q = qs.newQuery(
         "<trace>select r from /receipts r, r.items i where i.productId = 8 and r.customerId in (select c.id from /customers c where c.id in (select d.id from /customers d where d.profile='PremiumIndividual'))");
     SelectResults results = (SelectResults) q.execute();
-    assertEquals("Not the same size", 500, results.size());
+    assertThat(results).hasSize(500);
 
     for (int i = 1000; i < 1100; i++) {
       customersRegion.put(i, new Customer(i, i % 2 == 0 ? "PremiumIndividual" : "AverageJoe"));
@@ -406,10 +377,10 @@ public class INOperatorJUnitTest {
       }
     }
     results = (SelectResults) q.execute();
-    assertEquals("Not the same size after new inserts", 550, results.size());
+    assertThat(results).hasSize(550);
   }
 
-  public class Customer {
+  public static class Customer implements Serializable {
     public int id;
     public String profile;
 
@@ -427,7 +398,7 @@ public class INOperatorJUnitTest {
     }
   }
 
-  public class Receipt {
+  public static class Receipt implements Serializable {
     public int customerId;
     public Item[] items;
 
@@ -445,7 +416,7 @@ public class INOperatorJUnitTest {
     }
   }
 
-  public class Item {
+  public static class Item implements Serializable {
     public int productId;
 
     public Item(int productId) {

--- a/geode-core/src/test/java/org/apache/geode/cache/query/functional/IUMRMultiIndexesMultiRegionJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/functional/IUMRMultiIndexesMultiRegionJUnitTest.java
@@ -12,13 +12,9 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-/*
- * IUMRMultiIndexesMultiRegionJUnitTest.java
- *
- * Created on September 30, 2005, 2:54 PM
- */
 package org.apache.geode.cache.query.functional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -53,16 +49,12 @@ import org.apache.geode.cache.query.internal.index.IndexManager;
 import org.apache.geode.test.junit.categories.IntegrationTest;
 import org.apache.geode.test.junit.categories.OQLIndexTest;
 
-/**
- *
- */
 @Category({IntegrationTest.class, OQLIndexTest.class})
 public class IUMRMultiIndexesMultiRegionJUnitTest {
 
   @Before
   public void setUp() throws java.lang.Exception {
     CacheUtils.startCache();
-
   }
 
   @After
@@ -97,22 +89,11 @@ public class IUMRMultiIndexesMultiRegionJUnitTest {
     }
     String queries[] = {
         // Test case No. IUMR021
-        "SELECT DISTINCT * FROM /portfolio1 pf1, /portfolio2 pf2, /employees e WHERE pf1.status = 'active'",
-        // "SELECT DISTINCT * FROM /portfolio1 pf1, pf1.positions.values posit1, /portfolio2 pf2,
-        // /employees e WHERE posit1.secId='IBM'"
-
-    };
+        "SELECT DISTINCT * FROM /portfolio1 pf1, /portfolio2 pf2, /employees e WHERE pf1.status = 'active'",};
     // Execute Queries without Indexes
     for (int i = 0; i < queries.length; i++) {
-      Query q = null;
-      try {
-        q = CacheUtils.getQueryService().newQuery(queries[i]);
-        CacheUtils.getLogger().info("Executing query: " + queries[i]);
-        r[i][0] = q.execute();
-      } catch (Exception e) {
-        e.printStackTrace();
-        fail(q.getQueryString());
-      }
+      Query q = CacheUtils.getQueryService().newQuery(queries[i]);
+      r[i][0] = q.execute();
     }
     // Create Indexes
     qs.createIndex("statusIndexPf1", IndexType.FUNCTIONAL, "status", "/portfolio1");
@@ -120,45 +101,32 @@ public class IUMRMultiIndexesMultiRegionJUnitTest {
 
     // Execute Queries with Indexes
     for (int i = 0; i < queries.length; i++) {
-      Query q = null;
-      try {
-        q = CacheUtils.getQueryService().newQuery(queries[i]);
-        CacheUtils.getLogger().info("Executing query: " + queries[i]);
-        QueryObserverImpl observer = new QueryObserverImpl();
-        QueryObserverHolder.setInstance(observer);
-        r[i][1] = q.execute();
-        if (!observer.isIndexesUsed) {
-          fail("Index is NOT uesd");
-        }
-
-        Iterator itr = observer.indexesUsed.iterator();
-        while (itr.hasNext()) {
-          String indexUsed = itr.next().toString();
-          if (!(indexUsed).equals("statusIndexPf1")) {
-            fail("<statusIndexPf1> was expected but found " + indexUsed);
-          }
-          // assertIndexDetailsEquals("statusIndexPf1",itr.next().toString());
-        }
-
-        int indxs = observer.indexesUsed.size();
-
-        CacheUtils.log("**************************************************Indexes Used :::::: "
-            + indxs + " Index Name: " + observer.indexName);
-
-      } catch (Exception e) {
-        e.printStackTrace();
-        fail(q.getQueryString());
+      Query q = CacheUtils.getQueryService().newQuery(queries[i]);
+      QueryObserverImpl observer = new QueryObserverImpl();
+      QueryObserverHolder.setInstance(observer);
+      r[i][1] = q.execute();
+      if (!observer.isIndexesUsed) {
+        fail("Index is NOT uesd");
       }
+
+      Iterator itr = observer.indexesUsed.iterator();
+      while (itr.hasNext()) {
+        String indexUsed = itr.next().toString();
+        if (!(indexUsed).equals("statusIndexPf1")) {
+          fail("<statusIndexPf1> was expected but found " + indexUsed);
+        }
+      }
+
+      assertThat(observer.indexesUsed.size()).isGreaterThan(0);
     }
     StructSetOrResultsSet ssOrrs = new StructSetOrResultsSet();
     ssOrrs.CompareQueryResultsWithoutAndWithIndexes(r, queries.length, queries);
-  }// end of test1
+  }
 
   @Test
   public void testMultiIteratorsMultiRegion2() throws Exception {
     Object r[][] = new Object[4][2];
-    QueryService qs;
-    qs = CacheUtils.getQueryService();
+    QueryService qs = CacheUtils.getQueryService();
     Position.resetCounter();
     // Create Regions
     Region r1 = CacheUtils.createRegion("portfolio1", Portfolio.class);
@@ -185,70 +153,50 @@ public class IUMRMultiIndexesMultiRegionJUnitTest {
         "SELECT DISTINCT * FROM /portfolio1 pf1, /portfolio2 pf2, /employees e1 WHERE pf1.status = 'active' AND e1.empId < 10"};
     // Execute Queries without Indexes
     for (int i = 0; i < queries.length; i++) {
-      Query q = null;
-      try {
-        q = CacheUtils.getQueryService().newQuery(queries[i]);
-        CacheUtils.getLogger().info("Executing query: " + queries[i]);
-        r[i][0] = q.execute();
-
-      } catch (Exception e) {
-        e.printStackTrace();
-        fail(q.getQueryString());
-      }
+      Query q = CacheUtils.getQueryService().newQuery(queries[i]);
+      r[i][0] = q.execute();
     }
     // Create Indexes & Execute the queries
     qs.createIndex("statusIndexPf1", IndexType.FUNCTIONAL, "pf1.status", "/portfolio1 pf1");
     qs.createIndex("empIdIndex", IndexType.FUNCTIONAL, "e.empId", "/employees e");
 
     for (int i = 0; i < queries.length; i++) {
-      Query q = null;
-      try {
-        q = CacheUtils.getQueryService().newQuery(queries[i]);
-        CacheUtils.getLogger().info("Executing query: " + queries[i]);
-        QueryObserverImpl observer = new QueryObserverImpl();
-        QueryObserverHolder.setInstance(observer);
-        r[i][1] = q.execute();
-        if (!observer.isIndexesUsed) {
-          fail("Index is NOT uesd");
+      Query q = CacheUtils.getQueryService().newQuery(queries[i]);
+      QueryObserverImpl observer = new QueryObserverImpl();
+      QueryObserverHolder.setInstance(observer);
+      r[i][1] = q.execute();
+      if (!observer.isIndexesUsed) {
+        fail("Index is NOT uesd");
+      }
+      int indxs = observer.indexesUsed.size();
+      if (indxs != 2) {
+        fail("Both the idexes are not getting used.Only " + indxs + " index is getting used");
+      }
+
+      Iterator itr = observer.indexesUsed.iterator();
+      String temp;
+
+      while (itr.hasNext()) {
+        temp = itr.next().toString();
+
+        if (temp.equals("statusIndexPf1")) {
+          break;
+        } else if (temp.equals("empIdIndex")) {
+          break;
+        } else {
+          fail("indices used do not match with those which are expected to be used"
+              + "<statusIndexPf1> and <empIdIndex> were expected but found " + itr.next());
         }
-        int indxs = observer.indexesUsed.size();
-        CacheUtils.log("**************************************************Indexes Used :::::: "
-            + indxs + " Index Name: " + observer.indexName);
-        if (indxs != 2) {
-          fail("Both the idexes are not getting used.Only " + indxs + " index is getting used");
-        }
-
-        Iterator itr = observer.indexesUsed.iterator();
-        String temp;
-
-        while (itr.hasNext()) {
-          temp = itr.next().toString();
-
-          if (temp.equals("statusIndexPf1")) {
-            break;
-          } else if (temp.equals("empIdIndex")) {
-            break;
-          } else {
-            fail("indices used do not match with those which are expected to be used"
-                + "<statusIndexPf1> and <empIdIndex> were expected but found " + itr.next());
-          }
-          // assertIndexDetailsEquals("statusIndexPf1",itr.next().toString());
-        }
-
-      } catch (Exception e) {
-        e.printStackTrace();
-        fail(q.getQueryString());
       }
     }
     StructSetOrResultsSet ssORrs = new StructSetOrResultsSet();
     ssORrs.CompareQueryResultsWithoutAndWithIndexes(r, queries.length, queries);
-  }// end of test2
+  }
 
   @Test
   public void testMultiIteratorsMultiRegion3() throws Exception {
     Object r[][] = new Object[9][2];
-    QueryService qs;
-    qs = CacheUtils.getQueryService();
+    QueryService qs = CacheUtils.getQueryService();
     Position.resetCounter();
     // Create Regions
     Region r1 = CacheUtils.createRegion("portfolio1", Portfolio.class);
@@ -278,20 +226,11 @@ public class IUMRMultiIndexesMultiRegionJUnitTest {
         // Test Case No. IUMR006
         "SELECT DISTINCT coll1 as collHldrMap1 , coll2 as CollHldrMap2 FROM /portfolio1 pf1, /portfolio2 pf2, pf1.positions.values posit1, pf2.positions.values posit2,"
             + " pf1.collectionHolderMap.values coll1,pf2.collectionHolderMap.values coll2 "
-            + " WHERE posit1.secId='IBM' OR posit2.secId='IBM'",
-
-    };
+            + " WHERE posit1.secId='IBM' OR posit2.secId='IBM'",};
     // Execute Queries Without Indexes
     for (int i = 0; i < queries.length; i++) {
-      Query q = null;
-      try {
-        q = CacheUtils.getQueryService().newQuery(queries[i]);
-        CacheUtils.getLogger().info("Executing query: " + queries[i]);
-        r[i][0] = q.execute();
-      } catch (Exception e) {
-        e.printStackTrace();
-        fail(q.getQueryString());
-      }
+      Query q = CacheUtils.getQueryService().newQuery(queries[i]);
+      r[i][0] = q.execute();
     }
     // Create Indexes and Execute the Queries
     qs.createIndex("secIdIndexPf1", IndexType.FUNCTIONAL, "pos11.secId",
@@ -300,56 +239,43 @@ public class IUMRMultiIndexesMultiRegionJUnitTest {
         "/portfolio2 pf2, pf2.collectionHolderMap.values coll2, pf2.positions.values pos22");
 
     for (int i = 0; i < queries.length; i++) {
-      Query q = null;
-      try {
-        q = CacheUtils.getQueryService().newQuery(queries[i]);
-        CacheUtils.getLogger().info("Executing query: " + queries[i]);
-        QueryObserverImpl observer = new QueryObserverImpl();
-        QueryObserverHolder.setInstance(observer);
-        // try {Thread.sleep(5000);} catch(Exception e){}
-        r[i][1] = q.execute();
-        if (!observer.isIndexesUsed) {
-          fail("Index is NOT uesd");
+      Query q = CacheUtils.getQueryService().newQuery(queries[i]);
+      QueryObserverImpl observer = new QueryObserverImpl();
+      QueryObserverHolder.setInstance(observer);
+      r[i][1] = q.execute();
+      if (!observer.isIndexesUsed) {
+        fail("Index is NOT uesd");
+      }
+      int indxs = observer.indexesUsed.size();
+      if (indxs != 2) {
+        fail("Both the idexes are not getting used.Only " + indxs + " index is getting used");
+      }
+
+      Iterator itr = observer.indexesUsed.iterator();
+      String temp;
+
+      while (itr.hasNext()) {
+        temp = itr.next().toString();
+
+        if (temp.equals("secIdIndexPf1")) {
+          break;
+        } else if (temp.equals("secIdIndexPf2")) {
+          break;
+        } else {
+          fail("indices used do not match with those which are expected to be used"
+              + "<secIdIndexPf1> and <secIdIndexPf2> were expected but found " + itr.next());
         }
-        int indxs = observer.indexesUsed.size();
-        if (indxs != 2) {
-          fail("Both the idexes are not getting used.Only " + indxs + " index is getting used");
-        }
-
-        CacheUtils
-            .log("**************************************************Indexes Used :::::: " + indxs);
-
-        Iterator itr = observer.indexesUsed.iterator();
-        String temp;
-
-        while (itr.hasNext()) {
-          temp = itr.next().toString();
-
-          if (temp.equals("secIdIndexPf1")) {
-            break;
-          } else if (temp.equals("secIdIndexPf2")) {
-            break;
-          } else {
-            fail("indices used do not match with those which are expected to be used"
-                + "<secIdIndexPf1> and <secIdIndexPf2> were expected but found " + itr.next());
-          }
-        }
-
-      } catch (Exception e) {
-        e.printStackTrace();
-        fail(q.getQueryString());
       }
     }
     // Verify the Query Results
     StructSetOrResultsSet ssORrs = new StructSetOrResultsSet();
     ssORrs.CompareQueryResultsWithoutAndWithIndexes(r, queries.length, queries);
-  }// end of test3
+  }
 
   @Test
   public void testMultiIteratorsMultiRegion4() throws Exception {
     Object r[][] = new Object[4][2];
-    QueryService qs;
-    qs = CacheUtils.getQueryService();
+    QueryService qs = CacheUtils.getQueryService();
     Position.resetCounter();
     // Create Regions
     Region r1 = CacheUtils.createRegion("portfolio1", Portfolio.class);
@@ -367,14 +293,8 @@ public class IUMRMultiIndexesMultiRegionJUnitTest {
         "SELECT DISTINCT * FROM /portfolio1 pf1, pf1.positions.values posit1, /portfolio2 pf2, pf2.positions.values posit2 WHERE pf2.status='active' AND posit1.secId='IBM'"};
     // Execute Queries without Indexes
     for (int i = 0; i < queries.length; i++) {
-      Query q = null;
-      try {
-        q = CacheUtils.getQueryService().newQuery(queries[i]);
-        CacheUtils.getLogger().info("Executing query: " + queries[i]);
-        r[i][0] = q.execute();
-      } catch (Exception e) {
-        e.printStackTrace();
-      }
+      Query q = CacheUtils.getQueryService().newQuery(queries[i]);
+      r[i][0] = q.execute();
     }
 
     // Create Indexes
@@ -383,53 +303,43 @@ public class IUMRMultiIndexesMultiRegionJUnitTest {
     qs.createIndex("statusIndexPf2", IndexType.FUNCTIONAL, "pf2.status", "/portfolio2 pf2");
 
     for (int i = 0; i < queries.length; i++) {
-      Query q = null;
-      try {
-        q = CacheUtils.getQueryService().newQuery(queries[i]);
-        CacheUtils.getLogger().info("Executing query: " + queries[i]);
-        QueryObserverImpl observer = new QueryObserverImpl();
-        QueryObserverHolder.setInstance(observer);
-        r[i][1] = q.execute();
-        if (!observer.isIndexesUsed) {
-          fail("Index is NOT uesd");
+      Query q = CacheUtils.getQueryService().newQuery(queries[i]);
+      QueryObserverImpl observer = new QueryObserverImpl();
+      QueryObserverHolder.setInstance(observer);
+      r[i][1] = q.execute();
+      if (!observer.isIndexesUsed) {
+        fail("Index is NOT uesd");
+      }
+      int indxs = observer.indexesUsed.size();
+      if (indxs != 2) {
+        fail("Both the idexes are not getting used.Only " + indxs + " index is getting used");
+      }
+
+      Iterator itr = observer.indexesUsed.iterator();
+      String temp;
+
+      while (itr.hasNext()) {
+        temp = itr.next().toString();
+
+        if (temp.equals("secIdIndexPf1")) {
+          break;
+        } else if (temp.equals("statusIndexPf2")) {
+          break;
+        } else {
+          fail("indices used do not match with those which are expected to be used"
+              + "<statusIndexPf1> and <statusIndexPf2> were expected but found " + itr.next());
         }
-        int indxs = observer.indexesUsed.size();
-        if (indxs != 2) {
-          fail("Both the idexes are not getting used.Only " + indxs + " index is getting used");
-        }
-        CacheUtils
-            .log("**************************************************Indexes Used :::::: " + indxs);
-
-        Iterator itr = observer.indexesUsed.iterator();
-        String temp;
-
-        while (itr.hasNext()) {
-          temp = itr.next().toString();
-
-          if (temp.equals("secIdIndexPf1")) {
-            break;
-          } else if (temp.equals("statusIndexPf2")) {
-            break;
-          } else {
-            fail("indices used do not match with those which are expected to be used"
-                + "<statusIndexPf1> and <statusIndexPf2> were expected but found " + itr.next());
-          }
-        }
-
-      } catch (Exception e) {
-        e.printStackTrace();
       }
     }
     // Verify the Query Results
     StructSetOrResultsSet ssORrs = new StructSetOrResultsSet();
     ssORrs.CompareQueryResultsWithoutAndWithIndexes(r, queries.length, queries);
-  }// end of test4
+  }
 
   @Test
   public void testMultiIteratorsMultiRegion5() throws Exception {
     Object r[][] = new Object[4][2];
-    QueryService qs;
-    qs = CacheUtils.getQueryService();
+    QueryService qs = CacheUtils.getQueryService();
     Position.resetCounter();
     // Create Regions
     Region r1 = CacheUtils.createRegion("portfolio1", Portfolio.class);
@@ -452,20 +362,14 @@ public class IUMRMultiIndexesMultiRegionJUnitTest {
     }
     String queries[] = {
         // Test case IUMR025
-        // Three of the idexes must get used.. Presently only one Index is being used.
+        // Three of the indexes must get used.. Presently only one Index is being used.
         "SELECT DISTINCT * FROM /portfolio1 pf1, /portfolio2 pf2, /employees e1 WHERE pf1.status = 'active' AND pf2.status = 'active' AND e1.empId < 10"};
     // Execute Queries without Indexes
     for (int i = 0; i < queries.length; i++) {
-      Query q = null;
-      try {
-        q = CacheUtils.getQueryService().newQuery(queries[i]);
-        CacheUtils.getLogger().info("Executing query: " + queries[i]);
-        QueryObserverImpl observer = new QueryObserverImpl();
-        QueryObserverHolder.setInstance(observer);
-        r[i][0] = q.execute();
-      } catch (Exception e) {
-        e.printStackTrace();
-      }
+      Query q = CacheUtils.getQueryService().newQuery(queries[i]);
+      QueryObserverImpl observer = new QueryObserverImpl();
+      QueryObserverHolder.setInstance(observer);
+      r[i][0] = q.execute();
     }
     // Create Indexes and Execute the Queries
     qs.createIndex("statusIndexPf1", IndexType.FUNCTIONAL, "pf1.status", "/portfolio1 pf1");
@@ -473,57 +377,46 @@ public class IUMRMultiIndexesMultiRegionJUnitTest {
     qs.createIndex("empIdIndex", IndexType.FUNCTIONAL, "empId", "/employees");
 
     for (int i = 0; i < queries.length; i++) {
-      Query q = null;
-      try {
-        q = CacheUtils.getQueryService().newQuery(queries[i]);
-        CacheUtils.getLogger().info("Executing query: " + queries[i]);
-        QueryObserverImpl observer = new QueryObserverImpl();
-        QueryObserverHolder.setInstance(observer);
-        r[i][1] = q.execute();
-        if (!observer.isIndexesUsed) {
-          fail("Index is NOT uesd");
+      Query q = CacheUtils.getQueryService().newQuery(queries[i]);
+      QueryObserverImpl observer = new QueryObserverImpl();
+      QueryObserverHolder.setInstance(observer);
+      r[i][1] = q.execute();
+      if (!observer.isIndexesUsed) {
+        fail("Index is NOT uesd");
+      }
+      int indxs = observer.indexesUsed.size();
+      if (indxs != 3) {
+        fail("Three of the idexes are not getting used. Only " + indxs + " index is getting used");
+      }
+
+      Iterator itr = observer.indexesUsed.iterator();
+      String temp;
+
+      while (itr.hasNext()) {
+        temp = itr.next().toString();
+
+        if (temp.equals("statusIndexPf1")) {
+          break;
+        } else if (temp.equals("statusIndexPf2")) {
+          break;
+        } else if (temp.equals("empIdIndex")) {
+          break;
+        } else {
+          fail("indices used do not match with those which are expected to be used"
+              + "<statusIndexPf1>, <statusIndexPf2> and <empIdIndex> were expected but found "
+              + itr.next());
         }
-        int indxs = observer.indexesUsed.size();
-        if (indxs != 3) {
-          fail(
-              "Three of the idexes are not getting used. Only " + indxs + " index is getting used");
-        }
-        CacheUtils
-            .log("**************************************************Indexes Used :::::: " + indxs);
-
-        Iterator itr = observer.indexesUsed.iterator();
-        String temp;
-
-        while (itr.hasNext()) {
-          temp = itr.next().toString();
-
-          if (temp.equals("statusIndexPf1")) {
-            break;
-          } else if (temp.equals("statusIndexPf2")) {
-            break;
-          } else if (temp.equals("empIdIndex")) {
-            break;
-          } else {
-            fail("indices used do not match with those which are expected to be used"
-                + "<statusIndexPf1>, <statusIndexPf2> and <empIdIndex> were expected but found "
-                + itr.next());
-          }
-        }
-
-      } catch (Exception e) {
-        e.printStackTrace();
       }
     }
     // Verify the Query Results
     StructSetOrResultsSet ssORrs = new StructSetOrResultsSet();
     ssORrs.CompareQueryResultsWithoutAndWithIndexes(r, queries.length, queries);
-  }// end of test5
+  }
 
   @Test
   public void testMultiIteratorsMultiRegion6() throws Exception {
     Object r[][] = new Object[4][2];
-    QueryService qs;
-    qs = CacheUtils.getQueryService();
+    QueryService qs = CacheUtils.getQueryService();
     Position.resetCounter();
     // Create Regions
     Region r1 = CacheUtils.createRegion("portfolio1", Portfolio.class);
@@ -544,14 +437,8 @@ public class IUMRMultiIndexesMultiRegionJUnitTest {
             + " WHERE posit1.secId='IBM' AND posit2.secId='IBM'",};
     // Execute Queries Without Indexes
     for (int i = 0; i < queries.length; i++) {
-      Query q = null;
-      try {
-        q = CacheUtils.getQueryService().newQuery(queries[i]);
-        CacheUtils.getLogger().info("Executing query: " + queries[i]);
-        r[i][0] = q.execute();
-      } catch (Exception e) {
-        e.printStackTrace();
-      }
+      Query q = CacheUtils.getQueryService().newQuery(queries[i]);
+      r[i][0] = q.execute();
     }
     // Create Indexes and Execute the Queries
     qs.createIndex("secIdIndexPf1", IndexType.FUNCTIONAL, "pos11.secId",
@@ -560,54 +447,43 @@ public class IUMRMultiIndexesMultiRegionJUnitTest {
         "/portfolio2 pf2, pf2.positions.values pos22");
 
     for (int i = 0; i < queries.length; i++) {
-      Query q = null;
-      try {
-        q = CacheUtils.getQueryService().newQuery(queries[i]);
-        CacheUtils.getLogger().info("Executing query: " + queries[i]);
-        QueryObserverImpl observer = new QueryObserverImpl();
-        QueryObserverHolder.setInstance(observer);
-        r[i][1] = q.execute();
-        if (!observer.isIndexesUsed) {
-          fail("Index is NOT uesd");
+      Query q = CacheUtils.getQueryService().newQuery(queries[i]);
+      QueryObserverImpl observer = new QueryObserverImpl();
+      QueryObserverHolder.setInstance(observer);
+      r[i][1] = q.execute();
+      if (!observer.isIndexesUsed) {
+        fail("Index is NOT uesd");
+      }
+      int indxs = observer.indexesUsed.size();
+      if (indxs != 2) {
+        fail("Both the idexes are not getting used.Only " + indxs + " index is getting used");
+      }
+
+      Iterator itr = observer.indexesUsed.iterator();
+      String temp;
+
+      while (itr.hasNext()) {
+        temp = itr.next().toString();
+
+        if (temp.equals("secIdIndexPf1")) {
+          break;
+        } else if (temp.equals("secIdIndexPf2")) {
+          break;
+        } else {
+          fail("indices used do not match with those which are expected to be used"
+              + "<secIdIndexPf1> and <secIdIndexPf2> were expected but found " + itr.next());
         }
-        int indxs = observer.indexesUsed.size();
-        if (indxs != 2) {
-          fail("Both the idexes are not getting used.Only " + indxs + " index is getting used");
-        }
-        CacheUtils
-            .log("**************************************************Indexes Used :::::: " + indxs);
-
-        Iterator itr = observer.indexesUsed.iterator();
-        String temp;
-
-        while (itr.hasNext()) {
-          temp = itr.next().toString();
-
-          if (temp.equals("secIdIndexPf1")) {
-            break;
-          } else if (temp.equals("secIdIndexPf2")) {
-            break;
-          } else {
-            fail("indices used do not match with those which are expected to be used"
-                + "<secIdIndexPf1> and <secIdIndexPf2> were expected but found " + itr.next());
-          }
-        }
-
-      } catch (Exception e) {
-        e.printStackTrace();
       }
     }
     // Verify the Query Results
     StructSetOrResultsSet ssORrs = new StructSetOrResultsSet();
     ssORrs.CompareQueryResultsWithoutAndWithIndexes(r, queries.length, queries);
-  }// end of test6
+  }
 
   @Test
   public void testMultiIteratorsMultiRegion7() throws Exception {
-
     Object r[][] = new Object[4][2];
-    QueryService qs;
-    qs = CacheUtils.getQueryService();
+    QueryService qs = CacheUtils.getQueryService();
     Position.resetCounter();
     // Create Regions
     Region r1 = CacheUtils.createRegion("portfolio1", Portfolio.class);
@@ -623,19 +499,11 @@ public class IUMRMultiIndexesMultiRegionJUnitTest {
         // Task IUMR007
         "SELECT DISTINCT coll1 as collHldrMap1 , coll2 as CollHldrMap2 FROM /portfolio1 pf1, /portfolio2 pf2, pf1.positions.values posit1,pf2.positions.values posit2,"
             + "pf1.collectionHolderMap.values coll1, pf2.collectionHolderMap.values coll2 "
-            + "WHERE posit1.secId='IBM' OR posit2.secId='IBM'",
-
-    };
+            + "WHERE posit1.secId='IBM' OR posit2.secId='IBM'",};
     // Execute Queries Without Indexes
     for (int i = 0; i < queries.length; i++) {
-      Query q = null;
-      try {
-        q = CacheUtils.getQueryService().newQuery(queries[i]);
-        CacheUtils.getLogger().info("Executing query: " + queries[i]);
-        r[i][0] = q.execute();
-      } catch (Exception e) {
-        e.printStackTrace();
-      }
+      Query q = CacheUtils.getQueryService().newQuery(queries[i]);
+      r[i][0] = q.execute();
     }
     // Create Indexes and Execute the Queries
     qs.createIndex("secIdIndexPf1", IndexType.FUNCTIONAL, "pos11.secId",
@@ -644,53 +512,43 @@ public class IUMRMultiIndexesMultiRegionJUnitTest {
         "/portfolio2 pf2, pf2.collectionHolderMap.values coll2, pf2.positions.values pos22");
 
     for (int i = 0; i < queries.length; i++) {
-      Query q = null;
-      try {
-        q = CacheUtils.getQueryService().newQuery(queries[i]);
-        CacheUtils.getLogger().info("Executing query: " + queries[i]);
-        QueryObserverImpl observer = new QueryObserverImpl();
-        QueryObserverHolder.setInstance(observer);
-        r[i][1] = q.execute();
-        if (!observer.isIndexesUsed) {
-          fail("Index is NOT uesd");
+      Query q = CacheUtils.getQueryService().newQuery(queries[i]);
+      QueryObserverImpl observer = new QueryObserverImpl();
+      QueryObserverHolder.setInstance(observer);
+      r[i][1] = q.execute();
+      if (!observer.isIndexesUsed) {
+        fail("Index is NOT uesd");
+      }
+      int indxs = observer.indexesUsed.size();
+      if (indxs != 2) {
+        fail("Both the idexes are not getting used.Only " + indxs + " index is getting used");
+      }
+
+      Iterator itr = observer.indexesUsed.iterator();
+      String temp;
+
+      while (itr.hasNext()) {
+        temp = itr.next().toString();
+
+        if (temp.equals("secIdIndexPf1")) {
+          break;
+        } else if (temp.equals("secIdIndexPf2")) {
+          break;
+        } else {
+          fail("indices used do not match with those which are expected to be used"
+              + "<secIdIndexPf1> and <secIdIndexPf2> were expected but found " + itr.next());
         }
-        int indxs = observer.indexesUsed.size();
-        if (indxs != 2) {
-          fail("Both the idexes are not getting used.Only " + indxs + " index is getting used");
-        }
-        CacheUtils
-            .log("**************************************************Indexes Used :::::: " + indxs);
-
-        Iterator itr = observer.indexesUsed.iterator();
-        String temp;
-
-        while (itr.hasNext()) {
-          temp = itr.next().toString();
-
-          if (temp.equals("secIdIndexPf1")) {
-            break;
-          } else if (temp.equals("secIdIndexPf2")) {
-            break;
-          } else {
-            fail("indices used do not match with those which are expected to be used"
-                + "<secIdIndexPf1> and <secIdIndexPf2> were expected but found " + itr.next());
-          }
-        }
-
-      } catch (Exception e) {
-        e.printStackTrace();
       }
     }
     // Verify the Query Results
     StructSetOrResultsSet ssORrs = new StructSetOrResultsSet();
     ssORrs.CompareQueryResultsWithoutAndWithIndexes(r, queries.length, queries);
-  }// end of test7
+  }
 
   @Test
   public void testMultiIteratorsMultiRegion8() throws Exception {
     Object r[][] = new Object[4][2];
-    QueryService qs;
-    qs = CacheUtils.getQueryService();
+    QueryService qs = CacheUtils.getQueryService();
     Position.resetCounter();
     // Create Regions
     Region r1 = CacheUtils.createRegion("portfolio1", Portfolio.class);
@@ -715,15 +573,8 @@ public class IUMRMultiIndexesMultiRegionJUnitTest {
         "SELECT DISTINCT * FROM /portfolio1 pf1, pf1.positions.values posit1, /portfolio2 pf2, /employees e WHERE posit1.secId='IBM'"};
     // Execute Queries without Indexes
     for (int i = 0; i < queries.length; i++) {
-      Query q = null;
-      try {
-        q = CacheUtils.getQueryService().newQuery(queries[i]);
-        CacheUtils.getLogger().info("Executing query: " + queries[i]);
-        r[i][0] = q.execute();
-      } catch (Exception e) {
-        e.printStackTrace();
-        fail(q.getQueryString());
-      }
+      Query q = CacheUtils.getQueryService().newQuery(queries[i]);
+      r[i][0] = q.execute();
     }
     // Create Indexes
     qs.createIndex("statusIndexPf1", IndexType.FUNCTIONAL, "status", "/portfolio1");
@@ -732,39 +583,29 @@ public class IUMRMultiIndexesMultiRegionJUnitTest {
 
     // Execute Queries with Indexes
     for (int i = 0; i < queries.length; i++) {
-      Query q = null;
-      try {
-        q = CacheUtils.getQueryService().newQuery(queries[i]);
-        CacheUtils.getLogger().info("Executing query: " + queries[i]);
-        QueryObserverImpl observer = new QueryObserverImpl();
-        QueryObserverHolder.setInstance(observer);
-        r[i][1] = q.execute();
-        if (!observer.isIndexesUsed) {
-          fail("Index is NOT uesd");
-        }
-
-        Iterator itr = observer.indexesUsed.iterator();
-        assertEquals("secIdIndexPf1", itr.next().toString());
-
-        int indxs = observer.indexesUsed.size();
-        CacheUtils.log("**************************************************Indexes Used :::::: "
-            + indxs + " Index Name: " + observer.indexName);
-      } catch (Exception e) {
-        e.printStackTrace();
-        fail(q.getQueryString());
+      Query q = CacheUtils.getQueryService().newQuery(queries[i]);
+      QueryObserverImpl observer = new QueryObserverImpl();
+      QueryObserverHolder.setInstance(observer);
+      r[i][1] = q.execute();
+      if (!observer.isIndexesUsed) {
+        fail("Index is NOT uesd");
       }
+
+      Iterator itr = observer.indexesUsed.iterator();
+      assertEquals("secIdIndexPf1", itr.next().toString());
+
+      assertThat(observer.indexesUsed.size()).isGreaterThan(0);
     }
     StructSetOrResultsSet ssOrrs = new StructSetOrResultsSet();
     ssOrrs.CompareQueryResultsWithoutAndWithIndexes(r, queries.length, queries);
-  }// end of test8
+  }
 
   @Test
   public void testBasicCompositeIndexUsage() throws Exception {
     try {
       IndexManager.TEST_RANGEINDEX_ONLY = true;
 
-      QueryService qs;
-      qs = CacheUtils.getQueryService();
+      QueryService qs = CacheUtils.getQueryService();
       Position.resetCounter();
       // Create Regions
       Region r1 = CacheUtils.createRegion("portfolio", Portfolio.class);
@@ -780,8 +621,6 @@ public class IUMRMultiIndexesMultiRegionJUnitTest {
         r2.put(i + "", new Employee("empName", (20 + i), i /* empId */, "Mr.", (5000 + i), add1));
       }
 
-
-
       String queriesWithResCount[][] = {
           // Test case No. IUMR021
           {"SELECT DISTINCT * FROM /portfolio pf, /employee emp WHERE pf.ID = emp.empId",
@@ -791,7 +630,7 @@ public class IUMRMultiIndexesMultiRegionJUnitTest {
               "" + 1000},
           /*
            * Following query returns more (999001) than expected (1000) results as pf.ID > 0
-           * conditions is evalusted first for all Portfolio and Employee objects (999 * 1000) and
+           * conditions is evaluated first for all Portfolio and Employee objects (999 * 1000) and
            * then other condition with AND is executed for pf.ID = 0 and pf.status = ''active' and
            * pf.ID = emp.ID. So total results are 999001.
            *
@@ -803,37 +642,18 @@ public class IUMRMultiIndexesMultiRegionJUnitTest {
           {"SELECT * FROM /portfolio pf, /employee emp WHERE pf.ID = emp.empId AND (pf.status='active' OR pf.ID > 499)",
               "" + 750},
           {"SELECT pf.status, emp.empId, pf.getType() FROM /portfolio pf, /employee emp WHERE pf.ID = emp.empId AND (pf.status='active' OR pf.ID > 499)",
-              "" + 750},
-          // "SELECT DISTINCT * FROM /portfolio1 pf1, pf1.positions.values posit1, /portfolio2 pf2,
-          // /employees e WHERE posit1.secId='IBM'"
-
-      };
+              "" + 750},};
 
       String queries[] = new String[queriesWithResCount.length];
       Object r[][] = new Object[queries.length][2];
 
       // Execute Queries without Indexes
-      long t1 = -1;
-      long t2 = -1;
       for (int i = 0; i < queries.length; i++) {
-        Query q = null;
-        try {
-          queries[i] = queriesWithResCount[i][0];
-          q = CacheUtils.getQueryService().newQuery(queries[i]);
-          CacheUtils.getLogger().info("Executing query: " + queries[i]);
-          t1 = System.currentTimeMillis();
-          r[i][0] = q.execute();
-          assertTrue(r[i][0] instanceof SelectResults);
-          assertEquals(Integer.parseInt(queriesWithResCount[i][1]),
-              ((SelectResults) r[i][0]).size());
-          t2 = System.currentTimeMillis();
-          float x = (t2 - t1) / 1000f;
-          CacheUtils.log(
-              "Executing query: " + queries[i] + " without index. Time taken is " + x + "seconds");
-        } catch (Exception e) {
-          e.printStackTrace();
-          fail(q.getQueryString());
-        }
+        queries[i] = queriesWithResCount[i][0];
+        Query q = CacheUtils.getQueryService().newQuery(queries[i]);
+        r[i][0] = q.execute();
+        assertTrue(r[i][0] instanceof SelectResults);
+        assertEquals(Integer.parseInt(queriesWithResCount[i][1]), ((SelectResults) r[i][0]).size());
       }
       // Create Indexes
       qs.createIndex("idIndexPf", IndexType.FUNCTIONAL, "ID", "/portfolio");
@@ -842,67 +662,44 @@ public class IUMRMultiIndexesMultiRegionJUnitTest {
 
       // Execute Queries with Indexes
       for (int i = 0; i < queries.length; i++) {
-        Query q = null;
-        try {
-          q = CacheUtils.getQueryService().newQuery(queries[i]);
-          CacheUtils.getLogger().info("Executing query: " + queries[i]);
-          QueryObserverImpl observer = new QueryObserverImpl();
-          QueryObserverHolder.setInstance(observer);
-          t1 = System.currentTimeMillis();
-          r[i][1] = q.execute();
-          assertTrue(r[i][0] instanceof SelectResults);
-          assertEquals(Integer.parseInt(queriesWithResCount[i][1]),
-              ((SelectResults) r[i][0]).size());
-          t2 = System.currentTimeMillis();
-          float x = (t2 - t1) / 1000f;
-          CacheUtils.log("Executing query: " + queries[i] + " with index created. Time taken is "
-              + x + "seconds");
-          if (!observer.isIndexesUsed && i != 3 /* For join query without parenthesis */) {
-            fail("Index is NOT uesd for query" + queries[i]);
-          }
+        Query q = CacheUtils.getQueryService().newQuery(queries[i]);
+        QueryObserverImpl observer = new QueryObserverImpl();
+        QueryObserverHolder.setInstance(observer);
+        r[i][1] = q.execute();
+        assertTrue(r[i][0] instanceof SelectResults);
+        assertEquals(Integer.parseInt(queriesWithResCount[i][1]), ((SelectResults) r[i][0]).size());
+        if (!observer.isIndexesUsed && i != 3 /* For join query without parenthesis */) {
+          fail("Index is NOT used for query" + queries[i]);
+        }
 
-          Iterator itr = observer.indexesUsed.iterator();
-          while (itr.hasNext()) {
-            String temp = itr.next().toString();
-            if (!(temp.equals("idIndexPf") || temp.equals("empIdIndexPf2")
-                || temp.equals("statusIndexPf"))) {
-              fail("<idIndexPf> or <empIdIndexPf2>    was expected but found " + temp.toString());
-            }
-            // assertIndexDetailsEquals("statusIndexPf1",itr.next().toString());
+        Iterator itr = observer.indexesUsed.iterator();
+        while (itr.hasNext()) {
+          String temp = itr.next().toString();
+          if (!(temp.equals("idIndexPf") || temp.equals("empIdIndexPf2")
+              || temp.equals("statusIndexPf"))) {
+            fail("<idIndexPf> or <empIdIndexPf2>    was expected but found " + temp.toString());
           }
+        }
 
-          if (i != 3 /* For join query without parenthesis */) {
-            int indxs = observer.indexesUsed.size();
-            assertTrue("Indexes used is not of size >= 2", indxs >= 2);
-            CacheUtils.log("**************************************************Indexes Used :::::: "
-                + indxs + " Index Name: " + observer.indexName);
-          }
-
-        } catch (Exception e) {
-          e.printStackTrace();
-          fail(q.getQueryString());
+        if (i != 3 /* For join query without parenthesis */) {
+          int indxs = observer.indexesUsed.size();
+          assertTrue("Indexes used is not of size >= 2", indxs >= 2);
         }
       }
       StructSetOrResultsSet ssOrrs = new StructSetOrResultsSet();
       ssOrrs.CompareQueryResultsWithoutAndWithIndexes(r, queries.length, queries);
     } finally {
       IndexManager.TEST_RANGEINDEX_ONLY = false;
-
     }
-  }// end of test1
+  }
 
-
-  // !!!:ezoerner:20081031 disabled because it throws
-  // UnsupportedOperationException: Cannot do an equi-join between a region having a RangeIndex and
-  // a region having a CompactRangeIndex.
   @Test
   public void testBasicCompositeIndexUsageWithOneIndexExpansionAndTruncation() throws Exception {
     try {
       IndexManager.TEST_RANGEINDEX_ONLY = true;
 
       Object r[][] = new Object[1][2];
-      QueryService qs;
-      qs = CacheUtils.getQueryService();
+      QueryService qs = CacheUtils.getQueryService();
       Position.resetCounter();
       // Create Regions
       Region r1 = CacheUtils.createRegion("portfolio", Portfolio.class);
@@ -918,34 +715,13 @@ public class IUMRMultiIndexesMultiRegionJUnitTest {
         r2.put(i + "", new Employee("empName", (20 + i), i, "Mr.", (5000 + i), add1));
       }
 
-
-
       String queries[] = {
           // Test case No. IUMR021
-          "SELECT DISTINCT * FROM /portfolio pf, pf.positions pos, /employee emp WHERE pf.iD = emp.empId",
-          // "SELECT DISTINCT * FROM /portfolio1 pf1, pf1.positions.values posit1, /portfolio2 pf2,
-          // /employees e WHERE posit1.secId='IBM'"
-
-      };
+          "SELECT DISTINCT * FROM /portfolio pf, pf.positions pos, /employee emp WHERE pf.iD = emp.empId",};
       // Execute Queries without Indexes
-      long t1 = -1;
-      long t2 = -1;
       for (int i = 0; i < queries.length; i++) {
-        Query q = null;
-        try {
-          q = CacheUtils.getQueryService().newQuery(queries[i]);
-          CacheUtils.getLogger().info("Executing query: " + queries[i]);
-          t1 = System.currentTimeMillis();
-          r[i][0] = q.execute();
-          t2 = System.currentTimeMillis();
-          float x = (t2 - t1) / 1000f;
-
-          CacheUtils.log(
-              "Executing query: " + queries[i] + " without index. Time taken is " + x + "seconds");
-        } catch (Exception e) {
-          e.printStackTrace();
-          fail(q.getQueryString());
-        }
+        Query q = CacheUtils.getQueryService().newQuery(queries[i]);
+        r[i][0] = q.execute();
       }
       // Create Indexes
       qs.createIndex("idIndexPf", IndexType.FUNCTIONAL, "iD",
@@ -954,58 +730,38 @@ public class IUMRMultiIndexesMultiRegionJUnitTest {
 
       // Execute Queries with Indexes
       for (int i = 0; i < queries.length; i++) {
-        Query q = null;
-        try {
-          q = CacheUtils.getQueryService().newQuery(queries[i]);
-          CacheUtils.getLogger().info("Executing query: " + queries[i]);
-          QueryObserverImpl observer = new QueryObserverImpl();
-          QueryObserverHolder.setInstance(observer);
-          t1 = System.currentTimeMillis();
-          r[i][1] = q.execute();
-          t2 = System.currentTimeMillis();
-          float x = (t2 - t1) / 1000f;
-          CacheUtils.log("Executing query: " + queries[i] + " with index created. Time taken is "
-              + x + " seconds");
-          if (!observer.isIndexesUsed) {
-            fail("Index is NOT uesd");
-          }
-
-          Iterator itr = observer.indexesUsed.iterator();
-          while (itr.hasNext()) {
-            String temp = itr.next().toString();
-            if (!(temp.equals("idIndexPf") || temp.equals("empIdIndexPf2"))) {
-              fail("<idIndexPf> or <empIdIndexPf2>    was expected but found " + temp.toString());
-            }
-            // assertIndexDetailsEquals("statusIndexPf1",itr.next().toString());
-          }
-
-          int indxs = observer.indexesUsed.size();
-          assertTrue("Indexes used is not of size = 2", indxs == 2);
-          CacheUtils.log("**************************************************Indexes Used :::::: "
-              + indxs + " Index Name: " + observer.indexName);
-
-        } catch (Exception e) {
-          e.printStackTrace();
-          fail(q.getQueryString());
+        Query q = CacheUtils.getQueryService().newQuery(queries[i]);
+        QueryObserverImpl observer = new QueryObserverImpl();
+        QueryObserverHolder.setInstance(observer);
+        r[i][1] = q.execute();
+        if (!observer.isIndexesUsed) {
+          fail("Index is NOT uesd");
         }
+
+        Iterator itr = observer.indexesUsed.iterator();
+        while (itr.hasNext()) {
+          String temp = itr.next().toString();
+          if (!(temp.equals("idIndexPf") || temp.equals("empIdIndexPf2"))) {
+            fail("<idIndexPf> or <empIdIndexPf2>    was expected but found " + temp.toString());
+          }
+        }
+
+        int indxs = observer.indexesUsed.size();
+        assertTrue("Indexes used is not of size = 2", indxs == 2);
       }
       StructSetOrResultsSet ssOrrs = new StructSetOrResultsSet();
       ssOrrs.CompareQueryResultsWithoutAndWithIndexes(r, queries.length, queries);
     } finally {
       IndexManager.TEST_RANGEINDEX_ONLY = false;
-
     }
-  }// end of test1
+  }
 
-  // Asif: Equijoin between range index & compact index is not supported so
-  // allowing the test to run with Range index only
   @Test
   public void testBasicCompositeIndexUsageWithMultipleIndexes() throws Exception {
     try {
       IndexManager.TEST_RANGEINDEX_ONLY = true;
       Object r[][] = new Object[1][2];
-      QueryService qs;
-      qs = CacheUtils.getQueryService();
+      QueryService qs = CacheUtils.getQueryService();
       Position.resetCounter();
       // Create Regions
       Region r1 = CacheUtils.createRegion("portfolio", Portfolio.class);
@@ -1023,106 +779,63 @@ public class IUMRMultiIndexesMultiRegionJUnitTest {
 
       String queries[] = {
           // Test case No. IUMR021
-          "SELECT DISTINCT * FROM /portfolio pf, pf.positions pos, /employee emp WHERE pf.iD = emp.empId and pf.status='active' and emp.age > 900",
-          // "SELECT DISTINCT * FROM /portfolio1 pf1, pf1.positions.values posit1, /portfolio2 pf2,
-          // /employees e WHERE posit1.secId='IBM'"
-
-      };
+          "SELECT DISTINCT * FROM /portfolio pf, pf.positions pos, /employee emp WHERE pf.iD = emp.empId and pf.status='active' and emp.age > 900",};
       // Execute Queries without Indexes
-      long t1 = -1;
-      long t2 = -1;
       for (int i = 0; i < queries.length; i++) {
-        Query q = null;
-        try {
-          q = CacheUtils.getQueryService().newQuery(queries[i]);
-          CacheUtils.getLogger().info("Executing query: " + queries[i]);
-          t1 = System.currentTimeMillis();
-          r[i][0] = q.execute();
-          t2 = System.currentTimeMillis();
-          float x = (t2 - t1) / 1000f;
-
-          CacheUtils.log(
-              "Executing query: " + queries[i] + " without index. Time taken is " + x + "seconds");
-        } catch (Exception e) {
-          e.printStackTrace();
-          fail(q.getQueryString());
-        }
+        Query q = CacheUtils.getQueryService().newQuery(queries[i]);
+        r[i][0] = q.execute();
       }
       // Create Indexes
       qs.createIndex("idIndexPf", IndexType.FUNCTIONAL, "iD",
           "/portfolio pf , pf.collectionHolderMap");
       qs.createIndex("empIdIndexPf2", IndexType.FUNCTIONAL, "empId", "/employee");
-      // qs.createIndex("statusIndexPf2",IndexType.FUNCTIONAL,"status","/portfolio pf ,
-      // pf.positions");
       qs.createIndex("ageIndexemp", IndexType.FUNCTIONAL, "age", "/employee emp ");
       // Execute Queries with Indexes
       for (int i = 0; i < queries.length; i++) {
-        Query q = null;
-        try {
-          q = CacheUtils.getQueryService().newQuery(queries[i]);
-          CacheUtils.getLogger().info("Executing query: " + queries[i]);
-          QueryObserverImpl observer = new QueryObserverImpl();
-          QueryObserverHolder.setInstance(observer);
-          t1 = System.currentTimeMillis();
-          r[i][1] = q.execute();
-          t2 = System.currentTimeMillis();
-          float x = (t2 - t1) / 1000f;
-          CacheUtils.log("Executing query: " + queries[i] + " with index created. Time taken is "
-              + x + " seconds");
-          if (!observer.isIndexesUsed) {
-            fail("Index is NOT uesd");
-          }
-
-          Iterator itr = observer.indexesUsed.iterator();
-          while (itr.hasNext()) {
-            String temp = itr.next().toString();
-            if (!(temp.equals("ageIndexemp") || temp.equals("idIndexPf")
-                || temp.equals("empIdIndexPf2") || temp.equals("statusIndexPf2"))) {
-              fail("<idIndexPf> or <empIdIndexPf2>    was expected but found " + temp.toString());
-            }
-            // assertIndexDetailsEquals("statusIndexPf1",itr.next().toString());
-          }
-
-          int indxs = observer.indexesUsed.size();
-          assertTrue("Indexes used is not of size = 3", indxs == 3);
-          System.out
-              .println("**************************************************Indexes Used :::::: "
-                  + indxs + " Index Name: " + observer.indexName);
-
-        } catch (Exception e) {
-          e.printStackTrace();
-          fail(q.getQueryString());
+        Query q = CacheUtils.getQueryService().newQuery(queries[i]);
+        QueryObserverImpl observer = new QueryObserverImpl();
+        QueryObserverHolder.setInstance(observer);
+        r[i][1] = q.execute();
+        if (!observer.isIndexesUsed) {
+          fail("Index is NOT uesd");
         }
+
+        Iterator itr = observer.indexesUsed.iterator();
+        while (itr.hasNext()) {
+          String temp = itr.next().toString();
+          if (!(temp.equals("ageIndexemp") || temp.equals("idIndexPf")
+              || temp.equals("empIdIndexPf2") || temp.equals("statusIndexPf2"))) {
+            fail("<idIndexPf> or <empIdIndexPf2>    was expected but found " + temp.toString());
+          }
+        }
+
+        int indxs = observer.indexesUsed.size();
+        assertTrue("Indexes used is not of size = 3", indxs == 3);
       }
       StructSetOrResultsSet ssOrrs = new StructSetOrResultsSet();
       ssOrrs.CompareQueryResultsWithoutAndWithIndexes(r, queries.length, queries);
     } finally {
       IndexManager.TEST_RANGEINDEX_ONLY = false;
     }
-  }// end of test1
+  }
 
-  // !!!:ezoerner:20081031 disabled because it throws
-  // UnsupportedOperationException: Cannot do an equi-join between a region having a RangeIndex and
-  // a region having a CompactRangeIndex.
   @Test
-  public void testAssertionBug() {
+  public void testAssertionBug() throws Exception {
     try {
       IndexManager.TEST_RANGEINDEX_ONLY = true;
       Region region1 = CacheUtils.createRegion("Quotes1", Quote.class);
       Region region2 = CacheUtils.createRegion("Quotes2", Quote.class);
       Region region3 = CacheUtils.createRegion("Restricted1", Restricted.class);
       for (int i = 0; i < 10; i++) {
-        region1.put(new Integer(i), new Quote(i));
-        region2.put(new Integer(i), new Quote(i));
-        region3.put(new Integer(i), new Restricted(i));
+        region1.put(i, new Quote(i));
+        region2.put(i, new Quote(i));
+        region3.put(i, new Restricted(i));
       }
       QueryService qs = CacheUtils.getQueryService();
       ////////// creating indexes on region Quotes1
       qs.createIndex("Quotes1Region-quoteIdStrIndex", IndexType.PRIMARY_KEY, "q.quoteIdStr",
           "/Quotes1 q");
 
-      // qs.createIndex("Quotes1Region-cusipIndex1", IndexType.FUNCTIONAL, "q.cusip", "/Quotes1 q,
-      // q.restrict r");
       qs.createIndex("Quotes1Region-quoteTypeIndex", IndexType.FUNCTIONAL, "q.quoteType",
           "/Quotes1 q, q.restrict r");
 
@@ -1151,8 +864,6 @@ public class IUMRMultiIndexesMultiRegionJUnitTest {
       qs.createIndex("Quotes2Region-quoteIdStrIndex", IndexType.PRIMARY_KEY, "q.quoteIdStr",
           "/Quotes2 q");
 
-      // qs.createIndex("Quotes1Region-cusipIndex2", IndexType.FUNCTIONAL, "q.cusip", "/Quotes2 q,
-      // q.restrict r");
       qs.createIndex("Quotes2Region-quoteTypeIndex", IndexType.FUNCTIONAL, "q.quoteType",
           "/Quotes2 q, q.restrict r");
 
@@ -1178,8 +889,6 @@ public class IUMRMultiIndexesMultiRegionJUnitTest {
           "/Quotes2 q, q.restrict r");
 
       ////////// creating indexes on region Restricted1
-      // qs.createIndex("RestrictedRegion-cusip", IndexType.FUNCTIONAL, "r.cusip", "/Restricted1
-      ////////// r");
 
       qs.createIndex("RestrictedRegion-quoteTypeIndex", IndexType.FUNCTIONAL, "r.quoteType",
           "/Restricted1 r");
@@ -1190,26 +899,18 @@ public class IUMRMultiIndexesMultiRegionJUnitTest {
       Query q = qs.newQuery(
           "SELECT DISTINCT  q.cusip, q.quoteType, q.dealerPortfolio, q.channelName, q.dealerCode, q.priceType, q.price, q.lowerQty, q.upperQty, q.ytm, r.minQty, r.maxQty, r.incQty FROM /Quotes1 q, /Restricted1 r WHERE q.cusip = r.cusip AND q.quoteType = r.quoteType");
       q.execute();
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Test failed bcoz of exception " + e);
     } finally {
       IndexManager.TEST_RANGEINDEX_ONLY = false;
     }
   }
 
-
-  // !!!:ezoerner:20081031 disabled because it throws
-  // UnsupportedOperationException: Cannot do an equi-join between a region having a RangeIndex and
-  // a region having a CompactRangeIndex.
   @Test
   public void testBasicCompositeIndexUsageInAllGroupJunction() throws Exception {
     try {
       IndexManager.TEST_RANGEINDEX_ONLY = true;
 
       Object r[][] = new Object[1][2];
-      QueryService qs;
-      qs = CacheUtils.getQueryService();
+      QueryService qs = CacheUtils.getQueryService();
       Position.resetCounter();
       // Create Regions
       Region r1 = CacheUtils.createRegion("portfolio", Portfolio.class);
@@ -1230,34 +931,13 @@ public class IUMRMultiIndexesMultiRegionJUnitTest {
         r2.put(i + "", new Employee("empName", (20 + i), i, "Mr.", (5000 + i), add1));
       }
 
-
-
       String queries[] = {
           // Test case No. IUMR021
-          "SELECT DISTINCT * FROM /portfolio pf, pf.positions pos, /portfolio3 pf3, /employee emp WHERE pf.iD = emp.empId and pf.status='active' and emp.age > 50 and pf3.status='active'",
-          // "SELECT DISTINCT * FROM /portfolio1 pf1, pf1.positions.values posit1, /portfolio2 pf2,
-          // /employees e WHERE posit1.secId='IBM'"
-
-      };
+          "SELECT DISTINCT * FROM /portfolio pf, pf.positions pos, /portfolio3 pf3, /employee emp WHERE pf.iD = emp.empId and pf.status='active' and emp.age > 50 and pf3.status='active'",};
       // Execute Queries without Indexes
-      long t1 = -1;
-      long t2 = -1;
       for (int i = 0; i < queries.length; i++) {
-        Query q = null;
-        try {
-          q = CacheUtils.getQueryService().newQuery(queries[i]);
-          CacheUtils.getLogger().info("Executing query: " + queries[i]);
-          t1 = System.currentTimeMillis();
-          r[i][0] = q.execute();
-          t2 = System.currentTimeMillis();
-          float x = (t2 - t1) / 1000f;
-
-          CacheUtils.log(
-              "Executing query: " + queries[i] + " without index. Time taken is " + x + "seconds");
-        } catch (Exception e) {
-          e.printStackTrace();
-          fail(q.getQueryString());
-        }
+        Query q = CacheUtils.getQueryService().newQuery(queries[i]);
+        r[i][0] = q.execute();
       }
       // Create Indexes
       qs.createIndex("idIndexPf", IndexType.FUNCTIONAL, "iD",
@@ -1267,66 +947,49 @@ public class IUMRMultiIndexesMultiRegionJUnitTest {
       qs.createIndex("ageIndexemp", IndexType.FUNCTIONAL, "age", "/employee emp ");
       // Execute Queries with Indexes
       for (int i = 0; i < queries.length; i++) {
-        Query q = null;
-        try {
-          q = CacheUtils.getQueryService().newQuery(queries[i]);
-          CacheUtils.getLogger().info("Executing query: " + queries[i]);
-          QueryObserverImpl observer = new QueryObserverImpl();
-          QueryObserverHolder.setInstance(observer);
-          t1 = System.currentTimeMillis();
-          r[i][1] = q.execute();
-          t2 = System.currentTimeMillis();
-          float x = (t2 - t1) / 1000f;
-          CacheUtils.log("Executing query: " + queries[i] + " with index created. Time taken is "
-              + x + " seconds");
-          if (!observer.isIndexesUsed) {
-            fail("Index is NOT uesd");
-          }
-
-          Iterator itr = observer.indexesUsed.iterator();
-          while (itr.hasNext()) {
-            String temp = itr.next().toString();
-            if (!(temp.equals("ageIndexemp") || temp.equals("idIndexPf")
-                || temp.equals("empIdIndexPf2") || temp.equals("statusIndexPf3"))) {
-              fail("<idIndexPf> or <empIdIndexPf2>    was expected but found " + temp.toString());
-            }
-            // assertIndexDetailsEquals("statusIndexPf1",itr.next().toString());
-          }
-
-          int indxs = observer.indexesUsed.size();
-          assertTrue("Indexes used is not of size = 4 but of size = " + indxs, indxs == 4);
-          CacheUtils.log("**************************************************Indexes Used :::::: "
-              + indxs + " Index Name: " + observer.indexName);
-
-        } catch (Exception e) {
-          e.printStackTrace();
-          fail(q.getQueryString());
+        Query q = CacheUtils.getQueryService().newQuery(queries[i]);
+        QueryObserverImpl observer = new QueryObserverImpl();
+        QueryObserverHolder.setInstance(observer);
+        r[i][1] = q.execute();
+        if (!observer.isIndexesUsed) {
+          fail("Index is NOT uesd");
         }
+
+        Iterator itr = observer.indexesUsed.iterator();
+        while (itr.hasNext()) {
+          String temp = itr.next().toString();
+          if (!(temp.equals("ageIndexemp") || temp.equals("idIndexPf")
+              || temp.equals("empIdIndexPf2") || temp.equals("statusIndexPf3"))) {
+            fail("<idIndexPf> or <empIdIndexPf2>    was expected but found " + temp.toString());
+          }
+        }
+
+        int indxs = observer.indexesUsed.size();
+        assertTrue("Indexes used is not of size = 4 but of size = " + indxs, indxs == 4);
       }
       StructSetOrResultsSet ssOrrs = new StructSetOrResultsSet();
       ssOrrs.CompareQueryResultsWithoutAndWithIndexes(r, queries.length, queries);
     } finally {
       IndexManager.TEST_RANGEINDEX_ONLY = false;
-
     }
-  }// end of test1
+  }
 
-  class QueryObserverImpl extends QueryObserverAdapter {
+  private static class QueryObserverImpl extends QueryObserverAdapter {
     boolean isIndexesUsed = false;
     ArrayList indexesUsed = new ArrayList();
     String indexName;
 
+    @Override
     public void beforeIndexLookup(Index index, int oper, Object key) {
       indexName = index.getName();
       indexesUsed.add(index.getName());
     }
 
+    @Override
     public void afterIndexLookup(Collection results) {
       if (results != null) {
         isIndexesUsed = true;
       }
     }
   }
-
-
-}// end of class
+}

--- a/geode-core/src/test/java/org/apache/geode/cache/query/functional/IUMRShuffleIteratorsJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/functional/IUMRShuffleIteratorsJUnitTest.java
@@ -12,19 +12,17 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-/*
- * IUMRShuffleIteratorsJUnitTest.java
- *
- * Created on September 27, 2005, 1:04 PM
- */
 package org.apache.geode.cache.query.functional;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
 
 import org.junit.After;
@@ -74,7 +72,7 @@ public class IUMRShuffleIteratorsJUnitTest {
     str.add(new Street("DPRoad", "lane5"));
     str.add(new Street("DPStreet1", "lane5"));
     for (int i = 0; i < 4; i++) {
-      r3.put(new Integer(i), new Address("411001", "Pune", str, ph));
+      r3.put(i, new Address("411001", "Pune", str, ph));
     }
   }
 
@@ -91,47 +89,39 @@ public class IUMRShuffleIteratorsJUnitTest {
         "Select distinct * from /portfolios pf,/employees e  where pf.status='active'"};
 
     for (int i = 0; i < queries.length; i++) {
-      Query q = null;
-      q = CacheUtils.getQueryService().newQuery(queries[i]);
-      CacheUtils.getLogger().info("Executing query: " + queries[i]);
+      Query q = CacheUtils.getQueryService().newQuery(queries[i]);
       QueryObserverImpl observer = new QueryObserverImpl();
       QueryObserverHolder.setInstance(observer);
       q.execute();
       if (observer.isIndexesUsed) {
-        fail("Index is uesd");
+        fail("Index is used");
       }
     }
-  }// end of test 1
+  }
 
   @Test
   public void testQueryWithIndexOnFirstReg2() throws Exception {
     Object r[][] = new Object[9][2];
-    QueryService qs;
-    qs = CacheUtils.getQueryService();
+    QueryService qs = CacheUtils.getQueryService();
 
     String queries[] =
         {"Select distinct * from /portfolios pf,/employees e  where pf.status='active'"};
 
     // Execute Queries without Indexes
     for (int i = 0; i < queries.length; i++) {
-      Query q = null;
-      q = CacheUtils.getQueryService().newQuery(queries[i]);
-      CacheUtils.getLogger().info("Executing query: " + queries[i]);
+      Query q = CacheUtils.getQueryService().newQuery(queries[i]);
       r[i][0] = q.execute();
     }
     // Create Index and Execute the Queries
     qs.createIndex("statusIndex", IndexType.FUNCTIONAL, "status", "/portfolios");
     for (int i = 0; i < queries.length; i++) {
-      Query q = null;
-      q = CacheUtils.getQueryService().newQuery(queries[i]);
-      CacheUtils.getLogger().info("Executing query: " + queries[i]);
+      Query q = CacheUtils.getQueryService().newQuery(queries[i]);
       QueryObserverImpl observer = new QueryObserverImpl();
       QueryObserverHolder.setInstance(observer);
       r[i][1] = q.execute();
       if (!observer.isIndexesUsed) {
-        fail("Index is NOT uesd");
+        fail("Index is NOT used");
       }
-      CacheUtils.log("*****************IndexUsed::" + observer.IndexName);
 
       Iterator itr = observer.indexesUsed.iterator();
       assertEquals("statusIndex", itr.next().toString());
@@ -139,52 +129,44 @@ public class IUMRShuffleIteratorsJUnitTest {
     // Verifying the query results
     StructSetOrResultsSet ssORrs = new StructSetOrResultsSet();
     ssORrs.CompareQueryResultsWithoutAndWithIndexes(r, queries.length, queries);
-  } // end of test2
+  }
 
   @Test
   public void testQueryWithIndexOnSecondReg3() throws Exception {
     Object r[][] = new Object[9][2];
-    QueryService qs;
-    qs = CacheUtils.getQueryService();
+    QueryService qs = CacheUtils.getQueryService();
     String queries[] = {
         // Test Case No. IUMR001
         "Select distinct * from /portfolios pf, /employees e  where e.name ='empName'",};
     // Execute Queries without Indexes
     for (int i = 0; i < queries.length; i++) {
-      Query q = null;
-      q = CacheUtils.getQueryService().newQuery(queries[i]);
-      CacheUtils.getLogger().info("Executing query: " + queries[i]);
+      Query q = CacheUtils.getQueryService().newQuery(queries[i]);
       r[i][0] = q.execute();
     }
     // Create Index andExecute the Queries
     qs.createIndex("nameIndex", IndexType.FUNCTIONAL, "e.name", "/employees e");
     for (int i = 0; i < queries.length; i++) {
-      Query q = null;
-      q = CacheUtils.getQueryService().newQuery(queries[i]);
-      CacheUtils.getLogger().info("Executing query: " + queries[i]);
+      Query q = CacheUtils.getQueryService().newQuery(queries[i]);
       QueryObserverImpl observer = new QueryObserverImpl();
       QueryObserverHolder.setInstance(observer);
       r[i][1] = q.execute();
 
       if (!observer.isIndexesUsed) {
-        fail("Index is NOT uesd");
+        fail("Index is NOT used");
         // Test fails here. Index on second region is not getting used.
       }
-      CacheUtils.log("*****************IndexUsed::" + observer.IndexName);
       Iterator itr = observer.indexesUsed.iterator();
       assertEquals("nameIndex", itr.next().toString());
     }
     // Verifying the query results
     StructSetOrResultsSet ssORrs = new StructSetOrResultsSet();
     ssORrs.CompareQueryResultsWithoutAndWithIndexes(r, queries.length, queries);
-
-  } // end of test3
+  }
 
   @Test
   public void testQueryWithIndexOnBothReg4() throws Exception {
     Object r[][] = new Object[9][2];
-    QueryService qs;
-    qs = CacheUtils.getQueryService();
+    QueryService qs = CacheUtils.getQueryService();
 
     String queries[] = {
         // Test Case No. IUMR002
@@ -192,9 +174,7 @@ public class IUMRShuffleIteratorsJUnitTest {
 
     // Execute Query without Indexes
     for (int i = 0; i < queries.length; i++) {
-      Query q = null;
-      q = CacheUtils.getQueryService().newQuery(queries[i]);
-      CacheUtils.getLogger().info("Executing query: " + queries[i]);
+      Query q = CacheUtils.getQueryService().newQuery(queries[i]);
       r[i][0] = q.execute();
     }
 
@@ -203,17 +183,14 @@ public class IUMRShuffleIteratorsJUnitTest {
     qs.createIndex("statusIndex", IndexType.FUNCTIONAL, "pf.status", "/portfolios pf");
 
     for (int i = 0; i < queries.length; i++) {
-      Query q = null;
-      q = CacheUtils.getQueryService().newQuery(queries[i]);
-      CacheUtils.getLogger().info("Executing query: " + queries[i]);
+      Query q = CacheUtils.getQueryService().newQuery(queries[i]);
       QueryObserverImpl observer = new QueryObserverImpl();
       QueryObserverHolder.setInstance(observer);
       r[i][1] = q.execute();
       if (!observer.isIndexesUsed) {
-        fail("Index is NOT uesd");
+        fail("Index is NOT used");
       }
       int indxs = observer.indexesUsed.size();
-      CacheUtils.log("***********Indexes Used :::: " + indxs + " IndexName::" + observer.IndexName);
       if (indxs != 2) {
         fail("FAILED: Both The Indexes should be used. Presently only " + indxs
             + " Index(es) is used");
@@ -238,28 +215,21 @@ public class IUMRShuffleIteratorsJUnitTest {
     // Verifying the query results
     StructSetOrResultsSet ssORrs = new StructSetOrResultsSet();
     ssORrs.CompareQueryResultsWithoutAndWithIndexes(r, queries.length, queries);
-  } // end of test4
+  }
 
   @Test
   public void testWithThreeRegions5() throws Exception {
     Object r[][] = new Object[5][2];
-    QueryService qs;
-    qs = CacheUtils.getQueryService();
+    QueryService qs = CacheUtils.getQueryService();
 
     String queries[] = {
-        // Scenaerio A: If the Order of the Regions in Query are changed Index is not being used.
+        // Scenario A: If the Order of the Regions in Query are changed Index is not being used.
         "select distinct * from /portfolios p, /employees e, /address a, a.street s where s.street ='DPStreet1'",
-        "select distinct * from /address a, /portfolios p, /employees e, a.street s  where s.street ='DPStreet1'",
-        // Scenario B: Only Index on the first region in the Query is used
-        // "select distinct * from /address a, /portfolios p, /employees e, a.street s where
-        // p.status='active' and s.street ='DPStreet1'",
-    };
+        "select distinct * from /address a, /portfolios p, /employees e, a.street s  where s.street ='DPStreet1'",};
 
     // Execute queries without Indexes
     for (int i = 0; i < queries.length; i++) {
-      Query q = null;
-      q = CacheUtils.getQueryService().newQuery(queries[i]);
-      CacheUtils.getLogger().info("Executing query: " + queries[i]);
+      Query q = CacheUtils.getQueryService().newQuery(queries[i]);
       r[i][0] = q.execute();
     }
     // Create Indexes and Execute the queries
@@ -267,31 +237,25 @@ public class IUMRShuffleIteratorsJUnitTest {
     qs.createIndex("statusIndex", IndexType.FUNCTIONAL, "p.status", "/portfolios p");
     qs.createIndex("streetIndex", IndexType.FUNCTIONAL, "s.street", "/address a, a.street s");
     for (int i = 0; i < queries.length; i++) {
-      Query q = null;
-      q = CacheUtils.getQueryService().newQuery(queries[i]);
-      CacheUtils.getLogger().info("Executing query: " + queries[i]);
+      Query q = CacheUtils.getQueryService().newQuery(queries[i]);
       QueryObserverImpl observer = new QueryObserverImpl();
       QueryObserverHolder.setInstance(observer);
       r[i][1] = q.execute();
       if (!observer.isIndexesUsed) {
-        fail("Index is NOT uesd");
+        fail("Index is NOT used");
       }
-      int indxs = observer.indexesUsed.size();
-      CacheUtils
-          .log("*******************Indexes Used::: " + indxs + " IndexName::" + observer.IndexName);
       Iterator itr = observer.indexesUsed.iterator();
       assertEquals("streetIndex", itr.next().toString());
     }
     // Verifying the query results
     StructSetOrResultsSet ssORrs = new StructSetOrResultsSet();
     ssORrs.CompareQueryResultsWithoutAndWithIndexes(r, queries.length, queries);
-  } // end of test5
+  }
 
   @Test
   public void testShuffleIterators6() throws Exception {
     Object r[][] = new Object[5][2];
-    QueryService qs;
-    qs = CacheUtils.getQueryService();
+    QueryService qs = CacheUtils.getQueryService();
 
     String queries[] = {
         "select distinct * from /address itr1,itr1.phoneNo itr2,itr1.street itr3 where itr2.mobile>333",
@@ -299,27 +263,20 @@ public class IUMRShuffleIteratorsJUnitTest {
 
     // Execute the query without index
     for (int i = 0; i < queries.length; i++) {
-      Query q = null;
-      q = CacheUtils.getQueryService().newQuery(queries[i]);
-      CacheUtils.getLogger().info("Executing query: " + queries[i]);
+      Query q = CacheUtils.getQueryService().newQuery(queries[i]);
       r[i][0] = q.execute();
     }
     // Create index and Execute the query
     qs.createIndex("mobileIndex", IndexType.FUNCTIONAL, "itr2.mobile",
         "/address itr1,itr1.phoneNo itr2,itr1.street itr3");
     for (int i = 0; i < queries.length; i++) {
-      Query q = null;
-      q = CacheUtils.getQueryService().newQuery(queries[i]);
-      CacheUtils.getLogger().info("Executing query: " + queries[i]);
+      Query q = CacheUtils.getQueryService().newQuery(queries[i]);
       QueryObserverImpl observer = new QueryObserverImpl();
       QueryObserverHolder.setInstance(observer);
       r[i][1] = q.execute();
       if (!observer.isIndexesUsed) {
-        fail("Index is NOT uesd");
+        fail("Index is NOT used");
       }
-      int indxs = observer.indexesUsed.size();
-      CacheUtils
-          .log("*******************Indexes Used::: " + indxs + " IndexName::" + observer.IndexName);
 
       Iterator itr = observer.indexesUsed.iterator();
       assertEquals("mobileIndex", itr.next().toString());
@@ -327,22 +284,19 @@ public class IUMRShuffleIteratorsJUnitTest {
     // Verifying the query results
     StructSetOrResultsSet ssORrs = new StructSetOrResultsSet();
     ssORrs.CompareQueryResultsWithoutAndWithIndexes(r, queries.length, queries);
-  } // end test6
+  }
 
   @Test
   public void testWithThreeRegions7() throws Exception {
     Object r[][] = new Object[5][2];
-    QueryService qs;
-    qs = CacheUtils.getQueryService();
+    QueryService qs = CacheUtils.getQueryService();
 
     String queries[] = {
         // Only Index on the first region in the Query is used
         "select distinct * from /address a, /portfolios p, /employees e, a.street s where p.status='active' and s.street ='DPStreet1'",};
     // Execute queries without Indexes
     for (int i = 0; i < queries.length; i++) {
-      Query q = null;
-      q = CacheUtils.getQueryService().newQuery(queries[i]);
-      CacheUtils.getLogger().info("Executing query: " + queries[i]);
+      Query q = CacheUtils.getQueryService().newQuery(queries[i]);
       r[i][0] = q.execute();
     }
     // Create Indexes and Execute the queries
@@ -350,18 +304,13 @@ public class IUMRShuffleIteratorsJUnitTest {
     qs.createIndex("statusIndex", IndexType.FUNCTIONAL, "p.status", "/portfolios p");
     qs.createIndex("streetIndex", IndexType.FUNCTIONAL, "s.street", "/address a, a.street s");
     for (int i = 0; i < queries.length; i++) {
-      Query q = null;
-      q = CacheUtils.getQueryService().newQuery(queries[i]);
-      CacheUtils.getLogger().info("Executing query: " + queries[i]);
+      Query q = CacheUtils.getQueryService().newQuery(queries[i]);
       QueryObserverImpl observer = new QueryObserverImpl();
       QueryObserverHolder.setInstance(observer);
       r[i][1] = q.execute();
       if (!observer.isIndexesUsed) {
-        fail("Index is NOT uesd");
+        fail("Index is NOT used");
       }
-      int indxs = observer.indexesUsed.size();
-      CacheUtils
-          .log("*******************Indexes Used::: " + indxs + " IndexName::" + observer.IndexName);
 
       Iterator itr = observer.indexesUsed.iterator();
       String temp;
@@ -382,17 +331,17 @@ public class IUMRShuffleIteratorsJUnitTest {
     // Verifying the query results
     StructSetOrResultsSet ssORrs = new StructSetOrResultsSet();
     ssORrs.CompareQueryResultsWithoutAndWithIndexes(r, queries.length, queries);
-  } // end of test7
+  }
 
   private static class QueryObserverImpl extends QueryObserverAdapter {
 
-    boolean isIndexesUsed = false;
-    ArrayList indexesUsed = new ArrayList();
-    String IndexName;
+    private final List indexesUsed = Collections.synchronizedList(new ArrayList<>());
+    private volatile boolean isIndexesUsed = false;
+    private volatile String indexName;
 
     @Override
     public void beforeIndexLookup(Index index, int oper, Object key) {
-      IndexName = index.getName();
+      indexName = index.getName();
       indexesUsed.add(index.getName());
     }
 
@@ -403,5 +352,4 @@ public class IUMRShuffleIteratorsJUnitTest {
       }
     }
   }
-
-}// End of Class
+}

--- a/geode-core/src/test/java/org/apache/geode/cache/query/functional/LikePredicateJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/functional/LikePredicateJUnitTest.java
@@ -12,15 +12,14 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-/*
- * InOperatorTest.java
- *
- * Created on March 24, 2005, 5:08 PM
- */
 package org.apache.geode.cache.query.functional;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.List;
 
@@ -79,8 +78,6 @@ public class LikePredicateJUnitTest {
 
   /**
    * Tests simple % terminated pattern with atleast one preceding character
-   *
-   * @throws Exception
    */
   private void likePercentageTerminated_1(boolean useBindParam) throws Exception {
     Cache cache = CacheUtils.getCache();
@@ -95,7 +92,7 @@ public class LikePredicateJUnitTest {
       Portfolio pf = new Portfolio(i);
       pf.status = base + ch;
       ch += 1;
-      region.put(new Integer(i), pf);
+      region.put(i, pf);
     }
 
     base = "abd";
@@ -104,14 +101,11 @@ public class LikePredicateJUnitTest {
       Portfolio pf = new Portfolio(i);
       pf.status = base + ch;
       ch += 1;
-      region.put(new Integer(i), pf);
+      region.put(i, pf);
     }
 
     QueryService qs = cache.getQueryService();
 
-    Query q;
-    SelectResults results;
-    SelectResults expectedResults;
     String predicate = "";
     if (useBindParam) {
       predicate = "$1";
@@ -119,7 +113,8 @@ public class LikePredicateJUnitTest {
       predicate = " 'abc%'";
     }
 
-    q = qs.newQuery("SELECT distinct *  FROM /pos ps WHERE ps.status like " + predicate);
+    Query q = qs.newQuery("SELECT distinct *  FROM /pos ps WHERE ps.status like " + predicate);
+    SelectResults results;
     if (useBindParam) {
       results = (SelectResults) q.execute(new Object[] {"abc%"});
     } else {
@@ -127,9 +122,10 @@ public class LikePredicateJUnitTest {
     }
     ResultsBag bag = new ResultsBag(null);
     for (int i = 1; i < 6; ++i) {
-      bag.add(region.get(new Integer(i)));
+      bag.add(region.get(i));
     }
-    expectedResults = new ResultsCollectionWrapper(new ObjectTypeImpl(Object.class), bag.asSet());
+    SelectResults expectedResults =
+        new ResultsCollectionWrapper(new ObjectTypeImpl(Object.class), bag.asSet());
     SelectResults rs[][] = new SelectResults[][] {{results, expectedResults}};
     CacheUtils.compareResultsOfWithAndWithoutIndex(rs, this);
 
@@ -138,10 +134,12 @@ public class LikePredicateJUnitTest {
     QueryObserver old = QueryObserverHolder.setInstance(new QueryObserverAdapter() {
       private boolean indexCalled = false;
 
+      @Override
       public void afterIndexLookup(Collection results) {
         indexCalled = true;
       }
 
+      @Override
       public void endQuery() {
         assertTrue(indexCalled);
       }
@@ -157,7 +155,6 @@ public class LikePredicateJUnitTest {
     rs[0][1] = expectedResults;
     CacheUtils.compareResultsOfWithAndWithoutIndex(rs, this);
     QueryObserverHolder.setInstance(old);
-
   }
 
   @Test
@@ -172,8 +169,6 @@ public class LikePredicateJUnitTest {
 
   /**
    * Tests a pattern which just contains a single % indicating all match
-   *
-   * @throws Exception
    */
   private void likePercentageTerminated_2(boolean useBindParam) throws Exception {
     Cache cache = CacheUtils.getCache();
@@ -188,7 +183,7 @@ public class LikePredicateJUnitTest {
       Portfolio pf = new Portfolio(i);
       pf.status = base + ch;
       ch += 1;
-      region.put(new Integer(i), pf);
+      region.put(i, pf);
     }
 
     base = "abd";
@@ -197,14 +192,11 @@ public class LikePredicateJUnitTest {
       Portfolio pf = new Portfolio(i);
       pf.status = base + ch;
       ch += 1;
-      region.put(new Integer(i), pf);
+      region.put(i, pf);
     }
 
     QueryService qs = cache.getQueryService();
 
-    Query q;
-    SelectResults results;
-    SelectResults expectedResults;
     String predicate = "";
     if (useBindParam) {
       predicate = "$1";
@@ -212,7 +204,8 @@ public class LikePredicateJUnitTest {
       predicate = " '%'";
     }
 
-    q = qs.newQuery("SELECT distinct *  FROM /pos ps WHERE ps.status like " + predicate);
+    Query q = qs.newQuery("SELECT distinct *  FROM /pos ps WHERE ps.status like " + predicate);
+    SelectResults results;
     if (useBindParam) {
       results = (SelectResults) q.execute(new Object[] {"%"});
     } else {
@@ -220,9 +213,10 @@ public class LikePredicateJUnitTest {
     }
     ResultsBag bag = new ResultsBag(null);
     for (int i = 1; i < 11; ++i) {
-      bag.add(region.get(new Integer(i)));
+      bag.add(region.get(i));
     }
-    expectedResults = new ResultsCollectionWrapper(new ObjectTypeImpl(Object.class), bag.asSet());
+    SelectResults expectedResults =
+        new ResultsCollectionWrapper(new ObjectTypeImpl(Object.class), bag.asSet());
     SelectResults rs[][] = new SelectResults[][] {{results, expectedResults}};
     CacheUtils.compareResultsOfWithAndWithoutIndex(rs, this);
 
@@ -231,10 +225,12 @@ public class LikePredicateJUnitTest {
     QueryObserver old = QueryObserverHolder.setInstance(new QueryObserverAdapter() {
       private boolean indexCalled = false;
 
+      @Override
       public void afterIndexLookup(Collection results) {
         indexCalled = true;
       }
 
+      @Override
       public void endQuery() {
         assertTrue(indexCalled);
       }
@@ -250,7 +246,6 @@ public class LikePredicateJUnitTest {
     rs[0][1] = expectedResults;
     CacheUtils.compareResultsOfWithAndWithoutIndex(rs, this);
     QueryObserverHolder.setInstance(old);
-
   }
 
   @Test
@@ -265,8 +260,6 @@ public class LikePredicateJUnitTest {
 
   /**
    * Tests a simple % terminated like predicate with an OR condition
-   *
-   * @throws Exception
    */
   private void likePercentageTerminated_3(boolean useBindPrm) throws Exception {
     Cache cache = CacheUtils.getCache();
@@ -281,7 +274,7 @@ public class LikePredicateJUnitTest {
       Portfolio pf = new Portfolio(i);
       pf.status = base + ch;
       ch += 1;
-      region.put(new Integer(i), pf);
+      region.put(i, pf);
     }
 
     base = "abd";
@@ -290,22 +283,20 @@ public class LikePredicateJUnitTest {
       Portfolio pf = new Portfolio(i);
       pf.status = base + ch;
       ch += 1;
-      region.put(new Integer(i), pf);
+      region.put(i, pf);
     }
 
     QueryService qs = cache.getQueryService();
 
-    Query q;
-    SelectResults results;
-    SelectResults expectedResults;
     String predicate = "";
     if (useBindPrm) {
       predicate = "$1";
     } else {
       predicate = " 'abc%'";
     }
-    q = qs.newQuery(
+    Query q = qs.newQuery(
         "SELECT distinct *  FROM /pos ps WHERE ps.status like " + predicate + " OR ps.ID > 6");
+    SelectResults results;
     if (useBindPrm) {
       results = (SelectResults) q.execute(new Object[] {"abc%"});
     } else {
@@ -314,10 +305,11 @@ public class LikePredicateJUnitTest {
     ResultsBag bag = new ResultsBag(null);
     for (int i = 1; i < 11; ++i) {
       if (i != 6) {
-        bag.add(region.get(new Integer(i)));
+        bag.add(region.get(i));
       }
     }
-    expectedResults = new ResultsCollectionWrapper(new ObjectTypeImpl(Object.class), bag.asSet());
+    SelectResults expectedResults =
+        new ResultsCollectionWrapper(new ObjectTypeImpl(Object.class), bag.asSet());
     SelectResults rs[][] = new SelectResults[][] {{results, expectedResults}};
     CacheUtils.compareResultsOfWithAndWithoutIndex(rs, this);
 
@@ -327,10 +319,12 @@ public class LikePredicateJUnitTest {
     QueryObserver old = QueryObserverHolder.setInstance(new QueryObserverAdapter() {
       private boolean indexCalled = false;
 
+      @Override
       public void afterIndexLookup(Collection results) {
         indexCalled = true;
       }
 
+      @Override
       public void endQuery() {
         assertFalse(indexCalled);
       }
@@ -351,10 +345,12 @@ public class LikePredicateJUnitTest {
 
       private int i = 0;
 
+      @Override
       public void afterIndexLookup(Collection results) {
         indexCalled[i++] = true;
       }
 
+      @Override
       public void endQuery() {
         for (int i = 0; i < indexCalled.length; ++i) {
           assertTrue(indexCalled[i]);
@@ -373,7 +369,6 @@ public class LikePredicateJUnitTest {
     rs[0][1] = expectedResults;
     CacheUtils.compareResultsOfWithAndWithoutIndex(rs, this);
     QueryObserverHolder.setInstance(old);
-
   }
 
   @Test
@@ -388,8 +383,6 @@ public class LikePredicateJUnitTest {
 
   /**
    * Tests a simple % terminated like predicate with an AND condition
-   *
-   * @throws Exception
    */
   private void likePercentageTerminated_4(boolean useBindPrm) throws Exception {
     Cache cache = CacheUtils.getCache();
@@ -398,7 +391,6 @@ public class LikePredicateJUnitTest {
 
     Region region = cache.createRegion("pos", regionAttributes);
 
-
     String base = "abc";
     String pattern = base;
     // so we will get string like abcdcdcdcdcdc
@@ -406,7 +398,7 @@ public class LikePredicateJUnitTest {
       Portfolio pf = new Portfolio(i);
       pattern += "dc";
       pf.status = pattern;
-      region.put(new Integer(i), pf);
+      region.put(i, pf);
     }
 
     base = "abd";
@@ -417,22 +409,20 @@ public class LikePredicateJUnitTest {
       pattern += "dc";
       pf.status = pattern;
 
-      region.put(new Integer(i), pf);
+      region.put(i, pf);
     }
 
     QueryService qs = cache.getQueryService();
 
-    Query q;
-    SelectResults results;
-    SelectResults expectedResults;
     String predicate = "";
     if (useBindPrm) {
       predicate = "$1";
     } else {
       predicate = " 'abc%'";
     }
-    q = qs.newQuery("SELECT distinct *  FROM /pos ps WHERE ps.status like " + predicate
+    Query q = qs.newQuery("SELECT distinct *  FROM /pos ps WHERE ps.status like " + predicate
         + " AND ps.ID > 2 AND ps.ID < 150");
+    SelectResults results;
     if (useBindPrm) {
       results = (SelectResults) q.execute(new Object[] {"abc%"});
     } else {
@@ -440,9 +430,10 @@ public class LikePredicateJUnitTest {
     }
     ResultsBag bag = new ResultsBag(null);
     for (int i = 3; i < 150; ++i) {
-      bag.add(region.get(new Integer(i)));
+      bag.add(region.get(i));
     }
-    expectedResults = new ResultsCollectionWrapper(new ObjectTypeImpl(Object.class), bag.asSet());
+    SelectResults expectedResults =
+        new ResultsCollectionWrapper(new ObjectTypeImpl(Object.class), bag.asSet());
     SelectResults rs[][] = new SelectResults[][] {{results, expectedResults}};
     CacheUtils.compareResultsOfWithAndWithoutIndex(rs, this);
 
@@ -453,10 +444,12 @@ public class LikePredicateJUnitTest {
 
       private int i = 0;
 
+      @Override
       public void afterIndexLookup(Collection results) {
         indexCalled[i++] = true;
       }
 
+      @Override
       public void endQuery() {
         assertTrue(indexCalled[0]);
         assertFalse(indexCalled[1]);
@@ -478,10 +471,12 @@ public class LikePredicateJUnitTest {
 
       private int i = 0;
 
+      @Override
       public void afterIndexLookup(Collection results) {
         indexCalled[i++] = true;
       }
 
+      @Override
       public void endQuery() {
         // Only one indexed condition should be called
         boolean indexInvoked = false;
@@ -490,7 +485,6 @@ public class LikePredicateJUnitTest {
         }
         assertTrue(indexInvoked);
       }
-
     });
 
     if (useBindPrm) {
@@ -503,7 +497,6 @@ public class LikePredicateJUnitTest {
     rs[0][1] = expectedResults;
     CacheUtils.compareResultsOfWithAndWithoutIndex(rs, this);
     QueryObserverHolder.setInstance(old);
-
   }
 
   @Test
@@ -515,8 +508,6 @@ public class LikePredicateJUnitTest {
   public void testLikePercentageTerminated_5_withBindPrms() throws Exception {
     likePercentageTerminated_5(true);
   }
-
-
 
   private void likePercentageTerminated_5(boolean useBindPrm) throws Exception {
     Cache cache = CacheUtils.getCache();
@@ -531,22 +522,20 @@ public class LikePredicateJUnitTest {
       Portfolio pf = new Portfolio(i);
       pf.status = base + ch;
       ch += 1;
-      region.put(new Integer(i), pf);
+      region.put(i, pf);
     }
 
     QueryService qs = cache.getQueryService();
 
-    Query q;
-    SelectResults results;
-    SelectResults expectedResults;
     String predicate = "";
     if (useBindPrm) {
       predicate = "$1";
     } else {
       predicate = " 'a%c%'";
     }
-    q = qs.newQuery("SELECT distinct *  FROM /pos ps WHERE ps.status like " + predicate);
+    Query q = qs.newQuery("SELECT distinct *  FROM /pos ps WHERE ps.status like " + predicate);
 
+    SelectResults results;
     if (useBindPrm) {
       results = (SelectResults) q.execute(new Object[] {"a%bc%"});
     } else {
@@ -555,9 +544,10 @@ public class LikePredicateJUnitTest {
 
     ResultsBag bag = new ResultsBag(null);
     for (int i = 1; i < 6; ++i) {
-      bag.add(region.get(new Integer(i)));
+      bag.add(region.get(i));
     }
-    expectedResults = new ResultsCollectionWrapper(new ObjectTypeImpl(Object.class), bag.asSet());
+    SelectResults expectedResults =
+        new ResultsCollectionWrapper(new ObjectTypeImpl(Object.class), bag.asSet());
     SelectResults rs[][] = new SelectResults[][] {{results, expectedResults}};
     CacheUtils.compareResultsOfWithAndWithoutIndex(rs, this);
     // Create Index
@@ -618,8 +608,6 @@ public class LikePredicateJUnitTest {
 
   /**
    * Tests simple non % or non _ terminated string which in effect means equality
-   *
-   * @throws Exception
    */
   private void equalityForm_1(boolean useBindPrms) throws Exception {
     Cache cache = CacheUtils.getCache();
@@ -634,7 +622,7 @@ public class LikePredicateJUnitTest {
       Portfolio pf = new Portfolio(i);
       pf.status = base + ch;
       ch += 1;
-      region.put(new Integer(i), pf);
+      region.put(i, pf);
     }
 
     base = "abd";
@@ -643,21 +631,19 @@ public class LikePredicateJUnitTest {
       Portfolio pf = new Portfolio(i);
       pf.status = base + ch;
       ch += 1;
-      region.put(new Integer(i), pf);
+      region.put(i, pf);
     }
 
     QueryService qs = cache.getQueryService();
 
-    Query q;
-    SelectResults results;
-    SelectResults expectedResults;
     String predicate = "";
     if (useBindPrms) {
       predicate = "$1";
     } else {
       predicate = " 'abcd'";
     }
-    q = qs.newQuery("SELECT distinct *  FROM /pos ps WHERE ps.status like " + predicate);
+    Query q = qs.newQuery("SELECT distinct *  FROM /pos ps WHERE ps.status like " + predicate);
+    SelectResults results;
     if (useBindPrms) {
       results = (SelectResults) q.execute(new Object[] {"abcd"});
     } else {
@@ -666,8 +652,9 @@ public class LikePredicateJUnitTest {
 
     ResultsBag bag = new ResultsBag(null);
 
-    bag.add(region.get(new Integer(1)));
-    expectedResults = new ResultsCollectionWrapper(new ObjectTypeImpl(Object.class), bag.asSet());
+    bag.add(region.get(1));
+    SelectResults expectedResults =
+        new ResultsCollectionWrapper(new ObjectTypeImpl(Object.class), bag.asSet());
 
     SelectResults rs[][] = new SelectResults[][] {{results, expectedResults}};
     CacheUtils.compareResultsOfWithAndWithoutIndex(rs, this);
@@ -677,10 +664,12 @@ public class LikePredicateJUnitTest {
     QueryObserver old = QueryObserverHolder.setInstance(new QueryObserverAdapter() {
       private boolean indexCalled = false;
 
+      @Override
       public void afterIndexLookup(Collection results) {
         indexCalled = true;
       }
 
+      @Override
       public void endQuery() {
         assertTrue(indexCalled);
       }
@@ -696,7 +685,6 @@ public class LikePredicateJUnitTest {
     rs[0][1] = expectedResults;
     CacheUtils.compareResultsOfWithAndWithoutIndex(rs, this);
     QueryObserverHolder.setInstance(old);
-
   }
 
   @Test
@@ -711,8 +699,6 @@ public class LikePredicateJUnitTest {
 
   /**
    * Tests simple \% or \ _ terminated string which in effect means equality
-   *
-   * @throws Exception
    */
   private void equalityForm_2(boolean useBindPrms) throws Exception {
     Cache cache = CacheUtils.getCache();
@@ -726,7 +712,7 @@ public class LikePredicateJUnitTest {
     for (int i = 1; i < 6; ++i) {
       Portfolio pf = new Portfolio(i);
       pf.status = base + str;
-      region.put(new Integer(i), pf);
+      region.put(i, pf);
     }
 
     base = "abc";
@@ -734,21 +720,19 @@ public class LikePredicateJUnitTest {
     for (int i = 6; i < 11; ++i) {
       Portfolio pf = new Portfolio(i);
       pf.status = base + str;
-      region.put(new Integer(i), pf);
+      region.put(i, pf);
     }
 
     QueryService qs = cache.getQueryService();
 
-    Query q, q1;
-    SelectResults results;
-    SelectResults expectedResults;
     String predicate = "";
     if (useBindPrms) {
       predicate = "$1";
     } else {
       predicate = " 'abcd\\_'";
     }
-    q = qs.newQuery("SELECT distinct *  FROM /pos ps WHERE ps.status like " + predicate);
+    Query q = qs.newQuery("SELECT distinct *  FROM /pos ps WHERE ps.status like " + predicate);
+    SelectResults results;
     if (useBindPrms) {
       results = (SelectResults) q.execute(new Object[] {"abcd\\_"});
     } else {
@@ -758,9 +742,10 @@ public class LikePredicateJUnitTest {
     ResultsBag bag = new ResultsBag(null);
 
     for (int i = 1; i < 6; ++i) {
-      bag.add(region.get(new Integer(i)));
+      bag.add(region.get(i));
     }
-    expectedResults = new ResultsCollectionWrapper(new ObjectTypeImpl(Object.class), bag.asSet());
+    SelectResults expectedResults =
+        new ResultsCollectionWrapper(new ObjectTypeImpl(Object.class), bag.asSet());
 
     SelectResults rs[][] = new SelectResults[][] {{results, expectedResults}};
     CacheUtils.compareResultsOfWithAndWithoutIndex(rs, this);
@@ -770,7 +755,7 @@ public class LikePredicateJUnitTest {
     } else {
       predicate = " 'abcd\\%'";
     }
-    q1 = qs.newQuery("SELECT distinct *  FROM /pos ps WHERE ps.status like " + predicate);
+    Query q1 = qs.newQuery("SELECT distinct *  FROM /pos ps WHERE ps.status like " + predicate);
     if (useBindPrms) {
       results = (SelectResults) q1.execute(new Object[] {"abcd\\%"});
     } else {
@@ -778,7 +763,7 @@ public class LikePredicateJUnitTest {
     }
     bag = new ResultsBag(null);
     for (int i = 6; i < 11; ++i) {
-      bag.add(region.get(new Integer(i)));
+      bag.add(region.get(i));
     }
     SelectResults expectedResults1 =
         new ResultsCollectionWrapper(new ObjectTypeImpl(Object.class), bag.asSet());
@@ -792,10 +777,12 @@ public class LikePredicateJUnitTest {
     QueryObserver old = QueryObserverHolder.setInstance(new QueryObserverAdapter() {
       private boolean indexCalled = false;
 
+      @Override
       public void afterIndexLookup(Collection results) {
         indexCalled = true;
       }
 
+      @Override
       public void endQuery() {
         assertTrue(indexCalled);
       }
@@ -819,7 +806,6 @@ public class LikePredicateJUnitTest {
     rs1[0][1] = expectedResults1;
     CacheUtils.compareResultsOfWithAndWithoutIndex(rs1, this);
     QueryObserverHolder.setInstance(old);
-
   }
 
   @Test
@@ -834,8 +820,6 @@ public class LikePredicateJUnitTest {
 
   /**
    * Tests for regular expression meta chars. This has no special meaning with Like.
-   *
-   * @throws Exception
    */
   private void regexMetaChar(boolean useBindPrms) throws Exception {
     Cache cache = CacheUtils.getCache();
@@ -850,12 +834,12 @@ public class LikePredicateJUnitTest {
 
     // Add values to region.
     for (int i = 0; i < values.length; i++) {
-      region.put(new Integer(i), values[i]);
+      region.put(i, values[i]);
     }
 
     // Add % and _ with escape char.
-    region.put(new Integer(values.length + 1), "act%+ive");
-    region.put(new Integer(values.length + 2), "act_+ive");
+    region.put(values.length + 1, "act%+ive");
+    region.put(values.length + 2, "act_+ive");
 
     QueryService qs = cache.getQueryService();
     Query q;
@@ -907,8 +891,6 @@ public class LikePredicateJUnitTest {
 
   /**
    * Tests with combination of % and _ Supported from 6.6
-   *
-   * @throws Exception
    */
   private void enhancedLike(boolean useBindPrms) throws Exception {
     Cache cache = CacheUtils.getCache();
@@ -919,18 +901,17 @@ public class LikePredicateJUnitTest {
 
     String[] values = new String[] {"active",};
 
-    String[] likePredicates = new String[] {"active", "act%%ve", "a%e", "%ctiv%", "%c%iv%",
-        "%ctive", "%%ti%", "activ_", "_ctive", "ac_ive", "_c_iv_", "_ctiv%", "__tive", "act__e",
-        "a%iv_", "a_tiv%", "%", "ac%",};
-
     for (int i = 0; i < values.length; i++) {
-      region.put(new Integer(i), values[i]);
+      region.put(i, values[i]);
     }
 
     QueryService qs = cache.getQueryService();
     Query q;
     SelectResults results;
 
+    String[] likePredicates = new String[] {"active", "act%%ve", "a%e", "%ctiv%", "%c%iv%",
+        "%ctive", "%%ti%", "activ_", "_ctive", "ac_ive", "_c_iv_", "_ctiv%", "__tive", "act__e",
+        "a%iv_", "a_tiv%", "%", "ac%",};
     for (int i = 0; i < likePredicates.length; i++) {
       if (!useBindPrms) {
         q = qs.newQuery("select p from /pos.values p where p like '" + likePredicates[i] + "'");
@@ -987,21 +968,18 @@ public class LikePredicateJUnitTest {
     String[] values = new String[] {"ac\\tive", "X\\\\X", "Y%Y", "Z\\%Z", "pass\\ive",
         "inact\\%+ive", "1inact\\_+ive",};
 
-    String[] likePredicates = new String[] {"ac\\\\tive", "ac\\\\%", "ac_tive", "Y\\%Y", "X__X",
-        "X%X", "Z\\\\\\%Z", "inact\\\\%+ive", "1inact\\\\_+ive",};
-
-    String[] result = new String[] {"ac\\tive", "ac\\tive", "ac\\tive", "Y%Y", "X\\\\X", "X\\\\X",
-        "Z\\%Z", "inact\\%+ive", "1inact\\_+ive",};
-
-
     for (int i = 0; i < values.length; i++) {
-      region.put(new Integer(i), values[i]);
+      region.put(i, values[i]);
     }
 
     QueryService qs = cache.getQueryService();
     Query q;
     SelectResults results;
 
+    String[] result = new String[] {"ac\\tive", "ac\\tive", "ac\\tive", "Y%Y", "X\\\\X", "X\\\\X",
+        "Z\\%Z", "inact\\%+ive", "1inact\\_+ive",};
+    String[] likePredicates = new String[] {"ac\\\\tive", "ac\\\\%", "ac_tive", "Y\\%Y", "X__X",
+        "X%X", "Z\\\\\\%Z", "inact\\\\%+ive", "1inact\\\\_+ive",};
     for (int i = 0; i < likePredicates.length; i++) {
       if (!useBindPrms) {
         q = qs.newQuery("select p from /pos.values p where p like '" + likePredicates[i] + "'");
@@ -1040,8 +1018,6 @@ public class LikePredicateJUnitTest {
 
   /**
    * Query with index on other fields.
-   *
-   * @throws Exception
    */
   @Test
   public void testLikeWithOtherIndexedField() throws Exception {
@@ -1060,19 +1036,14 @@ public class LikePredicateJUnitTest {
       } else if ((i <= 2)) {
         pf.pkid = "2";
       }
-      region.put(new Integer(i), pf);
+      region.put(i, pf);
     }
 
     QueryService qs = cache.getQueryService();
 
-    Query q;
-    SelectResults results;
-    SelectResults expectedResults;
-
+    Query q = qs.newQuery(" SELECT  *  FROM /pos ps WHERE ps.status like '%b%'");
+    SelectResults results = (SelectResults) q.execute();
     int expectedResultSize = 2;
-
-    q = qs.newQuery(" SELECT  *  FROM /pos ps WHERE ps.status like '%b%'");
-    results = (SelectResults) q.execute();
     if (results.size() != expectedResultSize) {
       fail("Unexpected result. expected :" + expectedResultSize + " found : " + results.size());
     }
@@ -1086,7 +1057,7 @@ public class LikePredicateJUnitTest {
 
     // Query to be compared with indexed results.
     q = qs.newQuery(" SELECT  *  FROM /pos ps WHERE ps.status like '%b%' and ps.pkid = '1' ");
-    expectedResults = (SelectResults) q.execute();
+    SelectResults expectedResults = (SelectResults) q.execute();
     if (expectedResults.size() != expectedResultSize) {
       fail("Unexpected result. expected :" + expectedResultSize + " found : "
           + expectedResults.size());
@@ -1098,10 +1069,12 @@ public class LikePredicateJUnitTest {
     QueryObserver old = QueryObserverHolder.setInstance(new QueryObserverAdapter() {
       private boolean indexCalled = false;
 
+      @Override
       public void afterIndexLookup(Collection results) {
         indexCalled = true;
       }
 
+      @Override
       public void endQuery() {
         assertTrue(indexCalled);
       }
@@ -1126,13 +1099,10 @@ public class LikePredicateJUnitTest {
     }
 
     QueryObserverHolder.setInstance(old);
-
   }
 
   /**
    * Query with index on other fields.
-   *
-   * @throws Exception
    */
   @Test
   public void testLikeWithOtherIndexedField2() throws Exception {
@@ -1152,19 +1122,14 @@ public class LikePredicateJUnitTest {
       } else if ((i <= 2)) {
         pf.pkid = "2";
       }
-      region.put(new Integer(i), pf);
+      region.put(i, pf);
     }
 
     QueryService qs = cache.getQueryService();
 
-    Query q;
-    SelectResults results;
-    SelectResults expectedResults;
-
+    Query q = qs.newQuery(" SELECT  *  FROM /pos ps WHERE ps.status like '%b%'");
+    SelectResults results = (SelectResults) q.execute();
     int expectedResultSize = 2;
-
-    q = qs.newQuery(" SELECT  *  FROM /pos ps WHERE ps.status like '%b%'");
-    results = (SelectResults) q.execute();
     if (results.size() != expectedResultSize) {
       fail("Unexpected result. expected :" + expectedResultSize + " found : " + results.size());
     }
@@ -1196,7 +1161,7 @@ public class LikePredicateJUnitTest {
 
     // Query to be compared with indexed results.
     q = qs.newQuery(" SELECT  *  FROM /pos ps WHERE ps.status like '%b%' and ps.pkid = '1' ");
-    expectedResults = (SelectResults) q.execute();
+    SelectResults expectedResults = (SelectResults) q.execute();
     if (expectedResults.size() != expectedResultSize) {
       fail("Unexpected result. expected :" + expectedResultSize + " found : "
           + expectedResults.size());
@@ -1210,10 +1175,12 @@ public class LikePredicateJUnitTest {
     QueryObserver old = QueryObserverHolder.setInstance(new QueryObserverAdapter() {
       private boolean indexCalled = false;
 
+      @Override
       public void afterIndexLookup(Collection results) {
         indexCalled = true;
       }
 
+      @Override
       public void endQuery() {
         assertTrue(indexCalled);
       }
@@ -1256,7 +1223,6 @@ public class LikePredicateJUnitTest {
     }
 
     QueryObserverHolder.setInstance(old);
-
   }
 
   @Test
@@ -1267,7 +1233,6 @@ public class LikePredicateJUnitTest {
 
     Region region = cache.createRegion("pos", regionAttributes);
     QueryService qs = cache.getQueryService();
-    Query q;
     String[] queries = new String[] {
         " SELECT  status, pkid FROM /pos  WHERE status like 'inactive' and pkid like '1' ",
         " SELECT  status, pkid FROM /pos  WHERE status like 'active' or pkid like '1' ",
@@ -1301,9 +1266,10 @@ public class LikePredicateJUnitTest {
 
     for (int i = 0; i < 20; i++) {
       Portfolio pf = new Portfolio(i);
-      region.put(new Integer(i), pf);
+      region.put(i, pf);
     }
 
+    Query q;
     for (int i = 0; i < queries.length; i++) {
       q = qs.newQuery(queries[i]);
       sr[i][0] = (SelectResults) q.execute();
@@ -1320,17 +1286,15 @@ public class LikePredicateJUnitTest {
       try {
         sr[i][1] = (SelectResults) q.execute();
       } catch (Exception e) {
-        fail("Query execution failed for: " + queries[i]);
+        throw new RuntimeException("Query execution failed for: " + queries[i], e);
       }
     }
 
     // compare results.
     CacheUtils.compareResultsOfWithAndWithoutIndex(sr, this);
 
-    SelectResults results = null;
-
     q = qs.newQuery("SELECT  status  FROM /pos  WHERE status like 'inactive' and pkid like '1' ");
-    results = (SelectResults) q.execute();
+    SelectResults results = (SelectResults) q.execute();
     if (results.size() != 1) {
       fail("Unexpected result. expected :" + 1 + " found : " + results.size());
     }
@@ -1467,7 +1431,6 @@ public class LikePredicateJUnitTest {
     if (results.size() != 0) {
       fail("Unexpected result. expected :" + 0 + " found : " + results.size());
     }
-
   }
 
   @Test
@@ -1489,7 +1452,7 @@ public class LikePredicateJUnitTest {
       } else if (i == 3) {
         pf.status = null;
       }
-      region.put(new Integer(i), pf);
+      region.put(i, pf);
     }
 
     QueryService qs = cache.getQueryService();
@@ -1532,14 +1495,12 @@ public class LikePredicateJUnitTest {
 
     ResultsBag bag = new ResultsBag(null);
     for (int i = 1; i < 6; ++i) {
-      bag.add(region.get(new Integer(i)));
+      bag.add(region.get(i));
     }
   }
 
   /**
    * Tests with combination of % and _ and NOT with LIKE Supported from 6.6
-   *
-   * @throws Exception
    */
   private void enhancedNotLike(boolean useBindPrms, boolean useIndex) throws Exception {
     Cache cache = CacheUtils.getCache();
@@ -1550,16 +1511,8 @@ public class LikePredicateJUnitTest {
 
     String[] values = new String[] {"active", "inactive",};
 
-    String[] likePredicates1 = new String[] {"active", "act%%ve", "a%e", "activ_", "ac_ive",
-        "act__e", "a%iv_", "a_tiv%", "ac%",};
-
-    String[] likePredicates2 = new String[] {"%ctiv%", "%c%iv%", "%ctive", "%%ti%", "%",};
-
-    String[] likePredicates3 = new String[] {
-
-        "___ctive", "___c_iv_", "___ctiv%", "____tive",};
     for (int i = 0; i < values.length; i++) {
-      region.put(new Integer(i), values[i]);
+      region.put(i, values[i]);
     }
 
     QueryService qs = cache.getQueryService();
@@ -1570,6 +1523,8 @@ public class LikePredicateJUnitTest {
     Query q;
     SelectResults results;
 
+    String[] likePredicates1 = new String[] {"active", "act%%ve", "a%e", "activ_", "ac_ive",
+        "act__e", "a%iv_", "a_tiv%", "ac%",};
     for (int i = 0; i < likePredicates1.length; i++) {
       if (!useBindPrms) {
         q = qs.newQuery("select p from /pos p where NOT (p like '" + likePredicates1[i] + "')");
@@ -1586,6 +1541,7 @@ public class LikePredicateJUnitTest {
       }
     }
 
+    String[] likePredicates2 = new String[] {"%ctiv%", "%c%iv%", "%ctive", "%%ti%", "%",};
     for (int i = 0; i < likePredicates2.length; i++) {
       if (!useBindPrms) {
         q = qs.newQuery("select p from /pos p where NOT (p like '" + likePredicates2[i] + "')");
@@ -1601,6 +1557,7 @@ public class LikePredicateJUnitTest {
       }
     }
 
+    String[] likePredicates3 = new String[] {"___ctive", "___c_iv_", "___ctiv%", "____tive",};
     for (int i = 0; i < likePredicates3.length; i++) {
       if (!useBindPrms) {
         q = qs.newQuery("select p from /pos p where NOT (p like '" + likePredicates3[i] + "')");
@@ -1648,7 +1605,6 @@ public class LikePredicateJUnitTest {
     enhancedNotLike2(false, true);
   }
 
-
   private void enhancedNotLike2(boolean useBindPrms, boolean useIndex) throws Exception {
     Cache cache = CacheUtils.getCache();
     AttributesFactory attributesFactory = new AttributesFactory();
@@ -1659,24 +1615,22 @@ public class LikePredicateJUnitTest {
     String[] values = new String[] {"ac\\tive", "X\\\\X", "Y%Y", "Z\\%Z", "pass\\ive",
         "inact\\%+ive", "1inact\\_+ive",};
 
-    String[] likePredicates = new String[] {"ac\\\\tive", "ac\\\\%", "ac_tive", "Y\\%Y", "X__X",
-        "X%X", "Z\\\\\\%Z", "inact\\\\%+ive", "1inact\\\\_+ive",};
-
     String[] result = new String[] {"ac\\tive", "ac\\tive", "ac\\tive", "Y%Y", "X\\\\X", "X\\\\X",
         "Z\\%Z", "inact\\%+ive", "1inact\\_+ive",};
 
-
     for (int i = 0; i < values.length; i++) {
-      region.put(new Integer(i), values[i]);
+      region.put(i, values[i]);
     }
 
     QueryService qs = cache.getQueryService();
-    Query q;
-    SelectResults results;
     if (useIndex) {
       qs.createIndex("p", IndexType.FUNCTIONAL, "p", "/pos.values p");
     }
+    String[] likePredicates = new String[] {"ac\\\\tive", "ac\\\\%", "ac_tive", "Y\\%Y", "X__X",
+        "X%X", "Z\\\\\\%Z", "inact\\\\%+ive", "1inact\\\\_+ive",};
     for (int i = 0; i < likePredicates.length; i++) {
+      SelectResults results;
+      Query q;
       if (!useBindPrms) {
         q = qs
             .newQuery("select p from /pos.values p where NOT (p like '" + likePredicates[i] + "')");
@@ -1694,8 +1648,6 @@ public class LikePredicateJUnitTest {
 
   /**
    * Query with index on other fields.
-   *
-   * @throws Exception
    */
   @Test
   public void testNotLikeWithOtherIndexedField2() throws Exception {
@@ -1715,19 +1667,14 @@ public class LikePredicateJUnitTest {
       } else if ((i <= 2)) {
         pf.pkid = "2";
       }
-      region.put(new Integer(i), pf);
+      region.put(i, pf);
     }
 
     QueryService qs = cache.getQueryService();
 
-    Query q;
-    SelectResults results;
-    SelectResults expectedResults;
-
+    Query q = qs.newQuery(" SELECT  *  FROM /pos ps WHERE NOT (ps.status like '%b%')");
+    SelectResults results = (SelectResults) q.execute();
     int expectedResultSize = 2;
-
-    q = qs.newQuery(" SELECT  *  FROM /pos ps WHERE NOT (ps.status like '%b%')");
-    results = (SelectResults) q.execute();
     if (results.size() != expectedResultSize * 4) {
       fail("Unexpected result. expected :" + expectedResultSize * 4 + " found : " + results.size());
     }
@@ -1759,7 +1706,7 @@ public class LikePredicateJUnitTest {
 
     // Query to be compared with indexed results.
     q = qs.newQuery(" SELECT  *  FROM /pos ps WHERE NOT (ps.status like '%b%' and ps.pkid = '1' )");
-    expectedResults = (SelectResults) q.execute();
+    SelectResults expectedResults = (SelectResults) q.execute();
     if (expectedResults.size() != 8) {
       fail("Unexpected result. expected :" + size + " found : " + expectedResults.size());
     }
@@ -1768,7 +1715,6 @@ public class LikePredicateJUnitTest {
     qs.createIndex("pkid", IndexType.FUNCTIONAL, "ps.pkid", "/pos ps");
     qs.createIndex("status", IndexType.FUNCTIONAL, "ps.status", "/pos ps");
     qs.createIndex("id", IndexType.FUNCTIONAL, "ps.ID", "/pos ps");
-
 
     results = (SelectResults) q.execute();
     SelectResults rs[][] = new SelectResults[][] {{results, expectedResults}};
@@ -1789,10 +1735,12 @@ public class LikePredicateJUnitTest {
     QueryObserver old = QueryObserverHolder.setInstance(new QueryObserverAdapter() {
       private boolean indexCalled = false;
 
+      @Override
       public void afterIndexLookup(Collection results) {
         indexCalled = true;
       }
 
+      @Override
       public void endQuery() {
         assertTrue(indexCalled);
       }
@@ -1818,7 +1766,6 @@ public class LikePredicateJUnitTest {
     }
 
     QueryObserverHolder.setInstance(old);
-
   }
 
   @Test
@@ -1881,14 +1828,10 @@ public class LikePredicateJUnitTest {
     assertEquals(sr.size(), 1);
   }
 
-
   /**
    * Test to verify that query executes using index even when the index is being removed during the
    * execution
-   *
-   * @throws Exception
    */
-
   @Test
   public void testRemoveIndexDuringQueryinRR() throws Exception {
     removeIndexDuringQuery(false);
@@ -1901,7 +1844,6 @@ public class LikePredicateJUnitTest {
 
   private void removeIndexDuringQuery(boolean isPr) throws Exception {
     String regionName = "exampleRegion";
-    String name = "/" + regionName;
 
     Cache cache = CacheUtils.getCache();
     Region r1 = null;
@@ -1912,16 +1854,19 @@ public class LikePredicateJUnitTest {
     }
 
     QueryService qs = cache.getQueryService();
+    String name = "/" + regionName;
     qs.createIndex("status", "status", name);
     assertEquals(cache.getQueryService().getIndexes().size(), 1);
 
     QueryObserver old = QueryObserverHolder.setInstance(new QueryObserverAdapter() {
       private boolean indexCalled = false;
 
+      @Override
       public void afterIndexLookup(Collection results) {
         indexCalled = true;
       }
 
+      @Override
       public void endQuery() {
         assertTrue(indexCalled);
       }
@@ -1956,7 +1901,6 @@ public class LikePredicateJUnitTest {
 
     CacheUtils.compareResultsOfWithAndWithoutIndex(rs);
     QueryObserverHolder.setInstance(old);
-
   }
 
   @Test
@@ -1995,13 +1939,11 @@ public class LikePredicateJUnitTest {
     assertEquals(2, i2.getStatistics().getTotalUses());
     assertEquals(0, i3.getStatistics().getTotalUses());
 
-
     executeQueryMultipleTimes(
         "SELECT distinct *  FROM /pos ps WHERE ps.ID >= 0 and ps.status like 'in%ve'", false);
     assertEquals(6, i1.getStatistics().getTotalUses());
     assertEquals(2, i2.getStatistics().getTotalUses());
     assertEquals(0, i3.getStatistics().getTotalUses());
-
 
     executeQueryMultipleTimes(
         "SELECT distinct *  FROM /pos ps1, /pos2 ps2 WHERE ps1.status like 'in%ve' or ps2.description like 'X%X'",
@@ -2009,7 +1951,6 @@ public class LikePredicateJUnitTest {
     assertEquals(8, i1.getStatistics().getTotalUses());
     assertEquals(2, i2.getStatistics().getTotalUses());
     assertEquals(2, i3.getStatistics().getTotalUses());
-
   }
 
   @Test
@@ -2040,13 +1981,11 @@ public class LikePredicateJUnitTest {
     assertEquals(0, i2.getStatistics().getTotalUses());
     assertEquals(0, i3.getStatistics().getTotalUses());
 
-
     executeQueryMultipleTimes(
         "SELECT distinct *  FROM /pos ps WHERE ps.status like $1 or ps.description like $2", true);
     assertEquals(4, i1.getStatistics().getTotalUses());
     assertEquals(2, i2.getStatistics().getTotalUses());
     assertEquals(0, i3.getStatistics().getTotalUses());
-
 
     executeQueryMultipleTimes(
         "SELECT distinct *  FROM /pos ps WHERE ps.ID >= 0 and ps.status like $1", true);
@@ -2054,18 +1993,15 @@ public class LikePredicateJUnitTest {
     assertEquals(2, i2.getStatistics().getTotalUses());
     assertEquals(0, i3.getStatistics().getTotalUses());
 
-
     executeQueryMultipleTimes(
         "SELECT distinct *  FROM /pos ps1, /pos2 ps2 WHERE ps1.status like $1 or ps2.description like $2",
         true);
     assertEquals(8, i1.getStatistics().getTotalUses());
     assertEquals(2, i2.getStatistics().getTotalUses());
     assertEquals(2, i3.getStatistics().getTotalUses());
-
   }
 
   private void executeQueryMultipleTimes(String queryStr, boolean useBindParam) throws Exception {
-
     QueryService qs = CacheUtils.getCache().getQueryService();
     Region region = CacheUtils.getCache().getRegion("pos");
 
@@ -2079,8 +2015,7 @@ public class LikePredicateJUnitTest {
       results = (SelectResults) q.execute();
     }
 
-    // Execute the query again to verify if it is still using
-    // the index
+    // Execute the query again to verify if it is still using the index
     if (useBindParam) {
       results = (SelectResults) q.execute(new Object[] {"in%ve", "X%X"});
     } else {
@@ -2098,7 +2033,7 @@ public class LikePredicateJUnitTest {
     executeInvalidQueryWithLike(true);
   }
 
-  private void executeInvalidQueryWithLike(boolean useBindParam) {
+  private void executeInvalidQueryWithLike(boolean useBindParam) throws Exception {
     Cache cache = CacheUtils.getCache();
     AttributesFactory attributesFactory = new AttributesFactory();
     RegionAttributes regionAttributes = attributesFactory.create();
@@ -2110,8 +2045,6 @@ public class LikePredicateJUnitTest {
     region.put("key-" + 11, new PortfolioModifiedStatus(11));
     QueryService qs = cache.getQueryService();
 
-    Query[] q = new Query[4];
-    SelectResults[][] results = new SelectResults[2][2];
     String predicate = "";
     String predicate2 = "";
     if (useBindParam) {
@@ -2122,76 +2055,47 @@ public class LikePredicateJUnitTest {
       predicate2 = " 'inactive'";
     }
 
-    boolean exceptionThrown = false;
+    Query[] q = new Query[4];
     q[0] = qs.newQuery("SELECT distinct *  FROM /pos ps WHERE ps.status like " + predicate);
     q[1] = qs.newQuery("SELECT distinct *  FROM /pos ps WHERE ps.status = " + predicate2);
     q[2] =
         qs.newQuery("SELECT distinct *  FROM /pos ps WHERE NOT (ps.status like " + predicate + ")");
     q[3] =
         qs.newQuery("SELECT distinct *  FROM /pos ps WHERE NOT (ps.status = " + predicate2 + ")");
-    try {
-      if (useBindParam) {
-        results[0][0] = (SelectResults) q[0].execute(new Object[] {"%nactive"});
-        results[0][1] = (SelectResults) q[1].execute(new Object[] {"inactive"});
-        results[1][0] = (SelectResults) q[2].execute(new Object[] {"%nactive"});
-        results[1][1] = (SelectResults) q[3].execute(new Object[] {"inactive"});
-      } else {
-        results[0][0] = (SelectResults) q[0].execute();
-        results[0][1] = (SelectResults) q[1].execute();
-        results[1][0] = (SelectResults) q[2].execute();
-        results[1][1] = (SelectResults) q[3].execute();
-      }
-    } catch (Exception e) {
-      exceptionThrown = true;
-      fail("Query execution failed " + e);
+    SelectResults[][] results = new SelectResults[2][2];
+    if (useBindParam) {
+      results[0][0] = (SelectResults) q[0].execute(new Object[] {"%nactive"});
+      results[0][1] = (SelectResults) q[1].execute(new Object[] {"inactive"});
+      results[1][0] = (SelectResults) q[2].execute(new Object[] {"%nactive"});
+      results[1][1] = (SelectResults) q[3].execute(new Object[] {"inactive"});
+    } else {
+      results[0][0] = (SelectResults) q[0].execute();
+      results[0][1] = (SelectResults) q[1].execute();
+      results[1][0] = (SelectResults) q[2].execute();
+      results[1][1] = (SelectResults) q[3].execute();
     }
     assertTrue(results[0][0].size() > 0);
     assertTrue(CacheUtils.compareResultsOfWithAndWithoutIndex(results));
-    assertFalse("Query exception should not have been thrown", exceptionThrown);
 
-    try {
-      qs.createIndex("IDindex", "ps.ID", "/pos ps");
-    } catch (Exception e) {
-      fail("Index creation failed");
-    }
+    qs.createIndex("IDindex", "ps.ID", "/pos ps");
 
-    exceptionThrown = false;
-    try {
-      if (useBindParam) {
-        results[0][0] = (SelectResults) q[0].execute(new Object[] {"%nactive"});
-        results[0][1] = (SelectResults) q[1].execute(new Object[] {"inactive"});
-        results[1][0] = (SelectResults) q[2].execute(new Object[] {"%nactive"});
-        results[1][1] = (SelectResults) q[3].execute(new Object[] {"inactive"});
-      } else {
-        results[0][0] = (SelectResults) q[0].execute();
-        results[0][1] = (SelectResults) q[1].execute();
-        results[1][0] = (SelectResults) q[2].execute();
-        results[1][1] = (SelectResults) q[3].execute();
-      }
-    } catch (Exception e) {
-      exceptionThrown = true;
-      fail("Query execution failed " + e);
+    if (useBindParam) {
+      results[0][0] = (SelectResults) q[0].execute(new Object[] {"%nactive"});
+      results[0][1] = (SelectResults) q[1].execute(new Object[] {"inactive"});
+      results[1][0] = (SelectResults) q[2].execute(new Object[] {"%nactive"});
+      results[1][1] = (SelectResults) q[3].execute(new Object[] {"inactive"});
+    } else {
+      results[0][0] = (SelectResults) q[0].execute();
+      results[0][1] = (SelectResults) q[1].execute();
+      results[1][0] = (SelectResults) q[2].execute();
+      results[1][1] = (SelectResults) q[3].execute();
     }
     assertTrue(results[0][0].size() > 0);
     assertTrue(CacheUtils.compareResultsOfWithAndWithoutIndex(results));
-    assertFalse("Query exception should not have been thrown", exceptionThrown);
   }
 
   @Test
   public void testUndefined() throws Exception {
-    String[] queries = {"select * from /pos where status.toUpperCase() like '%ACT%'",
-        "select * from /pos where status.toUpperCase() like 'ACT%'",
-        "select * from /pos where status.toUpperCase() like '%IVE'",
-        "select * from /pos where status.toUpperCase() like 'ACT_VE'",
-        "select * from /pos where status like '%CT%'",
-        "select * from /pos where status like 'ACT%'",
-        "select * from /pos where status like 'ACT_VE'",
-        "select * from /pos where position1.secId like '%B%'",
-        "select * from /pos where position1.secId like 'IB%'",
-        "select * from /pos where position1.secId like 'I_M'",
-        "select * from /pos p, p.positions.values pos where pos.secId like '%B%'",
-        "select * from /pos p, p.positions.values pos where pos.secId like 'IB%'",
-        "select * from /pos p, p.positions.values pos where pos.secId like 'I_M'",};
     Cache cache = CacheUtils.getCache();
     AttributesFactory attributesFactory = new AttributesFactory();
     RegionAttributes regionAttributes = attributesFactory.create();
@@ -2211,6 +2115,19 @@ public class LikePredicateJUnitTest {
       region.put("key-" + i, p);
     }
 
+    String[] queries = {"select * from /pos where status.toUpperCase() like '%ACT%'",
+        "select * from /pos where status.toUpperCase() like 'ACT%'",
+        "select * from /pos where status.toUpperCase() like '%IVE'",
+        "select * from /pos where status.toUpperCase() like 'ACT_VE'",
+        "select * from /pos where status like '%CT%'",
+        "select * from /pos where status like 'ACT%'",
+        "select * from /pos where status like 'ACT_VE'",
+        "select * from /pos where position1.secId like '%B%'",
+        "select * from /pos where position1.secId like 'IB%'",
+        "select * from /pos where position1.secId like 'I_M'",
+        "select * from /pos p, p.positions.values pos where pos.secId like '%B%'",
+        "select * from /pos p, p.positions.values pos where pos.secId like 'IB%'",
+        "select * from /pos p, p.positions.values pos where pos.secId like 'I_M'",};
     SelectResults[][] res = new SelectResults[queries.length][2];
 
     QueryService qs = CacheUtils.getCache().getQueryService();
@@ -2222,7 +2139,7 @@ public class LikePredicateJUnitTest {
         results = (SelectResults) q.execute();
         res[i][0] = results;
       } catch (Exception e) {
-        fail("Query execution failed for query " + queries[i] + " with exception: " + e);
+        throw new RuntimeException("Query execution failed for query " + queries[i], e);
       }
       if (i < 10) {
         assertEquals("Query " + queries[i] + " should return 5 results and not " + results.size(),
@@ -2233,13 +2150,9 @@ public class LikePredicateJUnitTest {
       }
     }
 
-    try {
-      qs.createIndex("status", "status", region.getFullPath());
-      qs.createIndex("position1secId", "pos1.secId", region.getFullPath());
-      qs.createIndex("secId", "pos.secId", region.getFullPath() + " pos, pos.secId");
-    } catch (Exception e) {
-      fail("Index creation failed");
-    }
+    qs.createIndex("status", "status", region.getFullPath());
+    qs.createIndex("position1secId", "pos1.secId", region.getFullPath());
+    qs.createIndex("secId", "pos.secId", region.getFullPath() + " pos, pos.secId");
 
     for (int i = 0; i < queries.length; i++) {
       Query q = qs.newQuery(queries[i]);
@@ -2247,7 +2160,7 @@ public class LikePredicateJUnitTest {
         results = (SelectResults) q.execute();
         res[i][1] = results;
       } catch (Exception e) {
-        fail("Query execution failed for query " + queries[i] + " with exception: " + e);
+        throw new RuntimeException("Query execution failed for query " + queries[i], e);
       }
       if (i < 10) {
         assertEquals("Query " + queries[i] + " should return 5 results and not " + results.size(),
@@ -2281,10 +2194,10 @@ public class LikePredicateJUnitTest {
       }
     }
   }
-  private class PortfolioModifiedStatus {
+
+  private static class PortfolioModifiedStatus implements Serializable {
     public PortfolioModifiedStatus(int id) {
       String[] status = {"inactive", "active"};
     }
   }
-
 }

--- a/geode-core/src/test/java/org/apache/geode/cache/query/functional/MiscJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/functional/MiscJUnitTest.java
@@ -12,15 +12,13 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-/*
- * MiscJUnitTest.java JUnit based test
- *
- * Created on March 10, 2005, 6:36 PM
- */
 package org.apache.geode.cache.query.functional;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
 
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -76,8 +74,9 @@ public class MiscJUnitTest {
         "SELECT DISTINCT * FROM (SELECT DISTINCT * FROM /Portfolios where status = 'active') p  where p.ID = 0");
     Collection result = (Collection) query.execute();
     Portfolio p = (Portfolio) (result.iterator().next());
-    if (!p.status.equals("active") || p.getID() != 0)
+    if (!p.status.equals("active") || p.getID() != 0) {
       fail(query.getQueryString());
+    }
   }
 
   @Ignore("TODO: test is disabled")
@@ -92,8 +91,9 @@ public class MiscJUnitTest {
         "SELECT DISTINCT * FROM /Portfolios WHERE NOT (SELECT DISTINCT * FROM positions.values p WHERE p.secId = 'IBM').isEmpty");
     Collection result = (Collection) query.execute();
     Portfolio p = (Portfolio) (result.iterator().next());
-    if (!p.positions.containsKey("IBM"))
+    if (!p.positions.containsKey("IBM")) {
       fail(query.getQueryString());
+    }
   }
 
   @Ignore("TODO: test is disabled")
@@ -104,13 +104,15 @@ public class MiscJUnitTest {
     Query query =
         CacheUtils.getQueryService().newQuery("SELECT DISTINCT * FROM /Data where voidMethod");
     Collection result = (Collection) query.execute();
-    if (result.size() != 0)
+    if (result.size() != 0) {
       fail(query.getQueryString());
+    }
     query = CacheUtils.getQueryService()
         .newQuery("SELECT DISTINCT * FROM /Data where voidMethod = null ");
     result = (Collection) query.execute();
-    if (result.size() != 1)
+    if (result.size() != 1) {
       fail(query.getQueryString());
+    }
   }
 
   @Ignore("TODO: test is disabled")
@@ -120,8 +122,9 @@ public class MiscJUnitTest {
     for (int i = 0; i < testData.length; i++) {
       Query query = CacheUtils.getQueryService().newQuery("SELECT DISTINCT * FROM " + testData[i]);
       Object result = query.execute();
-      if (!result.equals(QueryService.UNDEFINED))
+      if (!result.equals(QueryService.UNDEFINED)) {
         fail(query.getQueryString());
+      }
     }
   }
 
@@ -141,8 +144,9 @@ public class MiscJUnitTest {
     StructType type = (StructType) result.getCollectionType().getElementType();
     String names[] = type.getFieldNames();
     List list = result.asList();
-    if (list.size() < 1)
+    if (list.size() < 1) {
       fail("Test failed as the resultset's size is zero");
+    }
     for (int i = 0; i < list.size(); ++i) {
       Struct stc = (Struct) list.get(i);
       if (!stc.get(names[2]).equals("YHOO")) {
@@ -159,15 +163,6 @@ public class MiscJUnitTest {
     region.put("2", new Portfolio(2));
     region.put("3", new Portfolio(3));
     QueryService qs = CacheUtils.getQueryService();
-    /*
-     * String qStr = "Select distinct structset.sos, structset.key " +
-     * "from /portfolios pfos, pfos.positions.values outerPos, " +
-     * "(SELECT DISTINCT key: key, sos: pos.sharesOutstanding "+
-     * "from /portfolios.entries pf, pf.value.positions.values pos " +
-     * "where outerPos.secId != 'IBM' AND " +
-     * "pf.key IN (select distinct * from pf.value.collectionHolderMap['0'].arr)) structset " +
-     * "where structset.sos > 2000";
-     */
 
     String qStr =
         "Select distinct * from /portfolios pf, pf.positions.values where status = 'active' and secId = 'IBM'";
@@ -186,8 +181,9 @@ public class MiscJUnitTest {
         "/portfolios pf, positions.values, pf.collectionHolderMap chm, chm.value.arr itr");
     Query q = qs.newQuery(qStr);
     SelectResults result = (SelectResults) q.execute();
-    if (result.size() == 0)
+    if (result.size() == 0) {
       fail("Test failed as size is zero");
+    }
   }
 
   @Test
@@ -221,12 +217,8 @@ public class MiscJUnitTest {
 
   @Test
   public void testBug40428_1() throws Exception {
-    Object shortData1 = new Object() {
-      public short shortField = 4;
-    };
-    Object shortData2 = new Object() {
-      public short shortField = 5;
-    };
+    HasShort shortData1 = new HasShort((short) 4);
+    HasShort shortData2 = new HasShort((short) 5);
     Region region = CacheUtils.createRegion("shortFieldTest", Object.class);
     region.put("0", shortData1);
     QueryService qs = CacheUtils.getQueryService();
@@ -244,12 +236,8 @@ public class MiscJUnitTest {
 
   @Test
   public void testBug40428_2() throws Exception {
-    Object shortData1 = new Object() {
-      public short shortField = 4;
-    };
-    Object shortData2 = new Object() {
-      public short shortField = 5;
-    };
+    HasShort shortData1 = new HasShort((short) 4);
+    HasShort shortData2 = new HasShort((short) 5);
 
     Region region = CacheUtils.createRegion("shortFieldTest", Object.class);
     region.put("0", shortData1);
@@ -312,7 +300,7 @@ public class MiscJUnitTest {
     String queryStr = " select distinct r.name, pVal, r.\"type\"  "
         + " from /new_pos r , r.positions.values pVal where "
         + "  (r.name='name_11' OR r.name='name_12') AND pVal.mktValue >=1.00";
-    this.bug40333Simulation(region, queryStr);
+    bug40333Simulation(region, queryStr);
   }
 
   /**
@@ -334,7 +322,7 @@ public class MiscJUnitTest {
     String queryStr = " select distinct r.name, pVal, r.\"type\"  "
         + " from /new_pos r , r.positions.values pVal where "
         + "  (r.name='name_11' OR r.name='name_12') AND pVal.mktValue < 1.00";
-    this.bug40333Simulation(region, queryStr);
+    bug40333Simulation(region, queryStr);
   }
 
   /**
@@ -350,7 +338,7 @@ public class MiscJUnitTest {
     String queryStr = " select distinct r.name, pVal, r.\"type\"  "
         + " from /new_pos r , r.positions.values pVal where "
         + " ( r.name IN Set('name_11' , 'name_12') OR false ) AND pVal.mktValue = 1.00";
-    this.bug40333Simulation(region, queryStr);
+    bug40333Simulation(region, queryStr);
   }
 
   /**
@@ -372,7 +360,7 @@ public class MiscJUnitTest {
     String queryStr = " select distinct r.name, pVal, r.\"type\"  "
         + " from /new_pos r , r.positions.values pVal where "
         + " ( r.name IN Set('name_11' , 'name_12') OR false ) AND pVal.mktValue < 1.00";
-    this.bug40333Simulation(region, queryStr);
+    bug40333Simulation(region, queryStr);
   }
 
   private void bug40333Simulation(final Region region, final String queryStr) throws Exception {
@@ -387,10 +375,10 @@ public class MiscJUnitTest {
     final boolean[] keepGoing = new boolean[] {true};
 
     Thread indexCreatorDestroyer = new Thread(new Runnable() {
+      @Override
       public void run() {
         boolean continueRunning = true;
         do {
-
           synchronized (lock) {
             continueRunning = keepGoing[0];
           }
@@ -423,7 +411,6 @@ public class MiscJUnitTest {
           }
         } while (continueRunning);
       }
-
     });
 
     indexCreatorDestroyer.start();
@@ -433,6 +420,7 @@ public class MiscJUnitTest {
     final int numTimesToRun = 75;
     for (int i = 0; i < THREAD_COUNT; ++i) {
       queryThreads[i] = new Thread(new Runnable() {
+        @Override
         public void run() {
           boolean continueRunning = true;
           for (int i = 0; i < numTimesToRun && continueRunning; ++i) {
@@ -474,7 +462,6 @@ public class MiscJUnitTest {
     synchronized (lock) {
       assertFalse(expectionOccurred[0]);
     }
-
   }
 
   @Test
@@ -558,5 +545,13 @@ public class MiscJUnitTest {
     assertEquals(result.size(), 1);
     pf = (Portfolio) result.iterator().next();
     assertEquals(pf.getID(), 3);
+  }
+
+  private static class HasShort implements Serializable {
+    public final short shortField;
+
+    HasShort(short shortField) {
+      this.shortField = shortField;
+    }
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/cache/query/functional/MultipleRegionsJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/functional/MultipleRegionsJUnitTest.java
@@ -12,12 +12,6 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-/*
- * MultipleRegionsJUnitTest.java
- *
- * Created on May 18, 2005, 5:02 PM
- */
-
 package org.apache.geode.cache.query.functional;
 
 import static org.junit.Assert.fail;
@@ -38,12 +32,8 @@ import org.apache.geode.cache.query.data.Portfolio;
 import org.apache.geode.test.junit.categories.IntegrationTest;
 import org.apache.geode.test.junit.categories.OQLQueryTest;
 
-/**
- *
- */
 @Category({IntegrationTest.class, OQLQueryTest.class})
 public class MultipleRegionsJUnitTest {
-
 
   @Before
   public void setUp() throws java.lang.Exception {
@@ -86,19 +76,12 @@ public class MultipleRegionsJUnitTest {
         "Select distinct * from /Portfolios, /Portfolios2",
         "Select distinct * from /Portfolios3, /Data", "Select distinct * from /Portfolios, /Data",
         "Select distinct * from /Portfolios pf, /Portfolios2, /Portfolios3, /Data where pf.status='active'"};
-    try {
-      for (int i = 0; i < queries.length; i++) {
-        Query query = qs.newQuery(queries[i]);
-        Object result = query.execute();
-        // CacheUtils.log(Utils.printResult(result));
-        if (((Collection) result).size() != SizeArray[i])
-          fail("Size of Result is not as Expected");
-      }
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail();
+
+    for (int i = 0; i < queries.length; i++) {
+      Query query = qs.newQuery(queries[i]);
+      Object result = query.execute();
+      if (((Collection) result).size() != SizeArray[i])
+        fail("Size of Result is not as Expected");
     }
   }
-
-
 }

--- a/geode-core/src/test/java/org/apache/geode/cache/query/functional/ReservedKeywordsJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/functional/ReservedKeywordsJUnitTest.java
@@ -12,11 +12,6 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-/*
- * ReservedKeywordsJUnitTest.java JUnit based test
- *
- * Created on March 10, 2005, 7:14 PM
- */
 package org.apache.geode.cache.query.functional;
 
 import static org.junit.Assert.fail;
@@ -35,8 +30,6 @@ import org.apache.geode.cache.query.data.Keywords;
 import org.apache.geode.test.junit.categories.IntegrationTest;
 import org.apache.geode.test.junit.categories.OQLQueryTest;
 
-/**
- */
 @Category({IntegrationTest.class, OQLQueryTest.class})
 public class ReservedKeywordsJUnitTest {
 
@@ -63,8 +56,9 @@ public class ReservedKeywordsJUnitTest {
       CacheUtils.log(qStr);
       query = CacheUtils.getQueryService().newQuery(qStr);
       result = (Collection) query.execute();
-      if (result.size() != 1)
+      if (result.size() != 1) {
         fail(query.getQueryString());
+      }
     }
     for (int i = 0; i < keywords.length; i++) {
       String qStr =
@@ -72,8 +66,9 @@ public class ReservedKeywordsJUnitTest {
       CacheUtils.log(qStr);
       query = CacheUtils.getQueryService().newQuery(qStr);
       result = (Collection) query.execute();
-      if (result.size() != 1)
+      if (result.size() != 1) {
         fail(query.getQueryString());
+      }
     }
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/cache/query/internal/CopyOnReadQueryJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/internal/CopyOnReadQueryJUnitTest.java
@@ -34,35 +34,24 @@ import org.apache.geode.cache.query.data.Position;
 import org.apache.geode.test.junit.categories.IntegrationTest;
 import org.apache.geode.test.junit.categories.OQLQueryTest;
 
-/**
- *
- *
- */
 @Category({IntegrationTest.class, OQLQueryTest.class})
 public class CopyOnReadQueryJUnitTest {
 
-  static int numObjects = 10;
-  static int objectsAndResultsMultiplier = 100;
-  QueryTestUtils utils;
-  static String regionName = "portfolios";
-  static final String indexName = "testIndex";
-  String[] queries = {"select * from /" + regionName + " p where p.indexKey = 1",
+  private static int numObjects = 10;
+  private static int objectsAndResultsMultiplier = 100;
+  private static String regionName = "portfolios";
+  private static final String indexName = "testIndex";
+
+  private QueryTestUtils utils;
+  private String[] queries = {"select * from /" + regionName + " p where p.indexKey = 1",
       "select distinct * from /" + regionName + " p where p.indexKey = 1 order by p.indexKey",
       "select * from /" + regionName + " p, p.positions.values pv where pv.secId = '1'",
       "select * from /" + regionName + " p where p in (select * from /" + regionName
-          + " pi where pi.indexKey = 1)",
+          + " pi where pi.indexKey = 1)"};
 
-      // "select * from /" + regionName + " p where p.ID = ELEMENT(select pi.ID from /" + regionName
-      // + " pi where pi.ID = 1)"
-  };
+  private int[] expectedResults = {1, 1, 1, 1};
 
-  int[] expectedResults = {1, 1, 1, 1// ,
-                                     // 1
-  };
-
-  boolean[] containsInnerQuery = {false, false, false, true
-
-  };
+  private boolean[] containsInnerQuery = {false, false, false, true};
 
   @Before
   public void setUp() throws java.lang.Exception {
@@ -78,14 +67,6 @@ public class CopyOnReadQueryJUnitTest {
     utils.closeCache();
   }
 
-
-  /**
-   *
-   * @param region
-   * @param numObjects
-   * @param objectsAndResultsMultiplier number of similar objects to put into the cache so that
-   *        results from queries will be satisfied by the multiple
-   */
   private void createData(Region region, int numObjects, int objectsAndResultsMultiplier) {
     for (int i = 0; i < numObjects; i++) {
       for (int j = 0; j < objectsAndResultsMultiplier; j++) {
@@ -153,7 +134,6 @@ public class CopyOnReadQueryJUnitTest {
     }
   }
 
-  // Test copy on read false
   @Test
   public void testCopyOnReadFalseWithHashIndexWithLocalRegion() throws Exception {
     utils.getCache().setCopyOnRead(false);
@@ -253,25 +233,6 @@ public class CopyOnReadQueryJUnitTest {
         objectsAndResultsMultiplier, true, false);
   }
 
-  // @Test
-  // public void testCopyOnReadFalseWithRangeIndexTupleWithPartitionedRegion() throws Exception {
-  // utils.getCache().setCopyOnRead(false);
-  // utils.createPartitionRegion(regionName, null);
-  // utils.createIndex(indexName, "pv.secId", "/" + regionName + " p, p.positions.values pv");
-  // helpExecuteQueriesCopyOnReadFalse(queries, expectedResults, numObjects,
-  // objectsAndResultsMultiplier, true, true);
-  // }
-
-  /**
-   *
-   * @param queries
-   * @param expectedResults
-   * @param numObjects
-   * @param objectsAndResultsMultiplier
-   * @param hasIndex
-   * @param isPR
-   * @throws Exception
-   */
   private void helpExecuteQueriesCopyOnRead(String[] queries, int[] expectedResults, int numObjects,
       int objectsAndResultsMultiplier, boolean hasIndex, boolean isPR) throws Exception {
     Region region = utils.getCache().getRegion("/" + regionName);
@@ -286,16 +247,6 @@ public class CopyOnReadQueryJUnitTest {
     }
   }
 
-  /**
-   *
-   * @param queries
-   * @param expectedResults
-   * @param numObjects
-   * @param objectsAndResultsMultiplier
-   * @param hasIndex
-   * @param isPR
-   * @throws Exception
-   */
   private void helpExecuteQueriesCopyOnReadFalse(String[] queries, int[] expectedResults,
       int numObjects, int objectsAndResultsMultiplier, boolean hasIndex, boolean isPR)
       throws Exception {
@@ -386,7 +337,6 @@ public class CopyOnReadQueryJUnitTest {
     // this point. These results themselves would have been copied
     assertEquals("Unexpected number of Portfolio instances",
         numInstances + expectedResultsSizeMultiplied * 2, Portfolio.instanceCount.get());
-
   }
 
   private void helpTestCopyOnReadFalse(String queryString, int expectedResultsSize, int numObjects,
@@ -444,8 +394,5 @@ public class CopyOnReadQueryJUnitTest {
     // deserialized value
     assertEquals("Unexpected number of Portfolio instances" + queryString, numInstances,
         Portfolio.instanceCount.get());
-
   }
-
-
 }

--- a/geode-core/src/test/java/org/apache/geode/cache/query/internal/QueryObserverCallbackJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/internal/QueryObserverCallbackJUnitTest.java
@@ -12,16 +12,9 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-/*
- * Created on Dec 12, 2005
- *
- * TODO To change the template for this generated file go to Window - Preferences - Java - Code
- * Style - Code Templates
- */
 package org.apache.geode.cache.query.internal;
 
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -47,15 +40,11 @@ import org.apache.geode.internal.cache.LocalRegion;
 import org.apache.geode.test.junit.categories.IntegrationTest;
 import org.apache.geode.test.junit.categories.OQLQueryTest;
 
-/**
- *
- *
- */
 @Category({IntegrationTest.class, OQLQueryTest.class})
 public class QueryObserverCallbackJUnitTest {
 
-  Region region;
-  QueryService qs;
+  private Region region;
+  private QueryService qs;
 
   @Before
   public void setUp() throws Exception {
@@ -67,376 +56,332 @@ public class QueryObserverCallbackJUnitTest {
     region.put("3", new Portfolio(3));
 
     qs = CacheUtils.getQueryService();
-
   }
 
   @After
   public void tearDown() throws Exception {
     CacheUtils.closeCache();
     IndexManager indexManager = ((LocalRegion) region).getIndexManager();
-    if (indexManager != null)
+    if (indexManager != null) {
       indexManager.destroy();
-  }
-
-  @Test
-  public void testBeforeAndAfterCartesianOfGroupJunctionsInAnAllGroupJunctionOfType_AND() {
-    try {
-      Region r3 = CacheUtils.createRegion("employees", Employee.class);
-      Set add1 = new HashSet();
-      add1.add(new Address("411045", "Baner"));
-      add1.add(new Address("411001", "DholePatilRd"));
-      for (int i = 0; i < 4; i++) {
-        r3.put(i + "", new Employee("empName", (20 + i), i, "Mr.", (5000 + i), add1));
-      }
-      Region r4 = CacheUtils.createRegion("portfolio1", Portfolio.class);
-      for (int i = 0; i < 4; i++) {
-        r4.put(i + "", new Portfolio(i));
-      }
-      Query query = qs.newQuery(
-          "select distinct * from /portfolio p, p.positions,/employees e, /portfolio1 p1 where p.ID = 1 and p1.ID = 2 and e.empId = 1");
-      qs.createIndex("statusIndex", IndexType.FUNCTIONAL, "status", "/portfolio");
-      qs.createIndex("idIndex", IndexType.FUNCTIONAL, "ID", "/portfolio");
-      qs.createIndex("idIndex1", IndexType.FUNCTIONAL, "ID", "/portfolio1");
-      qs.createIndex("empidIndex", IndexType.FUNCTIONAL, "empId", "/employees");
-      MyQueryObserverImpl inst = new MyQueryObserverImpl();
-      QueryObserverHolder.setInstance(inst);
-      query.execute();
-      assertTrue(
-          "beforeCartesianOfGroupJunctionsInAnAllGroupJunctionOfType_AND callbak not received",
-          inst.bfrCartesianOfGroupJunctionsInAnAllGroupJunctionOfType_AND);
-      assertTrue(
-          "afterCartesianOfGroupJunctionsInAnAllGroupJunctionOfType_AND callbak not received",
-          inst.aftCartesianOfGroupJunctionsInAnAllGroupJunctionOfType_AND);
-
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail(e.toString());
     }
   }
 
   @Test
-  public void testBeforeAndAfterCartesianOfCompositeGroupJunctionsInAnAllGroupJunctionOfType_AND() {
-    try {
-      Region r3 = CacheUtils.createRegion("employees", Employee.class);
-      Set add1 = new HashSet();
-      add1.add(new Address("411045", "Baner"));
-      add1.add(new Address("411001", "DholePatilRd"));
-      for (int i = 0; i < 4; i++) {
-        r3.put(i + "", new Employee("empName", (20 + i), i, "Mr.", (5000 + i), add1));
-      }
-      Region r4 = CacheUtils.createRegion("portfolio1", Portfolio.class);
-      for (int i = 0; i < 4; i++) {
-        r4.put(i + "", new Portfolio(i));
-      }
-      Query query = qs.newQuery(
-          "select distinct * from /portfolio p, p.positions,/employees e, /portfolio1 p1 where p.ID =p1.ID   and e.empId = 1 and p1.status = 'active' and p.status='active' ");
-      qs.createIndex("statusIndex1", IndexType.FUNCTIONAL, "status", "/portfolio");
-      qs.createIndex("statusIndex2", IndexType.FUNCTIONAL, "status", "/portfolio1");
-      qs.createIndex("idIndex", IndexType.FUNCTIONAL, "ID", "/portfolio");
-      qs.createIndex("idIndex1", IndexType.FUNCTIONAL, "ID", "/portfolio1");
-      qs.createIndex("empidIndex", IndexType.FUNCTIONAL, "empId", "/employees");
-      MyQueryObserverImpl inst = new MyQueryObserverImpl();
-      QueryObserverHolder.setInstance(inst);
-      query.execute();
-      assertTrue(
-          "beforeCartesianOfCompositeGroupJunctionsInAnAllGroupJunctionOfType_AND callbak not received",
-          inst.bfrCartesianOfGroupJunctionsInCompositeGroupJunctionOfType_AND);
-      assertTrue(
-          "afterCartesianOfCompositeGroupJunctionsInAnAllGroupJunctionOfType_AND callbak not received",
-          inst.aftCartesianOfGroupJunctionsInCompositeGroupJunctionOfType_AND);
-
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail(e.toString());
+  public void testBeforeAndAfterCartesianOfGroupJunctionsInAnAllGroupJunctionOfType_AND()
+      throws Exception {
+    Region r3 = CacheUtils.createRegion("employees", Employee.class);
+    Set add1 = new HashSet();
+    add1.add(new Address("411045", "Baner"));
+    add1.add(new Address("411001", "DholePatilRd"));
+    for (int i = 0; i < 4; i++) {
+      r3.put(i + "", new Employee("empName", (20 + i), i, "Mr.", (5000 + i), add1));
     }
+    Region r4 = CacheUtils.createRegion("portfolio1", Portfolio.class);
+    for (int i = 0; i < 4; i++) {
+      r4.put(i + "", new Portfolio(i));
+    }
+    Query query = qs.newQuery(
+        "select distinct * from /portfolio p, p.positions,/employees e, /portfolio1 p1 where p.ID = 1 and p1.ID = 2 and e.empId = 1");
+    qs.createIndex("statusIndex", IndexType.FUNCTIONAL, "status", "/portfolio");
+    qs.createIndex("idIndex", IndexType.FUNCTIONAL, "ID", "/portfolio");
+    qs.createIndex("idIndex1", IndexType.FUNCTIONAL, "ID", "/portfolio1");
+    qs.createIndex("empidIndex", IndexType.FUNCTIONAL, "empId", "/employees");
+    MyQueryObserverImpl inst = new MyQueryObserverImpl();
+    QueryObserverHolder.setInstance(inst);
+    query.execute();
+    assertTrue("beforeCartesianOfGroupJunctionsInAnAllGroupJunctionOfType_AND callbak not received",
+        inst.bfrCartesianOfGroupJunctionsInAnAllGroupJunctionOfType_AND);
+    assertTrue("afterCartesianOfGroupJunctionsInAnAllGroupJunctionOfType_AND callbak not received",
+        inst.aftCartesianOfGroupJunctionsInAnAllGroupJunctionOfType_AND);
   }
 
   @Test
-  public void testBeforeAndAfterCutDownAndExpansionOfSingleIndexResult() {
-    try {
-      Query query =
-          qs.newQuery("select distinct * from /portfolio p, p.positions where p.ID = 1  ");
-      qs.createIndex("idIndex", IndexType.FUNCTIONAL, "ID", "/portfolio");
-      MyQueryObserverImpl inst = new MyQueryObserverImpl();
-      QueryObserverHolder.setInstance(inst);
-      query.execute();
-      assertTrue("beforeCutDownAndExpansionOfSingleIndexResult callbak not received",
-          inst.bfrCutDownAndExpansionOfSingleIndexResult);
-      assertTrue("afterCutDownAndExpansionOfSingleIndexResult callbak not received",
-          inst.aftCutDownAndExpansionOfSingleIndexResult);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail(e.toString());
+  public void testBeforeAndAfterCartesianOfCompositeGroupJunctionsInAnAllGroupJunctionOfType_AND()
+      throws Exception {
+    Region r3 = CacheUtils.createRegion("employees", Employee.class);
+    Set add1 = new HashSet();
+    add1.add(new Address("411045", "Baner"));
+    add1.add(new Address("411001", "DholePatilRd"));
+    for (int i = 0; i < 4; i++) {
+      r3.put(i + "", new Employee("empName", (20 + i), i, "Mr.", (5000 + i), add1));
     }
+    Region r4 = CacheUtils.createRegion("portfolio1", Portfolio.class);
+    for (int i = 0; i < 4; i++) {
+      r4.put(i + "", new Portfolio(i));
+    }
+    Query query = qs.newQuery(
+        "select distinct * from /portfolio p, p.positions,/employees e, /portfolio1 p1 where p.ID =p1.ID   and e.empId = 1 and p1.status = 'active' and p.status='active' ");
+    qs.createIndex("statusIndex1", IndexType.FUNCTIONAL, "status", "/portfolio");
+    qs.createIndex("statusIndex2", IndexType.FUNCTIONAL, "status", "/portfolio1");
+    qs.createIndex("idIndex", IndexType.FUNCTIONAL, "ID", "/portfolio");
+    qs.createIndex("idIndex1", IndexType.FUNCTIONAL, "ID", "/portfolio1");
+    qs.createIndex("empidIndex", IndexType.FUNCTIONAL, "empId", "/employees");
+    MyQueryObserverImpl inst = new MyQueryObserverImpl();
+    QueryObserverHolder.setInstance(inst);
+    query.execute();
+    assertTrue(
+        "beforeCartesianOfCompositeGroupJunctionsInAnAllGroupJunctionOfType_AND callbak not received",
+        inst.bfrCartesianOfGroupJunctionsInCompositeGroupJunctionOfType_AND);
+    assertTrue(
+        "afterCartesianOfCompositeGroupJunctionsInAnAllGroupJunctionOfType_AND callbak not received",
+        inst.aftCartesianOfGroupJunctionsInCompositeGroupJunctionOfType_AND);
   }
 
   @Test
-  public void testBeforeAndAfterMergeJoinOfDoubleIndexResults() {
-    try {
-      Region r3 = CacheUtils.createRegion("employees", Employee.class);
-      Set add1 = new HashSet();
-      add1.add(new Address("411045", "Baner"));
-      add1.add(new Address("411001", "DholePatilRd"));
-      for (int i = 0; i < 4; i++) {
-        r3.put(i + "", new Employee("empName", (20 + i), i, "Mr.", (5000 + i), add1));
-      }
-
-      Query query = qs.newQuery(
-          "select distinct * from /portfolio p, p.positions,/employees e where p.ID =  e.empId  ");
-      qs.createIndex("idIndex", IndexType.FUNCTIONAL, "ID", "/portfolio");
-      qs.createIndex("empidIndex", IndexType.FUNCTIONAL, "empId", "/employees");
-      MyQueryObserverImpl inst = new MyQueryObserverImpl();
-      QueryObserverHolder.setInstance(inst);
-      query.execute();
-      assertTrue("beforeMergeJoinOfDoubleIndexResults callbak not received",
-          inst.bfrMergeJoinOfDoubleIndexResults);
-      assertTrue("afterMergeJoinOfDoubleIndexResults callbak not received",
-          inst.aftMergeJoinOfDoubleIndexResults);
-
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail(e.toString());
-    }
+  public void testBeforeAndAfterCutDownAndExpansionOfSingleIndexResult() throws Exception {
+    Query query = qs.newQuery("select distinct * from /portfolio p, p.positions where p.ID = 1  ");
+    qs.createIndex("idIndex", IndexType.FUNCTIONAL, "ID", "/portfolio");
+    MyQueryObserverImpl inst = new MyQueryObserverImpl();
+    QueryObserverHolder.setInstance(inst);
+    query.execute();
+    assertTrue("beforeCutDownAndExpansionOfSingleIndexResult callbak not received",
+        inst.bfrCutDownAndExpansionOfSingleIndexResult);
+    assertTrue("afterCutDownAndExpansionOfSingleIndexResult callbak not received",
+        inst.aftCutDownAndExpansionOfSingleIndexResult);
   }
 
   @Test
-  public void testBeforeAndAfterIterJoinOfSingleIndexResults() {
-    try {
-      Region r3 = CacheUtils.createRegion("employees", Employee.class);
-      Set add1 = new HashSet();
-      add1.add(new Address("411045", "Baner"));
-      add1.add(new Address("411001", "DholePatilRd"));
-      for (int i = 0; i < 4; i++) {
-        r3.put(i + "", new Employee("empName", (20 + i), i, "Mr.", (5000 + i), add1));
-      }
-      Region r4 = CacheUtils.createRegion("portfolio1", Portfolio.class);
-      for (int i = 0; i < 4; i++) {
-        r4.put(i + "", new Portfolio(i));
-      }
-      Query query = qs.newQuery(
-          "select distinct * from /portfolio p, p.positions,/employees e, /portfolio1 p1 where p.ID =p1.ID   and e.empId = p1.ID ");
-
-      qs.createIndex("idIndex", IndexType.FUNCTIONAL, "ID", "/portfolio");
-      qs.createIndex("idIndex1", IndexType.FUNCTIONAL, "ID", "/portfolio1");
-      qs.createIndex("empidIndex", IndexType.FUNCTIONAL, "empId", "/employees");
-      MyQueryObserverImpl inst = new MyQueryObserverImpl();
-      QueryObserverHolder.setInstance(inst);
-      query.execute();
-      assertTrue("beforeIterJoinOfSingleIndexResults callbak not received",
-          inst.bfrIterJoinOfSingleIndexResults);
-      assertTrue("afterIterJoinOfSingleIndexResults callbak not received",
-          inst.aftIterJoinOfSingleIndexResults);
-      assertTrue("Validate callback of Indexes", inst.dbIndx[2] == inst.usedIndx);
-      assertTrue("Validate callback of Indexes",
-          inst.unusedIndx == inst.dbIndx[0] || inst.unusedIndx == inst.dbIndx[1]);
-
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail(e.toString());
+  public void testBeforeAndAfterMergeJoinOfDoubleIndexResults() throws Exception {
+    Region r3 = CacheUtils.createRegion("employees", Employee.class);
+    Set add1 = new HashSet();
+    add1.add(new Address("411045", "Baner"));
+    add1.add(new Address("411001", "DholePatilRd"));
+    for (int i = 0; i < 4; i++) {
+      r3.put(i + "", new Employee("empName", (20 + i), i, "Mr.", (5000 + i), add1));
     }
+
+    Query query = qs.newQuery(
+        "select distinct * from /portfolio p, p.positions,/employees e where p.ID =  e.empId  ");
+    qs.createIndex("idIndex", IndexType.FUNCTIONAL, "ID", "/portfolio");
+    qs.createIndex("empidIndex", IndexType.FUNCTIONAL, "empId", "/employees");
+    MyQueryObserverImpl inst = new MyQueryObserverImpl();
+    QueryObserverHolder.setInstance(inst);
+    query.execute();
+    assertTrue("beforeMergeJoinOfDoubleIndexResults callbak not received",
+        inst.bfrMergeJoinOfDoubleIndexResults);
+    assertTrue("afterMergeJoinOfDoubleIndexResults callbak not received",
+        inst.aftMergeJoinOfDoubleIndexResults);
   }
 
   @Test
-  public void testBeforeRangeJunctionDoubleConditionLookup() {
-    try {
-      Region r3 = CacheUtils.createRegion("employees", Employee.class);
-      Set add1 = new HashSet();
-      add1.add(new Address("411045", "Baner"));
-      add1.add(new Address("411001", "DholePatilRd"));
-      for (int i = 0; i < 4; i++) {
-        r3.put(i + "", new Employee("empName", (20 + i), i, "Mr.", (5000 + i), add1));
-      }
-      Region r4 = CacheUtils.createRegion("portfolio1", Portfolio.class);
-      for (int i = 0; i < 4; i++) {
-        r4.put(i + "", new Portfolio(i));
-      }
-      Query query =
-          qs.newQuery("select distinct * from /portfolio p where p.ID > 1   and  p.ID < 3 ");
-
-      qs.createIndex("idIndex", IndexType.FUNCTIONAL, "ID", "/portfolio");
-      qs.createIndex("idIndex1", IndexType.FUNCTIONAL, "ID", "/portfolio1");
-      qs.createIndex("empidIndex", IndexType.FUNCTIONAL, "empId", "/employees");
-      MyQueryObserverImpl inst = new MyQueryObserverImpl();
-      QueryObserverHolder.setInstance(inst);
-      query.execute();
-      assertTrue(
-          "beforeIndexLookup For RangeJunction.DoubleCondnRangeJunctionEvaluator not invoked",
-          inst.beforeRangeJunctionDoubleCondnIndexLookup);
-
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail(e.toString());
+  public void testBeforeAndAfterIterJoinOfSingleIndexResults() throws Exception {
+    Region r3 = CacheUtils.createRegion("employees", Employee.class);
+    Set add1 = new HashSet();
+    add1.add(new Address("411045", "Baner"));
+    add1.add(new Address("411001", "DholePatilRd"));
+    for (int i = 0; i < 4; i++) {
+      r3.put(i + "", new Employee("empName", (20 + i), i, "Mr.", (5000 + i), add1));
     }
+    Region r4 = CacheUtils.createRegion("portfolio1", Portfolio.class);
+    for (int i = 0; i < 4; i++) {
+      r4.put(i + "", new Portfolio(i));
+    }
+    Query query = qs.newQuery(
+        "select distinct * from /portfolio p, p.positions,/employees e, /portfolio1 p1 where p.ID =p1.ID   and e.empId = p1.ID ");
+
+    qs.createIndex("idIndex", IndexType.FUNCTIONAL, "ID", "/portfolio");
+    qs.createIndex("idIndex1", IndexType.FUNCTIONAL, "ID", "/portfolio1");
+    qs.createIndex("empidIndex", IndexType.FUNCTIONAL, "empId", "/employees");
+    MyQueryObserverImpl inst = new MyQueryObserverImpl();
+    QueryObserverHolder.setInstance(inst);
+    query.execute();
+    assertTrue("beforeIterJoinOfSingleIndexResults callbak not received",
+        inst.bfrIterJoinOfSingleIndexResults);
+    assertTrue("afterIterJoinOfSingleIndexResults callbak not received",
+        inst.aftIterJoinOfSingleIndexResults);
+    assertTrue("Validate callback of Indexes", inst.dbIndx[2] == inst.usedIndx);
+    assertTrue("Validate callback of Indexes",
+        inst.unusedIndx == inst.dbIndx[0] || inst.unusedIndx == inst.dbIndx[1]);
   }
 
-  class MyQueryObserverImpl implements QueryObserver {
+  @Test
+  public void testBeforeRangeJunctionDoubleConditionLookup() throws Exception {
+    Region r3 = CacheUtils.createRegion("employees", Employee.class);
+    Set add1 = new HashSet();
+    add1.add(new Address("411045", "Baner"));
+    add1.add(new Address("411001", "DholePatilRd"));
+    for (int i = 0; i < 4; i++) {
+      r3.put(i + "", new Employee("empName", (20 + i), i, "Mr.", (5000 + i), add1));
+    }
+    Region r4 = CacheUtils.createRegion("portfolio1", Portfolio.class);
+    for (int i = 0; i < 4; i++) {
+      r4.put(i + "", new Portfolio(i));
+    }
+    Query query =
+        qs.newQuery("select distinct * from /portfolio p where p.ID > 1   and  p.ID < 3 ");
 
-    boolean aftCartesianOfGroupJunctionsInAnAllGroupJunctionOfType_AND = false;
-    boolean bfrCartesianOfGroupJunctionsInAnAllGroupJunctionOfType_AND = false;
-    boolean bfrCartesianOfGroupJunctionsInCompositeGroupJunctionOfType_AND = false;
-    boolean aftCartesianOfGroupJunctionsInCompositeGroupJunctionOfType_AND = false;
-    boolean bfrCutDownAndExpansionOfSingleIndexResult = false;
-    boolean aftCutDownAndExpansionOfSingleIndexResult = false;
-    boolean bfrMergeJoinOfDoubleIndexResults = false;
-    boolean aftMergeJoinOfDoubleIndexResults = false;
-    boolean bfrIterJoinOfSingleIndexResults = false;
-    boolean aftIterJoinOfSingleIndexResults = false;
-    boolean beforeRangeJunctionDoubleCondnIndexLookup = false;
-    Index usedIndx = null;
-    Index unusedIndx = null;
-    int j = 0;
-    Index[] dbIndx = new Index[3];
+    qs.createIndex("idIndex", IndexType.FUNCTIONAL, "ID", "/portfolio");
+    qs.createIndex("idIndex1", IndexType.FUNCTIONAL, "ID", "/portfolio1");
+    qs.createIndex("empidIndex", IndexType.FUNCTIONAL, "empId", "/employees");
+    MyQueryObserverImpl inst = new MyQueryObserverImpl();
+    QueryObserverHolder.setInstance(inst);
+    query.execute();
+    assertTrue("beforeIndexLookup For RangeJunction.DoubleCondnRangeJunctionEvaluator not invoked",
+        inst.beforeRangeJunctionDoubleCondnIndexLookup);
+  }
 
+  private static class MyQueryObserverImpl implements QueryObserver {
+
+    private boolean aftCartesianOfGroupJunctionsInAnAllGroupJunctionOfType_AND = false;
+    private boolean bfrCartesianOfGroupJunctionsInAnAllGroupJunctionOfType_AND = false;
+    private boolean bfrCartesianOfGroupJunctionsInCompositeGroupJunctionOfType_AND = false;
+    private boolean aftCartesianOfGroupJunctionsInCompositeGroupJunctionOfType_AND = false;
+    private boolean bfrCutDownAndExpansionOfSingleIndexResult = false;
+    private boolean aftCutDownAndExpansionOfSingleIndexResult = false;
+    private boolean bfrMergeJoinOfDoubleIndexResults = false;
+    private boolean aftMergeJoinOfDoubleIndexResults = false;
+    private boolean bfrIterJoinOfSingleIndexResults = false;
+    private boolean aftIterJoinOfSingleIndexResults = false;
+    private boolean beforeRangeJunctionDoubleCondnIndexLookup = false;
+    private Index usedIndx = null;
+    private Index unusedIndx = null;
+    private int j = 0;
+    private Index[] dbIndx = new Index[3];
+
+    @Override
     public void beforeIndexLookup(Index index, int oper, Object key) {
       dbIndx[j++] = index;
       if (j == 3)
         j = 0;
     }
 
-
+    @Override
     public void startQuery(Query query) {
-
-
+      // nothing
     }
 
+    @Override
     public void beforeQueryEvaluation(CompiledValue expression, ExecutionContext context) {
-
-
+      // nothing
     }
 
-
+    @Override
     public void startIteration(Collection collection, CompiledValue whereClause) {
-
+      // nothing
     }
 
+    @Override
     public void beforeIterationEvaluation(CompiledValue executer, Object currentObject) {
-
-
+      // nothing
     }
 
+    @Override
     public void afterIterationEvaluation(Object result) {
-
-
+      // nothing
     }
 
+    @Override
     public void endIteration(SelectResults results) {
-
+      // nothing
     }
 
+    @Override
     public void afterIndexLookup(Collection results) {
-
+      // nothing
     }
 
+    @Override
     public void afterQueryEvaluation(Object result) {
-
+      // nothing
     }
 
+    @Override
     public void endQuery() {
-
+      // nothing
     }
 
-
+    @Override
     public void beforeRerunningIndexCreationQuery() {
-
-
+      // nothing
     }
 
-
+    @Override
     public void beforeCartesianOfGroupJunctionsInAnAllGroupJunctionOfType_AND(
         Collection[] grpResults) {
       bfrCartesianOfGroupJunctionsInAnAllGroupJunctionOfType_AND = true;
-
     }
 
-
+    @Override
     public void afterCartesianOfGroupJunctionsInAnAllGroupJunctionOfType_AND() {
       aftCartesianOfGroupJunctionsInAnAllGroupJunctionOfType_AND = true;
-
     }
 
-
+    @Override
     public void beforeCartesianOfGroupJunctionsInCompositeGroupJunctionOfType_AND(
         Collection[] grpResults) {
       bfrCartesianOfGroupJunctionsInCompositeGroupJunctionOfType_AND = true;
-
     }
 
-
+    @Override
     public void afterCartesianOfGroupJunctionsInCompositeGroupJunctionOfType_AND() {
       aftCartesianOfGroupJunctionsInCompositeGroupJunctionOfType_AND = true;
-
     }
 
-
+    @Override
     public void beforeCutDownAndExpansionOfSingleIndexResult(Index index,
         Collection initialResult) {
       bfrCutDownAndExpansionOfSingleIndexResult = true;
-
     }
 
-
+    @Override
     public void afterCutDownAndExpansionOfSingleIndexResult(Collection finalResult) {
       aftCutDownAndExpansionOfSingleIndexResult = true;
-
     }
 
-
+    @Override
     public void beforeMergeJoinOfDoubleIndexResults(Index index1, Index index2,
         Collection initialResult) {
       bfrMergeJoinOfDoubleIndexResults = true;
-
     }
 
-
+    @Override
     public void afterMergeJoinOfDoubleIndexResults(Collection finalResult) {
       aftMergeJoinOfDoubleIndexResults = true;
-
     }
 
-
+    @Override
     public void beforeIterJoinOfSingleIndexResults(Index usedIndex, Index unusedIndex) {
       bfrIterJoinOfSingleIndexResults = true;
-      this.usedIndx = usedIndex;
-      this.unusedIndx = unusedIndex;
-
+      usedIndx = usedIndex;
+      unusedIndx = unusedIndex;
     }
 
-
+    @Override
     public void afterIterJoinOfSingleIndexResults(Collection finalResult) {
       aftIterJoinOfSingleIndexResults = true;
-
     }
 
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * org.apache.geode.cache.query.internal.QueryObserver#beforeIndexLookup(org.apache.geode.cache.
-     * query.Index, int, java.lang.Object, int, java.lang.Object, java.util.Set)
-     */
+    @Override
     public void beforeIndexLookup(Index index, int lowerBoundOperator, Object lowerBoundKey,
         int upperBoundOperator, Object upperBoundKey, Set NotEqualKeys) {
       beforeRangeJunctionDoubleCondnIndexLookup = true;
     }
 
-
+    @Override
     public void beforeApplyingProjectionOnFilterEvaluatedResults(
         Object preProjectionAppliedResult) {
-
+      // nothing
     }
 
+    @Override
+    public void invokedQueryUtilsIntersection(SelectResults sr1, SelectResults sr2) {
+      // nothing
+    }
 
-    public void invokedQueryUtilsIntersection(SelectResults sr1, SelectResults sr2) {}
+    @Override
+    public void invokedQueryUtilsUnion(SelectResults sr1, SelectResults sr2) {
+      // nothing
+    }
 
+    @Override
+    public void limitAppliedAtIndexLevel(Index index, int limit, Collection indexResult) {
+      // nothing
+    }
 
-    public void invokedQueryUtilsUnion(SelectResults sr1, SelectResults sr2) {}
-
-    public void limitAppliedAtIndexLevel(Index index, int limit, Collection indexResult) {}
-
+    @Override
     public void orderByColumnsEqual() {
-
+      // nothing
     }
-
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/cache/query/internal/QueryUtilsJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/internal/QueryUtilsJUnitTest.java
@@ -12,16 +12,10 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-/*
- * Created on Oct 13, 2005
- *
- *
- */
 package org.apache.geode.cache.query.internal;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -45,14 +39,10 @@ import org.apache.geode.cache.query.internal.types.ObjectTypeImpl;
 import org.apache.geode.test.junit.categories.IntegrationTest;
 import org.apache.geode.test.junit.categories.OQLQueryTest;
 
-/**
- *
- *
- */
 @Category({IntegrationTest.class, OQLQueryTest.class})
 public class QueryUtilsJUnitTest {
 
-  Region region;
+  private Region region;
 
   @Before
   public void setUp() throws Exception {
@@ -65,9 +55,8 @@ public class QueryUtilsJUnitTest {
   }
 
   @Test
-  public void testObtainTheBottomMostCompiledValue() {
+  public void testObtainTheBottomMostCompiledValue() throws Exception {
     QCompiler compiler = new QCompiler();
-    // List list = compiler.compileFromClause("/portfolio p, p.positions");
     CompiledRegion cr = new CompiledRegion("/portfolio");
     CompiledID cid = new CompiledID("id");
     CompiledPath cp1 = new CompiledPath(new CompiledPath(cid, "path1"), "path2");
@@ -79,172 +68,120 @@ public class QueryUtilsJUnitTest {
   }
 
   @Test
-  public void testCutDownAndExpandIndexResultsWithNoCutDownAndTwoFinalIters() {
-    try {
-      region = CacheUtils.createRegion("portfolio", Portfolio.class);
-      Portfolio[] po =
-          new Portfolio[] {new Portfolio(0), new Portfolio(1), new Portfolio(2), new Portfolio(3)};
-      region.put("0", new Portfolio(0));
-      region.put("1", new Portfolio(1));
-      region.put("2", new Portfolio(2));
-      region.put("3", new Portfolio(3));
-      // compileFromClause returns a List<CompiledIteratorDef>
-      QCompiler compiler = new QCompiler();
-      List list = compiler.compileFromClause("/portfolio p, p.positions");
-      ExecutionContext context = new ExecutionContext(null, CacheUtils.getCache());
-      context.newScope(context.associateScopeID());
-      RuntimeIterator[] indexToItrMappping = new RuntimeIterator[1];
-      RuntimeIterator expand = null;
-      boolean set = false;
+  public void testCutDownAndExpandIndexResultsWithNoCutDownAndTwoFinalIters() throws Exception {
+    region = CacheUtils.createRegion("portfolio", Portfolio.class);
+    Portfolio[] po =
+        new Portfolio[] {new Portfolio(0), new Portfolio(1), new Portfolio(2), new Portfolio(3)};
+    region.put("0", new Portfolio(0));
+    region.put("1", new Portfolio(1));
+    region.put("2", new Portfolio(2));
+    region.put("3", new Portfolio(3));
+    // compileFromClause returns a List<CompiledIteratorDef>
+    QCompiler compiler = new QCompiler();
+    List list = compiler.compileFromClause("/portfolio p, p.positions");
+    ExecutionContext context = new ExecutionContext(null, CacheUtils.getCache());
+    context.newScope(context.associateScopeID());
+    RuntimeIterator[] indexToItrMappping = new RuntimeIterator[1];
+    RuntimeIterator expand = null;
+    boolean set = false;
 
-      Iterator iter = list.iterator();
-      while (iter.hasNext()) {
-        CompiledIteratorDef iterDef = (CompiledIteratorDef) iter.next();
-        context.addDependencies(new CompiledID("dummy"), iterDef.computeDependencies(context));
-        RuntimeIterator rIter = iterDef.getRuntimeIterator(context);
-        if (!set) {
-          set = true;
-          indexToItrMappping[0] = rIter;
-        } else {
-          expand = rIter;
-        }
-        context.bindIterator(rIter);
-        context.addToIndependentRuntimeItrMap(iterDef);
+    Iterator iter = list.iterator();
+    while (iter.hasNext()) {
+      CompiledIteratorDef iterDef = (CompiledIteratorDef) iter.next();
+      context.addDependencies(new CompiledID("dummy"), iterDef.computeDependencies(context));
+      RuntimeIterator rIter = iterDef.getRuntimeIterator(context);
+      if (!set) {
+        set = true;
+        indexToItrMappping[0] = rIter;
+      } else {
+        expand = rIter;
       }
-      List finalList = new ArrayList();
-      finalList.add(indexToItrMappping[0]);
-      finalList.add(expand);
-      ResultsSet indexResult = new ResultsSet(new ObjectTypeImpl(Portfolio.class));
-      for (int i = 0; i < po.length; ++i)
-        indexResult.add(po[i]);
-      List expandList = new LinkedList();
-      expandList.add(expand);
-      List dataList = new ArrayList();
-      dataList.add(indexResult);
-      dataList.add(indexToItrMappping);
-      dataList.add(expandList);
-      dataList.add(finalList);
-      dataList.add(context);
-      dataList.add(new ArrayList());
-      SelectResults results = QueryUtils.testCutDownAndExpandIndexResults(dataList);
-      /*
-       * SelectResults results = QueryUtils.cutDownAndExpandIndexResults( indexResult,
-       * indexToItrMappping, expandList, finalList, context, new ArrayList());
-       */
-      assertTrue("Resultset obtained not of type StructBag", results instanceof StructBag);
-      StructBag st = (StructBag) results;
-      assertTrue("StructBag not of size expected as 8", st.size() == 8);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Test failed because of exception " + e);
+      context.bindIterator(rIter);
+      context.addToIndependentRuntimeItrMap(iterDef);
     }
+    List finalList = new ArrayList();
+    finalList.add(indexToItrMappping[0]);
+    finalList.add(expand);
+    ResultsSet indexResult = new ResultsSet(new ObjectTypeImpl(Portfolio.class));
+    for (int i = 0; i < po.length; ++i)
+      indexResult.add(po[i]);
+    List expandList = new LinkedList();
+    expandList.add(expand);
+    List dataList = new ArrayList();
+    dataList.add(indexResult);
+    dataList.add(indexToItrMappping);
+    dataList.add(expandList);
+    dataList.add(finalList);
+    dataList.add(context);
+    dataList.add(new ArrayList());
+    SelectResults results = QueryUtils.testCutDownAndExpandIndexResults(dataList);
+    assertTrue("Resultset obtained not of type StructBag", results instanceof StructBag);
+    StructBag st = (StructBag) results;
+    assertTrue("StructBag not of size expected as 8", st.size() == 8);
   }
-
 
   @Test
-  public void testCutDownAndExpandIndexResultsWithNoCutDownAndThreeFinalIters() {
-    try {
-      region = CacheUtils.createRegion("portfolio", Portfolio.class);
-      Portfolio[] po =
-          new Portfolio[] {new Portfolio(0), new Portfolio(1), new Portfolio(2), new Portfolio(3)};
-      region.put("0", new Portfolio(0));
-      region.put("1", new Portfolio(1));
-      region.put("2", new Portfolio(2));
-      region.put("3", new Portfolio(3));
+  public void testCutDownAndExpandIndexResultsWithNoCutDownAndThreeFinalIters() throws Exception {
+    region = CacheUtils.createRegion("portfolio", Portfolio.class);
+    Portfolio[] po =
+        new Portfolio[] {new Portfolio(0), new Portfolio(1), new Portfolio(2), new Portfolio(3)};
+    region.put("0", new Portfolio(0));
+    region.put("1", new Portfolio(1));
+    region.put("2", new Portfolio(2));
+    region.put("3", new Portfolio(3));
 
-      Region r3 = CacheUtils.createRegion("employees", Employee.class);
-      Set add1 = new HashSet();
-      add1.add(new Address("411045", "Baner"));
-      add1.add(new Address("411001", "DholePatilRd"));
-      for (int i = 0; i < 4; i++) {
-        r3.put(i + "", new Employee("empName", (20 + i), i, "Mr.", (5000 + i), add1));
-      }
-      // compileFromClause returns a List<CompiledIteratorDef>
-      QCompiler compiler = new QCompiler();
-      List list = compiler.compileFromClause("/portfolio p, p.positions, /employees e");
-      ExecutionContext context = new ExecutionContext(null, CacheUtils.getCache());
-      context.newScope(context.associateScopeID());
-      RuntimeIterator[] indexToItrMappping = new RuntimeIterator[1];
-      RuntimeIterator expand[] = new RuntimeIterator[2];
-      boolean set = false;
-      int j = 0;
-
-      Iterator iter = list.iterator();
-      while (iter.hasNext()) {
-        CompiledIteratorDef iterDef = (CompiledIteratorDef) iter.next();
-        context.addDependencies(new CompiledID("dummy"), iterDef.computeDependencies(context));
-        RuntimeIterator rIter = iterDef.getRuntimeIterator(context);
-        if (!set) {
-          set = true;
-          indexToItrMappping[0] = rIter;
-        } else {
-          expand[j++] = rIter;
-        }
-        context.bindIterator(rIter);
-        context.addToIndependentRuntimeItrMap(iterDef);
-      }
-      List finalList = new ArrayList();
-      finalList.add(indexToItrMappping[0]);
-
-      ResultsSet indexResult = new ResultsSet(new ObjectTypeImpl(Portfolio.class));
-      for (int i = 0; i < po.length; ++i)
-        indexResult.add(po[i]);
-      List expandList = new LinkedList();
-      expandList.add(expand[0]);
-      expandList.add(expand[1]);
-      finalList.addAll(expandList);
-      List dataList = new ArrayList();
-      dataList.add(indexResult);
-      dataList.add(indexToItrMappping);
-      dataList.add(expandList);
-      dataList.add(finalList);
-      dataList.add(context);
-      dataList.add(new ArrayList());
-      SelectResults results = QueryUtils.testCutDownAndExpandIndexResults(dataList);
-
-      assertTrue("Resultset obtained not of type structbag", results instanceof StructBag);
-      StructBag st = (StructBag) results;
-      assertTrue("StructSet not of size expected as 32", st.size() == 32);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Test failed because of exception " + e);
+    Region r3 = CacheUtils.createRegion("employees", Employee.class);
+    Set add1 = new HashSet();
+    add1.add(new Address("411045", "Baner"));
+    add1.add(new Address("411001", "DholePatilRd"));
+    for (int i = 0; i < 4; i++) {
+      r3.put(i + "", new Employee("empName", (20 + i), i, "Mr.", (5000 + i), add1));
     }
+    // compileFromClause returns a List<CompiledIteratorDef>
+    QCompiler compiler = new QCompiler();
+    List list = compiler.compileFromClause("/portfolio p, p.positions, /employees e");
+    ExecutionContext context = new ExecutionContext(null, CacheUtils.getCache());
+    context.newScope(context.associateScopeID());
+    RuntimeIterator[] indexToItrMappping = new RuntimeIterator[1];
+    RuntimeIterator expand[] = new RuntimeIterator[2];
+    boolean set = false;
+    int j = 0;
+
+    Iterator iter = list.iterator();
+    while (iter.hasNext()) {
+      CompiledIteratorDef iterDef = (CompiledIteratorDef) iter.next();
+      context.addDependencies(new CompiledID("dummy"), iterDef.computeDependencies(context));
+      RuntimeIterator rIter = iterDef.getRuntimeIterator(context);
+      if (!set) {
+        set = true;
+        indexToItrMappping[0] = rIter;
+      } else {
+        expand[j++] = rIter;
+      }
+      context.bindIterator(rIter);
+      context.addToIndependentRuntimeItrMap(iterDef);
+    }
+    List finalList = new ArrayList();
+    finalList.add(indexToItrMappping[0]);
+
+    ResultsSet indexResult = new ResultsSet(new ObjectTypeImpl(Portfolio.class));
+    for (int i = 0; i < po.length; ++i)
+      indexResult.add(po[i]);
+    List expandList = new LinkedList();
+    expandList.add(expand[0]);
+    expandList.add(expand[1]);
+    finalList.addAll(expandList);
+    List dataList = new ArrayList();
+    dataList.add(indexResult);
+    dataList.add(indexToItrMappping);
+    dataList.add(expandList);
+    dataList.add(finalList);
+    dataList.add(context);
+    dataList.add(new ArrayList());
+    SelectResults results = QueryUtils.testCutDownAndExpandIndexResults(dataList);
+
+    assertTrue("Resultset obtained not of type structbag", results instanceof StructBag);
+    StructBag st = (StructBag) results;
+    assertTrue("StructSet not of size expected as 32", st.size() == 32);
   }
-
-  /*
-   * @Test public void testCutDownAndExpandIndexResultsWithManyFinalIters() { region =
-   * CacheUtils.createRegion("portfolio", Portfolio.class); Portfolio[] po = new Portfolio[] { new
-   * Portfolio(0), new Portfolio(1), new Portfolio(2), new Portfolio(3)}; region.put("0", new
-   * Portfolio(0)); region.put("1", new Portfolio(1)); region.put("2", new Portfolio(2));
-   * region.put("3", new Portfolio(3));
-   *
-   * Region r3 = CacheUtils.createRegion("employees", Employee.class); Set add1 = new HashSet();
-   * add1.add(new Address("411045", "Baner")); add1.add(new Address("411001", "DholePatilRd"));
-   * for(int i=0;i<4;i++){ r3.put(i+"", new Employee("empName",(20+i),i,"Mr.",(5000+i),add1)); } //
-   * compileFromClause returns a List<CompiledIteratorDef> QCompiler compiler = new
-   * QCompiler(CacheUtils.getLogger()); List list = compiler.
-   * compileFromClause("/portfolio p1, p1.positions, /employees e, /portfolio p2, p2.positions");
-   * ExecutionContext context = new ExecutionContext(null, CacheUtils.getCache());
-   * context.newScope(); RuntimeIterator[] indexToItrMappping = new RuntimeIterator[1];
-   * RuntimeIterator expand[] = new RuntimeIterator[2]; boolean set = false; int j = 0; try {
-   * Iterator iter = list.iterator(); while (iter.hasNext()) { CompiledIteratorDef iterDef =
-   * (CompiledIteratorDef) iter.next(); context.addDependencies(new CompiledID("dummy"), iterDef
-   * .computeDependencies(context)); RuntimeIterator rIter = iterDef.getRuntimeIterator(context); if
-   * (!set) { set = true; indexToItrMappping[0] = rIter; } else { expand[j++] = rIter; }
-   * context.bindIterator(rIter); context.addToIndependentRuntimeItrMap(iterDef); } List finalList =
-   * new ArrayList(); finalList.add(indexToItrMappping[0]);
-   *
-   * //ResultsSet indexResult = new ResultsSet(new ObjectTypeImpl( Portfolio.class)); ResultsSet
-   * indexResult = new ResultsSet(new ObjectTypeImpl( Portfolio.class)); for (int i = 0; i <
-   * po.length; ++i) indexResult.add(po[i]); List expandList = new LinkedList();
-   * expandList.add(expand[0]); expandList.add(expand[1]); finalList.addAll(expandList);
-   * SelectResults results = QueryUtils.cutDownAndExpandIndexResults( indexResult,
-   * indexToItrMappping, expandList, finalList, context, new ArrayList());
-   * assertTrue("Resultset obtaine dnot of type strcutset", results instanceof StructSet); StructSet
-   * st = (StructSet) results; assertTrue("StructSet not of size expected as 32", st.size() == 32);
-   * } catch (Exception e) { e.printStackTrace(); fail("Test failed because of exception " + e); } }
-   */
-
-
-
 }

--- a/geode-core/src/test/java/org/apache/geode/cache/query/internal/index/HashIndexQueryIntegrationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/internal/index/HashIndexQueryIntegrationTest.java
@@ -87,10 +87,7 @@ public class HashIndexQueryIntegrationTest {
 
   /**
    * Helper that tests that hash index is used and that it returns the correct result
-   *
-   * @throws Exception
    */
-
   private void helpTestHashIndexForQuery(String query) throws Exception {
     helpTestHashIndexForQuery(query, "p.ID", "/portfolios p");
   }
@@ -100,7 +97,7 @@ public class HashIndexQueryIntegrationTest {
     SelectResults nonIndexedResults = (SelectResults) qs.newQuery(query).execute();
     assertFalse(observer.indexUsed);
 
-    index = (Index) qs.createHashIndex("idHash", indexedExpression, regionPath);
+    index = qs.createHashIndex("idHash", indexedExpression, regionPath);
     SelectResults indexedResults = (SelectResults) qs.newQuery(query).execute();
     assertEquals(nonIndexedResults.size(), indexedResults.size());
     assertTrue(observer.indexUsed);
@@ -112,26 +109,21 @@ public class HashIndexQueryIntegrationTest {
     SelectResults nonIndexedResults = (SelectResults) qs.newQuery(query).execute(params);
     assertFalse(observer.indexUsed);
 
-    index = (Index) qs.createHashIndex("idHash", indexedExpression, regionPath);
+    index = qs.createHashIndex("idHash", indexedExpression, regionPath);
     SelectResults indexedResults = (SelectResults) qs.newQuery(query).execute(params);
     assertEquals(nonIndexedResults.size(), indexedResults.size());
     assertTrue(observer.indexUsed);
   }
 
-
-  /*
+  /**
    * helper method to test against a compact range index instead of hash index
-   *
-   * @param query
-   *
-   * @throws Exception
    */
   private void helpTestCRIndexForQuery(String query, String indexedExpression, String regionPath)
       throws Exception {
     SelectResults nonIndexedResults = (SelectResults) qs.newQuery(query).execute();
     assertFalse(observer.indexUsed);
 
-    index = (Index) qs.createIndex("crIndex", indexedExpression, regionPath);
+    index = qs.createIndex("crIndex", indexedExpression, regionPath);
     SelectResults indexedResults = (SelectResults) qs.newQuery(query).execute();
     assertEquals(nonIndexedResults.size(), indexedResults.size());
     assertTrue(observer.indexUsed);
@@ -139,8 +131,6 @@ public class HashIndexQueryIntegrationTest {
 
   /**
    * Tests that hash index with And query for local region
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexWithORQueryForLocalRegion() throws Exception {
@@ -191,8 +181,6 @@ public class HashIndexQueryIntegrationTest {
 
   /**
    * Tests that hash index with And query for local region
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexWithNestedQueryForLocalRegion() throws Exception {
@@ -210,8 +198,6 @@ public class HashIndexQueryIntegrationTest {
 
   /**
    * Tests that hash index with Short vs Integer comparison
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexWithNestedQueryWithShortVsIntegerCompareForLocalRegion()
@@ -229,49 +215,8 @@ public class HashIndexQueryIntegrationTest {
         "p.shortID", "/portfolios p");
   }
 
-
-  /**
-   * Tests that hash index with comparison between float and integer
-   *
-   * @throws Exception
-   */
-  // @Test
-  // public void testHashIndexQueryWithFloatVsIntegerCompareForLocalRegion() throws Exception {
-  // createLocalRegion("portfolios");
-  // int numEntries = 1000;
-  // int numIds = 100;
-  // for (int i = 0; i < numEntries; i++) {
-  // Portfolio p = new Portfolio(i % (numIds));
-  // p.shortID = (short)i;
-  // region.put("" + i, p);
-  // }
-  // helpTestHashIndexForQuery("SELECT * FROM /portfolios p WHERE p.ID = 1.0f", "p.ID", "/portfolios
-  // p");
-  // }
-
-  /**
-   * Tests that hash index with comparison between float and integer
-   *
-   * @throws Exception
-   */
-  // @Test
-  // public void testHashIndexNotEqualsWithFloatVsIntegerLocalRegion() throws Exception {
-  // createLocalRegion("portfolios");
-  // int numEntries = 1000;
-  // int numIds = 100;
-  // for (int i = 0; i < numEntries; i++) {
-  // Portfolio p = new Portfolio(i % (numIds));
-  // p.shortID = (short)i;
-  // region.put("" + i, p);
-  // }
-  // helpTestCRIndexForQuery("SELECT * FROM /portfolios p WHERE p.ID != 1.0f", "p.ID", "/portfolios
-  // p");
-  // }
-
   /**
    * Tests that hash index with And query for local region
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexWithAndQueryForLocalRegion() throws Exception {
@@ -289,8 +234,6 @@ public class HashIndexQueryIntegrationTest {
 
   /**
    * Tests that hash index is used and that it returns the correct result for local region
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexWithLimitQueryForLocalRegion() throws Exception {
@@ -308,8 +251,6 @@ public class HashIndexQueryIntegrationTest {
 
   /**
    * Tests that hash index is used and that it returns the correct result for local region
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexEntriesQueryForLocalRegion() throws Exception {
@@ -321,8 +262,6 @@ public class HashIndexQueryIntegrationTest {
 
   /**
    * Tests that hash index is used and that it returns the correct result for local region
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexValueQueryForLocalRegion() throws Exception {
@@ -334,8 +273,6 @@ public class HashIndexQueryIntegrationTest {
 
   /**
    * Tests that hash index is used and that it returns the correct result for local region
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexKeySetQueryForLocalRegion() throws Exception {
@@ -347,8 +284,6 @@ public class HashIndexQueryIntegrationTest {
 
   /**
    * Tests that hash index is used and that it returns the correct result for local region
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexEqualsForSingleResultOnLocalRegion() throws Exception {
@@ -359,8 +294,6 @@ public class HashIndexQueryIntegrationTest {
 
   /**
    * Tests that hash index is used and that it returns the correct result for replicated region
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexEqualsForSingleResultOnReplicatedRegion() throws Exception {
@@ -371,8 +304,6 @@ public class HashIndexQueryIntegrationTest {
 
   /**
    * Tests that hash index is used and that it returns the correct result for partitioned region
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexEqualsForSingleResultOnPartitionedRegion() throws Exception {
@@ -383,69 +314,45 @@ public class HashIndexQueryIntegrationTest {
 
   /**
    * Tests that hash index is used and that it returns the correct result
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexAndEquiJoinForSingleResultQueryWithHashIndex() throws Exception {
     createReplicatedRegion("portfolios");
     createData(region, 200);
     createJoinTable(400);
-    Index index = (Index) qs.createHashIndex("index2", "p2.ID", "/portfolios2 p2");
+    Index index = qs.createHashIndex("index2", "p2.ID", "/portfolios2 p2");
     helpTestHashIndexForQuery(
         "Select * FROM /portfolios p, /portfolios2 p2 where (p.ID = 1 or p.ID = 2 )and p.ID = p2.ID");
   }
 
   /**
    * Tests that hash index is used and that it returns the correct result
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexAndEquiJoinForSingleResultQueryWithCompactRangeIndex() throws Exception {
     createReplicatedRegion("portfolios");
     createData(region, 200);
     createJoinTable(400);
-    Index index = (Index) qs.createIndex("index2", "p2.ID", "/portfolios2 p2");
+    Index index = qs.createIndex("index2", "p2.ID", "/portfolios2 p2");
     helpTestHashIndexForQuery(
         "Select * FROM /portfolios p, /portfolios2 p2 where (p.ID = 1 or p.ID = 2 )and p.ID = p2.ID");
   }
 
   /**
    * Tests that hash index is used and that it returns the correct result
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexAndEquiJoinForSingleResultQueryWithRangeIndex() throws Exception {
     createReplicatedRegion("portfolios");
     createData(region, 200);
     createJoinTable(400);
-    Index index =
-        (Index) qs.createIndex("index2", "p2.ID", "/portfolios2 p2, p2.positions.values v");
+    Index index = qs.createIndex("index2", "p2.ID", "/portfolios2 p2, p2.positions.values v");
     helpTestHashIndexForQuery(
         "Select * FROM /portfolios p, /portfolios2 p2 where (p.ID = 1 or p.ID = 2 )and p.ID = p2.ID");
   }
 
   /**
    * Tests that hash index is used and that it returns the correct result
-   *
-   * @throws Exception
-   */
-  // @Test
-  // public void testHashIndexAndEquiJoinForSingleResultQueryWithMapRangeIndex() throws Exception {
-  // createReplicatedRegion("portfolios");
-  // createData(region, 1000);
-  // createJoinTable(2000);
-  // Index index = (Index)qs.createIndex("index2","p2.names[*]", "/portfolios2 p2");
-  // helpTestHashIndexForQuery("Select * FROM /portfolios p, /portfolios2 p2 where (p.names['1'] or
-  // p.names['2'] ) and p.names = p2.names", "p.names[*]", "/portfolios p");
-  // }
-
-  /**
-   * Tests that hash index is used and that it returns the correct result
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexAndEquiJoinForSingleResultQueryWithHashIndexLessEntries()
@@ -453,15 +360,13 @@ public class HashIndexQueryIntegrationTest {
     createReplicatedRegion("portfolios");
     createData(region, 400);
     createJoinTable(200);
-    Index index = (Index) qs.createHashIndex("index2", "p2.ID", "/portfolios2 p2");
+    Index index = qs.createHashIndex("index2", "p2.ID", "/portfolios2 p2");
     helpTestHashIndexForQuery(
         "Select * FROM /portfolios p, /portfolios2 p2 where (p.ID = 1 or p.ID = 2 )and p.ID = p2.ID");
   }
 
   /**
    * Tests that hash index is used and that it returns the correct result
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexAndEquiJoinForSingleResultQueryWithCompactRangeIndexLessEntries()
@@ -469,15 +374,13 @@ public class HashIndexQueryIntegrationTest {
     createReplicatedRegion("portfolios");
     createData(region, 400);
     createJoinTable(200);
-    Index index = (Index) qs.createIndex("index2", "p2.ID", "/portfolios2 p2");
+    Index index = qs.createIndex("index2", "p2.ID", "/portfolios2 p2");
     helpTestHashIndexForQuery(
         "Select * FROM /portfolios p, /portfolios2 p2 where (p.ID = 1 or p.ID = 2 )and p.ID = p2.ID");
   }
 
   /**
    * Tests that hash index is used and that it returns the correct result
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexAndEquiJoinForSingleResultQueryWithRangeIndexLessEntries()
@@ -485,33 +388,13 @@ public class HashIndexQueryIntegrationTest {
     createReplicatedRegion("portfolios");
     createData(region, 400);
     createJoinTable(200);
-    Index index =
-        (Index) qs.createIndex("index2", "p2.ID", "/portfolios2 p2, p2.positions.values v");
+    Index index = qs.createIndex("index2", "p2.ID", "/portfolios2 p2, p2.positions.values v");
     helpTestHashIndexForQuery(
         "Select * FROM /portfolios p, /portfolios2 p2 where (p.ID = 1 or p.ID = 2 )and p.ID = p2.ID");
   }
 
   /**
-   * Tests that hash index is used and that it returns the correct result
-   *
-   * @throws Exception
-   */
-  // @Test
-  // public void testHashIndexAndEquiJoinForSingleResultQueryWithMapRangeIndexLessEntries() throws
-  // Exception {
-  // createReplicatedRegion("portfolios");
-  // createData(region, 1000);
-  // createJoinTable(500);
-  // Index index = (Index)qs.createIndex("index2","p2.positions[*]", "/portfolios2 p2");
-  // helpTestHashIndexForQuery("Select * FROM /portfolios p, /portfolios2 p2 where
-  // p.positions['IBM'] and p.positions['IBM']=p2.positions['IBM']", "p.positions[*]", "/portfolios
-  // p");
-  // }
-
-  /**
    * Tests that hash index is used and that it returns the correct number of results on local region
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexEqualsForMultipleResultQueryOnLocalRegion() throws Exception {
@@ -531,8 +414,6 @@ public class HashIndexQueryIntegrationTest {
   /**
    * Tests that hash index is used and that it returns the correct number of results on replicated
    * region
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexEqualsForMultipleResultQueryOnReplicatedRegion() throws Exception {
@@ -552,8 +433,6 @@ public class HashIndexQueryIntegrationTest {
   /**
    * Tests that hash index is used and that it returns the correct number of results on partitioned
    * region
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexEqualsForMultipleResultQueryOnPartitionedRegion() throws Exception {
@@ -570,19 +449,15 @@ public class HashIndexQueryIntegrationTest {
     helpTestHashIndexForQuery("Select * FROM /portfolios p where p.ID = 1");
   }
 
-
   /**
    * Tests that hash index is used and that it returns the correct number of results
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexEquiJoinForMultipleResultQueryWithHashIndex() throws Exception {
     createReplicatedRegion("portfolios");
     createJoinTable(400);
-    index = (HashIndex) qs.createHashIndex("idHash", "p.ID", "/portfolios p");
-    Index index = (Index) qs.createHashIndex("index2", "p2.ID", "/portfolios2 p2");
-
+    index = qs.createHashIndex("idHash", "p.ID", "/portfolios p");
+    Index index = qs.createHashIndex("index2", "p2.ID", "/portfolios2 p2");
 
     int numEntries = 200;
     int numIds = 100;
@@ -601,8 +476,6 @@ public class HashIndexQueryIntegrationTest {
   /**
    * Tests that hash index is used and that the value is correctly removed from the index where only
    * 1 value is using the key for partitioned regions
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexRemoveOnLocalRegion() throws Exception {
@@ -613,8 +486,6 @@ public class HashIndexQueryIntegrationTest {
   /**
    * Tests that hash index is used and that the value is correctly removed from the index where only
    * 1 value is using the key for replicated regions
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexRemoveOnReplicatedRegion() throws Exception {
@@ -634,7 +505,7 @@ public class HashIndexQueryIntegrationTest {
     createPartitionedRegion("portfolios");
     createData(region, 200);
     region.destroy("1");
-    index = (Index) qs.createHashIndex("idHash", "p.ID", "/portfolios p");
+    index = qs.createHashIndex("idHash", "p.ID", "/portfolios p");
     SelectResults results =
         (SelectResults) qs.newQuery("Select * FROM /portfolios p where p.ID = 1").execute();
     assertEquals(noIndexResults.size(), results.size());
@@ -644,8 +515,6 @@ public class HashIndexQueryIntegrationTest {
   /**
    * Tests that hash index is used and that the value is correctly removed from the index where only
    * 1 value is using the key for partitioned regions
-   *
-   * @throws Exception
    */
   private void helpTestHashIndexRemove() throws Exception {
     createData(region, 200);
@@ -656,7 +525,7 @@ public class HashIndexQueryIntegrationTest {
     region.clear();
     createData(region, 200);
     region.destroy("1");
-    index = (Index) qs.createHashIndex("idHash", "p.ID", "/portfolios p");
+    index = qs.createHashIndex("idHash", "p.ID", "/portfolios p");
     SelectResults results =
         (SelectResults) qs.newQuery("Select * FROM /portfolios p where p.ID = 1").execute();
     assertEquals(noIndexResults.size(), results.size());
@@ -666,8 +535,6 @@ public class HashIndexQueryIntegrationTest {
   /**
    * Tests that hash index is used and that the value is correctly removed from the index where
    * multiple entries are using the key on localRegion
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexRemoveFromCommonKeyQueryOnLocalRegion() throws Exception {
@@ -678,8 +545,6 @@ public class HashIndexQueryIntegrationTest {
   /**
    * Tests that hash index is used and that the value is correctly removed from the index where
    * multiple entries are using the key on replicated region
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexRemoveFromCommonKeyQueryOnReplicatedRegion() throws Exception {
@@ -690,8 +555,6 @@ public class HashIndexQueryIntegrationTest {
   /**
    * Tests that hash index is used and that the value is correctly removed from the index where
    * multiple entries are using the key on partitioned region
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexRemoveFromCommonKeyQueryOnPartitionedRegion() throws Exception {
@@ -715,7 +578,7 @@ public class HashIndexQueryIntegrationTest {
         (SelectResults) qs.newQuery("Select * FROM /portfolios p where p.ID = 2").execute();
 
     region.clear();
-    index = (HashIndex) qs.createHashIndex("idHash", "p.ID", "/portfolios p");
+    index = qs.createHashIndex("idHash", "p.ID", "/portfolios p");
     for (int i = 0; i < numEntries; i++) {
       Portfolio p = new Portfolio(i % (numIds));
       p.shortID = (short) i;
@@ -735,8 +598,6 @@ public class HashIndexQueryIntegrationTest {
 
   /**
    * Tests that hash index is used and that it returns the correct result on local region
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexNotEqualsQueryOnLocalRegion() throws Exception {
@@ -747,8 +608,6 @@ public class HashIndexQueryIntegrationTest {
 
   /**
    * Tests that hash index is used and that it returns the correct result on replicated region
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexNotEqualsQueryOnReplicatedRegion() throws Exception {
@@ -759,8 +618,6 @@ public class HashIndexQueryIntegrationTest {
 
   /**
    * Tests that hash index is used and that it returns the correct result on partitioned region
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexNotEqualsQueryOnPartitionedRegion() throws Exception {
@@ -772,8 +629,6 @@ public class HashIndexQueryIntegrationTest {
   /**
    * Tests that hash index is used and that it returns the correct number of results for local
    * region
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexNotEqualsForMultipleResultQueryForLocalRegion() throws Exception {
@@ -791,8 +646,6 @@ public class HashIndexQueryIntegrationTest {
   /**
    * Tests that hash index is used and that it returns the correct number of results for replicated
    * region
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexNotEqualsForMultipleResultQueryForReplicatedRegion() throws Exception {
@@ -810,8 +663,6 @@ public class HashIndexQueryIntegrationTest {
   /**
    * Tests that hash index is used and that it returns the correct number of results for partitioned
    * region
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexNotEqualsForMultipleResultQueryForPartitionedRegion() throws Exception {
@@ -828,8 +679,6 @@ public class HashIndexQueryIntegrationTest {
 
   /**
    * Tests that hash index is used and that it returns the correct result
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexInQueryForLocalRegion() throws Exception {
@@ -840,8 +689,6 @@ public class HashIndexQueryIntegrationTest {
 
   /**
    * Tests that hash index is used and that it returns the correct result
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexInQueryForReplicatedRegion() throws Exception {
@@ -852,8 +699,6 @@ public class HashIndexQueryIntegrationTest {
 
   /**
    * Tests that hash index is used and that it returns the correct result
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexInQueryForPartitionedRegion() throws Exception {
@@ -864,8 +709,6 @@ public class HashIndexQueryIntegrationTest {
 
   /**
    * Tests that hash index is used and that it returns the correct result for local region
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexNotUsedInRangeQueryForLocalRegion() throws Exception {
@@ -876,8 +719,6 @@ public class HashIndexQueryIntegrationTest {
 
   /**
    * Tests that hash index is used and that it returns the correct result for replicated region
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexNotUsedInRangeQueryForReplicatedRegion() throws Exception {
@@ -888,8 +729,6 @@ public class HashIndexQueryIntegrationTest {
 
   /**
    * Tests that hash index is used and that it returns the correct result for partitioned region
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexNotUsedInRangeQueryForPartitionedRegion() throws Exception {
@@ -900,8 +739,6 @@ public class HashIndexQueryIntegrationTest {
 
   /**
    * Tests that hash index is used and that it returns the correct result
-   *
-   * @throws Exception
    */
   private void helpTestHashIndexNotUsedInRangeQuery() throws Exception {
     SelectResults results =
@@ -911,8 +748,6 @@ public class HashIndexQueryIntegrationTest {
 
   /**
    * Test order by asc query for local region using hash index
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexOrderByAscQueryForLocalRegion() throws Exception {
@@ -923,8 +758,6 @@ public class HashIndexQueryIntegrationTest {
 
   /**
    * Test order by asc query for replicated region using hash index
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexOrderByAscQueryForReplicatedRegion() throws Exception {
@@ -935,8 +768,6 @@ public class HashIndexQueryIntegrationTest {
 
   /**
    * Test order by asc query for partitioned region using hash index
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexOrderByAscQueryForPartitionedRegion() throws Exception {
@@ -946,7 +777,7 @@ public class HashIndexQueryIntegrationTest {
   }
 
   private void helpTestHashIndexOrderByAscQuery() throws Exception {
-    index = (Index) qs.createHashIndex("idHash", "p.ID", "/portfolios p");
+    index = qs.createHashIndex("idHash", "p.ID", "/portfolios p");
     SelectResults results = (SelectResults) qs
         .newQuery("Select * FROM /portfolios p where p.ID != 0 order by ID asc ").execute();
     assertEquals(199, results.size());
@@ -960,8 +791,6 @@ public class HashIndexQueryIntegrationTest {
 
   /**
    * Test order by desc query for local region using hash index
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexOrderByDescQueryForLocalRegion() throws Exception {
@@ -972,8 +801,6 @@ public class HashIndexQueryIntegrationTest {
 
   /**
    * Test order by desc query for replicated region using hash index
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexOrderByDescQueryForReplicatedRegion() throws Exception {
@@ -984,8 +811,6 @@ public class HashIndexQueryIntegrationTest {
 
   /**
    * Test order by desc query for partitioned region using hash index
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexOrderByDescQueryForPartitionedRegion() throws Exception {
@@ -996,8 +821,6 @@ public class HashIndexQueryIntegrationTest {
 
   /**
    * Tests that hash index on non sequential hashes for local region
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexOnNonSequentialHashForLocalRegion() throws Exception {
@@ -1024,8 +847,6 @@ public class HashIndexQueryIntegrationTest {
 
   /**
    * Tests that hash index on non sequential hashes for replicated region
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexOnNonSequentialHashForReplicatedRegion() throws Exception {
@@ -1052,8 +873,6 @@ public class HashIndexQueryIntegrationTest {
 
   /**
    * Tests that hash index on non sequential hashes for partitioned region
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexOnNonSequentialHashForPartitionedRegion() throws Exception {
@@ -1079,7 +898,7 @@ public class HashIndexQueryIntegrationTest {
   }
 
   private void helpTestHashIndexOrderByDescQuery() throws Exception {
-    index = (Index) qs.createHashIndex("idHash", "p.ID", "/portfolios p");
+    index = qs.createHashIndex("idHash", "p.ID", "/portfolios p");
     SelectResults results = (SelectResults) qs
         .newQuery("Select * FROM /portfolios p where p.ID != 0 order by ID desc ").execute();
     assertEquals(199, results.size());
@@ -1093,8 +912,6 @@ public class HashIndexQueryIntegrationTest {
 
   /**
    * test async exception for hash index using partitioned region
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexAsyncMaintenanceExceptionForPartitionedRegion() throws Exception {
@@ -1109,7 +926,7 @@ public class HashIndexQueryIntegrationTest {
     } catch (UnsupportedOperationException e) {
       expected = true;
     } catch (IndexInvalidException e) {
-      // for partition region execption;
+      // for partition region exception;
       expected = true;
     }
 
@@ -1118,8 +935,6 @@ public class HashIndexQueryIntegrationTest {
 
   /**
    * test multiple iterators exception for hash index using local region
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexMultipleIteratorsExceptionForLocalRegion() throws Exception {
@@ -1129,8 +944,6 @@ public class HashIndexQueryIntegrationTest {
 
   /**
    * test multiple iterators exception for hash index using replicated region
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexMultipleIteratorsExceptionForReplicatedRegion() throws Exception {
@@ -1140,8 +953,6 @@ public class HashIndexQueryIntegrationTest {
 
   /**
    * test multiple iterators exception for hash index using partiioned region
-   *
-   * @throws Exception
    */
   @Test
   public void testHashIndexMultipleIteratorsExceptionForPartitionedRegion() throws Exception {
@@ -1161,8 +972,6 @@ public class HashIndexQueryIntegrationTest {
 
   /**
    * test remove and not equals Query
-   *
-   * @throws Exception
    */
   @Test
   public void testRemoveAndNotEqualsQuery() throws Exception {
@@ -1172,7 +981,7 @@ public class HashIndexQueryIntegrationTest {
 
   private void helpTestRemoveAndNotEqualsQuery() throws Exception {
     int numEntries = 200;
-    index = (HashIndex) qs.createHashIndex("idHash", "p.ID", "/portfolios p");
+    index = qs.createHashIndex("idHash", "p.ID", "/portfolios p");
     for (int i = 0; i < numEntries; i++) {
       Portfolio p = new Portfolio(i);
       p.shortID = (short) i;
@@ -1202,14 +1011,12 @@ public class HashIndexQueryIntegrationTest {
     params[0] = new Identifier("Customer" + 1);
     params[1] = new Identifier("Customer" + 1);
     String query = "select * from /relationships.keySet k where k.leftKey = $1 OR k.rightKey = $2";
-    // String query = "select * from /relationships r where r.relationship.key IN (select * from
-    // /relationships.keySet k where k.leftKey = $1 OR k.rightKey = $2)";
     SelectResults nonIndexedResults = (SelectResults) qs.newQuery(query).execute(params);
     assertFalse(observer.indexUsed);
 
-    index = (Index) qs.createHashIndex("leftKey", "k.leftKey", "/relationships.keySet k");
-    Index index2 = (Index) qs.createHashIndex("rightKey", "k.rightKey", "/relationships.keySet k");
-    Index index3 = (Index) qs.createKeyIndex("keyIndex", "r.key", "/relationships r");
+    index = qs.createHashIndex("leftKey", "k.leftKey", "/relationships.keySet k");
+    Index index2 = qs.createHashIndex("rightKey", "k.rightKey", "/relationships.keySet k");
+    Index index3 = qs.createKeyIndex("keyIndex", "r.key", "/relationships r");
     SelectResults indexedResults = (SelectResults) qs.newQuery(query).execute(params);
     assertEquals(nonIndexedResults.size(), indexedResults.size());
     assertEquals(nonIndexedResults.size(), numEntries / numIds);
@@ -1229,7 +1036,7 @@ public class HashIndexQueryIntegrationTest {
   }
 
   private void helpTestHashIndexRecreate() throws Exception {
-    index = (Index) qs.createHashIndex("idHash", "p.ID", "/portfolios p");
+    index = qs.createHashIndex("idHash", "p.ID", "/portfolios p");
     createData(region, 200);
 
     SelectResults noIndexResults =
@@ -1383,6 +1190,7 @@ public class HashIndexQueryIntegrationTest {
       Index index = qs.createHashIndex("idHash", "p", "/portfolios p");
 
       Thread puts = new Thread(new Runnable() {
+        @Override
         public void run() {
           for (int j = 0; j < 20; j++) {
             for (int i = 0; i < 2; i++) {
@@ -1394,6 +1202,7 @@ public class HashIndexQueryIntegrationTest {
       });
 
       Thread morePuts = new Thread(new Runnable() {
+        @Override
         public void run() {
           for (int j = 0; j < 20; j++) {
             for (int i = 0; i < 1; i++) {
@@ -1405,6 +1214,7 @@ public class HashIndexQueryIntegrationTest {
       });
 
       Thread evenMorePuts = new Thread(new Runnable() {
+        @Override
         public void run() {
           for (int j = 0; j < 20; j++) {
             for (int i = 0; i < 1; i++) {
@@ -1449,150 +1259,6 @@ public class HashIndexQueryIntegrationTest {
     assertEquals(1, results.size());
     assertTrue(observer.indexUsed);
   }
-
-
-  // private void printIndex(Index index) {
-  // if (index instanceof PartitionedIndex) {
-  // Iterator it = ((PartitionedIndex)index).getBucketIndexes().iterator();
-  // while (it.hasNext()) {
-  // ((HashIndex)it.next()).printAll();
-  // }
-  // }
-  // else {
-  // System.out.println(((HashIndex)index).printAll());
-  // }
-  // }
-
-
-  private class RelationshipKey implements Comparable {
-    public Identifier leftKey;
-    public Identifier rightKey;
-
-    public RelationshipKey(int leftKeyId, int rightKeyId) {
-      this.leftKey = new Identifier("Customer" + leftKeyId);
-      this.rightKey = new Identifier("Customer" + rightKeyId);
-    }
-
-    public Identifier getLeftKey() {
-      return leftKey;
-    }
-
-    public Identifier getRightKey() {
-      return rightKey;
-    }
-
-    public int compareTo(Object o) {
-      if (o instanceof RelationshipKey) {
-        return leftKey.compareTo(((RelationshipKey) o).leftKey);
-      }
-      throw new ClassCastException("Unable to cast " + o + " to Identifier");
-    }
-
-    public boolean equals(Object o) {
-      if (o instanceof RelationshipKey) {
-        return leftKey.equals(((RelationshipKey) o).leftKey)
-            && rightKey.equals(((RelationshipKey) o).rightKey);
-      }
-      return false;
-    }
-
-    @Override
-    public int hashCode() {
-      return leftKey.hashCode();
-    }
-  }
-
-  private class Schema {
-    public Relationship relationship;
-
-    public Schema(Relationship relationship) {
-      this.relationship = relationship;
-    }
-
-    public Relationship getRelationship() {
-      return relationship;
-    }
-  }
-
-  private class Relationship {
-    public RelationshipKey key;
-
-    public Relationship(RelationshipKey key) {
-      this.key = key;
-    }
-
-    public RelationshipKey getKey() {
-      return key;
-    }
-  }
-
-  public class Identifier implements Comparable {
-    private int hashCode = 0;
-    public String id;
-
-    public Identifier(String id) {
-      this.id = id;
-    }
-
-    @Override
-    public int compareTo(Object o) {
-      if (o instanceof Identifier) {
-        String otherId = ((Identifier) o).id;
-        return id.compareTo(otherId);
-      }
-      throw new ClassCastException("Unable to cast " + o + " to Identifier");
-    }
-
-    public boolean equals(Object o) {
-      if (o instanceof Identifier) {
-        return id.equals(((Identifier) o).id);
-      }
-      return false;
-    }
-
-    @Override
-    public int hashCode() {
-      if (this.hashCode == 0) {
-        this.hashCode = id.hashCode();
-        this.hashCode += 7 * "something".hashCode();
-      }
-
-      return this.hashCode;
-    }
-  }
-
-  public class SameHashObject implements Serializable {
-
-    public int ID = 0;
-    public String stringValue;
-    private int uniqueId = 0;
-
-    public SameHashObject(int i, int uniqueId, String stringValue) {
-      ID = i;
-      this.uniqueId = uniqueId;
-      this.stringValue = stringValue;
-    }
-
-    public SameHashObject(int i, int uniqueId) {
-      this(i, uniqueId, "" + i);
-    }
-
-    public boolean equals(Object o) {
-      if (o instanceof SameHashObject) {
-        return ID == ((SameHashObject) o).ID;
-      }
-      return false;
-    }
-
-    public int hashCode() {
-      return 99;
-    }
-
-    public String toString() {
-      return "SameHashObject:" + ID + ":" + uniqueId + " :" + stringValue;
-    }
-  }
-
 
   private void createLocalRegion(String regionName) throws ParseException {
     createLocalRegion(regionName, true);
@@ -1654,15 +1320,148 @@ public class HashIndexQueryIntegrationTest {
     }
   }
 
+  private static class RelationshipKey implements Comparable, Serializable {
+    public Identifier leftKey;
+    public Identifier rightKey;
 
-  class MyQueryObserverAdapter extends QueryObserverAdapter {
+    public RelationshipKey(int leftKeyId, int rightKeyId) {
+      this.leftKey = new Identifier("Customer" + leftKeyId);
+      this.rightKey = new Identifier("Customer" + rightKeyId);
+    }
+
+    public Identifier getLeftKey() {
+      return leftKey;
+    }
+
+    public Identifier getRightKey() {
+      return rightKey;
+    }
+
+    @Override
+    public int compareTo(Object o) {
+      if (o instanceof RelationshipKey) {
+        return leftKey.compareTo(((RelationshipKey) o).leftKey);
+      }
+      throw new ClassCastException("Unable to cast " + o + " to Identifier");
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o instanceof RelationshipKey) {
+        return leftKey.equals(((RelationshipKey) o).leftKey)
+            && rightKey.equals(((RelationshipKey) o).rightKey);
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      return leftKey.hashCode();
+    }
+  }
+
+  private static class Schema implements Serializable {
+    public Relationship relationship;
+
+    public Schema(Relationship relationship) {
+      this.relationship = relationship;
+    }
+
+    public Relationship getRelationship() {
+      return relationship;
+    }
+  }
+
+  private static class Relationship implements Serializable {
+    public RelationshipKey key;
+
+    public Relationship(RelationshipKey key) {
+      this.key = key;
+    }
+
+    public RelationshipKey getKey() {
+      return key;
+    }
+  }
+
+  private static class Identifier implements Comparable, Serializable {
+    private int hashCode = 0;
+    public String id;
+
+    public Identifier(String id) {
+      this.id = id;
+    }
+
+    @Override
+    public int compareTo(Object o) {
+      if (o instanceof Identifier) {
+        String otherId = ((Identifier) o).id;
+        return id.compareTo(otherId);
+      }
+      throw new ClassCastException("Unable to cast " + o + " to Identifier");
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o instanceof Identifier) {
+        return id.equals(((Identifier) o).id);
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      if (this.hashCode == 0) {
+        this.hashCode = id.hashCode();
+        this.hashCode += 7 * "something".hashCode();
+      }
+
+      return this.hashCode;
+    }
+  }
+
+  private static class MyQueryObserverAdapter extends QueryObserverAdapter {
     public boolean indexUsed = false;
 
+    @Override
     public void afterIndexLookup(Collection results) {
       super.afterIndexLookup(results);
       indexUsed = true;
     }
-  };
+  }
 
+  private static class SameHashObject implements Serializable {
 
+    public int ID = 0;
+    public String stringValue;
+    private int uniqueId = 0;
+
+    public SameHashObject(int i, int uniqueId, String stringValue) {
+      ID = i;
+      this.uniqueId = uniqueId;
+      this.stringValue = stringValue;
+    }
+
+    public SameHashObject(int i, int uniqueId) {
+      this(i, uniqueId, "" + i);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o instanceof SameHashObject) {
+        return ID == ((SameHashObject) o).ID;
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      return 99;
+    }
+
+    @Override
+    public String toString() {
+      return "SameHashObject:" + ID + ":" + uniqueId + " :" + stringValue;
+    }
+  }
 }

--- a/geode-core/src/test/java/org/apache/geode/cache/query/internal/index/IndexMaintenanceJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/internal/index/IndexMaintenanceJUnitTest.java
@@ -12,18 +12,14 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-/**
- * Created on May 31, 2007
- *
- */
 package org.apache.geode.cache.query.internal.index;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -64,49 +60,34 @@ import org.apache.geode.internal.cache.persistence.query.CloseableIterator;
 import org.apache.geode.test.junit.categories.IntegrationTest;
 import org.apache.geode.test.junit.categories.OQLIndexTest;
 
-/**
- *
- */
 @Category({IntegrationTest.class, OQLIndexTest.class})
 public class IndexMaintenanceJUnitTest {
 
   private QueryService qs;
-
   private Region region;
-
-  protected boolean indexUsed = false;
-
   private Set idSet;
-
-  private void init() {
-    idSet = new HashSet();
-    try {
-      CacheUtils.startCache();
-      Cache cache = CacheUtils.getCache();
-      region = CacheUtils.createRegion("portfolio", Portfolio.class);
-      region.put("0", new Portfolio(0));
-      region.put("1", new Portfolio(1));
-      region.put("2", new Portfolio(2));
-      region.put("3", new Portfolio(3));
-      for (int j = 0; j < 6; ++j) {
-        idSet.add(j + "");
-      }
-      qs = cache.getQueryService();
-
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
-
-  }
 
   @Before
   public void setUp() throws Exception {
-    init();
+    idSet = new HashSet();
+
+    CacheUtils.startCache();
+    Cache cache = CacheUtils.getCache();
+    region = CacheUtils.createRegion("portfolio", Portfolio.class);
+    region.put("0", new Portfolio(0));
+    region.put("1", new Portfolio(1));
+    region.put("2", new Portfolio(2));
+    region.put("3", new Portfolio(3));
+    for (int j = 0; j < 6; ++j) {
+      idSet.add(j + "");
+    }
+    qs = cache.getQueryService();
   }
 
   @After
   public void tearDown() throws Exception {
     CacheUtils.closeCache();
+    DefaultQueryService.TEST_QUERY_HETEROGENEOUS_OBJECTS = false;
     IndexManager.TEST_RANGEINDEX_ONLY = false;
   }
 
@@ -114,91 +95,80 @@ public class IndexMaintenanceJUnitTest {
    * Tests Index maintenance on heterogenous objects
    */
   @Test
-  public void testIndexMaintenanceWithHeterogenousObjects() {
-    try {
-      DefaultQueryService.TEST_QUERY_HETEROGENEOUS_OBJECTS = true;
-      IndexManager.TEST_RANGEINDEX_ONLY = true;
-      Cache cache = CacheUtils.getCache();
-      qs = cache.getQueryService();
-      region = CacheUtils.createRegion("portfolio1", null);
-      idSet.clear();
-      Portfolio p = new Portfolio(4);
-      region.put("4", p);
-      idSet.add("" + p.getID());
-      p = new Portfolio(5);
-      region.put("5", p);
-      idSet.add("" + p.getID());
-      region.put("6", new Integer(6));
-      Index i1 = qs.createIndex("indx1", IndexType.FUNCTIONAL, "pf.getID()", "/portfolio1 pf");
-      RangeIndex ri = (RangeIndex) i1;
-      assertEquals(2, ri.valueToEntriesMap.size());
-      Iterator itr = ri.valueToEntriesMap.values().iterator();
-      while (itr.hasNext()) {
-        RangeIndex.RegionEntryToValuesMap re2ValMap =
-            (RangeIndex.RegionEntryToValuesMap) itr.next();
-        assertEquals(1, re2ValMap.map.size());
-        Object obj = re2ValMap.map.values().iterator().next();
-        assertFalse(obj instanceof Collection);
-        assertTrue(obj instanceof Portfolio);
-        Portfolio pf = (Portfolio) obj;
-        assertTrue(idSet.contains(String.valueOf(pf.getID())));
-      }
-      assertEquals(1, ri.undefinedMappedEntries.map.size());
-      Map.Entry entry = (Map.Entry) ri.undefinedMappedEntries.map.entrySet().iterator().next();
+  public void testIndexMaintenanceWithHeterogenousObjects() throws Exception {
+    DefaultQueryService.TEST_QUERY_HETEROGENEOUS_OBJECTS = true;
+    IndexManager.TEST_RANGEINDEX_ONLY = true;
+    Cache cache = CacheUtils.getCache();
+    qs = cache.getQueryService();
+    region = CacheUtils.createRegion("portfolio1", null);
+    idSet.clear();
+    Portfolio p = new Portfolio(4);
+    region.put("4", p);
+    idSet.add("" + p.getID());
+    p = new Portfolio(5);
+    region.put("5", p);
+    idSet.add("" + p.getID());
+    region.put("6", 6);
+    Index i1 = qs.createIndex("indx1", IndexType.FUNCTIONAL, "pf.getID()", "/portfolio1 pf");
+    RangeIndex ri = (RangeIndex) i1;
+    assertEquals(2, ri.valueToEntriesMap.size());
+    Iterator itr = ri.valueToEntriesMap.values().iterator();
+    while (itr.hasNext()) {
+      RangeIndex.RegionEntryToValuesMap re2ValMap = (RangeIndex.RegionEntryToValuesMap) itr.next();
+      assertEquals(1, re2ValMap.map.size());
+      Object obj = re2ValMap.map.values().iterator().next();
+      assertFalse(obj instanceof Collection);
+      assertTrue(obj instanceof Portfolio);
+      Portfolio pf = (Portfolio) obj;
+      assertTrue(idSet.contains(String.valueOf(pf.getID())));
+    }
+    assertEquals(1, ri.undefinedMappedEntries.map.size());
+    Map.Entry entry = (Map.Entry) ri.undefinedMappedEntries.map.entrySet().iterator().next();
+    assertFalse(entry.getValue() instanceof Collection);
+    assertTrue(entry.getValue() instanceof Integer);
+    assertTrue(entry.getValue().equals(6));
+
+    region.put("7", 7);
+    idSet.add(7);
+    assertEquals(2, ri.undefinedMappedEntries.map.size());
+    itr = ri.undefinedMappedEntries.map.entrySet().iterator();
+    while (itr.hasNext()) {
+      entry = (Map.Entry) itr.next();
       assertFalse(entry.getValue() instanceof Collection);
       assertTrue(entry.getValue() instanceof Integer);
-      assertTrue(entry.getValue().equals(new Integer(6)));
+      idSet.contains(entry.getValue());
+    }
 
-      region.put("7", new Integer(7));
-      idSet.add(new Integer(7));
-      assertEquals(2, ri.undefinedMappedEntries.map.size());
-      itr = ri.undefinedMappedEntries.map.entrySet().iterator();
-      while (itr.hasNext()) {
-        entry = (Map.Entry) itr.next();
-        assertFalse(entry.getValue() instanceof Collection);
-        assertTrue(entry.getValue() instanceof Integer);
-        idSet.contains(entry.getValue());
-      }
+    region.remove("7");
+    idSet.remove(7);
+    Index i2 = qs.createIndex("indx2", IndexType.FUNCTIONAL, "pf.pkid", "/portfolio1 pf");
+    ri = (RangeIndex) i2;
+    assertEquals(2, ri.valueToEntriesMap.size());
+    itr = ri.valueToEntriesMap.values().iterator();
+    while (itr.hasNext()) {
+      RangeIndex.RegionEntryToValuesMap re2ValMap = (RangeIndex.RegionEntryToValuesMap) itr.next();
+      assertEquals(1, re2ValMap.map.size());
+      Object obj = re2ValMap.map.values().iterator().next();
+      assertFalse(obj instanceof Collection);
+      assertTrue(obj instanceof Portfolio);
+      Portfolio pf = (Portfolio) obj;
+      assertTrue(idSet.contains(String.valueOf(pf.getID())));
+    }
+    assertEquals(1, ri.undefinedMappedEntries.map.size());
+    entry = (Map.Entry) ri.undefinedMappedEntries.map.entrySet().iterator().next();
+    assertFalse(entry.getValue() instanceof Collection);
+    assertTrue(entry.getValue() instanceof Integer);
+    assertTrue(entry.getValue().equals(6));
 
-      region.remove("7");
-      idSet.remove(new Integer(7));
-      Index i2 = qs.createIndex("indx2", IndexType.FUNCTIONAL, "pf.pkid", "/portfolio1 pf");
-      ri = (RangeIndex) i2;
-      assertEquals(2, ri.valueToEntriesMap.size());
-      itr = ri.valueToEntriesMap.values().iterator();
-      while (itr.hasNext()) {
-        RangeIndex.RegionEntryToValuesMap re2ValMap =
-            (RangeIndex.RegionEntryToValuesMap) itr.next();
-        assertEquals(1, re2ValMap.map.size());
-        Object obj = re2ValMap.map.values().iterator().next();
-        assertFalse(obj instanceof Collection);
-        assertTrue(obj instanceof Portfolio);
-        Portfolio pf = (Portfolio) obj;
-        assertTrue(idSet.contains(String.valueOf(pf.getID())));
-      }
-      assertEquals(1, ri.undefinedMappedEntries.map.size());
-      entry = (Map.Entry) ri.undefinedMappedEntries.map.entrySet().iterator().next();
+    region.put("7", 7);
+    idSet.add(7);
+    assertEquals(2, ri.undefinedMappedEntries.map.size());
+    itr = ri.undefinedMappedEntries.map.entrySet().iterator();
+    while (itr.hasNext()) {
+      entry = (Map.Entry) itr.next();
       assertFalse(entry.getValue() instanceof Collection);
       assertTrue(entry.getValue() instanceof Integer);
-      assertTrue(entry.getValue().equals(new Integer(6)));
-
-      region.put("7", new Integer(7));
-      idSet.add(new Integer(7));
-      assertEquals(2, ri.undefinedMappedEntries.map.size());
-      itr = ri.undefinedMappedEntries.map.entrySet().iterator();
-      while (itr.hasNext()) {
-        entry = (Map.Entry) itr.next();
-        assertFalse(entry.getValue() instanceof Collection);
-        assertTrue(entry.getValue() instanceof Integer);
-        idSet.contains(entry.getValue());
-      }
-
-    } catch (Exception e) {
-      CacheUtils.getLogger().error(e);
-      fail(e.toString());
-    } finally {
-      DefaultQueryService.TEST_QUERY_HETEROGENEOUS_OBJECTS = false;
-      IndexManager.TEST_RANGEINDEX_ONLY = false;
+      idSet.contains(entry.getValue());
     }
   }
 
@@ -206,88 +176,84 @@ public class IndexMaintenanceJUnitTest {
    * Tests query on region containing heterogenous objects
    */
   @Test
-  public void testQueryOnHeterogenousObjects() {
-    try {
-      DefaultQueryService.TEST_QUERY_HETEROGENEOUS_OBJECTS = true;
-      Cache cache = CacheUtils.getCache();
-      region = CacheUtils.createRegion("portfolio1", null);
-      for (int i = 0; i < 5; ++i) {
-        Portfolio p = new Portfolio(i + 1);
-        region.put(new Integer(i + 1), p);
-      }
-
-      for (int i = 5; i < 10; ++i) {
-        region.put(new Integer(i + 1), new Integer(i + 1));
-      }
-      String queryStr = "Select distinct * from /portfolio1 pf1 where pf1.getID() > 3";
-      Query q = qs.newQuery(queryStr);
-      SelectResults rs = (SelectResults) q.execute();
-      assertEquals(2, rs.size());
-      Iterator itr = rs.iterator();
-      while (itr.hasNext()) {
-        Portfolio p = (Portfolio) itr.next();
-        assertTrue(p == region.get(new Integer(4)) || p == region.get(new Integer(5)));
-      }
-
-      Index i1 = qs.createIndex("indx1", IndexType.FUNCTIONAL, "pf.getID()", "/portfolio1 pf");
-      QueryObserver old = QueryObserverHolder.setInstance(new QueryObserverAdapter() {
-        private boolean indexUsed = false;
-
-        public void beforeIndexLookup(Index index, int oper, Object key) {
-          indexUsed = true;
-        }
-
-        public void endQuery() {
-          assertTrue(indexUsed);
-        }
-      });
-
-      rs = (SelectResults) q.execute();
-      assertEquals(2, rs.size());
-      itr = rs.iterator();
-      while (itr.hasNext()) {
-        Portfolio p = (Portfolio) itr.next();
-        assertTrue(p == region.get(new Integer(4)) || p == region.get(new Integer(5)));
-      }
-      qs.removeIndex(i1);
-
-      queryStr = "Select distinct * from /portfolio1 pf1 where pf1.pkid > '3'";
-      q = qs.newQuery(queryStr);
-      rs = (SelectResults) q.execute();
-      assertEquals(2, rs.size());
-      itr = rs.iterator();
-      while (itr.hasNext()) {
-        Portfolio p = (Portfolio) itr.next();
-        assertTrue(p == region.get(new Integer(4)) || p == region.get(new Integer(5)));
-      }
-
-      i1 = qs.createIndex("indx1", IndexType.FUNCTIONAL, "pf.pkid", "/portfolio1 pf");
-      QueryObserverHolder.setInstance(new QueryObserverAdapter() {
-        private boolean indexUsed = false;
-
-        public void beforeIndexLookup(Index index, int oper, Object key) {
-          indexUsed = true;
-        }
-
-        public void endQuery() {
-          assertTrue(indexUsed);
-        }
-      });
-
-      rs = (SelectResults) q.execute();
-      assertEquals(2, rs.size());
-      itr = rs.iterator();
-      while (itr.hasNext()) {
-        Portfolio p = (Portfolio) itr.next();
-        assertTrue(p == region.get(new Integer(4)) || p == region.get(new Integer(5)));
-      }
-    } catch (Exception e) {
-      CacheUtils.getLogger().error(e);
-      fail(e.toString());
-    } finally {
-      DefaultQueryService.TEST_QUERY_HETEROGENEOUS_OBJECTS = false;
+  public void testQueryOnHeterogenousObjects() throws Exception {
+    DefaultQueryService.TEST_QUERY_HETEROGENEOUS_OBJECTS = true;
+    Cache cache = CacheUtils.getCache();
+    region = CacheUtils.createRegion("portfolio1", null);
+    for (int i = 0; i < 5; ++i) {
+      Portfolio p = new Portfolio(i + 1);
+      region.put(i + 1, p);
     }
 
+    for (int i = 5; i < 10; ++i) {
+      region.put(i + 1, i + 1);
+    }
+    String queryStr = "Select distinct * from /portfolio1 pf1 where pf1.getID() > 3";
+    Query q = qs.newQuery(queryStr);
+    SelectResults rs = (SelectResults) q.execute();
+    assertEquals(2, rs.size());
+    Iterator itr = rs.iterator();
+    while (itr.hasNext()) {
+      Portfolio p = (Portfolio) itr.next();
+      assertTrue(p == region.get(4) || p == region.get(5));
+    }
+
+    Index i1 = qs.createIndex("indx1", IndexType.FUNCTIONAL, "pf.getID()", "/portfolio1 pf");
+    QueryObserver old = QueryObserverHolder.setInstance(new QueryObserverAdapter() {
+      private boolean indexUsed = false;
+
+      @Override
+      public void beforeIndexLookup(Index index, int oper, Object key) {
+        indexUsed = true;
+      }
+
+      @Override
+      public void endQuery() {
+        assertTrue(indexUsed);
+      }
+    });
+
+    rs = (SelectResults) q.execute();
+    assertEquals(2, rs.size());
+    itr = rs.iterator();
+    while (itr.hasNext()) {
+      Portfolio p = (Portfolio) itr.next();
+      assertTrue(p == region.get(4) || p == region.get(5));
+    }
+    qs.removeIndex(i1);
+
+    queryStr = "Select distinct * from /portfolio1 pf1 where pf1.pkid > '3'";
+    q = qs.newQuery(queryStr);
+    rs = (SelectResults) q.execute();
+    assertEquals(2, rs.size());
+    itr = rs.iterator();
+    while (itr.hasNext()) {
+      Portfolio p = (Portfolio) itr.next();
+      assertTrue(p == region.get(4) || p == region.get(5));
+    }
+
+    i1 = qs.createIndex("indx1", IndexType.FUNCTIONAL, "pf.pkid", "/portfolio1 pf");
+    QueryObserverHolder.setInstance(new QueryObserverAdapter() {
+      private boolean indexUsed = false;
+
+      @Override
+      public void beforeIndexLookup(Index index, int oper, Object key) {
+        indexUsed = true;
+      }
+
+      @Override
+      public void endQuery() {
+        assertTrue(indexUsed);
+      }
+    });
+
+    rs = (SelectResults) q.execute();
+    assertEquals(2, rs.size());
+    itr = rs.iterator();
+    while (itr.hasNext()) {
+      Portfolio p = (Portfolio) itr.next();
+      assertTrue(p == region.get(4) || p == region.get(5));
+    }
   }
 
   /**
@@ -295,21 +261,14 @@ public class IndexMaintenanceJUnitTest {
    * implemented in DummyQRegion
    */
   @Test
-  public void testIndexMaintenanceWithIndexOnMethodKeys() {
-    try {
-      Index i1 =
-          qs.createIndex("indx1", IndexType.FUNCTIONAL, "ks.toString", "/portfolio.keys() ks");
-      CacheUtils.getCache();
-      region = CacheUtils.getRegion("/portfolio");
-      region.put("4", new Portfolio(4));
-      region.put("5", new Portfolio(5));
-      CompactRangeIndex ri = (CompactRangeIndex) i1;
-      validateIndexForKeys(ri);
-
-    } catch (Exception e) {
-      CacheUtils.getLogger().error(e);
-      fail(e.toString());
-    }
+  public void testIndexMaintenanceWithIndexOnMethodKeys() throws Exception {
+    Index i1 = qs.createIndex("indx1", IndexType.FUNCTIONAL, "ks.toString", "/portfolio.keys() ks");
+    CacheUtils.getCache();
+    region = CacheUtils.getRegion("/portfolio");
+    region.put("4", new Portfolio(4));
+    region.put("5", new Portfolio(5));
+    CompactRangeIndex ri = (CompactRangeIndex) i1;
+    validateIndexForKeys(ri);
   }
 
   /**
@@ -317,20 +276,14 @@ public class IndexMaintenanceJUnitTest {
    * implemented in DummyQRegion
    */
   @Test
-  public void testIndexMaintenanceWithIndexOnMethodAsList() {
-    try {
-      Index i1 =
-          qs.createIndex("indx1", IndexType.FUNCTIONAL, "pf.getID", "/portfolio.asList() pf");
-      CacheUtils.getCache();
-      region = CacheUtils.getRegion("/portfolio");
-      region.put("4", new Portfolio(4));
-      region.put("5", new Portfolio(5));
-      CompactRangeIndex ri = (CompactRangeIndex) i1;
-      validateIndexForValues(ri);
-    } catch (Exception e) {
-      CacheUtils.getLogger().error(e);
-      fail(e.toString());
-    }
+  public void testIndexMaintenanceWithIndexOnMethodAsList() throws Exception {
+    Index i1 = qs.createIndex("indx1", IndexType.FUNCTIONAL, "pf.getID", "/portfolio.asList() pf");
+    CacheUtils.getCache();
+    region = CacheUtils.getRegion("/portfolio");
+    region.put("4", new Portfolio(4));
+    region.put("5", new Portfolio(5));
+    CompactRangeIndex ri = (CompactRangeIndex) i1;
+    validateIndexForValues(ri);
   }
 
   /**
@@ -338,21 +291,15 @@ public class IndexMaintenanceJUnitTest {
    * implemented in DummyQRegion
    */
   @Test
-  public void testIndexMaintenanceWithIndexOnMethodValues() {
-    try {
-      Index i1 =
-          qs.createIndex("indx1", IndexType.FUNCTIONAL, "pf.getID", "/portfolio.values() pf");
-      assertTrue(i1 instanceof CompactRangeIndex);
-      Cache cache = CacheUtils.getCache();
-      region = CacheUtils.getRegion("/portfolio");
-      region.put("4", new Portfolio(4));
-      region.put("5", new Portfolio(5));
-      CompactRangeIndex ri = (CompactRangeIndex) i1;
-      validateIndexForValues(ri);
-    } catch (Exception e) {
-      CacheUtils.getLogger().error(e);
-      fail(e.toString());
-    }
+  public void testIndexMaintenanceWithIndexOnMethodValues() throws Exception {
+    Index i1 = qs.createIndex("indx1", IndexType.FUNCTIONAL, "pf.getID", "/portfolio.values() pf");
+    assertTrue(i1 instanceof CompactRangeIndex);
+    Cache cache = CacheUtils.getCache();
+    region = CacheUtils.getRegion("/portfolio");
+    region.put("4", new Portfolio(4));
+    region.put("5", new Portfolio(5));
+    CompactRangeIndex ri = (CompactRangeIndex) i1;
+    validateIndexForValues(ri);
   }
 
   /**
@@ -360,21 +307,16 @@ public class IndexMaintenanceJUnitTest {
    * implemented in DummyQRegion
    */
   @Test
-  public void testIndexMaintenanceWithIndexOnMethodGetValues() {
-    try {
-      Index i1 =
-          qs.createIndex("indx1", IndexType.FUNCTIONAL, "pf.getID", "/portfolio.getValues() pf");
-      assertTrue(i1 instanceof CompactRangeIndex);
-      Cache cache = CacheUtils.getCache();
-      region = CacheUtils.getRegion("/portfolio");
-      region.put("4", new Portfolio(4));
-      region.put("5", new Portfolio(5));
-      CompactRangeIndex ri = (CompactRangeIndex) i1;
-      validateIndexForValues(ri);
-    } catch (Exception e) {
-      CacheUtils.getLogger().error(e);
-      fail(e.toString());
-    }
+  public void testIndexMaintenanceWithIndexOnMethodGetValues() throws Exception {
+    Index i1 =
+        qs.createIndex("indx1", IndexType.FUNCTIONAL, "pf.getID", "/portfolio.getValues() pf");
+    assertTrue(i1 instanceof CompactRangeIndex);
+    Cache cache = CacheUtils.getCache();
+    region = CacheUtils.getRegion("/portfolio");
+    region.put("4", new Portfolio(4));
+    region.put("5", new Portfolio(5));
+    CompactRangeIndex ri = (CompactRangeIndex) i1;
+    validateIndexForValues(ri);
   }
 
   /**
@@ -382,21 +324,15 @@ public class IndexMaintenanceJUnitTest {
    * implemented in DummyQRegion
    */
   @Test
-  public void testIndexMaintenanceWithIndexOnMethodtoArray() {
-    try {
-      Index i1 =
-          qs.createIndex("indx1", IndexType.FUNCTIONAL, "pf.getID", "/portfolio.toArray() pf");
-      assertTrue(i1 instanceof CompactRangeIndex);
-      Cache cache = CacheUtils.getCache();
-      region = CacheUtils.getRegion("/portfolio");
-      region.put("4", new Portfolio(4));
-      region.put("5", new Portfolio(5));
-      CompactRangeIndex ri = (CompactRangeIndex) i1;
-      validateIndexForValues(ri);
-    } catch (Exception e) {
-      CacheUtils.getLogger().error(e);
-      fail(e.toString());
-    }
+  public void testIndexMaintenanceWithIndexOnMethodtoArray() throws Exception {
+    Index i1 = qs.createIndex("indx1", IndexType.FUNCTIONAL, "pf.getID", "/portfolio.toArray() pf");
+    assertTrue(i1 instanceof CompactRangeIndex);
+    Cache cache = CacheUtils.getCache();
+    region = CacheUtils.getRegion("/portfolio");
+    region.put("4", new Portfolio(4));
+    region.put("5", new Portfolio(5));
+    CompactRangeIndex ri = (CompactRangeIndex) i1;
+    validateIndexForValues(ri);
   }
 
   /**
@@ -404,19 +340,14 @@ public class IndexMaintenanceJUnitTest {
    * implemented in DummyQRegion
    */
   @Test
-  public void testIndexMaintenanceWithIndexOnMethodAsSet() {
-    try {
-      Index i1 = qs.createIndex("indx1", IndexType.FUNCTIONAL, "pf.getID", "/portfolio.asSet() pf");
-      CacheUtils.getCache();
-      region = CacheUtils.getRegion("/portfolio");
-      region.put("4", new Portfolio(4));
-      region.put("5", new Portfolio(5));
-      CompactRangeIndex ri = (CompactRangeIndex) i1;
-      validateIndexForValues(ri);
-    } catch (Exception e) {
-      CacheUtils.getLogger().error(e);
-      fail(e.toString());
-    }
+  public void testIndexMaintenanceWithIndexOnMethodAsSet() throws Exception {
+    Index i1 = qs.createIndex("indx1", IndexType.FUNCTIONAL, "pf.getID", "/portfolio.asSet() pf");
+    CacheUtils.getCache();
+    region = CacheUtils.getRegion("/portfolio");
+    region.put("4", new Portfolio(4));
+    region.put("5", new Portfolio(5));
+    CompactRangeIndex ri = (CompactRangeIndex) i1;
+    validateIndexForValues(ri);
   }
 
   /**
@@ -424,20 +355,15 @@ public class IndexMaintenanceJUnitTest {
    * implemented in DummyQRegion
    */
   @Test
-  public void testIndexMaintenanceWithIndexOnMethodKeySet() {
-    try {
-      Index i1 =
-          qs.createIndex("indx1", IndexType.FUNCTIONAL, "ks.toString", "/portfolio.keySet() ks");
-      CacheUtils.getCache();
-      region = CacheUtils.getRegion("/portfolio");
-      region.put("4", new Portfolio(4));
-      region.put("5", new Portfolio(5));
-      CompactRangeIndex ri = (CompactRangeIndex) i1;
-      validateIndexForKeys(ri);
-    } catch (Exception e) {
-      CacheUtils.getLogger().error(e);
-      fail(e.toString());
-    }
+  public void testIndexMaintenanceWithIndexOnMethodKeySet() throws Exception {
+    Index i1 =
+        qs.createIndex("indx1", IndexType.FUNCTIONAL, "ks.toString", "/portfolio.keySet() ks");
+    CacheUtils.getCache();
+    region = CacheUtils.getRegion("/portfolio");
+    region.put("4", new Portfolio(4));
+    region.put("5", new Portfolio(5));
+    CompactRangeIndex ri = (CompactRangeIndex) i1;
+    validateIndexForKeys(ri);
   }
 
   /**
@@ -445,20 +371,15 @@ public class IndexMaintenanceJUnitTest {
    * implemented in DummyQRegion
    */
   @Test
-  public void testIndexMaintenanceWithIndexOnMethodGetKeys() {
-    try {
-      Index i1 =
-          qs.createIndex("indx1", IndexType.FUNCTIONAL, "ks.toString", "/portfolio.getKeys() ks");
-      CacheUtils.getCache();
-      region = CacheUtils.getRegion("/portfolio");
-      region.put("4", new Portfolio(4));
-      region.put("5", new Portfolio(5));
-      CompactRangeIndex ri = (CompactRangeIndex) i1;
-      validateIndexForKeys(ri);
-    } catch (Exception e) {
-      CacheUtils.getLogger().error(e);
-      fail(e.toString());
-    }
+  public void testIndexMaintenanceWithIndexOnMethodGetKeys() throws Exception {
+    Index i1 =
+        qs.createIndex("indx1", IndexType.FUNCTIONAL, "ks.toString", "/portfolio.getKeys() ks");
+    CacheUtils.getCache();
+    region = CacheUtils.getRegion("/portfolio");
+    region.put("4", new Portfolio(4));
+    region.put("5", new Portfolio(5));
+    CompactRangeIndex ri = (CompactRangeIndex) i1;
+    validateIndexForKeys(ri);
   }
 
   /**
@@ -466,20 +387,15 @@ public class IndexMaintenanceJUnitTest {
    * implemented in DummyQRegion
    */
   @Test
-  public void testIndexMaintenanceWithIndexOnMethodEntrySet() {
-    try {
-      Index i1 = qs.createIndex("indx1", IndexType.FUNCTIONAL, "entries.value.getID",
-          "/portfolio.entrySet() entries");
-      CacheUtils.getCache();
-      region = CacheUtils.getRegion("/portfolio");
-      region.put("4", new Portfolio(4));
-      region.put("5", new Portfolio(5));
-      CompactRangeIndex ri = (CompactRangeIndex) i1;
-      validateIndexForEntries(ri);
-    } catch (Exception e) {
-      CacheUtils.getLogger().error(e);
-      fail(e.toString());
-    }
+  public void testIndexMaintenanceWithIndexOnMethodEntrySet() throws Exception {
+    Index i1 = qs.createIndex("indx1", IndexType.FUNCTIONAL, "entries.value.getID",
+        "/portfolio.entrySet() entries");
+    CacheUtils.getCache();
+    region = CacheUtils.getRegion("/portfolio");
+    region.put("4", new Portfolio(4));
+    region.put("5", new Portfolio(5));
+    CompactRangeIndex ri = (CompactRangeIndex) i1;
+    validateIndexForEntries(ri);
   }
 
   /**
@@ -487,20 +403,15 @@ public class IndexMaintenanceJUnitTest {
    * implemented in DummyQRegion
    */
   @Test
-  public void testIndexMaintenanceWithIndexOnMethodGetEntries() {
-    try {
-      Index i1 = qs.createIndex("indx1", IndexType.FUNCTIONAL, "entries.value.getID",
-          "/portfolio.getEntries() entries");
-      CacheUtils.getCache();
-      region = CacheUtils.getRegion("/portfolio");
-      region.put("4", new Portfolio(4));
-      region.put("5", new Portfolio(5));
-      CompactRangeIndex ri = (CompactRangeIndex) i1;
-      validateIndexForEntries(ri);
-    } catch (Exception e) {
-      CacheUtils.getLogger().error(e);
-      fail(e.toString());
-    }
+  public void testIndexMaintenanceWithIndexOnMethodGetEntries() throws Exception {
+    Index i1 = qs.createIndex("indx1", IndexType.FUNCTIONAL, "entries.value.getID",
+        "/portfolio.getEntries() entries");
+    CacheUtils.getCache();
+    region = CacheUtils.getRegion("/portfolio");
+    region.put("4", new Portfolio(4));
+    region.put("5", new Portfolio(5));
+    CompactRangeIndex ri = (CompactRangeIndex) i1;
+    validateIndexForEntries(ri);
   }
 
   @Test
@@ -733,7 +644,6 @@ public class IndexMaintenanceJUnitTest {
         }
       }
     }
-
   }
 
   @Test
@@ -810,7 +720,6 @@ public class IndexMaintenanceJUnitTest {
         assertEquals(ID + 1 - j, entryMap.getNumEntries());
         for (Integer elem : expectedElements) {
           RegionEntry re = testRgn.basicGetEntry(elem);
-
           assertTrue(entryMap.containsEntry(re));
         }
       }
@@ -976,113 +885,7 @@ public class IndexMaintenanceJUnitTest {
         }
       }
     }
-
   }
-
-  // @Test
-  // public void testCompactMapIndexRecreationForAllKeys() throws Exception
-  // {
-  //
-  // QueryService qs;
-  // qs = CacheUtils.getQueryService();
-  // LocalRegion testRgn = (LocalRegion)CacheUtils.createRegion("testRgn", null);
-  // int ID = 1;
-  // // Add some test data now
-  // // Add 5 main objects. 1 will contain key1, 2 will contain key1 & key2
-  // // and so on
-  // for (; ID <= 5; ++ID) {
-  // MapKeyIndexData mkid = new MapKeyIndexData(ID);
-  // for (int j = 1; j <= ID; ++j) {
-  // mkid.maap.put("key" + j, "val" + j);
-  // }
-  // testRgn.put(ID, mkid);
-  // }
-  // --ID;
-  // Index i1 = qs.createIndex("Index1", IndexType.FUNCTIONAL, "objs.maap[*]",
-  // "/testRgn objs");
-  // assertIndexDetailsEquals(i1.getCanonicalizedIndexedExpression(), "index_iter1.maap[*]");
-  // assertTrue(i1 instanceof CompactMapRangeIndex);
-  // CompactMapRangeIndex mri = (CompactMapRangeIndex)i1;
-  // // Test index maintenance
-  // // addition of new Portfolio object
-  // Map<Object, CompactRangeIndex> indxMap = mri.getRangeIndexHolderForTesting();
-  // assertIndexDetailsEquals(indxMap.size(), ID);
-  // for (int j = 1; j <= ID; ++j) {
-  // assertTrue(indxMap.containsKey("key" + j));
-  // CompactRangeIndex rng = indxMap.get("key" + j);
-  // Iterator itr = rng.valueToEntriesMap.values().iterator();
-  // assertIndexDetailsEquals(rng.valueToEntriesMap.size(), 1);
-  // assertTrue(rng.valueToEntriesMap.containsKey("val" + j));
-  // Set<Integer> expectedElements = new HashSet<Integer>();
-  // for (int k = j; k <= ID; ++k) {
-  // expectedElements.add(k);
-  // }
-  // Object mapValue = rng.valueToEntriesMap.get("val" + j);
-  // int size = 0;
-  // if (mapValue instanceof RegionEntry) {
-  // size = 1;
-  // }
-  // else if (mapValue instanceof ConcurrentHashSet) {
-  // size = ((ConcurrentHashSet)mapValue).size();
-  // }
-  // assertIndexDetailsEquals(expectedElements.size(), size);
-  // for (Integer elem : expectedElements) {
-  // RegionEntry re = testRgn.basicGetEntry(elem);
-  // if (mapValue instanceof RegionEntry) {
-  // assertTrue(mapValue.equals(re));
-  // }
-  // else if (mapValue instanceof ConcurrentHashSet) {
-  // assertTrue(((ConcurrentHashSet)mapValue).contains(re));
-  // }
-  // else {
-  // fail("no map value");
-  // }
-  // }
-  // }
-  // IndexManager im = testRgn.getIndexManager();
-  // im.rerunIndexCreationQuery();
-  // ID =5;
-  // i1 =im.getIndex("Index1");
-  // assertIndexDetailsEquals(i1.getCanonicalizedIndexedExpression(), "index_iter1.maap[*]");
-  // assertTrue(i1 instanceof CompactMapRangeIndex);
-  // mri = (CompactMapRangeIndex)i1;
-  // // Test index maintenance
-  // // addition of new Portfolio object
-  // indxMap = mri.getRangeIndexHolderForTesting();
-  // assertIndexDetailsEquals(indxMap.size(), ID);
-  // for (int j = 1; j <= ID; ++j) {
-  // assertTrue(indxMap.containsKey("key" + j));
-  // CompactRangeIndex rng = indxMap.get("key" + j);
-  // Iterator itr = rng.valueToEntriesMap.values().iterator();
-  // assertIndexDetailsEquals(rng.valueToEntriesMap.size(), 1);
-  // assertTrue(rng.valueToEntriesMap.containsKey("val" + j));
-  // Set<Integer> expectedElements = new HashSet<Integer>();
-  // for (int k = j; k <= ID; ++k) {
-  // expectedElements.add(k);
-  // }
-  // Object mapValue = rng.valueToEntriesMap.get("val" + j);
-  // int size = 0;
-  // if (mapValue instanceof RegionEntry) {
-  // size = 1;
-  // }
-  // else if (mapValue instanceof ConcurrentHashSet) {
-  // size = ((ConcurrentHashSet)mapValue).size();
-  // }
-  // assertIndexDetailsEquals(expectedElements.size(), size);
-  // for (Integer elem : expectedElements) {
-  // RegionEntry re = testRgn.basicGetEntry(elem);
-  // if (mapValue instanceof RegionEntry) {
-  // assertTrue(mapValue.equals(re));
-  // }
-  // else if (mapValue instanceof ConcurrentHashSet) {
-  // assertTrue(((ConcurrentHashSet)mapValue).contains(re));
-  // }
-  // else {
-  // fail("no map value");
-  // }
-  // }
-  // }
-  // }
 
   @Test
   public void testMapIndexRecreationForAllKeys() throws Exception {
@@ -1159,135 +962,84 @@ public class IndexMaintenanceJUnitTest {
         }
       }
     }
-
   }
 
   /**
    * Tests Index maintenance on data loaded via cache loader
    */
   @Test
-  public void testIndexMaintenanceOnCacheLoadedData() {
-    try {
-      IndexManager.TEST_RANGEINDEX_ONLY = true;
-      Cache cache = CacheUtils.getCache();
-      qs = cache.getQueryService();
-      region = CacheUtils.createRegion("portfolio1", null);
-      AttributesMutator am = region.getAttributesMutator();
-      am.setCacheLoader(new CacheLoader() {
+  public void testIndexMaintenanceOnCacheLoadedData() throws Exception {
+    IndexManager.TEST_RANGEINDEX_ONLY = true;
+    Cache cache = CacheUtils.getCache();
+    qs = cache.getQueryService();
+    region = CacheUtils.createRegion("portfolio1", null);
+    AttributesMutator am = region.getAttributesMutator();
+    am.setCacheLoader(new CacheLoader() {
 
-        public Object load(LoaderHelper helper) throws CacheLoaderException {
-          String key = (String) helper.getKey();
-          Portfolio p = new Portfolio(Integer.parseInt(key));
-          return p;
-        }
-
-        public void close() {
-          // TODO Auto-generated method stub
-
-        }
-
-      });
-
-      Index i1 = qs.createIndex("indx1", IndexType.FUNCTIONAL, "pf.getID()", "/portfolio1 pf");
-      List keys = new ArrayList();
-      keys.add("1");
-      keys.add("2");
-      keys.add("3");
-      keys.add("4");
-
-      region.getAll(keys);
-
-    } catch (Exception e) {
-      CacheUtils.getLogger().error(e);
-      fail(e.toString());
-    }
-  }
-
-  /**
-   * Tests Index maintenance on data loaded via cache loader
-   */
-  @Test
-  public void testIndexMaintenanceOnPutAll() {
-    try {
-      IndexManager.TEST_RANGEINDEX_ONLY = true;
-      Cache cache = CacheUtils.getCache();
-      qs = cache.getQueryService();
-      region = CacheUtils.createRegion("portfolio1", null);
-      region.put("1", new Portfolio(1));
-      Index i1 = qs.createIndex("indx1", IndexType.FUNCTIONAL, "posvals.secId",
-          "/portfolio1 pf, pf.positions.values posvals ");
-      Map data = new HashMap();
-      for (int i = 1; i < 11; ++i) {
-        data.put("" + i, new Portfolio(i + 2));
+      @Override
+      public Object load(LoaderHelper helper) throws CacheLoaderException {
+        String key = (String) helper.getKey();
+        Portfolio p = new Portfolio(Integer.parseInt(key));
+        return p;
       }
 
-      region.putAll(data);
+      @Override
+      public void close() {
+        // nothing
+      }
+    });
 
-      // region.putAll(data);
+    Index i1 = qs.createIndex("indx1", IndexType.FUNCTIONAL, "pf.getID()", "/portfolio1 pf");
+    List keys = new ArrayList();
+    keys.add("1");
+    keys.add("2");
+    keys.add("3");
+    keys.add("4");
 
-    } catch (Exception e) {
-      CacheUtils.getLogger().error(e);
-      fail(e.toString());
+    region.getAll(keys);
+  }
+
+  /**
+   * Tests Index maintenance on data loaded via cache loader
+   */
+  @Test
+  public void testIndexMaintenanceOnPutAll() throws Exception {
+    IndexManager.TEST_RANGEINDEX_ONLY = true;
+    Cache cache = CacheUtils.getCache();
+    qs = cache.getQueryService();
+    region = CacheUtils.createRegion("portfolio1", null);
+    region.put("1", new Portfolio(1));
+    Index i1 = qs.createIndex("indx1", IndexType.FUNCTIONAL, "posvals.secId",
+        "/portfolio1 pf, pf.positions.values posvals ");
+    Map data = new HashMap();
+    for (int i = 1; i < 11; ++i) {
+      data.put("" + i, new Portfolio(i + 2));
     }
+
+    region.putAll(data);
   }
 
   @Test
-  public void testBug43597() {
-    try {
-      IndexManager.TEST_RANGEINDEX_ONLY = true;
-      Cache cache = CacheUtils.getCache();
-      qs = cache.getQueryService();
-      region = CacheUtils.createRegion("portfolio1", null);
-      Index i1 = qs.createIndex("indx1", IndexType.FUNCTIONAL, "posvals",
-          "/portfolio1 pf, pf.getCollectionHolderMap.values posvals ");
-      Portfolio pf1 = new Portfolio(1);
-      Map collHolderMap = pf1.getCollectionHolderMap();
-      collHolderMap.clear();
-      collHolderMap.put(1, 1);
-      collHolderMap.put(2, 1);
-      region.put("1", pf1);
+  public void testBug43597() throws Exception {
+    IndexManager.TEST_RANGEINDEX_ONLY = true;
+    Cache cache = CacheUtils.getCache();
+    qs = cache.getQueryService();
+    region = CacheUtils.createRegion("portfolio1", null);
+    Index i1 = qs.createIndex("indx1", IndexType.FUNCTIONAL, "posvals",
+        "/portfolio1 pf, pf.getCollectionHolderMap.values posvals ");
+    Portfolio pf1 = new Portfolio(1);
+    Map collHolderMap = pf1.getCollectionHolderMap();
+    collHolderMap.clear();
+    collHolderMap.put(1, 1);
+    collHolderMap.put(2, 1);
+    region.put("1", pf1);
 
-      pf1 = new Portfolio(2);
-      collHolderMap = pf1.getCollectionHolderMap();
-      collHolderMap.clear();
-      collHolderMap.put(3, 1);
-      collHolderMap.put(4, 1);
-      region.put("1", pf1);
-
-
-      // region.putAll(data);
-
-    } catch (Exception e) {
-      CacheUtils.getLogger().error(e);
-      fail(e.toString());
-    }
-  }
-
-  private void validateIndexForValues(RangeIndex ri) {
-    assertEquals(6, ri.valueToEntriesMap.size());
-    Iterator itr = ri.valueToEntriesMap.values().iterator();
-    while (itr.hasNext()) {
-      RangeIndex.RegionEntryToValuesMap re2ValMap = (RangeIndex.RegionEntryToValuesMap) itr.next();
-      assertEquals(1, re2ValMap.map.size());
-      Object obj = re2ValMap.map.values().iterator().next();
-      assertFalse(obj instanceof Collection);
-      assertTrue(obj instanceof Portfolio);
-      assertTrue(idSet.contains(String.valueOf(((Portfolio) obj).getID())));
-
-    }
-  }
-
-  private void validateIndexForKeys(RangeIndex ri) {
-    assertEquals(6, ri.valueToEntriesMap.size());
-    Iterator itr = ri.valueToEntriesMap.values().iterator();
-    while (itr.hasNext()) {
-      RangeIndex.RegionEntryToValuesMap re2ValMap = (RangeIndex.RegionEntryToValuesMap) itr.next();
-      assertEquals(1, re2ValMap.map.size());
-      Object obj = re2ValMap.map.values().iterator().next();
-      assertFalse(obj instanceof Collection);
-      assertTrue(obj instanceof String);
-      assertTrue(idSet.contains(obj));
-    }
+    pf1 = new Portfolio(2);
+    collHolderMap = pf1.getCollectionHolderMap();
+    collHolderMap.clear();
+    collHolderMap.put(3, 1);
+    collHolderMap.put(4, 1);
+    region.put("1", pf1);
   }
 
   private void validateIndexForKeys(CompactRangeIndex ri) {
@@ -1320,20 +1072,6 @@ public class IndexMaintenanceJUnitTest {
     }
   }
 
-  private void validateIndexForEntries(RangeIndex ri) {
-    assertEquals(6, ri.valueToEntriesMap.size());
-    Iterator itr = ri.valueToEntriesMap.values().iterator();
-    while (itr.hasNext()) {
-      RangeIndex.RegionEntryToValuesMap re2ValMap = (RangeIndex.RegionEntryToValuesMap) itr.next();
-      assertEquals(1, re2ValMap.map.size());
-      Object obj = re2ValMap.map.values().iterator().next();
-      assertFalse(obj instanceof Collection);
-      assertTrue(obj instanceof Region.Entry);
-      Portfolio pf = (Portfolio) ((Region.Entry) obj).getValue();
-      assertTrue(idSet.contains(String.valueOf(pf.getID())));
-    }
-  }
-
   private void validateIndexForValues(CompactRangeIndex ri) {
     assertEquals(6, ri.getIndexStorage().size());
     CloseableIterator<IndexStoreEntry> itr = null;
@@ -1350,7 +1088,7 @@ public class IndexMaintenanceJUnitTest {
     }
   }
 
-  static class MapKeyIndexData {
+  private static class MapKeyIndexData implements Serializable {
     int id;
     public Map maap = new HashMap();
 
@@ -1362,5 +1100,4 @@ public class IndexMaintenanceJUnitTest {
       this.maap.put(key, value);
     }
   }
-
 }

--- a/geode-core/src/test/java/org/apache/geode/cache/query/internal/index/MapRangeIndexMaintenanceJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/internal/index/MapRangeIndexMaintenanceJUnitTest.java
@@ -12,14 +12,10 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-/**
- *
- */
 package org.apache.geode.cache.query.internal.index;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -35,7 +31,6 @@ import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.cache.Scope;
 import org.apache.geode.cache.query.CacheUtils;
 import org.apache.geode.cache.query.Index;
-import org.apache.geode.cache.query.IndexMaintenanceException;
 import org.apache.geode.cache.query.Query;
 import org.apache.geode.cache.query.QueryService;
 import org.apache.geode.cache.query.SelectResults;
@@ -46,18 +41,14 @@ import org.apache.geode.cache.query.internal.QueryObserverHolder;
 import org.apache.geode.test.junit.categories.IntegrationTest;
 import org.apache.geode.test.junit.categories.OQLIndexTest;
 
-/**
- *
- */
 @Category({IntegrationTest.class, OQLIndexTest.class})
 public class MapRangeIndexMaintenanceJUnitTest {
 
-  static QueryService qs;
-  static Region region;
-  static Index keyIndex1;
+  private static final String INDEX_NAME = "keyIndex1";
 
-  public static final int NUM_BKTS = 20;
-  public static final String INDEX_NAME = "keyIndex1";
+  private static QueryService qs;
+  private static Region region;
+  private static Index keyIndex1;
 
   @Before
   public void setUp() throws Exception {
@@ -80,13 +71,12 @@ public class MapRangeIndexMaintenanceJUnitTest {
     p.positions = null;
     region.put(1, p);
 
-    keyIndex1 = (IndexProtocol) qs.createIndex(INDEX_NAME, "positions[*]", "/portfolio ");
+    keyIndex1 = qs.createIndex(INDEX_NAME, "positions[*]", "/portfolio ");
 
     SelectResults result = (SelectResults) qs
         .newQuery("select * from /portfolio p where p.positions['SUN'] = null").execute();
     assertEquals(0, result.size());
   }
-
 
   @Test
   public void testMapIndexIsUsedWithBindKeyParameter() throws Exception {
@@ -123,18 +113,8 @@ public class MapRangeIndexMaintenanceJUnitTest {
     assertEquals(numInstruments, results.size());
   }
 
-  private static class MyQueryObserverAdapter extends IndexTrackingQueryObserver {
-    public boolean indexUsed = false;
-
-    public void afterIndexLookup(Collection results) {
-      super.afterIndexLookup(results);
-      indexUsed = true;
-    }
-  }
-
   @Test
   public void testNullMapKeysInIndexOnLocalRegionForCompactMap() throws Exception {
-
     // Create Partition Region
     AttributesFactory af = new AttributesFactory();
     af.setScope(Scope.LOCAL);
@@ -148,8 +128,7 @@ public class MapRangeIndexMaintenanceJUnitTest {
     assertEquals(100, region.size());
     qs = CacheUtils.getQueryService();
 
-    keyIndex1 =
-        (IndexProtocol) qs.createIndex(INDEX_NAME, "positions['SUN', 'IBM']", "/portfolio p");
+    keyIndex1 = qs.createIndex(INDEX_NAME, "positions['SUN', 'IBM']", "/portfolio p");
 
     assertTrue(keyIndex1 instanceof CompactMapRangeIndex);
 
@@ -159,18 +138,10 @@ public class MapRangeIndexMaintenanceJUnitTest {
     region.put(1, p);
 
     // Now mapkeys are null for key 1
-    try {
-      region.invalidate(1);
-    } catch (NullPointerException e) {
-      fail("Test Failed! region.destroy got NullPointerException!");
-    }
+    region.invalidate(1);
 
     // Now mapkeys are null for key 1
-    try {
-      region.destroy(1);
-    } catch (NullPointerException e) {
-      fail("Test Failed! region.destroy got NullPointerException!");
-    }
+    region.destroy(1);
   }
 
   @Test
@@ -189,8 +160,7 @@ public class MapRangeIndexMaintenanceJUnitTest {
     assertEquals(100, region.size());
     qs = CacheUtils.getQueryService();
 
-    keyIndex1 =
-        (IndexProtocol) qs.createIndex(INDEX_NAME, "positions['SUN', 'IBM']", "/portfolio ");
+    keyIndex1 = qs.createIndex(INDEX_NAME, "positions['SUN', 'IBM']", "/portfolio ");
 
     assertTrue(keyIndex1 instanceof MapRangeIndex);
 
@@ -200,28 +170,17 @@ public class MapRangeIndexMaintenanceJUnitTest {
     region.put(1, p);
 
     // Now mapkeys are null for key 1
-    try {
-      region.invalidate(1);
-    } catch (NullPointerException e) {
-      fail("Test Failed! region.destroy got NullPointerException!");
-    }
+    region.invalidate(1);
 
     // Now mapkeys are null for key 1
-    try {
-      region.destroy(1);
-    } catch (NullPointerException e) {
-      fail("Test Failed! region.destroy got NullPointerException!");
-    }
+    region.destroy(1);
   }
 
   /**
    * Test index object's comapreTo Function implementation correctness for indexes.
-   *
-   * @throws Exception
    */
   @Test
   public void testDuplicateKeysInCompactRangeIndexOnLocalRegion() throws Exception {
-
     // Create Partition Region
     AttributesFactory af = new AttributesFactory();
     af.setScope(Scope.LOCAL);
@@ -235,7 +194,7 @@ public class MapRangeIndexMaintenanceJUnitTest {
 
     qs = CacheUtils.getQueryService();
 
-    keyIndex1 = (IndexProtocol) qs.createIndex(INDEX_NAME, "positions[*]", "/portfolio");
+    keyIndex1 = qs.createIndex(INDEX_NAME, "positions[*]", "/portfolio");
 
     assertTrue(keyIndex1 instanceof CompactMapRangeIndex);
 
@@ -250,26 +209,11 @@ public class MapRangeIndexMaintenanceJUnitTest {
     region.put(Integer.toString(2), p2);
 
     // Following destroy fails if fix for 44123 is not there.
-    try {
-      region.destroy(Integer.toString(1));
-    } catch (NullPointerException e) {
-      fail("Test Failed! region.destroy got NullPointerException!");
-    } catch (Exception ex) {
-      if (ex instanceof IndexMaintenanceException) {
-        if (!ex.getCause().getMessage().contains("compareTo function is errorneous")) {
-          fail("Test Failed! Did not get expected exception IMQException." + ex.getMessage());
-        }
-      } else {
-        ex.printStackTrace();
-        fail("Test Failed! Did not get expected exception IMQException.");
-      }
-    }
+    region.destroy(Integer.toString(1));
   }
 
   /**
    * Test index object's comapreTo Function implementation correctness for indexes.
-   *
-   * @throws Exception
    */
   @Test
   public void testDuplicateKeysInRangeIndexOnLocalRegion() throws Exception {
@@ -288,7 +232,7 @@ public class MapRangeIndexMaintenanceJUnitTest {
 
     qs = CacheUtils.getQueryService();
 
-    keyIndex1 = (IndexProtocol) qs.createIndex(INDEX_NAME, "positions[*]", "/portfolio");
+    keyIndex1 = qs.createIndex(INDEX_NAME, "positions[*]", "/portfolio");
 
     assertTrue(keyIndex1 instanceof MapRangeIndex);
 
@@ -303,20 +247,7 @@ public class MapRangeIndexMaintenanceJUnitTest {
     region.put(Integer.toString(2), p2);
 
     // Following destroy fails if fix for 44123 is not there.
-    try {
-      region.destroy(Integer.toString(1));
-    } catch (NullPointerException e) {
-      fail("Test Failed! region.destroy got NullPointerException!");
-    } catch (Exception ex) {
-      if (ex instanceof IndexMaintenanceException) {
-        if (!ex.getCause().getMessage().contains("compareTo function is errorneous")) {
-          fail("Test Failed! Did not get expected exception IMQException." + ex.getMessage());
-        }
-      } else {
-        ex.printStackTrace();
-        fail("Test Failed! Did not get expected exception IMQException.");
-      }
-    }
+    region.destroy(Integer.toString(1));
   }
 
   @Test
@@ -327,8 +258,7 @@ public class MapRangeIndexMaintenanceJUnitTest {
 
     region = CacheUtils.createRegion("portfolio", af.create(), false);
     qs = CacheUtils.getQueryService();
-    keyIndex1 =
-        (IndexProtocol) qs.createIndex(INDEX_NAME, "positions['SUN', 'IBM']", "/portfolio ");
+    keyIndex1 = qs.createIndex(INDEX_NAME, "positions['SUN', 'IBM']", "/portfolio ");
     assertTrue("Index should be a MapRangeIndex ", keyIndex1 instanceof MapRangeIndex);
 
     if (region.size() == 0) {
@@ -346,10 +276,8 @@ public class MapRangeIndexMaintenanceJUnitTest {
     qs.removeIndexes();
 
     // recreate index to verify they get updated correctly
-    keyIndex1 =
-        (IndexProtocol) qs.createIndex(INDEX_NAME, "positions['SUN', 'IBM']", "/portfolio ");
+    keyIndex1 = qs.createIndex(INDEX_NAME, "positions['SUN', 'IBM']", "/portfolio ");
     assertTrue("Index should be a MapRangeIndex ", keyIndex1 instanceof MapRangeIndex);
-
   }
 
   @Test
@@ -359,8 +287,7 @@ public class MapRangeIndexMaintenanceJUnitTest {
 
     region = CacheUtils.createRegion("portfolio", af.create(), false);
     qs = CacheUtils.getQueryService();
-    keyIndex1 =
-        (IndexProtocol) qs.createIndex(INDEX_NAME, "positions['SUN', 'IBM']", "/portfolio ");
+    keyIndex1 = qs.createIndex(INDEX_NAME, "positions['SUN', 'IBM']", "/portfolio ");
     assertTrue("Index should be a CompactMapRangeIndex ",
         keyIndex1 instanceof CompactMapRangeIndex);
 
@@ -379,8 +306,7 @@ public class MapRangeIndexMaintenanceJUnitTest {
     qs.removeIndexes();
 
     // recreate index to verify they get updated correctly
-    keyIndex1 =
-        (IndexProtocol) qs.createIndex(INDEX_NAME, "positions['SUN', 'IBM']", "/portfolio ");
+    keyIndex1 = qs.createIndex(INDEX_NAME, "positions['SUN', 'IBM']", "/portfolio ");
     assertTrue("Index should be a CompactMapRangeIndex ",
         keyIndex1 instanceof CompactMapRangeIndex);
   }
@@ -390,7 +316,7 @@ public class MapRangeIndexMaintenanceJUnitTest {
     region =
         CacheUtils.getCache().createRegionFactory(RegionShortcut.REPLICATE).create("portfolio");
     qs = CacheUtils.getQueryService();
-    keyIndex1 = (IndexProtocol) qs.createIndex(INDEX_NAME, "positions[*]", "/portfolio ");
+    keyIndex1 = qs.createIndex(INDEX_NAME, "positions[*]", "/portfolio ");
 
     Portfolio p = new Portfolio(1, 1);
     p.positions = new HashMap();
@@ -418,7 +344,7 @@ public class MapRangeIndexMaintenanceJUnitTest {
     region =
         CacheUtils.getCache().createRegionFactory(RegionShortcut.REPLICATE).create("portfolio");
     qs = CacheUtils.getQueryService();
-    keyIndex1 = (IndexProtocol) qs.createIndex(INDEX_NAME, "positions[*]", "/portfolio ");
+    keyIndex1 = qs.createIndex(INDEX_NAME, "positions[*]", "/portfolio ");
 
     Portfolio p = new Portfolio(1, 1);
     p.positions = new HashMap();
@@ -454,7 +380,7 @@ public class MapRangeIndexMaintenanceJUnitTest {
     region.put(1, p);
     qs = CacheUtils.getQueryService();
 
-    keyIndex1 = (IndexProtocol) qs.createIndex(INDEX_NAME, "positions[*]", "/portfolio");
+    keyIndex1 = qs.createIndex(INDEX_NAME, "positions[*]", "/portfolio");
 
     assertTrue(keyIndex1 instanceof CompactMapRangeIndex);
 
@@ -486,7 +412,7 @@ public class MapRangeIndexMaintenanceJUnitTest {
     region.put(1, p);
     qs = CacheUtils.getQueryService();
 
-    keyIndex1 = (IndexProtocol) qs.createIndex(INDEX_NAME, "positions[*]", "/portfolio");
+    keyIndex1 = qs.createIndex(INDEX_NAME, "positions[*]", "/portfolio");
 
     assertTrue(keyIndex1 instanceof CompactMapRangeIndex);
 
@@ -520,7 +446,7 @@ public class MapRangeIndexMaintenanceJUnitTest {
     region.put(1, p);
     qs = CacheUtils.getQueryService();
 
-    keyIndex1 = (IndexProtocol) qs.createIndex(INDEX_NAME, "positions[*]", "/portfolio");
+    keyIndex1 = qs.createIndex(INDEX_NAME, "positions[*]", "/portfolio");
 
     Portfolio p2 = new Portfolio(1, 1);
     HashMap map2 = new HashMap();
@@ -547,7 +473,7 @@ public class MapRangeIndexMaintenanceJUnitTest {
     region.put(1, p);
     qs = CacheUtils.getQueryService();
 
-    keyIndex1 = (IndexProtocol) qs.createIndex(INDEX_NAME, "positions[*]", "/portfolio");
+    keyIndex1 = qs.createIndex(INDEX_NAME, "positions[*]", "/portfolio");
 
     Portfolio p2 = new Portfolio(1, 1);
     HashMap map2 = new HashMap();
@@ -577,14 +503,13 @@ public class MapRangeIndexMaintenanceJUnitTest {
     region.put(1, p);
     qs = CacheUtils.getQueryService();
 
-    keyIndex1 = (IndexProtocol) qs.createIndex(INDEX_NAME, "positions[*]", "/portfolio");
+    keyIndex1 = qs.createIndex(INDEX_NAME, "positions[*]", "/portfolio");
     region.put(1, p);
 
     SelectResults results = (SelectResults) qs
         .newQuery("select * from /portfolio p where p.positions['SUN'] = 1").execute();
     assertEquals(1, results.size());
   }
-
 
   @Test
   public void updatingWithSameKeysDifferentValuesShouldRetainIndexMappings() throws Exception {
@@ -600,7 +525,7 @@ public class MapRangeIndexMaintenanceJUnitTest {
     region.put(1, p);
     qs = CacheUtils.getQueryService();
 
-    keyIndex1 = (IndexProtocol) qs.createIndex(INDEX_NAME, "positions[*]", "/portfolio");
+    keyIndex1 = qs.createIndex(INDEX_NAME, "positions[*]", "/portfolio");
     Portfolio p2 = new Portfolio(1, 1);
     HashMap map2 = new HashMap();
     p2.positions = map2;
@@ -633,7 +558,6 @@ public class MapRangeIndexMaintenanceJUnitTest {
     p1.positions = map1;
     region.put(1, p1);
 
-
     Portfolio p2 = new Portfolio(1, 1);
     HashMap map2 = new HashMap();
     p2.positions = map2;
@@ -659,7 +583,6 @@ public class MapRangeIndexMaintenanceJUnitTest {
         .execute();
     assertEquals(1, results.size());
 
-
     results = (SelectResults) qs
         .newQuery("select * from /portfolio p where p.positions['GOOG'] = 1").execute();
 
@@ -681,7 +604,6 @@ public class MapRangeIndexMaintenanceJUnitTest {
     map1.put("IBM", 2);
     p1.positions = map1;
     region.put(1, p1);
-
 
     SelectResults results = (SelectResults) qs
         .newQuery("select * from /portfolio p where p.positions['SUN'] = 1").execute();
@@ -708,7 +630,6 @@ public class MapRangeIndexMaintenanceJUnitTest {
         .execute();
     assertEquals(1, results.size());
 
-
     results = (SelectResults) qs
         .newQuery("select * from /portfolio p where p.positions['GOOG'] = 1").execute();
 
@@ -731,8 +652,6 @@ public class MapRangeIndexMaintenanceJUnitTest {
     p1.positions = map1;
     region.put(1, p1);
 
-
-
     SelectResults results = (SelectResults) qs
         .newQuery("select * from /portfolio p where p.positions['SUN'] = 1").execute();
     assertEquals(1, results.size());
@@ -746,7 +665,6 @@ public class MapRangeIndexMaintenanceJUnitTest {
     results = (SelectResults) qs.newQuery("select * from /portfolio p where p.positions['SUN'] = 1")
         .execute();
     assertEquals(0, results.size());
-
 
     Portfolio p3 = new Portfolio(1, 1);
     HashMap map3 = new HashMap();
@@ -762,7 +680,6 @@ public class MapRangeIndexMaintenanceJUnitTest {
     results = (SelectResults) qs.newQuery("select * from /portfolio p where p.positions['SUN'] = 3")
         .execute();
     assertEquals(1, results.size());
-
 
     results = (SelectResults) qs
         .newQuery("select * from /portfolio p where p.positions['GOOG'] = 1").execute();
@@ -786,7 +703,6 @@ public class MapRangeIndexMaintenanceJUnitTest {
     p1.positions = map1;
     region.put(1, p1);
 
-
     SelectResults results = (SelectResults) qs
         .newQuery("select * from /portfolio p where p.positions['SUN'] = 1").execute();
     assertEquals(1, results.size());
@@ -796,7 +712,6 @@ public class MapRangeIndexMaintenanceJUnitTest {
     p2.positions = map2;
     map2.put("GOOG", 1);
     region.put(1, p2);
-
 
     results = (SelectResults) qs.newQuery("select * from /portfolio p where p.positions['SUN'] = 1")
         .execute();
@@ -816,7 +731,6 @@ public class MapRangeIndexMaintenanceJUnitTest {
     results = (SelectResults) qs.newQuery("select * from /portfolio p where p.positions['IBM'] = 2")
         .execute();
     assertEquals(1, results.size());
-
   }
 
   @Test
@@ -859,7 +773,6 @@ public class MapRangeIndexMaintenanceJUnitTest {
     results = (SelectResults) qs.newQuery("select * from /portfolio p where p.positions['IBM'] = 2")
         .execute();
     assertEquals(1, results.size());
-
   }
 
   @Test
@@ -906,9 +819,7 @@ public class MapRangeIndexMaintenanceJUnitTest {
     results = (SelectResults) qs.newQuery("select * from /portfolio p where p.positions['IBM'] = 2")
         .execute();
     assertEquals(1, results.size());
-
   }
-
 
   @Test
   public void updatingWithSameKeysSameValuesAfterRemovingShouldReinsertIndexMappingsWithTwoRegionPuts()
@@ -943,7 +854,6 @@ public class MapRangeIndexMaintenanceJUnitTest {
     map2.put("GOOG", 1);
     region.put(1, p3);
 
-
     results = (SelectResults) qs.newQuery("select * from /portfolio p where p.positions['SUN'] = 1")
         .execute();
     assertEquals(1, results.size());
@@ -962,7 +872,6 @@ public class MapRangeIndexMaintenanceJUnitTest {
     results = (SelectResults) qs.newQuery("select * from /portfolio p where p.positions['IBM'] = 2")
         .execute();
     assertEquals(2, results.size());
-
   }
 
   @Test
@@ -988,7 +897,6 @@ public class MapRangeIndexMaintenanceJUnitTest {
     p2.positions = map1;
     region.put(2, p2);
 
-
     SelectResults results = (SelectResults) qs
         .newQuery("select * from /portfolio p where p.positions['SUN'] = 1").execute();
     assertEquals(2, results.size());
@@ -1013,7 +921,6 @@ public class MapRangeIndexMaintenanceJUnitTest {
     results = (SelectResults) qs.newQuery("select * from /portfolio p where p.positions['IBM'] = 2")
         .execute();
     assertEquals(2, results.size());
-
   }
 
   @Test
@@ -1038,7 +945,6 @@ public class MapRangeIndexMaintenanceJUnitTest {
     map2.put("IBM", 2);
     p2.positions = map2;
     region.put(2, p2);
-
 
     SelectResults results = (SelectResults) qs
         .newQuery("select * from /portfolio p where p.positions['SUN'] = 1").execute();
@@ -1068,7 +974,6 @@ public class MapRangeIndexMaintenanceJUnitTest {
     results = (SelectResults) qs.newQuery("select * from /portfolio p where p.positions['IBM'] = 2")
         .execute();
     assertEquals(2, results.size());
-
   }
 
   @Test
@@ -1087,14 +992,12 @@ public class MapRangeIndexMaintenanceJUnitTest {
     p1.positions = map1;
     region.put(1, p1);
 
-
     Portfolio p3 = new Portfolio(1, 1);
     HashMap map3 = new HashMap();
     p3.positions = map3;
     map3.put("SUN", 5);
     map3.put("IBM", 6);
     region.put(2, p3);
-
 
     Portfolio p2 = new Portfolio(1, 1);
     HashMap map2 = new HashMap();
@@ -1120,7 +1023,6 @@ public class MapRangeIndexMaintenanceJUnitTest {
     results = (SelectResults) qs.newQuery("select * from /portfolio p where p.positions['SUN'] = 3")
         .execute();
     assertEquals(1, results.size());
-
 
     results = (SelectResults) qs
         .newQuery("select * from /portfolio p where p.positions['GOOG'] = 1").execute();
@@ -1151,7 +1053,6 @@ public class MapRangeIndexMaintenanceJUnitTest {
     p2.positions = map2;
     region.put(2, p2);
 
-
     SelectResults results = (SelectResults) qs
         .newQuery("select * from /portfolio p where p.positions['SUN'] = 1").execute();
     assertEquals(1, results.size());
@@ -1177,7 +1078,6 @@ public class MapRangeIndexMaintenanceJUnitTest {
         .execute();
     assertEquals(1, results.size());
 
-
     results = (SelectResults) qs
         .newQuery("select * from /portfolio p where p.positions['GOOG'] = 1").execute();
 
@@ -1200,7 +1100,6 @@ public class MapRangeIndexMaintenanceJUnitTest {
     p1.positions = map1;
     region.put(1, p1);
 
-
     Portfolio p2 = new Portfolio(1, 1);
     HashMap map2 = new HashMap();
     map2.put("SUN", 5);
@@ -1222,7 +1121,6 @@ public class MapRangeIndexMaintenanceJUnitTest {
         .execute();
     assertEquals(0, results.size());
 
-
     Portfolio p3 = new Portfolio(1, 1);
     HashMap map3 = new HashMap();
     p3.positions = map3;
@@ -1238,35 +1136,42 @@ public class MapRangeIndexMaintenanceJUnitTest {
         .execute();
     assertEquals(1, results.size());
 
-
     results = (SelectResults) qs
         .newQuery("select * from /portfolio p where p.positions['GOOG'] = 1").execute();
 
     assertEquals(0, results.size());
   }
 
-
   /**
    * TestObject with wrong comareTo() implementation implementation. Which throws NullPointer while
    * removing mapping from a MapRangeIndex.
-   *
    */
-  public class TestObject implements Cloneable, Comparable {
+  private static class TestObject implements Cloneable, Comparable {
+    String name;
+    int id;
+
     public TestObject(String name, int id) {
-      super();
       this.name = name;
       this.id = id;
     }
 
-    String name;
-    int id;
-
     @Override
     public int compareTo(Object o) {
-      if (id == ((TestObject) o).id)
+      if (id == ((TestObject) o).id) {
         return 0;
-      else
+      } else {
         return id > ((TestObject) o).id ? -1 : 1;
+      }
+    }
+  }
+
+  private static class MyQueryObserverAdapter extends IndexTrackingQueryObserver {
+    public boolean indexUsed = false;
+
+    @Override
+    public void afterIndexLookup(Collection results) {
+      super.afterIndexLookup(results);
+      indexUsed = true;
     }
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/cache30/CacheXml80DUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache30/CacheXml80DUnitTest.java
@@ -14,11 +14,14 @@
  */
 package org.apache.geode.cache30;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.FileWriter;
 import java.io.PrintWriter;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -48,6 +51,7 @@ import org.apache.geode.internal.cache.xmlcache.RegionAttributesCreation;
 import org.apache.geode.test.junit.categories.DistributedTest;
 
 @Category(DistributedTest.class)
+@SuppressWarnings("serial")
 public class CacheXml80DUnitTest extends CacheXml70DUnitTest {
 
   @Override
@@ -55,7 +59,6 @@ public class CacheXml80DUnitTest extends CacheXml70DUnitTest {
     return CacheXml.VERSION_8_0;
   }
 
-  @SuppressWarnings("rawtypes")
   @Test
   public void testCompressor() throws Exception {
     final String regionName = "testCompressor";
@@ -220,11 +223,8 @@ public class CacheXml80DUnitTest extends CacheXml70DUnitTest {
   }
 
   private static class QueryObserverImpl extends QueryObserverAdapter {
-
     boolean isIndexesUsed = false;
-
-    List<String> indexesUsed = new ArrayList<String>();
-
+    List<String> indexesUsed = new ArrayList<>();
     String indexName;
 
     @Override
@@ -248,7 +248,7 @@ public class CacheXml80DUnitTest extends CacheXml70DUnitTest {
     }
   }
 
-  private static class TestObject {
+  private static class TestObject implements Serializable {
     public int CR_ID;
     public int CR_ID_2;
     public int R_ID;

--- a/geode-core/src/test/java/org/apache/geode/cache30/CacheXml81DUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache30/CacheXml81DUnitTest.java
@@ -14,7 +14,10 @@
  */
 package org.apache.geode.cache30;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -41,6 +44,7 @@ import org.apache.geode.test.junit.categories.DistributedTest;
  * @since GemFire 8.1
  */
 @Category(DistributedTest.class)
+@SuppressWarnings("serial")
 public class CacheXml81DUnitTest extends CacheXml80DUnitTest {
 
   @Override
@@ -74,8 +78,7 @@ public class CacheXml81DUnitTest extends CacheXml80DUnitTest {
     assertEquals(0, extension.onCreateCounter.get());
     assertEquals(1, extension.getXmlGeneratorCounter.get());
 
-    @SuppressWarnings("unchecked")
-    final Extensible<Cache> c = (Extensible<Cache>) getCache();
+    final Extensible<Cache> c = getCache();
     assertNotNull(c);
     final MockCacheExtension m =
         (MockCacheExtension) c.getExtensionPoint().getExtensions().iterator().next();
@@ -96,7 +99,6 @@ public class CacheXml81DUnitTest extends CacheXml80DUnitTest {
     final String regionName = "testRegionExtension";
     final CacheCreation cache = new CacheCreation();
     final RegionAttributesCreation attrs = new RegionAttributesCreation(cache);
-    @SuppressWarnings("unchecked")
     Extensible<Region<?, ?>> region =
         (Extensible<Region<?, ?>>) cache.createRegion(regionName, attrs);
 
@@ -113,7 +115,6 @@ public class CacheXml81DUnitTest extends CacheXml80DUnitTest {
     assertEquals(0, extension.onCreateCounter.get());
     assertEquals(1, extension.getXmlGeneratorCounter.get());
 
-    @SuppressWarnings("unchecked")
     final Extensible<Region<?, ?>> r = (Extensible<Region<?, ?>>) getCache().getRegion(regionName);
     assertNotNull(r);
     final MockRegionExtension m =
@@ -136,7 +137,6 @@ public class CacheXml81DUnitTest extends CacheXml80DUnitTest {
     final String regionName = "testRegionExtension";
     final CacheCreation cache = new CacheCreation();
     final RegionAttributesCreation attrs = new RegionAttributesCreation(cache);
-    @SuppressWarnings("unchecked")
     Extensible<Region<?, ?>> region =
         (Extensible<Region<?, ?>>) cache.createRegion(regionName, attrs);
 
@@ -160,5 +160,4 @@ public class CacheXml81DUnitTest extends CacheXml80DUnitTest {
       }
     }
   }
-
 }

--- a/geode-core/src/test/java/org/apache/geode/cache30/PRBucketSynchronizationDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache30/PRBucketSynchronizationDUnitTest.java
@@ -14,10 +14,13 @@
  */
 package org.apache.geode.cache30;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
 
-import java.util.*;
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
 
+import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -27,10 +30,8 @@ import org.apache.geode.cache.EvictionAction;
 import org.apache.geode.cache.EvictionAttributes;
 import org.apache.geode.cache.Operation;
 import org.apache.geode.cache.PartitionAttributesFactory;
-import org.apache.geode.distributed.*;
-import org.apache.geode.distributed.internal.InternalDistributedSystem;
+import org.apache.geode.distributed.ConfigurationProperties;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
-import org.apache.geode.distributed.internal.membership.gms.MembershipManagerHelper;
 import org.apache.geode.internal.cache.BucketRegion;
 import org.apache.geode.internal.cache.EntryEventImpl;
 import org.apache.geode.internal.cache.LocalRegion;
@@ -44,37 +45,31 @@ import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.test.dunit.DistributedTestUtils;
 import org.apache.geode.test.dunit.Host;
 import org.apache.geode.test.dunit.IgnoredException;
-import org.apache.geode.test.dunit.LogWriterUtils;
-import org.apache.geode.test.dunit.SerializableCallable;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.Wait;
 import org.apache.geode.test.dunit.WaitCriterion;
-import org.apache.geode.test.dunit.cache.internal.JUnit4CacheTestCase;
-import org.apache.geode.test.dunit.internal.JUnit4DistributedTestCase;
+import org.apache.geode.test.dunit.cache.CacheTestCase;
 import org.apache.geode.test.junit.categories.DistributedTest;
 
 /**
  * concurrency-control tests for client/server
- *
- *
  */
 @Category(DistributedTest.class)
-public class PRBucketSynchronizationDUnitTest extends JUnit4CacheTestCase {
-  static enum TestType {
-    IN_MEMORY, OVERFLOW, PERSISTENT
-  };
+@SuppressWarnings("serial")
+public class PRBucketSynchronizationDUnitTest extends CacheTestCase {
 
-  public static LocalRegion TestRegion;
+  private static LocalRegion testRegion;
 
-  public PRBucketSynchronizationDUnitTest() {
-    super();
+  @After
+  public void tearDown() {
+    disconnectAllFromDS();
   }
 
   @Override
   public Properties getDistributedSystemProperties() {
-    Properties result = super.getDistributedSystemProperties();
-    result.put(ConfigurationProperties.ENABLE_NETWORK_PARTITION_DETECTION, "false");
-    return result;
+    Properties config = super.getDistributedSystemProperties();
+    config.put(ConfigurationProperties.ENABLE_NETWORK_PARTITION_DETECTION, "false");
+    return config;
   }
 
   @Test
@@ -96,232 +91,191 @@ public class PRBucketSynchronizationDUnitTest extends JUnit4CacheTestCase {
    * We hit this problem in bug #45669. A primary was lost and we did not see secondary buckets
    * perform a delta-GII.
    */
-  public void doBucketsSyncOnPrimaryLoss(TestType typeOfTest) {
+  private void doBucketsSyncOnPrimaryLoss(TestType typeOfTest) {
     IgnoredException.addIgnoredException("killing member's ds");
     IgnoredException.addIgnoredException("killing member's ds");
     Host host = Host.getHost(0);
     VM vm0 = host.getVM(0);
     VM vm1 = host.getVM(1);
     VM vm2 = host.getVM(2);
-    Set<VM> verifyVMs = new HashSet<VM>();
+    Set<VM> verifyVMs = new HashSet<>();
 
-    final String name = this.getUniqueName() + "Region";
+    final String name = getUniqueName() + "Region";
 
     verifyVMs.add(vm0);
     verifyVMs.add(vm1);
     verifyVMs.add(vm2);
 
-    disconnectAllFromDS();
-    try {
-      createRegion(vm0, name, typeOfTest);
-      createRegion(vm1, name, typeOfTest);
-      createRegion(vm2, name, typeOfTest);
+    createRegion(vm0, name, typeOfTest);
+    createRegion(vm1, name, typeOfTest);
+    createRegion(vm2, name, typeOfTest);
 
-      createEntry1(vm0);
+    createEntry1(vm0);
 
-      VM primaryOwner;
-      if (isPrimaryForBucket0(vm0))
-        primaryOwner = vm0;
-      else if (isPrimaryForBucket0(vm1))
-        primaryOwner = vm1;
-      else
-        primaryOwner = vm2;
+    VM primaryOwner;
+    if (isPrimaryForBucket0(vm0)) {
+      primaryOwner = vm0;
+    } else if (isPrimaryForBucket0(vm1)) {
+      primaryOwner = vm1;
+    } else {
+      primaryOwner = vm2;
+    }
 
-      verifyVMs.remove(primaryOwner);
+    verifyVMs.remove(primaryOwner);
 
-      // cause one of the VMs to throw away the next operation
-      VM creatorVM = null;
-      InternalDistributedMember primaryID = getID(primaryOwner);
-      VersionSource primaryVersionID = getVersionID(primaryOwner);
-      for (VM vm : verifyVMs) {
-        creatorVM = vm;
-        createEntry2(creatorVM, primaryID, primaryVersionID);
-        break;
-      }
+    // cause one of the VMs to throw away the next operation
+    VM creatorVM = null;
+    InternalDistributedMember primaryID = getId(primaryOwner);
+    VersionSource primaryVersionID = getVersionID(primaryOwner);
+    for (VM vm : verifyVMs) {
+      creatorVM = vm;
+      createEntry2(creatorVM, primaryID, primaryVersionID);
+      break;
+    }
 
-      verifyVMs.remove(creatorVM);
+    verifyVMs.remove(creatorVM);
 
-      // Now we crash the primary bucket owner simulating death during distribution.
-      // The backup buckets should perform a delta-GII for the lost member and
-      // get back in sync
-      DistributedTestUtils.crashDistributedSystem(primaryOwner);
+    // Now we crash the primary bucket owner simulating death during distribution.
+    // The backup buckets should perform a delta-GII for the lost member and
+    // get back in sync
+    DistributedTestUtils.crashDistributedSystem(primaryOwner);
 
-      for (VM vm : verifyVMs) {
-        verifySynchronized(vm, primaryID);
-      }
-    } finally {
-      disconnectAllFromDS();
+    for (VM vm : verifyVMs) {
+      verifySynchronized(vm, primaryID);
     }
   }
 
-
-  // private void closeCache(VM vm) {
-  // vm.invoke(new SerializableCallable() {
-  // public Object call() throws Exception {
-  // closeCache();
-  // return null;
-  // }
-  // });
-  // }
-
-  private boolean createEntry1(VM vm) {
-    return (Boolean) vm.invoke(new SerializableCallable("create entry1") {
-      public Object call() {
-        TestRegion.create("Object1", Integer.valueOf(1));
-        return true;
-      }
+  private void createEntry1(VM vm) {
+    vm.invoke("create entry1", () -> {
+      testRegion.create("Object1", 1);
     });
   }
 
   private boolean isPrimaryForBucket0(VM vm) {
-    return (Boolean) vm.invoke(new SerializableCallable("is primary?") {
-      public Object call() {
-        PartitionedRegion pr = (PartitionedRegion) TestRegion;
-        return pr.getDataStore().getLocalBucketById(0).getBucketAdvisor().isPrimary();
-      }
+    return vm.invoke("is primary?", () -> {
+      PartitionedRegion pr = (PartitionedRegion) testRegion;
+      return pr.getDataStore().getLocalBucketById(0).getBucketAdvisor().isPrimary();
     });
   }
 
-  private InternalDistributedMember getID(VM vm) {
-    return (InternalDistributedMember) vm.invoke(new SerializableCallable("get dmID") {
-      public Object call() {
-        return TestRegion.getCache().getMyId();
-      }
+  private InternalDistributedMember getId(VM vm) {
+    return vm.invoke("get dmID", () -> {
+      return testRegion.getCache().getMyId();
     });
   }
-
 
   private VersionSource getVersionID(VM vm) {
-    return (VersionSource) vm.invoke(new SerializableCallable("get versionID") {
-      public Object call() {
-        return TestRegion.getVersionMember();
-      }
+    return vm.invoke("get versionID", () -> {
+      return testRegion.getVersionMember();
     });
   }
 
-  private boolean createEntry2(VM vm, final InternalDistributedMember primary,
+  private void createEntry2(VM vm, final InternalDistributedMember primary,
       final VersionSource primaryVersionID) {
-    return (Boolean) vm.invoke(new SerializableCallable("create entry2") {
-      public Object call() {
-        // create a fake event that looks like it came from the primary and apply it to
-        // this cache
-        PartitionedRegion pr = (PartitionedRegion) TestRegion;
-        BucketRegion bucket = pr.getDataStore().getLocalBucketById(0);
-        VersionTag tag = new VMVersionTag();
-        tag.setMemberID(primaryVersionID);
-        tag.setRegionVersion(2);
-        tag.setEntryVersion(1);
-        tag.setIsRemoteForTesting();
-        EntryEventImpl event =
-            EntryEventImpl.create(bucket, Operation.CREATE, "Object3", true, primary, true, false);
-        LogWriterUtils.getLogWriter().info("applying this event to the cache: " + event);
-        event.setNewValue(new VMCachedDeserializable("value3", 12));
-        event.setVersionTag(tag);
-        bucket.getRegionMap().basicPut(event, System.currentTimeMillis(), true, false, null, false,
-            false);
-        event.release();
+    vm.invoke("create entry2", () -> {
+      // create a fake event that looks like it came from the primary and apply it to this cache
+      PartitionedRegion pr = (PartitionedRegion) testRegion;
+      BucketRegion bucket = pr.getDataStore().getLocalBucketById(0);
+      VersionTag tag = new VMVersionTag();
+      tag.setMemberID(primaryVersionID);
+      tag.setRegionVersion(2);
+      tag.setEntryVersion(1);
+      tag.setIsRemoteForTesting();
+      EntryEventImpl event =
+          EntryEventImpl.create(bucket, Operation.CREATE, "Object3", true, primary, true, false);
+      event.setNewValue(new VMCachedDeserializable("value3", 12));
+      event.setVersionTag(tag);
+      bucket.getRegionMap().basicPut(event, System.currentTimeMillis(), true, false, null, false,
+          false);
+      event.release();
 
-        // now create a tombstone so we can be sure these are transferred in delta-GII
-        tag = new VMVersionTag();
-        tag.setMemberID(primaryVersionID);
-        tag.setRegionVersion(3);
-        tag.setEntryVersion(1);
-        tag.setIsRemoteForTesting();
-        event =
-            EntryEventImpl.create(bucket, Operation.CREATE, "Object5", true, primary, true, false);
-        event.setNewValue(Token.TOMBSTONE);
-        event.setVersionTag(tag);
-        LogWriterUtils.getLogWriter().info("applying this event to the cache: " + event);
-        bucket.getRegionMap().basicPut(event, System.currentTimeMillis(), true, false, null, false,
-            false);
-        event.release();
+      // now create a tombstone so we can be sure these are transferred in delta-GII
+      tag = new VMVersionTag();
+      tag.setMemberID(primaryVersionID);
+      tag.setRegionVersion(3);
+      tag.setEntryVersion(1);
+      tag.setIsRemoteForTesting();
+      event =
+          EntryEventImpl.create(bucket, Operation.CREATE, "Object5", true, primary, true, false);
+      event.setNewValue(Token.TOMBSTONE);
+      event.setVersionTag(tag);
+      bucket.getRegionMap().basicPut(event, System.currentTimeMillis(), true, false, null, false,
+          false);
+      event.release();
 
-        bucket.dumpBackingMap();
-        LogWriterUtils.getLogWriter()
-            .info("bucket version vector is now " + bucket.getVersionVector().fullToString());
-        assertTrue("bucket should hold entry Object3 now", bucket.containsKey("Object3"));
-        return true;
-      }
+      bucket.dumpBackingMap();
+      assertTrue("bucket should hold entry Object3 now", bucket.containsKey("Object3"));
     });
   }
 
   private void verifySynchronized(VM vm, final InternalDistributedMember crashedMember) {
-    vm.invoke(new SerializableCallable("check that synchronization happened") {
-      public Object call() throws Exception {
-        PartitionedRegion pr = (PartitionedRegion) TestRegion;
-        final BucketRegion bucket = pr.getDataStore().getLocalBucketById(0);
-        Wait.waitForCriterion(new WaitCriterion() {
-          String waitingFor = "primary is still in membership view: " + crashedMember;
-          boolean dumped = false;
+    vm.invoke("check that synchronization happened", () -> {
+      PartitionedRegion pr = (PartitionedRegion) testRegion;
+      final BucketRegion bucket = pr.getDataStore().getLocalBucketById(0);
 
-          public boolean done() {
-            if (TestRegion.getCache().getDistributionManager().isCurrentMember(crashedMember)) {
-              LogWriterUtils.getLogWriter().info(waitingFor);
-              return false;
-            }
-            if (!TestRegion.containsKey("Object3")) {
-              waitingFor = "entry for Object3 not found";
-              LogWriterUtils.getLogWriter().info(waitingFor);
-              return false;
-            }
-            RegionEntry re = bucket.getRegionMap().getEntry("Object5");
-            if (re == null) {
-              if (!dumped) {
-                dumped = true;
-                bucket.dumpBackingMap();
-              }
-              waitingFor = "entry for Object5 not found";
-              LogWriterUtils.getLogWriter().info(waitingFor);
-              return false;
-            }
-            if (!re.isTombstone()) {
-              if (!dumped) {
-                dumped = true;
-                bucket.dumpBackingMap();
-              }
-              waitingFor = "Object5 is not a tombstone but should be: " + re;
-              LogWriterUtils.getLogWriter().info(waitingFor);
-              return false;
-            }
-            return true;
+      Wait.waitForCriterion(new WaitCriterion() {
+        String waitingFor = "primary is still in membership view: " + crashedMember;
+        boolean dumped = false;
+
+        @Override
+        public boolean done() {
+          if (testRegion.getCache().getDistributionManager().isCurrentMember(crashedMember)) {
+            return false;
           }
-
-          public String description() {
-            return waitingFor;
+          if (!testRegion.containsKey("Object3")) {
+            waitingFor = "entry for Object3 not found";
+            return false;
           }
+          RegionEntry re = bucket.getRegionMap().getEntry("Object5");
+          if (re == null) {
+            if (!dumped) {
+              dumped = true;
+              bucket.dumpBackingMap();
+            }
+            waitingFor = "entry for Object5 not found";
+            return false;
+          }
+          if (!re.isTombstone()) {
+            if (!dumped) {
+              dumped = true;
+              bucket.dumpBackingMap();
+            }
+            waitingFor = "Object5 is not a tombstone but should be: " + re;
+            return false;
+          }
+          return true;
+        }
 
-        }, 30000, 5000, true);
-        return null;
-      }
+        @Override
+        public String description() {
+          return waitingFor;
+        }
+      }, 30000, 5000, true);
     });
   }
 
-
   private void createRegion(VM vm, final String regionName, final TestType typeOfTest) {
-    SerializableCallable createRegion = new SerializableCallable() {
-      @SuppressWarnings("deprecation")
-      public Object call() throws Exception {
-        // TombstoneService.VERBOSE = true;
-        AttributesFactory af = new AttributesFactory();
-        af.setDataPolicy(DataPolicy.PARTITION);
-        af.setPartitionAttributes((new PartitionAttributesFactory()).setTotalNumBuckets(2)
-            .setRedundantCopies(3).create());
-        switch (typeOfTest) {
-          case IN_MEMORY:
-            break;
-          case PERSISTENT:
-            af.setDataPolicy(DataPolicy.PERSISTENT_PARTITION);
-            break;
-          case OVERFLOW:
-            af.setEvictionAttributes(
-                EvictionAttributes.createLRUEntryAttributes(5, EvictionAction.OVERFLOW_TO_DISK));
-            break;
-        }
-        TestRegion = (LocalRegion) createRootRegion(regionName, af.create());
-        return null;
+    vm.invoke(() -> {
+      AttributesFactory af = new AttributesFactory();
+      af.setDataPolicy(DataPolicy.PARTITION);
+      af.setPartitionAttributes(
+          (new PartitionAttributesFactory()).setTotalNumBuckets(2).setRedundantCopies(3).create());
+      switch (typeOfTest) {
+        case IN_MEMORY:
+          break;
+        case PERSISTENT:
+          af.setDataPolicy(DataPolicy.PERSISTENT_PARTITION);
+          break;
+        case OVERFLOW:
+          af.setEvictionAttributes(
+              EvictionAttributes.createLRUEntryAttributes(5, EvictionAction.OVERFLOW_TO_DISK));
+          break;
       }
-    };
-    vm.invoke(createRegion);
+      testRegion = (LocalRegion) createRootRegion(regionName, af.create());
+    });
   }
 
+  enum TestType {
+    IN_MEMORY, OVERFLOW, PERSISTENT
+  }
 }

--- a/geode-core/src/test/java/org/apache/geode/cache30/RRSynchronizationDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache30/RRSynchronizationDUnitTest.java
@@ -14,47 +14,59 @@
  */
 package org.apache.geode.cache30;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
 
-import java.util.*;
+import java.util.Properties;
 
+import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import org.apache.geode.cache.*;
-import org.apache.geode.distributed.*;
+import org.apache.geode.cache.AttributesFactory;
+import org.apache.geode.cache.DataPolicy;
+import org.apache.geode.cache.EvictionAction;
+import org.apache.geode.cache.EvictionAttributes;
+import org.apache.geode.cache.Operation;
+import org.apache.geode.cache.Scope;
+import org.apache.geode.distributed.ConfigurationProperties;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
-import org.apache.geode.internal.cache.*;
+import org.apache.geode.internal.cache.DistributedRegion;
+import org.apache.geode.internal.cache.EntryEventImpl;
+import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.RegionEntry;
+import org.apache.geode.internal.cache.Token;
+import org.apache.geode.internal.cache.VMCachedDeserializable;
 import org.apache.geode.internal.cache.versions.VMVersionTag;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionTag;
-import org.apache.geode.test.dunit.*;
-import org.apache.geode.test.dunit.cache.internal.JUnit4CacheTestCase;
-import org.apache.geode.test.dunit.internal.JUnit4DistributedTestCase;
+import org.apache.geode.test.dunit.DistributedTestUtils;
+import org.apache.geode.test.dunit.Host;
+import org.apache.geode.test.dunit.IgnoredException;
+import org.apache.geode.test.dunit.VM;
+import org.apache.geode.test.dunit.Wait;
+import org.apache.geode.test.dunit.WaitCriterion;
+import org.apache.geode.test.dunit.cache.CacheTestCase;
 import org.apache.geode.test.junit.categories.DistributedTest;
 
 /**
  * concurrency-control tests for client/server
- *
- *
  */
 @Category(DistributedTest.class)
-public class RRSynchronizationDUnitTest extends JUnit4CacheTestCase {
-  static enum TestType {
-    IN_MEMORY, OVERFLOW, PERSISTENT
-  };
+@SuppressWarnings("serial")
+public class RRSynchronizationDUnitTest extends CacheTestCase {
 
-  public static LocalRegion TestRegion;
+  private static LocalRegion testRegion;
 
-  public RRSynchronizationDUnitTest() {
-    super();
+  @After
+  public void tearDown() {
+    disconnectAllFromDS();
   }
 
   @Override
   public Properties getDistributedSystemProperties() {
-    Properties result = super.getDistributedSystemProperties();
-    result.put(ConfigurationProperties.ENABLE_NETWORK_PARTITION_DETECTION, "false");
-    return result;
+    Properties config = super.getDistributedSystemProperties();
+    config.put(ConfigurationProperties.ENABLE_NETWORK_PARTITION_DETECTION, "false");
+    return config;
   }
 
   @Test
@@ -72,193 +84,159 @@ public class RRSynchronizationDUnitTest extends JUnit4CacheTestCase {
     doRegionsSyncOnPeerLoss(TestType.OVERFLOW);
   }
 
-
   /**
    * We hit this problem in bug #45669. delta-GII was not being distributed in the 7.0 release.
    */
-  public void doRegionsSyncOnPeerLoss(TestType typeOfTest) {
+  private void doRegionsSyncOnPeerLoss(TestType typeOfTest) {
     IgnoredException.addIgnoredException("killing member's ds");
     Host host = Host.getHost(0);
     VM vm0 = host.getVM(0);
     VM vm1 = host.getVM(1);
     VM vm2 = host.getVM(2);
 
-    final String name = this.getUniqueName() + "Region";
+    final String name = getUniqueName() + "Region";
 
-    disconnectAllFromDS();
+    createRegion(vm0, name, typeOfTest);
+    createRegion(vm1, name, typeOfTest);
+    createRegion(vm2, name, typeOfTest);
 
-    try {
-      createRegion(vm0, name, typeOfTest);
-      createRegion(vm1, name, typeOfTest);
-      createRegion(vm2, name, typeOfTest);
-
-      createEntry1(vm0);
+    createEntry1(vm0);
 
 
-      // cause one of the VMs to throw away the next operation
-      InternalDistributedMember crashedID = getID(vm0);
-      VersionSource crashedVersionID = getVersionID(vm0);
-      createEntry2(vm1, crashedID, crashedVersionID);
+    // cause one of the VMs to throw away the next operation
+    InternalDistributedMember crashedID = getId(vm0);
+    VersionSource crashedVersionID = getVersionId(vm0);
+    createEntry2(vm1, crashedID, crashedVersionID);
 
-      // Now we crash the member who "modified" vm1's cache.
-      // The other replicates should perform a delta-GII for the lost member and
-      // get back in sync
-      DistributedTestUtils.crashDistributedSystem(vm0);
+    // Now we crash the member who "modified" vm1's cache.
+    // The other replicates should perform a delta-GII for the lost member and
+    // get back in sync
+    DistributedTestUtils.crashDistributedSystem(vm0);
 
-      verifySynchronized(vm2, crashedID);
-    } finally {
-      disconnectAllFromDS();
-    }
+    verifySynchronized(vm2, crashedID);
   }
 
-
-  private boolean createEntry1(VM vm) {
-    return (Boolean) vm.invoke(new SerializableCallable("create entry1") {
-      public Object call() {
-        TestRegion.create("Object1", Integer.valueOf(1));
-        return true;
-      }
+  private void createEntry1(VM vm) {
+    vm.invoke("create entry1", () -> {
+      testRegion.create("Object1", Integer.valueOf(1));
     });
   }
 
-  private InternalDistributedMember getID(VM vm) {
-    return (InternalDistributedMember) vm.invoke(new SerializableCallable("get dmID") {
-      public Object call() {
-        return TestRegion.getCache().getMyId();
-      }
+  private InternalDistributedMember getId(VM vm) {
+    return vm.invoke("get dmId", () -> {
+      return testRegion.getCache().getMyId();
     });
   }
 
-
-  private VersionSource getVersionID(VM vm) {
-    return (VersionSource) vm.invoke(new SerializableCallable("get versionID") {
-      public Object call() {
-        return TestRegion.getVersionMember();
-      }
+  private VersionSource getVersionId(VM vm) {
+    return vm.invoke("get versionID", () -> {
+      return testRegion.getVersionMember();
     });
   }
 
-  private boolean createEntry2(VM vm, final InternalDistributedMember forMember,
+  private void createEntry2(VM vm, final InternalDistributedMember forMember,
       final VersionSource memberVersionID) {
-    return (Boolean) vm.invoke(new SerializableCallable("create entry2") {
-      public Object call() {
-        // create a fake event that looks like it came from the lost member and apply it to
-        // this cache
-        DistributedRegion dr = (DistributedRegion) TestRegion;
-        VersionTag tag = new VMVersionTag();
-        tag.setMemberID(memberVersionID);
-        tag.setRegionVersion(2);
-        tag.setEntryVersion(1);
-        tag.setIsRemoteForTesting();
-        EntryEventImpl event =
-            EntryEventImpl.create(dr, Operation.CREATE, "Object3", true, forMember, true, false);
-        LogWriterUtils.getLogWriter().info("applying this event to the cache: " + event);
-        event.setNewValue(new VMCachedDeserializable("value3", 12));
-        event.setVersionTag(tag);
-        dr.getRegionMap().basicPut(event, System.currentTimeMillis(), true, false, null, false,
-            false);
-        event.release();
+    vm.invoke("create entry2", () -> {
+      // create a fake event that looks like it came from the lost member and apply it to this cache
+      DistributedRegion dr = (DistributedRegion) testRegion;
+      VersionTag tag = new VMVersionTag();
+      tag.setMemberID(memberVersionID);
+      tag.setRegionVersion(2);
+      tag.setEntryVersion(1);
+      tag.setIsRemoteForTesting();
+      EntryEventImpl event =
+          EntryEventImpl.create(dr, Operation.CREATE, "Object3", true, forMember, true, false);
+      event.setNewValue(new VMCachedDeserializable("value3", 12));
+      event.setVersionTag(tag);
+      dr.getRegionMap().basicPut(event, System.currentTimeMillis(), true, false, null, false,
+          false);
+      event.release();
 
-        // now create a tombstone so we can be sure these are transferred in delta-GII
-        tag = new VMVersionTag();
-        tag.setMemberID(memberVersionID);
-        tag.setRegionVersion(3);
-        tag.setEntryVersion(1);
-        tag.setIsRemoteForTesting();
-        event =
-            EntryEventImpl.create(dr, Operation.CREATE, "Object5", true, forMember, true, false);
-        event.setNewValue(Token.TOMBSTONE);
-        event.setVersionTag(tag);
-        LogWriterUtils.getLogWriter().info("applying this event to the cache: " + event);
-        dr.getRegionMap().basicPut(event, System.currentTimeMillis(), true, false, null, false,
-            false);
-        event.release();
+      // now create a tombstone so we can be sure these are transferred in delta-GII
+      tag = new VMVersionTag();
+      tag.setMemberID(memberVersionID);
+      tag.setRegionVersion(3);
+      tag.setEntryVersion(1);
+      tag.setIsRemoteForTesting();
+      event = EntryEventImpl.create(dr, Operation.CREATE, "Object5", true, forMember, true, false);
+      event.setNewValue(Token.TOMBSTONE);
+      event.setVersionTag(tag);
+      dr.getRegionMap().basicPut(event, System.currentTimeMillis(), true, false, null, false,
+          false);
+      event.release();
 
-        dr.dumpBackingMap();
-        LogWriterUtils.getLogWriter()
-            .info("version vector is now " + dr.getVersionVector().fullToString());
-        assertTrue("should hold entry Object3 now", dr.containsKey("Object3"));
-        return true;
-      }
+      dr.dumpBackingMap();
+      assertTrue("should hold entry Object3 now", dr.containsKey("Object3"));
     });
   }
 
   private void verifySynchronized(VM vm, final InternalDistributedMember crashedMember) {
-    vm.invoke(new SerializableCallable("check that synchronization happened") {
-      public Object call() throws Exception {
-        final DistributedRegion dr = (DistributedRegion) TestRegion;
-        Wait.waitForCriterion(new WaitCriterion() {
-          String waitingFor = "crashed member is still in membership view: " + crashedMember;
-          boolean dumped = false;
+    vm.invoke("check that synchronization happened", () -> {
+      final DistributedRegion dr = (DistributedRegion) testRegion;
 
-          public boolean done() {
-            if (TestRegion.getCache().getDistributionManager().isCurrentMember(crashedMember)) {
-              LogWriterUtils.getLogWriter().info(waitingFor);
-              return false;
-            }
-            if (!TestRegion.containsKey("Object3")) {
-              waitingFor = "entry for Object3 not found";
-              LogWriterUtils.getLogWriter().info(waitingFor);
-              return false;
-            }
-            RegionEntry re = dr.getRegionMap().getEntry("Object5");
-            if (re == null) {
-              if (!dumped) {
-                dumped = true;
-                dr.dumpBackingMap();
-              }
-              waitingFor = "entry for Object5 not found";
-              LogWriterUtils.getLogWriter().info(waitingFor);
-              return false;
-            }
-            if (!re.isTombstone()) {
-              if (!dumped) {
-                dumped = true;
-                dr.dumpBackingMap();
-              }
-              waitingFor = "Object5 is not a tombstone but should be: " + re;
-              LogWriterUtils.getLogWriter().info(waitingFor);
-              return false;
-            }
-            return true;
+      Wait.waitForCriterion(new WaitCriterion() {
+        String waitingFor = "crashed member is still in membership view: " + crashedMember;
+        boolean dumped = false;
+
+        @Override
+        public boolean done() {
+          if (testRegion.getCache().getDistributionManager().isCurrentMember(crashedMember)) {
+            return false;
           }
-
-          public String description() {
-            return waitingFor;
+          if (!testRegion.containsKey("Object3")) {
+            waitingFor = "entry for Object3 not found";
+            return false;
           }
+          RegionEntry re = dr.getRegionMap().getEntry("Object5");
+          if (re == null) {
+            if (!dumped) {
+              dumped = true;
+              dr.dumpBackingMap();
+            }
+            waitingFor = "entry for Object5 not found";
+            return false;
+          }
+          if (!re.isTombstone()) {
+            if (!dumped) {
+              dumped = true;
+              dr.dumpBackingMap();
+            }
+            waitingFor = "Object5 is not a tombstone but should be: " + re;
+            return false;
+          }
+          return true;
+        }
 
-        }, 30000, 5000, true);
-        return null;
-      }
+        @Override
+        public String description() {
+          return waitingFor;
+        }
+      }, 30000, 5000, true);
     });
   }
 
-
   private void createRegion(VM vm, final String regionName, final TestType typeOfTest) {
-    SerializableCallable createRegion = new SerializableCallable() {
-      @SuppressWarnings("deprecation")
-      public Object call() throws Exception {
-        // TombstoneService.VERBOSE = true;
-        AttributesFactory af = new AttributesFactory();
-        af.setScope(Scope.DISTRIBUTED_NO_ACK);
-        switch (typeOfTest) {
-          case IN_MEMORY:
-            af.setDataPolicy(DataPolicy.REPLICATE);
-            break;
-          case PERSISTENT:
-            af.setDataPolicy(DataPolicy.PERSISTENT_REPLICATE);
-            break;
-          case OVERFLOW:
-            af.setDataPolicy(DataPolicy.REPLICATE);
-            af.setEvictionAttributes(
-                EvictionAttributes.createLRUEntryAttributes(5, EvictionAction.OVERFLOW_TO_DISK));
-            break;
-        }
-        TestRegion = (LocalRegion) createRootRegion(regionName, af.create());
-        return null;
+    vm.invoke(() -> {
+      AttributesFactory af = new AttributesFactory();
+      af.setScope(Scope.DISTRIBUTED_NO_ACK);
+      switch (typeOfTest) {
+        case IN_MEMORY:
+          af.setDataPolicy(DataPolicy.REPLICATE);
+          break;
+        case PERSISTENT:
+          af.setDataPolicy(DataPolicy.PERSISTENT_REPLICATE);
+          break;
+        case OVERFLOW:
+          af.setDataPolicy(DataPolicy.REPLICATE);
+          af.setEvictionAttributes(
+              EvictionAttributes.createLRUEntryAttributes(5, EvictionAction.OVERFLOW_TO_DISK));
+          break;
       }
-    };
-    vm.invoke(createRegion);
+      testRegion = (LocalRegion) createRootRegion(regionName, af.create());
+    });
   }
 
+  enum TestType {
+    IN_MEMORY, OVERFLOW, PERSISTENT
+  }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/BrokenSerializationConsistencyRegressionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/BrokenSerializationConsistencyRegressionTest.java
@@ -1,0 +1,216 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache;
+
+import static com.googlecode.catchexception.CatchException.catchException;
+import static com.googlecode.catchexception.CatchException.caughtException;
+import static org.apache.geode.cache.RegionShortcut.REPLICATE;
+import static org.apache.geode.internal.lang.SystemPropertyHelper.EARLY_ENTRY_EVENT_SERIALIZATION;
+import static org.apache.geode.internal.lang.SystemPropertyHelper.GEODE_PREFIX;
+import static org.apache.geode.test.dunit.Host.getHost;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.io.Serializable;
+import java.io.UncheckedIOException;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.DataSerializable;
+import org.apache.geode.ToDataException;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionFactory;
+import org.apache.geode.pdx.PdxReader;
+import org.apache.geode.pdx.PdxSerializable;
+import org.apache.geode.pdx.PdxWriter;
+import org.apache.geode.test.dunit.VM;
+import org.apache.geode.test.dunit.rules.CacheRule;
+import org.apache.geode.test.dunit.rules.DistributedTestRule;
+import org.apache.geode.test.junit.categories.DistributedTest;
+
+@Category(DistributedTest.class)
+public class BrokenSerializationConsistencyRegressionTest implements Serializable {
+
+  private static final String REGION_NAME = "replicateRegion";
+  private static final String REGION_NAME2 = "replicateRegion2";
+  private static final String KEY = "key";
+
+  private VM vm0;
+
+  private transient FailsToDataSerialize valueFailsToSerialize;
+  private transient FailsToPdxSerialize pdxValueFailsToSerialize;
+  private transient String stringValue;
+  private transient PdxValue pdxValue;
+  private transient byte[] bytesValue;
+
+  @ClassRule
+  public static DistributedTestRule distributedTestRule = new DistributedTestRule();
+
+  @Rule
+  public CacheRule cacheRule = new CacheRule();
+
+  @Before
+  public void setUpAll() {
+    vm0 = getHost(0).getVM(0);
+
+    System.setProperty(GEODE_PREFIX + EARLY_ENTRY_EVENT_SERIALIZATION, "true");
+    createReplicateRegions();
+
+    vm0.invoke(() -> {
+      System.setProperty(GEODE_PREFIX + EARLY_ENTRY_EVENT_SERIALIZATION, "true");
+      createReplicateRegions();
+    });
+
+    valueFailsToSerialize = new FailsToDataSerialize();
+    pdxValueFailsToSerialize = new FailsToPdxSerialize();
+
+    stringValue = "hello world";
+    pdxValue = new PdxValue();
+    bytesValue = new byte[] {0, 1, 2};
+  }
+
+  @Test
+  public void pdxValuePdxSerializes() {
+    Region<String, PdxValue> region = cacheRule.getCache().getRegion(REGION_NAME);
+    region.put(KEY, pdxValue);
+
+    vm0.invoke(() -> {
+      Region<String, PdxValue> regionOnVm0 = cacheRule.getCache().getRegion(REGION_NAME);
+      assertThat(regionOnVm0.get(KEY)).isInstanceOf(PdxValue.class);
+    });
+  }
+
+  @Test
+  public void bytesValueDataSerializes() {
+    Region<String, byte[]> region = cacheRule.getCache().getRegion(REGION_NAME);
+    region.put(KEY, bytesValue);
+
+    vm0.invoke(() -> {
+      Region<String, byte[]> regionOnVm0 = cacheRule.getCache().getRegion(REGION_NAME);
+      assertThat(regionOnVm0.get(KEY)).isNotNull().isInstanceOf(byte[].class);
+    });
+  }
+
+  @Test
+  public void failureToDataSerializeFailsToPropagate() {
+    Region<String, DataSerializable> region = cacheRule.getCache().getRegion(REGION_NAME);
+    catchException(region).put(KEY, valueFailsToSerialize);
+
+    Exception caughtException = caughtException();
+    assertThat(caughtException).isInstanceOf(ToDataException.class);
+    assertThat(caughtException.getCause()).isInstanceOf(IOException.class)
+        .hasMessage("FailsToSerialize");
+    assertThat(region.get(KEY)).isNull();
+
+    vm0.invoke(() -> {
+      Region<String, DataSerializable> regionOnVm0 = cacheRule.getCache().getRegion(REGION_NAME);
+      assertThat(regionOnVm0.get(KEY)).isNull();
+    });
+  }
+
+  @Test
+  public void failureToDataSerializeFailsToPropagateInTransaction() {
+    Region<String, DataSerializable> region = cacheRule.getCache().getRegion(REGION_NAME);
+    Region<String, String> region2 = cacheRule.getCache().getRegion(REGION_NAME2);
+    TXManagerImpl txManager = cacheRule.getCache().getTxManager();
+    txManager.begin();
+    region2.put(KEY, stringValue);
+    region.put(KEY, valueFailsToSerialize);
+    catchException(txManager).commit();
+
+    Exception caughtException = caughtException();
+    assertThat(caughtException).isInstanceOf(ToDataException.class);
+    assertThat(caughtException.getCause()).isInstanceOf(IOException.class)
+        .hasMessage("FailsToSerialize");
+    assertThat(region.get(KEY)).isNull();
+    assertThat(region2.get(KEY)).isNull();
+
+    vm0.invoke(() -> {
+      Region<String, DataSerializable> regionOnVm0 = cacheRule.getCache().getRegion(REGION_NAME);
+      Region<String, String> region2OnVm0 = cacheRule.getCache().getRegion(REGION_NAME2);
+      assertThat(regionOnVm0.get(KEY)).isNull();
+      assertThat(region2OnVm0.get(KEY)).isNull();
+    });
+  }
+
+  @Test
+  public void failureToPdxSerializeFails() {
+    Region<String, PdxSerializable> region = cacheRule.getCache().getRegion(REGION_NAME);
+    catchException(region).put(KEY, pdxValueFailsToSerialize);
+
+    Exception caughtException = caughtException();
+    assertThat(caughtException).isInstanceOf(ToDataException.class);
+    assertThat(caughtException.getCause()).isInstanceOf(UncheckedIOException.class);
+    assertThat(caughtException.getCause().getCause()).isInstanceOf(IOException.class)
+        .hasMessage("FailsToSerialize");
+    assertThat(region.get(KEY)).isNull();
+
+    vm0.invoke(() -> {
+      Region<String, PdxSerializable> regionOnVm0 = cacheRule.getCache().getRegion(REGION_NAME);
+      assertThat(regionOnVm0.get(KEY)).isNull();
+    });
+  }
+
+  private void createReplicateRegions() {
+    RegionFactory<?, ?> regionFactory = cacheRule.getOrCreateCache().createRegionFactory(REPLICATE);
+    regionFactory.create(REGION_NAME);
+    regionFactory.create(REGION_NAME2);
+  }
+
+  private static class FailsToDataSerialize implements DataSerializable {
+
+    @Override
+    public void toData(DataOutput out) throws IOException {
+      throw new IOException("FailsToSerialize");
+    }
+
+    @Override
+    public void fromData(DataInput in) throws IOException, ClassNotFoundException {
+      // nothing
+    }
+  }
+
+  private static class FailsToPdxSerialize implements PdxSerializable {
+
+    @Override
+    public void toData(PdxWriter writer) {
+      throw new UncheckedIOException(new IOException("FailsToSerialize"));
+    }
+
+    @Override
+    public void fromData(PdxReader reader) {
+      // nothing
+    }
+  }
+
+  public static class PdxValue implements PdxSerializable {
+
+    @Override
+    public void toData(PdxWriter writer) {
+      // nothing
+    }
+
+    @Override
+    public void fromData(PdxReader reader) {
+      // nothing
+    }
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/ClientDeserializationCopyOnReadRegressionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/ClientDeserializationCopyOnReadRegressionTest.java
@@ -12,10 +12,16 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.geode.cache30;
+package org.apache.geode.internal.cache;
 
-import static org.apache.geode.distributed.ConfigurationProperties.*;
-import static org.apache.geode.test.dunit.Assert.*;
+import static org.apache.geode.distributed.ConfigurationProperties.DELTA_PROPAGATION;
+import static org.apache.geode.internal.lang.SystemPropertyHelper.EARLY_ENTRY_EVENT_SERIALIZATION;
+import static org.apache.geode.internal.lang.SystemPropertyHelper.GEODE_PREFIX;
+import static org.apache.geode.test.dunit.Assert.assertEquals;
+import static org.apache.geode.test.dunit.Assert.assertSame;
+import static org.apache.geode.test.dunit.Assert.assertTrue;
+import static org.apache.geode.test.dunit.Assert.fail;
+import static org.apache.geode.test.dunit.Host.getHost;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -25,8 +31,14 @@ import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import junitparams.naming.TestCaseName;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import org.apache.geode.CopyHelper;
 import org.apache.geode.DataSerializable;
@@ -38,16 +50,10 @@ import org.apache.geode.cache.PartitionAttributesFactory;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionAttributes;
 import org.apache.geode.cache.Scope;
+import org.apache.geode.cache30.CacheSerializableRunnable;
+import org.apache.geode.cache30.ClientServerTestCase;
 import org.apache.geode.internal.NanoTimer;
-import org.apache.geode.internal.cache.BucketRegion;
 import org.apache.geode.internal.cache.BucketRegion.RawValue;
-import org.apache.geode.internal.cache.CacheServerImpl;
-import org.apache.geode.internal.cache.CachedDeserializable;
-import org.apache.geode.internal.cache.EnumListenerEvent;
-import org.apache.geode.internal.cache.EventID;
-import org.apache.geode.internal.cache.KeyInfo;
-import org.apache.geode.internal.cache.LocalRegion;
-import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.internal.cache.PartitionedRegionDataStore.BucketVisitor;
 import org.apache.geode.internal.cache.ha.HARegionQueue;
 import org.apache.geode.internal.cache.tier.sockets.CacheClientProxy;
@@ -55,19 +61,57 @@ import org.apache.geode.internal.cache.tier.sockets.ClientProxyMembershipID;
 import org.apache.geode.internal.cache.tier.sockets.ClientUpdateMessageImpl;
 import org.apache.geode.test.dunit.Assert;
 import org.apache.geode.test.dunit.Host;
+import org.apache.geode.test.dunit.Invoke;
 import org.apache.geode.test.dunit.NetworkUtils;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.Wait;
 import org.apache.geode.test.dunit.WaitCriterion;
+import org.apache.geode.test.dunit.rules.DistributedRestoreSystemProperties;
 import org.apache.geode.test.junit.categories.ClientServerTest;
 import org.apache.geode.test.junit.categories.DistributedTest;
 
 /**
+ * Client side deserialization should not throw EOFException when copy-on-read is true.
+ *
+ * <p>
+ * TRAC #38741: EOFException during deserialize on client update with copy-on-read=true
+ *
  * @since GemFire bugfix5.7
  */
 @Category({DistributedTest.class, ClientServerTest.class})
-public class Bug38741DUnitTest extends ClientServerTestCase {
+@RunWith(JUnitParamsRunner.class)
+@SuppressWarnings("serial")
+public class ClientDeserializationCopyOnReadRegressionTest extends ClientServerTestCase {
 
+  private String k1 = "k1";
+  private String k2 = "k2";
+  private String k3 = "k3";
+
+  private VM client;
+  private VM server;
+  private String rName;
+  private int ports[];
+
+  @Rule
+  public DistributedRestoreSystemProperties restoreSystemProperties =
+      new DistributedRestoreSystemProperties();
+
+  @Before
+  public void setUp() {
+    client = getHost(0).getVM(2);
+    server = getHost(0).getVM(3);
+    rName = getUniqueName();
+    ports = createUniquePorts(1);
+  }
+
+  @Override
+  public Properties getDistributedSystemProperties() {
+    Properties props = new Properties();
+    props.setProperty(DELTA_PROPAGATION, "false");
+    return props;
+  }
+
+  @Override
   protected RegionAttributes getRegionAttributes() {
     AttributesFactory factory = new AttributesFactory();
     factory.setScope(Scope.DISTRIBUTED_ACK);
@@ -77,26 +121,21 @@ public class Bug38741DUnitTest extends ClientServerTestCase {
   /**
    * Test that CopyOnRead doesn't cause {@link HARegionQueue#peek()} to create a copy, assuming that
    * creating copies performs a serialize and de-serialize operation.
-   *
-   * @throws Exception when there is a failure
-   * @since GemFire bugfix5.7
    */
   @Test
-  public void testCopyOnReadWithBridgeServer() throws Exception {
-    final Host h = Host.getHost(0);
-    final VM client = h.getVM(2);
-    final VM server = h.getVM(3);
-    final String rName = getUniqueName();
-    final int ports[] = createUniquePorts(1);
-    final String k1 = "k1";
-    final String k2 = "k2";
-    final String k3 = "k3";
+  @Parameters({"true", "false"})
+  @TestCaseName("{method}({params})")
+  public void testCopyOnReadWithBridgeServer(final boolean serializeEarlyEnabled) throws Exception {
+    System.setProperty(GEODE_PREFIX + EARLY_ENTRY_EVENT_SERIALIZATION, "true");
+    Invoke.invokeInEveryVM(
+        () -> System.setProperty(GEODE_PREFIX + EARLY_ENTRY_EVENT_SERIALIZATION, "true"));
 
     createBridgeServer(server, rName, ports[0]);
     // Put an instance of SerializationCounter to assert copy-on-read behavior
     // when notifyBySubscription is true
     server.invoke(
         new CacheSerializableRunnable("Enable copy on read and assert server copy behavior") {
+          @Override
           public void run2() throws CacheException {
             final LocalRegion r = (LocalRegion) getRootRegion(rName);
 
@@ -119,36 +158,36 @@ public class Bug38741DUnitTest extends ClientServerTestCase {
             assertEquals(cui.getKeyOfInterest(), cuiCopy.getKeyOfInterest());
             assertEquals(1, key.count.get());
 
-
             SerializationCountingKey ks1 = new SerializationCountingKey(k1);
-            { // Make sure nothing (HARegion) has serialized/de-serialized this instance
+            { // AbstractRegionMap basicPut now serializes newValue in EntryEventImpl
+              // which can be used for delivering client update message later
               SerializationCountingValue sc = new SerializationCountingValue();
               r.put(ks1, sc);
-              assertEquals(0, sc.count.get());
+              assertEquals(1, sc.count.get());
               assertEquals(0, ks1.count.get());
             }
 
             { // No copy should be made upon get (assert standard no copy behavior)
               SerializationCountingValue sc = (SerializationCountingValue) r.get(ks1);
-              assertEquals(0, sc.count.get());
+              assertEquals(1, sc.count.get());
               assertEquals(0, ks1.count.get());
             }
 
             // enable copy on read
             getCache().setCopyOnRead(true);
 
-            { // Assert standard copy on read behavior
+            { // Assert standard copy on read behavior and basicPut in AbstractRegionMap
               SerializationCountingValue sc = (SerializationCountingValue) r.get(ks1);
-              assertEquals(1, sc.count.get());
+              assertEquals(2, sc.count.get());
               assertEquals(0, ks1.count.get());
             }
 
             { // Put another counter with copy-on-read true
-              // Again check that nothing (HARegion) has performed serialization
+              // AbstractRegionMap basicPut now serializes newValue
               SerializationCountingValue sc = new SerializationCountingValue();
               SerializationCountingKey ks3 = new SerializationCountingKey(k3);
               r.put(ks3, sc);
-              assertEquals(0, sc.count.get());
+              assertEquals(1, sc.count.get());
               assertEquals(0, ks3.count.get());
             }
           }
@@ -159,6 +198,7 @@ public class Bug38741DUnitTest extends ClientServerTestCase {
     // (in the event that the above code didn't already create a HARegion)
     final String serverHostName = NetworkUtils.getServerHostName(server.getHost());
     client.invoke(new CacheSerializableRunnable("Assert server copy behavior from client") {
+      @Override
       public void run2() throws CacheException {
         getCache();
 
@@ -169,21 +209,23 @@ public class Bug38741DUnitTest extends ClientServerTestCase {
         Region r = createRootRegion(rName, factory.create());
         SerializationCountingKey ks1 = new SerializationCountingKey(k1);
         SerializationCountingKey ks3 = new SerializationCountingKey(k3);
+        // original two serializations on server and one serialization for register interest
         r.registerInterest(ks1, InterestResultPolicy.KEYS_VALUES);
-        r.registerInterest(new SerializationCountingKey(k2), InterestResultPolicy.KEYS_VALUES); // entry
-                                                                                                // shouldn't
-                                                                                                // exist
-                                                                                                // yet
+        // entry shouldn't exist yet
+        r.registerInterest(new SerializationCountingKey(k2), InterestResultPolicy.KEYS_VALUES);
+        // original one serializations on server and one serialization for register interest
         r.registerInterest(ks3, InterestResultPolicy.KEYS_VALUES);
 
-        { // Once for the get on the server, once to send the value to this client
+        { // get from local cache.
+          // original two serializations on server and one for previous register interest
           SerializationCountingValue sc = (SerializationCountingValue) r.get(ks1);
-          assertEquals(2, sc.count.get());
+          assertEquals(3, sc.count.get());
         }
 
-        { // Once to send the value to this client
+        { // get from local cache,
+          // one from register interest key and one original put into AbstractRegionMap
           SerializationCountingValue sc = (SerializationCountingValue) r.get(ks3);
-          assertEquals(1, sc.count.get());
+          assertEquals(2, sc.count.get());
         }
       }
     });
@@ -191,6 +233,7 @@ public class Bug38741DUnitTest extends ClientServerTestCase {
     // Put an instance of SerializationCounter to assert copy-on-read behavior
     // once a client has registered interest
     server.invoke(new CacheSerializableRunnable("Assert copy behavior after client is setup") {
+      @Override
       public void run2() throws CacheException {
         Region r = getRootRegion(rName);
         CacheServerImpl bsi = (CacheServerImpl) getCache().getCacheServers().iterator().next();
@@ -200,10 +243,12 @@ public class Bug38741DUnitTest extends ClientServerTestCase {
         final CacheClientProxy ccp = (CacheClientProxy) cp.iterator().next();
         // Wait for messages to drain to capture a stable "processed message count"
         WaitCriterion ev = new WaitCriterion() {
+          @Override
           public boolean done() {
             return ccp.getHARegionQueue().size() == 0;
           }
 
+          @Override
           public String description() {
             return "region queue never became empty";
           }
@@ -222,10 +267,12 @@ public class Bug38741DUnitTest extends ClientServerTestCase {
 
         // Wait to know that the data has been at least serialized (possibly sent)
         ev = new WaitCriterion() {
+          @Override
           public boolean done() {
             return ccp.getStatistics().getMessagesProcessed() != currMesgCount;
           }
 
+          @Override
           public String description() {
             return null;
           }
@@ -242,6 +289,7 @@ public class Bug38741DUnitTest extends ClientServerTestCase {
     // Double-check the serialization count in the event that the previous check
     // missed the copy due to race conditions
     client.invoke(new CacheSerializableRunnable("Assert copy behavior from client after update") {
+      @Override
       public void run2() throws CacheException {
         Region r = getRootRegion(rName);
         { // Once to send the value to this client via the updater thread
@@ -267,18 +315,17 @@ public class Bug38741DUnitTest extends ClientServerTestCase {
   /**
    * Test to ensure that a PartitionedRegion doesn't make more than the expected number of copies
    * when copy-on-read is set to true
-   *
-   * @throws Exception
    */
   @Test
   public void testPartitionedRegionAndCopyOnRead() throws Exception {
-    final Host h = Host.getHost(0);
+    final Host h = getHost(0);
     final VM accessor = h.getVM(2);
     final VM datastore = h.getVM(3);
     final String rName = getUniqueName();
     final String k1 = "k1";
 
     datastore.invoke(new CacheSerializableRunnable("Create PR DataStore") {
+      @Override
       public void run2() throws CacheException {
         AttributesFactory factory = new AttributesFactory();
         factory.setPartitionAttributes(
@@ -288,6 +335,7 @@ public class Bug38741DUnitTest extends ClientServerTestCase {
     });
 
     accessor.invoke(new CacheSerializableRunnable("Create PR Accessor and put new value") {
+      @Override
       public void run2() throws CacheException {
         AttributesFactory factory = new AttributesFactory();
         factory.setPartitionAttributes(
@@ -307,6 +355,7 @@ public class Bug38741DUnitTest extends ClientServerTestCase {
     });
 
     datastore.invoke(new CacheSerializableRunnable("assert datastore entry serialization count") {
+      @Override
       public void run2() throws CacheException {
         PartitionedRegion pr = (PartitionedRegion) getRootRegion(rName);
         // Visit the one bucket (since there is only one value in the entire PR)
@@ -315,6 +364,7 @@ public class Bug38741DUnitTest extends ClientServerTestCase {
         // (by de-serializing the value stored in the map, which would then have to be
         // re-serialized).
         pr.getDataStore().visitBuckets(new BucketVisitor() {
+          @Override
           public void visit(Integer bucketId, Region r) {
             BucketRegion br = (BucketRegion) r;
             try {
@@ -335,6 +385,7 @@ public class Bug38741DUnitTest extends ClientServerTestCase {
     });
 
     accessor.invoke(new CacheSerializableRunnable("assert accessor entry serialization count") {
+      @Override
       public void run2() throws CacheException {
         Region r = getRootRegion(rName);
         SerializationCountingValue v1 = (SerializationCountingValue) r.get(k1);
@@ -350,6 +401,7 @@ public class Bug38741DUnitTest extends ClientServerTestCase {
     });
 
     datastore.invoke(new CacheSerializableRunnable("assert value serialization") {
+      @Override
       public void run2() throws CacheException {
         Region r = getRootRegion(rName);
         SerializationCountingValue v1 = (SerializationCountingValue) r.get(k1);
@@ -365,34 +417,30 @@ public class Bug38741DUnitTest extends ClientServerTestCase {
     });
   }
 
-  public Properties getDistributedSystemProperties() {
-    Properties props = new Properties();
-    props.setProperty(DELTA_PROPAGATION, "false");
-    return props;
-  }
-
-  public static class SerializationCountingValue implements DataSerializable {
-    private static final long serialVersionUID = 1L;
+  private static class SerializationCountingValue implements DataSerializable {
     public final AtomicInteger count = new AtomicInteger();
 
-    public SerializationCountingValue() {}
+    public SerializationCountingValue() {
+      // nothing
+    }
 
+    @Override
     public void fromData(DataInput in) throws IOException, ClassNotFoundException {
       count.set(in.readInt());
     }
 
+    @Override
     public void toData(DataOutput out) throws IOException {
       out.writeInt(count.addAndGet(1));
-      // GemFireCacheImpl.getInstance().getLogger().info("DEBUG "+this, new
-      // RuntimeException("STACK"));
     }
 
+    @Override
     public String toString() {
       return getClass().getName() + "@" + System.identityHashCode(this) + "; count=" + count;
     }
   }
-  public static class SerializationCountingKey extends SerializationCountingValue {
-    private static final long serialVersionUID = 1L;
+
+  private static class SerializationCountingKey extends SerializationCountingValue {
     private String k;
 
     public SerializationCountingKey(String k) {
@@ -403,16 +451,19 @@ public class Bug38741DUnitTest extends ClientServerTestCase {
       super();
     }
 
+    @Override
     public void fromData(DataInput in) throws IOException, ClassNotFoundException {
       super.fromData(in);
       k = DataSerializer.readString(in);
     }
 
+    @Override
     public void toData(DataOutput out) throws IOException {
       super.toData(out);
       DataSerializer.writeString(k, out);
     }
 
+    @Override
     public boolean equals(Object obj) {
       if (obj == this) {
         return true;
@@ -424,10 +475,12 @@ public class Bug38741DUnitTest extends ClientServerTestCase {
       return false;
     }
 
+    @Override
     public int hashCode() {
       return k.hashCode();
     }
 
+    @Override
     public String toString() {
       return super.toString() + "; k=" + k;
     }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/EntryEventSerializationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/EntryEventSerializationTest.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache;
+
+import static com.googlecode.catchexception.CatchException.catchException;
+import static com.googlecode.catchexception.CatchException.caughtException;
+import static org.apache.geode.internal.lang.SystemPropertyHelper.EARLY_ENTRY_EVENT_SERIALIZATION;
+import static org.apache.geode.internal.lang.SystemPropertyHelper.GEODE_PREFIX;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.NotSerializableException;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
+import org.junit.experimental.categories.Category;
+import org.mockito.ArgumentCaptor;
+
+import org.apache.geode.SerializationException;
+import org.apache.geode.cache.Scope;
+import org.apache.geode.pdx.internal.PdxInstanceImpl;
+import org.apache.geode.test.junit.categories.UnitTest;
+
+@Category(UnitTest.class)
+public class EntryEventSerializationTest {
+
+  private InternalRegion region;
+  private InternalEntryEvent event;
+
+  private EntryEventSerialization instance;
+
+  @Rule
+  public RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
+
+  @Before
+  public void setUp() {
+    System.setProperty(GEODE_PREFIX + EARLY_ENTRY_EVENT_SERIALIZATION, "true");
+
+    region = mock(InternalRegion.class);
+    event = mock(InternalEntryEvent.class);
+
+    when(region.getScope()).thenReturn(Scope.DISTRIBUTED_ACK);
+    when(event.basicGetNewValue()).thenReturn("newValue");
+
+    instance = new EntryEventSerialization();
+  }
+
+  @Test
+  public void serializeNewValueIfNeeded_bothNull() {
+    assertThatThrownBy(() -> instance.serializeNewValueIfNeeded(null, null))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void serializeNewValueIfNeeded_regionNull() {
+    assertThatThrownBy(() -> instance.serializeNewValueIfNeeded(null, event))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void serializeNewValueIfNeeded_eventNull() {
+    assertThatThrownBy(() -> instance.serializeNewValueIfNeeded(region, null))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void serializeNewValueIfNeeded_bothMocks() {
+    assertThatCode(() -> instance.serializeNewValueIfNeeded(region, event))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  public void localRegionDoesNothing() {
+    when(region.getScope()).thenReturn(Scope.LOCAL);
+
+    instance.serializeNewValueIfNeeded(region, event);
+
+    verify(event, times(0)).setCachedSerializedNewValue(any());
+  }
+
+  @Test
+  public void distributedAckRegionSetsCachedSerializedNewValue() {
+    instance.serializeNewValueIfNeeded(region, event);
+
+    ArgumentCaptor<byte[]> captor = ArgumentCaptor.forClass(byte[].class);
+    verify(event, times(1)).setCachedSerializedNewValue(captor.capture());
+    assertThat(captor.getValue().length).isGreaterThan(0);
+  }
+
+  @Test
+  public void distributedNoAckRegionSetsCachedSerializedNewValue() {
+    when(region.getScope()).thenReturn(Scope.DISTRIBUTED_NO_ACK);
+
+    instance.serializeNewValueIfNeeded(region, event);
+
+    ArgumentCaptor<byte[]> captor = ArgumentCaptor.forClass(byte[].class);
+    verify(event, times(1)).setCachedSerializedNewValue(captor.capture());
+    assertThat(captor.getValue().length).isGreaterThan(0);
+  }
+
+  @Test
+  public void globalRegionSetsCachedSerializedNewValue() {
+    when(region.getScope()).thenReturn(Scope.GLOBAL);
+
+    instance.serializeNewValueIfNeeded(region, event);
+
+    ArgumentCaptor<byte[]> captor = ArgumentCaptor.forClass(byte[].class);
+    verify(event, times(1)).setCachedSerializedNewValue(captor.capture());
+    assertThat(captor.getValue().length).isGreaterThan(0);
+  }
+
+  @Test
+  public void hasCachedSerializedNewValueDoesNothing() {
+    when(event.getCachedSerializedNewValue()).thenReturn(new byte[0]);
+
+    instance.serializeNewValueIfNeeded(region, event);
+
+    verify(event, times(0)).setCachedSerializedNewValue(any());
+  }
+
+  @Test
+  public void newValueIsByteArrayDoesNothing() {
+    when(event.basicGetNewValue()).thenReturn(new byte[0]);
+
+    instance.serializeNewValueIfNeeded(region, event);
+
+    verify(event, times(0)).setCachedSerializedNewValue(any());
+  }
+
+  @Test
+  public void newValueIsCachedDeserializableUsesItsSerializedValue() {
+    CachedDeserializable newValue = mock(CachedDeserializable.class);
+    when(event.basicGetNewValue()).thenReturn(newValue);
+    byte[] bytes = new byte[] {0, 3, 4};
+    when(newValue.getSerializedValue()).thenReturn(bytes);
+
+    instance.serializeNewValueIfNeeded(region, event);
+
+    ArgumentCaptor<byte[]> captor = ArgumentCaptor.forClass(byte[].class);
+    verify(event, times(1)).setCachedSerializedNewValue(captor.capture());
+    assertThat(captor.getValue()).isEqualTo(bytes);
+  }
+
+  @Test
+  public void newValueIsSerializableUsesItsSerializedValue() {
+    String newValue = "newValue";
+    when(event.basicGetNewValue()).thenReturn(newValue);
+
+    instance.serializeNewValueIfNeeded(region, event);
+
+    ArgumentCaptor<byte[]> captor = ArgumentCaptor.forClass(byte[].class);
+    verify(event, times(1)).setCachedSerializedNewValue(captor.capture());
+    assertThat(captor.getValue()).isEqualTo(EntryEventImpl.serialize(newValue));
+  }
+
+  @Test
+  public void newValueIsNotSerializableThrows() {
+    Object newValue = new Object();
+    when(event.basicGetNewValue()).thenReturn(newValue);
+
+    catchException(instance).serializeNewValueIfNeeded(region, event);
+
+    Exception thrown = caughtException();
+    assertThat(thrown).isInstanceOf(SerializationException.class);
+    assertThat(thrown.getCause()).isInstanceOf(NotSerializableException.class);
+  }
+
+  @Test
+  public void newValueIsPdxInstanceUsesItsSerializedValue() throws Exception {
+    PdxInstanceImpl newValue = mock(PdxInstanceImpl.class);
+    when(event.basicGetNewValue()).thenReturn(newValue);
+    byte[] bytes = new byte[] {0, 3, 4};
+    when(newValue.toBytes()).thenReturn(bytes);
+
+    instance.serializeNewValueIfNeeded(region, event);
+
+    ArgumentCaptor<byte[]> captor = ArgumentCaptor.forClass(byte[].class);
+    verify(event, times(1)).setCachedSerializedNewValue(captor.capture());
+    assertThat(captor.getValue()).isEqualTo(bytes);
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/EvictionAttributesImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/EvictionAttributesImplTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.commons.lang.SerializationUtils;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.internal.util.BlobHelper;
+import org.apache.geode.test.junit.categories.UnitTest;
+
+@Category(UnitTest.class)
+public class EvictionAttributesImplTest {
+
+  @Test
+  public void dataSerializes() throws Exception {
+    EvictionAttributesImpl evictionAttributes = new EvictionAttributesImpl();
+    byte[] bytes = BlobHelper.serializeToBlob(evictionAttributes);
+    assertThat(bytes).isNotNull().isNotEmpty();
+    assertThat(BlobHelper.deserializeBlob(bytes)).isNotSameAs(evictionAttributes)
+        .isInstanceOf(EvictionAttributesImpl.class);
+  }
+
+  @Test
+  public void serializes() throws Exception {
+    EvictionAttributesImpl evictionAttributes = new EvictionAttributesImpl();
+    byte[] bytes = SerializationUtils.serialize(evictionAttributes);
+    assertThat(bytes).isNotNull().isNotEmpty();
+    assertThat(SerializationUtils.deserialize(bytes)).isNotSameAs(evictionAttributes)
+        .isInstanceOf(EvictionAttributesImpl.class);
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionRegionConfigTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionRegionConfigTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.apache.commons.lang.SerializationUtils;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.cache.EvictionAttributes;
+import org.apache.geode.cache.ExpirationAttributes;
+import org.apache.geode.cache.PartitionAttributes;
+import org.apache.geode.cache.PartitionAttributesFactory;
+import org.apache.geode.cache.Scope;
+import org.apache.geode.internal.util.BlobHelper;
+import org.apache.geode.test.junit.categories.UnitTest;
+
+@Category(UnitTest.class)
+public class PartitionRegionConfigTest {
+
+  private int prId;
+  private String path;
+  private PartitionAttributes partitionAttributes;
+  private Scope scope;
+  private EvictionAttributes evictionAttributes;
+  private ExpirationAttributes regionIdleTimeout;
+  private ExpirationAttributes regionTimeToLive;
+  private ExpirationAttributes entryIdleTimeout;
+  private ExpirationAttributes entryTimeToLive;
+  private Set<String> gatewaySenderIds;
+
+  @Before
+  public void setUp() {
+    prId = 0;
+    path = null;
+    partitionAttributes = new PartitionAttributesFactory().create();
+    scope = Scope.DISTRIBUTED_ACK;
+    evictionAttributes = new EvictionAttributesImpl();
+    regionIdleTimeout = new ExpirationAttributes();
+    regionTimeToLive = new ExpirationAttributes();
+    entryIdleTimeout = new ExpirationAttributes();
+    entryTimeToLive = new ExpirationAttributes();
+    gatewaySenderIds = Collections.emptySet();
+  }
+
+  @Test
+  public void dataSerializes() throws Exception {
+    PartitionRegionConfig config = new PartitionRegionConfig(prId, path, partitionAttributes, scope,
+        evictionAttributes, regionIdleTimeout, regionTimeToLive, entryIdleTimeout, entryTimeToLive,
+        gatewaySenderIds);
+    byte[] bytes = BlobHelper.serializeToBlob(config);
+    assertThat(bytes).isNotNull().isNotEmpty();
+    assertThat(BlobHelper.deserializeBlob(bytes)).isNotSameAs(config)
+        .isInstanceOf(PartitionRegionConfig.class);
+  }
+
+  @Ignore("GEODE-4812")
+  @Test
+  public void serializes() throws Exception {
+    PartitionRegionConfig config = new PartitionRegionConfig();
+    byte[] bytes = SerializationUtils.serialize(config);
+    assertThat(bytes).isNotNull().isNotEmpty();
+    assertThat(SerializationUtils.deserialize(bytes)).isNotSameAs(config)
+        .isInstanceOf(PartitionRegionConfig.class);
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionedRegionQueryEvaluatorIntegrationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionedRegionQueryEvaluatorIntegrationTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.net.UnknownHostException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -26,14 +27,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TestName;
 
-import org.apache.geode.LogWriter;
-import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.ExpirationAttributes;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.Scope;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -44,24 +43,16 @@ import org.apache.geode.internal.util.VersionedArrayList;
 import org.apache.geode.test.junit.categories.IntegrationTest;
 
 /**
- * This class is an integration test for <code>PartitionedRegionQueryEvaluator</code> class.
+ * This class is an integration test for {@link PartitionedRegionQueryEvaluator} class.
  */
 @Category(IntegrationTest.class)
 public class PartitionedRegionQueryEvaluatorIntegrationTest {
+
   @Rule
   public TestName name = new TestName();
-  LogWriter logger = null;
-
-  @Before
-  public void setUp() throws Exception {
-    if (logger == null) {
-      logger = PartitionedRegionTestHelper.getLogger();
-    }
-  }
 
   /**
    * Test for the helper method getNodeToBucketMap.
-   *
    */
   @Test
   public void testGetNodeToBucketMap() {
@@ -112,16 +103,12 @@ public class PartitionedRegionQueryEvaluatorIntegrationTest {
           buckList.contains(new Integer(i)));
     }
     clearAllPartitionedRegion(pr);
-    logger.info("************test ended successfully **********");
-
   }
 
   /**
    * This function populates bucket2Node region of the partition region
-   *
-   * @param pr
    */
-  public void populateBucket2Node(PartitionedRegion pr, List nodes, int numOfBuckets) {
+  private void populateBucket2Node(PartitionedRegion pr, List nodes, int numOfBuckets) {
     assertEquals(0, pr.getRegionAdvisor().getCreatedBucketsCount());
     final RegionAdvisor ra = pr.getRegionAdvisor();
     int nodeListCnt = 0;
@@ -160,9 +147,6 @@ public class PartitionedRegionQueryEvaluatorIntegrationTest {
 
   /**
    * This function decides number of the nodes in the list of bucket2Node region
-   *
-   * @param i
-   * @return
    */
   private int setNodeListCnt(int i) {
     int nListcnt = 0;
@@ -197,16 +181,12 @@ public class PartitionedRegionQueryEvaluatorIntegrationTest {
       case 9:
         nListcnt = 2;
         break;
-
     }
     return nListcnt;
   }
 
   /**
    * This functions number of new nodes specified by nCount.
-   *
-   * @param nCount
-   * @return
    */
   private ArrayList createNodeList(int nCount) {
     ArrayList nodeList = new ArrayList(nCount);
@@ -217,7 +197,6 @@ public class PartitionedRegionQueryEvaluatorIntegrationTest {
   }
 
   private ArrayList createDataStoreList(int nCount) {
-    // ArrayList<InternalDistributedMember>
     ArrayList nodeList = new ArrayList(nCount);
     for (int i = 0; i < nCount; i++) {
       nodeList.add(createDataStoreMember(i));
@@ -240,22 +219,19 @@ public class PartitionedRegionQueryEvaluatorIntegrationTest {
 
   /**
    * this function creates new node.
-   *
-   * @return
    */
-  public Node createNode(int i) {
+  private Node createNode(int i) {
     Node node = new Node(new InternalDistributedMember("host" + i, 3033), i);
     node.setPRType(Node.DATASTORE);
     return node;
   }
 
   private void populateAllPartitionedRegion(PartitionedRegion pr, List nodes) {
-    // int totalNodes = 4;
     Region rootReg = PartitionedRegionHelper.getPRRoot(pr.getCache());
-    // Region allPRs = PartitionedRegionHelper.getPRConfigRegion(rootReg, pr
-    // .getCache());
     PartitionRegionConfig prConf = new PartitionRegionConfig(pr.getPRId(), pr.getFullPath(),
-        pr.getPartitionAttributes(), pr.getScope());
+        pr.getPartitionAttributes(), pr.getScope(), new EvictionAttributesImpl(),
+        new ExpirationAttributes(), new ExpirationAttributes(), new ExpirationAttributes(),
+        new ExpirationAttributes(), Collections.emptySet());
     RegionAdvisor ra = pr.getRegionAdvisor();
     for (Iterator itr = nodes.iterator(); itr.hasNext();) {
       Node n = (Node) itr.next();

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/QueryCommandIntegrationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/QueryCommandIntegrationTest.java
@@ -12,12 +12,12 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package org.apache.geode.management.internal.cli.commands;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
+import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
@@ -42,7 +42,7 @@ import org.apache.geode.test.junit.rules.Server;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
 @Category(IntegrationTest.class)
-public class QueryCommandTest {
+public class QueryCommandIntegrationTest {
 
   private final String DEFAULT_FETCH_SIZE = String.valueOf(Gfsh.DEFAULT_APP_FETCH_SIZE);
 
@@ -76,7 +76,7 @@ public class QueryCommandTest {
     connect(server);
   }
 
-  void connect(Server server) throws Exception {
+  protected void connect(Server server) throws Exception {
     gfsh.connectAndVerify(server.getJmxPort(), GfshCommandRule.PortType.jmxManager);
   }
 
@@ -212,7 +212,7 @@ public class QueryCommandTest {
     return multilineString.split("[\\r\\n]+");
   }
 
-  public static class Customer {
+  public static class Customer implements Serializable {
     public String name;
     public String address;
 

--- a/geode-core/src/test/java/org/apache/geode/management/model/EmptyObject.java
+++ b/geode-core/src/test/java/org/apache/geode/management/model/EmptyObject.java
@@ -14,8 +14,7 @@
  */
 package org.apache.geode.management.model;
 
-/**
- */
-public class EmptyObject {
+import java.io.Serializable;
 
+public class EmptyObject implements Serializable {
 }

--- a/geode-web/src/test/java/org/apache/geode/management/internal/cli/commands/QueryCommandOverHttpTest.java
+++ b/geode-web/src/test/java/org/apache/geode/management/internal/cli/commands/QueryCommandOverHttpTest.java
@@ -21,10 +21,10 @@ import org.apache.geode.test.junit.rules.GfshCommandRule;
 import org.apache.geode.test.junit.rules.Server;
 
 @Category(IntegrationTest.class)
-public class QueryCommandOverHttpTest extends QueryCommandTest {
+public class QueryCommandOverHttpTest extends QueryCommandIntegrationTest {
 
   @Override
-  void connect(Server server) throws Exception {
+  protected void connect(Server server) throws Exception {
     gfsh.connectAndVerify(server.getHttpPort(), GfshCommandRule.PortType.http);
   }
 }


### PR DESCRIPTION
1) first commit is the actual new feature
2) second commit fixes up bad tests that were using non-serializable objects

GEODE-4769: optional early serialization of EntryEvent key and new value

If enabled, Regions and Transactions will serialize key and value before
updating the local cache. This prevents inconsistency between distributed
members caused by any failure to serialize the key or value.

This feature is disabled by default. To enable it, specify the system
property geode.earlyEntryEventSerialization=true.
