### PR TITLE
GEODE-4715 ReconnectDUnitTest calls static methods to obtain cache an…

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/cache30/ReconnectDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache30/ReconnectDUnitTest.java
@@ -49,6 +49,7 @@ import org.apache.geode.distributed.internal.membership.gms.mgr.GMSMembershipMan
 import org.apache.geode.internal.AvailablePort;
 import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.internal.cache.GemFireCacheImpl;
+import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.xmlcache.CacheXmlGenerator;
 import org.apache.geode.test.dunit.*;
 import org.apache.geode.test.dunit.cache.internal.JUnit4CacheTestCase;
@@ -78,15 +79,13 @@ public class ReconnectDUnitTest extends JUnit4CacheTestCase {
     Host.getHost(0).getVM(locatorVMNumber).invoke(new SerializableRunnable("start locator") {
       public void run() {
         try {
-          InternalDistributedSystem ds = InternalDistributedSystem.getConnectedInstance();
-          if (ds != null) {
-            ds.disconnect();
-          }
+          disconnectFromDS();
           dsProperties = null;
           locatorPort = locPort;
           Properties props = getDistributedSystemProperties();
           locator = Locator.startLocatorAndDS(locatorPort, new File(""), props);
-          ReconnectDUnitTest.savedSystem = InternalDistributedSystem.getConnectedInstance();
+          cache = ((InternalLocator) locator).getCache();
+          ReconnectDUnitTest.savedSystem = locator.getDistributedSystem();
           IgnoredException.addIgnoredException(
               "org.apache.geode.ForcedDisconnectException||Possible loss of quorum");
           // MembershipManagerHelper.getMembershipManager(InternalDistributedSystem.getConnectedInstance()).setDebugJGroups(true);
@@ -146,14 +145,11 @@ public class ReconnectDUnitTest extends JUnit4CacheTestCase {
         dsProperties = null;
         locator = null;
         locatorPort = 0;
-        InternalDistributedSystem ds = InternalDistributedSystem.getAnyInstance();
-        if (ds != null) {
-          ds.disconnect();
-        }
       }
     };
     Invoke.invokeInEveryVM(disconnect);
     disconnect.run();
+    disconnectAllFromDS();
   }
 
   /**
@@ -163,12 +159,8 @@ public class ReconnectDUnitTest extends JUnit4CacheTestCase {
     AttributesFactory factory = new AttributesFactory();
 
     {
-      // TestCacheListener listener = new TestCacheListener(){}; // this needs to be serializable
-      // callbacks.add(listener);
-      // factory.setDataPolicy(DataPolicy.REPLICATE);
       factory.setDataPolicy(DataPolicy.REPLICATE);
       factory.setScope(Scope.DISTRIBUTED_ACK);
-      // factory.setCacheListener(listener);
     }
 
     return factory.create();
@@ -189,10 +181,10 @@ public class ReconnectDUnitTest extends JUnit4CacheTestCase {
     final String xmlFileLoc = (new File(".")).getAbsolutePath();
 
     // disable disconnects in the locator so we have some stability
-    host.getVM(locatorVMNumber).invoke(new SerializableRunnable("disable force-disconnect") {
+    locatorVm.invoke(new SerializableRunnable("disable force-disconnect") {
       public void run() {
         GMSMembershipManager mgr = (GMSMembershipManager) MembershipManagerHelper
-            .getMembershipManager(InternalDistributedSystem.getConnectedInstance());
+            .getMembershipManager(Locator.getLocator().getDistributedSystem());
         mgr.disableDisconnectOnQuorumLossForTesting();
       }
     });
@@ -205,7 +197,7 @@ public class ReconnectDUnitTest extends JUnit4CacheTestCase {
             props.put(CACHE_XML_FILE, xmlFileLoc + fileSeparator + "MyDisconnect-cache.xml");
             props.put(MAX_NUM_RECONNECT_TRIES, "2");
             // props.put("log-file", "autoReconnectVM"+VM.getCurrentVMNum()+"_"+getPID()+".log");
-            Cache cache = new CacheFactory(props).create();
+            cache = (InternalCache) new CacheFactory(props).create();
             IgnoredException.addIgnoredException(
                 "org.apache.geode.ForcedDisconnectException||Possible loss of quorum");
             Region myRegion = cache.getRegion("root/myRegion");
@@ -271,8 +263,7 @@ public class ReconnectDUnitTest extends JUnit4CacheTestCase {
             Properties props = getDistributedSystemProperties();
             props.put(CACHE_XML_FILE, xmlFileLoc + fileSeparator + "MyDisconnect-cache.xml");
             props.put(MAX_WAIT_TIME_RECONNECT, "1000");
-            props.put(MAX_NUM_RECONNECT_TRIES, "2");
-            Cache cache = new CacheFactory(props).create();
+            cache = (InternalCache) new CacheFactory(props).create();
             Region myRegion = cache.getRegion("root/myRegion");
             ReconnectDUnitTest.savedSystem = cache.getDistributedSystem();
             myRegion.put("MyKey1", "MyValue1");
@@ -287,11 +278,10 @@ public class ReconnectDUnitTest extends JUnit4CacheTestCase {
             final Properties props = getDistributedSystemProperties();
             props.put(CACHE_XML_FILE, xmlFileLoc + fileSeparator + "MyDisconnect-cache.xml");
             props.put(MAX_WAIT_TIME_RECONNECT, "5000");
-            props.put(MAX_NUM_RECONNECT_TRIES, "2");
             props.put(START_LOCATOR, "localhost[" + secondLocPort + "]");
             props.put(LOCATORS, props.get(LOCATORS) + ",localhost[" + secondLocPort + "]");
             getSystem(props);
-            final Cache cache = getCache();
+            cache = getCache();
             ReconnectDUnitTest.savedSystem = cache.getDistributedSystem();
             Region myRegion = cache.getRegion("root/myRegion");
             myRegion.put("Mykey2", "MyValue2");
@@ -303,7 +293,7 @@ public class ReconnectDUnitTest extends JUnit4CacheTestCase {
                     Wait.pause(100);
                   }
                   try {
-                    new CacheFactory(props).create();
+                    cache = (InternalCache) new CacheFactory(props).create();
                     LogWriterUtils.getLogWriter().error(
                         "testReconnectCollidesWithApplication failed - application thread was able to create a cache");
                   } catch (IllegalStateException cacheExists) {
@@ -344,12 +334,15 @@ public class ReconnectDUnitTest extends JUnit4CacheTestCase {
             try {
               ds.waitUntilReconnected(60, TimeUnit.SECONDS);
               ReconnectDUnitTest.savedSystem = ds.getReconnectedSystem();
-              InternalLocator locator = (InternalLocator) Locator.getLocator();
+              locator = (InternalLocator) Locator.getLocator();
               assertTrue("Expected system to be restarted", ds.getReconnectedSystem() != null);
               assertTrue("Expected system to be running", ds.getReconnectedSystem().isConnected());
               assertTrue("Expected there to be a locator", locator != null);
-              assertTrue("Expected locator to be restarted", !locator.isStopped());
+              assertTrue("Expected locator to be restarted",
+                  !((InternalLocator) locator).isStopped());
               failure = false;
+              cache = ((InternalLocator) locator).getCache();
+              system = cache.getInternalDistributedSystem();
               return ds.getReconnectedSystem().getDistributedMember();
             } catch (InterruptedException e) {
               LogWriterUtils.getLogWriter().warning("interrupted while waiting for reconnect");
@@ -380,7 +373,7 @@ public class ReconnectDUnitTest extends JUnit4CacheTestCase {
         }, 10000, 1000, true);
         ds.stopReconnecting();
         assertFalse(ds.isReconnecting());
-        DistributedSystem newDs = InternalDistributedSystem.getAnyInstance();
+        DistributedSystem newDs = ds.getReconnectedSystem();
         if (newDs != null) {
           LogWriterUtils.getLogWriter()
               .warning("expected distributed system to be disconnected: " + newDs);
@@ -404,7 +397,7 @@ public class ReconnectDUnitTest extends JUnit4CacheTestCase {
   private DistributedMember getDMID(VM vm) {
     return (DistributedMember) vm.invoke(new SerializableCallable("get ID") {
       public Object call() {
-        ReconnectDUnitTest.savedSystem = InternalDistributedSystem.getAnyInstance();
+        ReconnectDUnitTest.savedSystem = cache.getDistributedSystem(); // InternalDistributedSystem.getAnyInstance();
         return ReconnectDUnitTest.savedSystem.getDistributedMember();
       }
     });
@@ -487,11 +480,12 @@ public class ReconnectDUnitTest extends JUnit4CacheTestCase {
       locatorPort = locPort;
       Properties props = getDistributedSystemProperties();
       props.put(MAX_WAIT_TIME_RECONNECT, "1000");
-      props.put(MAX_NUM_RECONNECT_TRIES, "2");
       props.put(LOCATORS, props.get(LOCATORS) + ",localhost[" + locPort + "]");
       props.put(ENABLE_CLUSTER_CONFIGURATION, "false");
       try {
-        Locator.startLocatorAndDS(secondLocPort, null, props);
+        InternalLocator locator =
+            (InternalLocator) Locator.startLocatorAndDS(secondLocPort, null, props);
+        cache = locator.getCache();
       } catch (IOException e) {
         Assert.fail("exception starting locator", e);
       }
@@ -508,9 +502,8 @@ public class ReconnectDUnitTest extends JUnit4CacheTestCase {
       Properties props = getDistributedSystemProperties();
       props.put(CACHE_XML_FILE, xmlFileLoc + fileSeparator + "MyDisconnect-cache.xml");
       props.put(MAX_WAIT_TIME_RECONNECT, "1000");
-      props.put(MAX_NUM_RECONNECT_TRIES, "2");
       ReconnectDUnitTest.savedSystem = getSystem(props);
-      Cache cache = getCache();
+      cache = getCache();
       Region myRegion = cache.getRegion("root/myRegion");
       myRegion.put("MyKey1", "MyValue1");
       return savedSystem.getDistributedMember();
@@ -918,7 +911,6 @@ public class ReconnectDUnitTest extends JUnit4CacheTestCase {
               Object value = null;
               Region.Entry keyValue = null;
               try {
-                Cache cache = CacheFactory.getAnyInstance();
                 if (cache == null) {
                   excuse = "no cache";
                   return false;
@@ -974,7 +966,6 @@ public class ReconnectDUnitTest extends JUnit4CacheTestCase {
 
           Wait.waitForCriterion(ev, 60 * 1000, 200, true); // was 5 * 60 * 1000
 
-          Cache cache = CacheFactory.getAnyInstance();
           if (cache != null) {
             cache.getDistributedSystem().disconnect();
           }
@@ -1223,8 +1214,8 @@ public class ReconnectDUnitTest extends JUnit4CacheTestCase {
         // a new system the old reference to DTC.system can cause
         // trouble, so we first null it out.
         nullSystem();
-        final DistributedSystem msys = InternalDistributedSystem.getAnyInstance();
         final Locator oldLocator = Locator.getLocator();
+        final DistributedSystem msys = cache.getDistributedSystem();
         MembershipManagerHelper.crashDistributedSystem(msys);
         if (oldLocator != null) {
           WaitCriterion wc = new WaitCriterion() {
@@ -1246,17 +1237,6 @@ public class ReconnectDUnitTest extends JUnit4CacheTestCase {
     } else {
       return (Boolean) fd.call();
     }
-  }
-
-  private static int getPID() {
-    String name = java.lang.management.ManagementFactory.getRuntimeMXBean().getName();
-    int idx = name.indexOf('@');
-    try {
-      return Integer.parseInt(name.substring(0, idx));
-    } catch (NumberFormatException nfe) {
-      // something changed in the RuntimeMXBean name
-    }
-    return 0;
   }
 
   /**

--- a/geode-core/src/test/java/org/apache/geode/test/dunit/internal/JUnit4DistributedTestCase.java
+++ b/geode-core/src/test/java/org/apache/geode/test/dunit/internal/JUnit4DistributedTestCase.java
@@ -91,7 +91,7 @@ public abstract class JUnit4DistributedTestCase implements DistributedTestFixtur
   private static final Set<String> testHistory = new LinkedHashSet<>();
 
   /** This VM's connection to the distributed system */
-  private static InternalDistributedSystem system;
+  protected static InternalDistributedSystem system;
   private static Class lastSystemCreatedInTest;
   private static Properties lastSystemProperties;
   private static volatile String testMethodName;


### PR DESCRIPTION
…d distributed system

Removed fishing for cache/distributed system and replaced with use of
superclass "cache" and "distributedSystem" variables.


Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
