### PR TITLE
GEODE-4875: make a public ClusterConfigurationService interface

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/ClusterConfigurationService.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/ClusterConfigurationService.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.geode.distributed;
+
+import org.apache.geode.annotations.Experimental;
+
+@Experimental
+public interface ClusterConfigurationService {
+}

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/AbstractDistributionConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/AbstractDistributionConfig.java
@@ -1086,7 +1086,8 @@ public abstract class AbstractDistributionConfig extends AbstractConfig
         LocalizedStrings.AbstractDistributionConfig_USE_SHARED_CONFIGURATION.toLocalizedString());
     m.put(LOAD_CLUSTER_CONFIGURATION_FROM_DIR,
         LocalizedStrings.AbstractDistributionConfig_LOAD_SHARED_CONFIGURATION_FROM_DIR
-            .toLocalizedString(ClusterConfigurationService.CLUSTER_CONFIG_ARTIFACTS_DIR_NAME));
+            .toLocalizedString(
+                InternalClusterConfigurationService.CLUSTER_CONFIG_ARTIFACTS_DIR_NAME));
     m.put(CLUSTER_CONFIGURATION_DIR,
         LocalizedStrings.AbstractDistributionConfig_CLUSTER_CONFIGURATION_DIR.toLocalizedString());
     m.put(SSL_SERVER_ALIAS, LocalizedStrings.AbstractDistributionConfig_SERVER_SSL_ALIAS_0

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
@@ -173,7 +173,7 @@ public class InternalLocator extends Locator implements ConnectListener {
 
   private final AtomicBoolean shutdownHandled = new AtomicBoolean(false);
 
-  private ClusterConfigurationService sharedConfig;
+  private InternalClusterConfigurationService sharedConfig;
 
   private volatile boolean isSharedConfigurationStarted = false;
 
@@ -485,7 +485,7 @@ public class InternalLocator extends Locator implements ConnectListener {
     this.server.start();
   }
 
-  public ClusterConfigurationService getSharedConfiguration() {
+  public InternalClusterConfigurationService getSharedConfiguration() {
     return this.sharedConfig;
   }
 
@@ -1042,7 +1042,7 @@ public class InternalLocator extends Locator implements ConnectListener {
       }
       this.productUseLog.monitorUse(newSystem);
       if (isSharedConfigurationEnabled()) {
-        this.sharedConfig = new ClusterConfigurationService(newCache);
+        this.sharedConfig = new InternalClusterConfigurationService(newCache);
         startSharedConfigurationService();
       }
       if (!this.server.isAlive()) {
@@ -1163,7 +1163,7 @@ public class InternalLocator extends Locator implements ConnectListener {
 
     @Override
     public void restarting(DistributedSystem ds, GemFireCache cache,
-        ClusterConfigurationService sharedConfig) {
+        InternalClusterConfigurationService sharedConfig) {
       if (ds != null) {
         for (TcpHandler handler : this.allHandlers) {
           handler.restarting(ds, cache, sharedConfig);
@@ -1327,7 +1327,7 @@ public class InternalLocator extends Locator implements ConnectListener {
     try {
       if (locator.sharedConfig == null) {
         // locator.sharedConfig will already be created in case of auto-reconnect
-        locator.sharedConfig = new ClusterConfigurationService(locator.myCache);
+        locator.sharedConfig = new InternalClusterConfigurationService(locator.myCache);
       }
       locator.sharedConfig.initSharedConfiguration(locator.loadFromSharedConfigDir());
       logger.info(

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/ServerLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/ServerLocator.java
@@ -279,7 +279,7 @@ public class ServerLocator implements TcpHandler, DistributionAdvisee {
   }
 
   public void restarting(DistributedSystem ds, GemFireCache cache,
-      ClusterConfigurationService sharedConfig) {
+      InternalClusterConfigurationService sharedConfig) {
     if (ds != null) {
       this.loadSnapshot = new LocatorLoadSnapshot();
       this.ds = (InternalDistributedSystem) ds;

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocator.java
@@ -40,8 +40,8 @@ import org.apache.geode.DataSerializer;
 import org.apache.geode.InternalGemFireException;
 import org.apache.geode.cache.GemFireCache;
 import org.apache.geode.distributed.DistributedSystem;
-import org.apache.geode.distributed.internal.ClusterConfigurationService;
 import org.apache.geode.distributed.internal.ClusterDistributionManager;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.LocatorStats;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -385,7 +385,7 @@ public class GMSLocator implements Locator, NetLocator {
 
   @Override
   public void restarting(DistributedSystem ds, GemFireCache cache,
-      ClusterConfigurationService sharedConfig) {
+      InternalClusterConfigurationService sharedConfig) {
     setMembershipManager(((InternalDistributedSystem) ds).getDM().getMembershipManager());
   }
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/TcpHandler.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/TcpHandler.java
@@ -18,7 +18,7 @@ import java.io.IOException;
 
 import org.apache.geode.cache.GemFireCache;
 import org.apache.geode.distributed.DistributedSystem;
-import org.apache.geode.distributed.internal.ClusterConfigurationService;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 
 /**
  * A handler which responds to messages for the {@link TcpServer}
@@ -50,7 +50,7 @@ public interface TcpHandler {
    * @param sharedConfig TODO
    */
   void restarting(DistributedSystem ds, GemFireCache cache,
-      ClusterConfigurationService sharedConfig);
+      InternalClusterConfigurationService sharedConfig);
 
   /**
    * Initialize the handler with the TcpServer. Called before the TcpServer starts accepting

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/TcpServer.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/TcpServer.java
@@ -44,10 +44,10 @@ import org.apache.geode.DataSerializer;
 import org.apache.geode.SystemFailure;
 import org.apache.geode.cache.IncompatibleVersionException;
 import org.apache.geode.cache.UnsupportedVersionException;
-import org.apache.geode.distributed.internal.ClusterConfigurationService;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.DistributionConfigImpl;
 import org.apache.geode.distributed.internal.DistributionStats;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.InternalLocator;
 import org.apache.geode.distributed.internal.PoolStatHelper;
@@ -204,7 +204,7 @@ public class TcpServer {
   }
 
   public void restarting(InternalDistributedSystem ds, InternalCache cache,
-      ClusterConfigurationService sharedConfig) throws IOException {
+      InternalClusterConfigurationService sharedConfig) throws IOException {
     this.shuttingDown = false;
     this.handler.restarting(ds, cache, sharedConfig);
     startServerThread();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/ClusterConfigurationLoader.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/ClusterConfigurationLoader.java
@@ -51,8 +51,8 @@ import org.apache.geode.cache.execute.FunctionService;
 import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.LockServiceDestroyedException;
-import org.apache.geode.distributed.internal.ClusterConfigurationService;
 import org.apache.geode.distributed.internal.DistributionConfig;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.ClassPathLoader;
 import org.apache.geode.internal.ConfigSource;
@@ -174,7 +174,7 @@ public class ClusterConfigurationLoader {
 
     // apply the cluster config first
     Configuration clusterConfiguration =
-        requestedConfiguration.get(ClusterConfigurationService.CLUSTER_CONFIG);
+        requestedConfiguration.get(InternalClusterConfigurationService.CLUSTER_CONFIG);
     if (clusterConfiguration != null) {
       String cacheXmlContent = clusterConfiguration.getCacheXmlContent();
       if (StringUtils.isNotBlank(cacheXmlContent)) {
@@ -226,7 +226,7 @@ public class ClusterConfigurationLoader {
 
     // apply the cluster config first
     Configuration clusterConfiguration =
-        requestedConfiguration.get(ClusterConfigurationService.CLUSTER_CONFIG);
+        requestedConfiguration.get(InternalClusterConfigurationService.CLUSTER_CONFIG);
     if (clusterConfiguration != null) {
       runtimeProps.putAll(clusterConfiguration.getGemfireProperties());
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
@@ -154,13 +154,13 @@ import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.distributed.DistributedSystemDisconnectedException;
 import org.apache.geode.distributed.Locator;
 import org.apache.geode.distributed.internal.CacheTime;
-import org.apache.geode.distributed.internal.ClusterConfigurationService;
 import org.apache.geode.distributed.internal.ClusterDistributionManager;
 import org.apache.geode.distributed.internal.DistributionAdvisee;
 import org.apache.geode.distributed.internal.DistributionAdvisor;
 import org.apache.geode.distributed.internal.DistributionAdvisor.Profile;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.DistributionManager;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.InternalLocator;
 import org.apache.geode.distributed.internal.PooledExecutorWithDMStats;
@@ -1056,8 +1056,8 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
           .create(LocalizedStrings.GemFireCache_RECEIVED_SHARED_CONFIGURATION_FROM_LOCATORS));
       logger.info(response.describeConfig());
 
-      Configuration clusterConfig =
-          response.getRequestedConfiguration().get(ClusterConfigurationService.CLUSTER_CONFIG);
+      Configuration clusterConfig = response.getRequestedConfiguration()
+          .get(InternalClusterConfigurationService.CLUSTER_CONFIG);
       Properties clusterSecProperties =
           clusterConfig == null ? new Properties() : clusterConfig.getGemfireProperties();
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/JmxManagerLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/JmxManagerLocator.java
@@ -27,7 +27,7 @@ import org.apache.geode.cache.GemFireCache;
 import org.apache.geode.cache.execute.FunctionContext;
 import org.apache.geode.cache.execute.FunctionService;
 import org.apache.geode.distributed.DistributedSystem;
-import org.apache.geode.distributed.internal.ClusterConfigurationService;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.distributed.internal.tcpserver.TcpHandler;
 import org.apache.geode.distributed.internal.tcpserver.TcpServer;
@@ -70,7 +70,7 @@ public class JmxManagerLocator implements TcpHandler {
 
   @Override
   public void restarting(DistributedSystem ds, GemFireCache cache,
-      ClusterConfigurationService sharedConfig) {
+      InternalClusterConfigurationService sharedConfig) {
     this.cache = (InternalCache) cache;
   }
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/AlterAsyncEventQueueCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/AlterAsyncEventQueueCommand.java
@@ -34,7 +34,7 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 import org.apache.geode.cache.Region;
-import org.apache.geode.distributed.internal.ClusterConfigurationService;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.Result;
 import org.apache.geode.management.internal.cli.AbstractCliAroundInterceptor;
@@ -85,7 +85,7 @@ public class AlterAsyncEventQueueCommand extends GfshCommand {
 
     // need not check if any running servers has this async-event-queue. A server with this queue id
     // may be shutdown, but we still need to update Cluster Configuration.
-    ClusterConfigurationService service = getSharedConfiguration();
+    InternalClusterConfigurationService service = getSharedConfiguration();
 
     if (service == null) {
       return ResultBuilder.createUserErrorResult("Cluster Configuration Service is not available. "

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateJndiBindingCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateJndiBindingCommand.java
@@ -34,7 +34,7 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 import org.apache.geode.distributed.DistributedMember;
-import org.apache.geode.distributed.internal.ClusterConfigurationService;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.internal.datasource.ConfigProperty;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.management.cli.CliMetaData;
@@ -159,7 +159,7 @@ public class CreateJndiBindingCommand extends GfshCommand {
 
     Result result;
     boolean persisted = false;
-    ClusterConfigurationService service = getSharedConfiguration();
+    InternalClusterConfigurationService service = getSharedConfiguration();
 
     if (service != null) {
       Element existingBinding =

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DeployCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DeployCommand.java
@@ -36,7 +36,7 @@ import org.springframework.shell.core.annotation.CliOption;
 
 import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.distributed.DistributedMember;
-import org.apache.geode.distributed.internal.ClusterConfigurationService;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
@@ -136,7 +136,7 @@ public class DeployCommand extends GfshCommand {
     }
 
     Result result = ResultBuilder.buildResult(tabularData);
-    ClusterConfigurationService sc = getSharedConfiguration();
+    InternalClusterConfigurationService sc = getSharedConfiguration();
     if (sc == null) {
       result.setCommandPersisted(false);
     } else {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyJndiBindingCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyJndiBindingCommand.java
@@ -31,7 +31,7 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 import org.apache.geode.distributed.DistributedMember;
-import org.apache.geode.distributed.internal.ClusterConfigurationService;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.Result;
 import org.apache.geode.management.internal.cli.exceptions.EntityNotFoundException;
@@ -65,7 +65,7 @@ public class DestroyJndiBindingCommand extends GfshCommand {
 
     Result result;
     boolean persisted = false;
-    ClusterConfigurationService service = getSharedConfiguration();
+    InternalClusterConfigurationService service = getSharedConfiguration();
     if (service != null) {
       Element existingBinding =
           service.getXmlElement("cluster", "jndi-binding", "jndi-name", jndiName);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExportImportClusterConfigurationCommands.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExportImportClusterConfigurationCommands.java
@@ -37,7 +37,7 @@ import org.xml.sax.SAXException;
 
 import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.distributed.DistributedMember;
-import org.apache.geode.distributed.internal.ClusterConfigurationService;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.distributed.internal.InternalLocator;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.management.cli.CliMetaData;
@@ -93,7 +93,7 @@ public class ExportImportClusterConfigurationCommands extends GfshCommand {
     }
 
     File zipFile = tempDir.resolve("exportedCC.zip").toFile();
-    ClusterConfigurationService sc = locator.getSharedConfiguration();
+    InternalClusterConfigurationService sc = locator.getSharedConfiguration();
 
     Result result;
     try {
@@ -158,7 +158,7 @@ public class ExportImportClusterConfigurationCommands extends GfshCommand {
     InfoResultData infoData = ResultBuilder.createInfoResultData();
     String zipFilePath = filePathFromShell.get(0);
 
-    ClusterConfigurationService sc = locator.getSharedConfiguration();
+    InternalClusterConfigurationService sc = locator.getSharedConfiguration();
 
     // backup the old config
     for (Configuration config : sc.getConfigurationRegion().values()) {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/GfshCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/GfshCommand.java
@@ -27,7 +27,7 @@ import org.apache.geode.cache.execute.Function;
 import org.apache.geode.cache.execute.FunctionService;
 import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.distributed.DistributedMember;
-import org.apache.geode.distributed.internal.ClusterConfigurationService;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.distributed.internal.InternalLocator;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.security.SecurityService;
@@ -65,7 +65,7 @@ public abstract class GfshCommand implements CommandMarker {
     return getGfsh() != null && getGfsh().isConnectedAndReady();
   }
 
-  public ClusterConfigurationService getSharedConfiguration() {
+  public InternalClusterConfigurationService getSharedConfiguration() {
     InternalLocator locator = InternalLocator.getLocator();
     return locator == null ? null : locator.getSharedConfiguration();
   }
@@ -74,7 +74,7 @@ public abstract class GfshCommand implements CommandMarker {
     if (result == null) {
       throw new IllegalArgumentException("Result should not be null");
     }
-    ClusterConfigurationService sc = getSharedConfiguration();
+    InternalClusterConfigurationService sc = getSharedConfiguration();
     if (sc == null) {
       result.setCommandPersisted(false);
     } else {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListJndiBindingCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListJndiBindingCommand.java
@@ -24,7 +24,7 @@ import org.springframework.shell.core.annotation.CliCommand;
 
 import org.apache.geode.cache.execute.Function;
 import org.apache.geode.distributed.DistributedMember;
-import org.apache.geode.distributed.internal.ClusterConfigurationService;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.internal.cache.configuration.CacheConfig;
 import org.apache.geode.internal.cache.configuration.JndiBindingsType;
 import org.apache.geode.internal.logging.LogService;
@@ -54,7 +54,7 @@ public class ListJndiBindingCommand extends GfshCommand {
     TabularResultData configTable = null;
     TabularResultData memberTable = null;
 
-    ClusterConfigurationService ccService = getSharedConfiguration();
+    InternalClusterConfigurationService ccService = getSharedConfiguration();
     if (ccService != null) {
       configTable = resultSection.addTable();
       configTable.setHeader("Configured JNDI bindings: ");

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/i18n/CliStrings.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/i18n/CliStrings.java
@@ -41,8 +41,8 @@ import java.text.MessageFormat;
 import org.apache.geode.cache.PartitionAttributesFactory;
 import org.apache.geode.cache.server.CacheServer;
 import org.apache.geode.distributed.ConfigurationProperties;
-import org.apache.geode.distributed.internal.ClusterConfigurationService;
 import org.apache.geode.distributed.internal.DistributionConfig;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.internal.cache.xmlcache.CacheXml;
 import org.apache.geode.management.internal.cli.shell.Gfsh;
 
@@ -2410,7 +2410,7 @@ public class CliStrings {
   public static final String START_LOCATOR__LOAD__SHARED_CONFIGURATION__FROM__FILESYSTEM__HELP =
       "When \" " + START_LOCATOR__LOAD__SHARED_CONFIGURATION__FROM__FILESYSTEM
           + " \" is set to true, the locator loads the cluster configuration from the \""
-          + ClusterConfigurationService.CLUSTER_CONFIG_ARTIFACTS_DIR_NAME + "\" directory.";
+          + InternalClusterConfigurationService.CLUSTER_CONFIG_ARTIFACTS_DIR_NAME + "\" directory.";
   public static final String START_LOCATOR__CLUSTER__CONFIG__DIR = "cluster-config-dir";
   public static final String START_LOCATOR__CLUSTER__CONFIG__DIR__HELP =
       "Directory used by the cluster configuration service to store the cluster configuration on the filesystem";

--- a/geode-core/src/main/java/org/apache/geode/management/internal/configuration/callbacks/ConfigurationChangeListener.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/configuration/callbacks/ConfigurationChangeListener.java
@@ -27,7 +27,7 @@ import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.EntryEvent;
 import org.apache.geode.cache.util.CacheListenerAdapter;
 import org.apache.geode.distributed.DistributedMember;
-import org.apache.geode.distributed.internal.ClusterConfigurationService;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.management.internal.configuration.domain.Configuration;
@@ -39,9 +39,9 @@ import org.apache.geode.management.internal.configuration.domain.Configuration;
 public class ConfigurationChangeListener extends CacheListenerAdapter<String, Configuration> {
   private static final Logger logger = LogService.getLogger();
 
-  private final ClusterConfigurationService sharedConfig;
+  private final InternalClusterConfigurationService sharedConfig;
 
-  public ConfigurationChangeListener(ClusterConfigurationService sharedConfig) {
+  public ConfigurationChangeListener(InternalClusterConfigurationService sharedConfig) {
     this.sharedConfig = sharedConfig;
   }
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/configuration/functions/DownloadJarFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/configuration/functions/DownloadJarFunction.java
@@ -30,7 +30,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.geode.cache.execute.FunctionContext;
 import org.apache.geode.cache.execute.FunctionException;
 import org.apache.geode.distributed.Locator;
-import org.apache.geode.distributed.internal.ClusterConfigurationService;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.distributed.internal.InternalLocator;
 import org.apache.geode.internal.cache.execute.InternalFunction;
 import org.apache.geode.internal.logging.LogService;
@@ -50,7 +50,7 @@ public class DownloadJarFunction implements InternalFunction<Object[]> {
 
     RemoteInputStream result = null;
     if (locator != null && group != null && jarName != null) {
-      ClusterConfigurationService sharedConfig = locator.getSharedConfiguration();
+      InternalClusterConfigurationService sharedConfig = locator.getSharedConfiguration();
       if (sharedConfig != null) {
         try {
           File jarFile = sharedConfig.getPathToJarOnThisLocator(group, jarName).toFile();

--- a/geode-core/src/main/java/org/apache/geode/management/internal/configuration/functions/GetClusterConfigurationFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/configuration/functions/GetClusterConfigurationFunction.java
@@ -21,7 +21,7 @@ import java.util.Set;
 import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.cache.execute.FunctionContext;
-import org.apache.geode.distributed.internal.ClusterConfigurationService;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.distributed.internal.InternalLocator;
 import org.apache.geode.internal.cache.execute.InternalFunction;
 import org.apache.geode.internal.logging.LogService;
@@ -32,7 +32,7 @@ public class GetClusterConfigurationFunction implements InternalFunction {
 
   @Override
   public void execute(FunctionContext context) {
-    ClusterConfigurationService clusterConfigurationService =
+    InternalClusterConfigurationService clusterConfigurationService =
         InternalLocator.getLocator().getSharedConfiguration();
 
     Set<String> groups = (Set<String>) context.getArguments();

--- a/geode-core/src/main/java/org/apache/geode/management/internal/configuration/handlers/SharedConfigurationStatusRequestHandler.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/configuration/handlers/SharedConfigurationStatusRequestHandler.java
@@ -18,7 +18,7 @@ import java.io.IOException;
 
 import org.apache.geode.cache.GemFireCache;
 import org.apache.geode.distributed.DistributedSystem;
-import org.apache.geode.distributed.internal.ClusterConfigurationService;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.distributed.internal.InternalLocator;
 import org.apache.geode.distributed.internal.tcpserver.TcpHandler;
 import org.apache.geode.distributed.internal.tcpserver.TcpServer;
@@ -56,7 +56,7 @@ public class SharedConfigurationStatusRequestHandler implements TcpHandler {
 
   @Override
   public void restarting(DistributedSystem system, GemFireCache cache,
-      ClusterConfigurationService sharedConfig) {
+      InternalClusterConfigurationService sharedConfig) {
 
   }
 

--- a/geode-core/src/test/java/org/apache/geode/cache/client/internal/AutoConnectionSourceImplJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/client/internal/AutoConnectionSourceImplJUnitTest.java
@@ -17,7 +17,6 @@ package org.apache.geode.cache.client.internal;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
@@ -47,7 +46,11 @@ import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.junit.experimental.categories.Category;
 
 import org.apache.geode.CancelCriterion;
-import org.apache.geode.cache.*;
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.CacheFactory;
+import org.apache.geode.cache.GemFireCache;
+import org.apache.geode.cache.NoSubscriptionServersAvailableException;
+import org.apache.geode.cache.RegionService;
 import org.apache.geode.cache.client.NoAvailableLocatorsException;
 import org.apache.geode.cache.client.SubscriptionNotEnabledException;
 import org.apache.geode.cache.client.internal.locator.ClientConnectionRequest;
@@ -55,8 +58,8 @@ import org.apache.geode.cache.client.internal.locator.ClientConnectionResponse;
 import org.apache.geode.cache.client.internal.locator.LocatorListResponse;
 import org.apache.geode.cache.query.QueryService;
 import org.apache.geode.distributed.DistributedSystem;
-import org.apache.geode.distributed.internal.ClusterConfigurationService;
 import org.apache.geode.distributed.internal.DistributionConfig;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.PoolStatHelper;
 import org.apache.geode.distributed.internal.ServerLocation;
@@ -416,7 +419,7 @@ public class AutoConnectionSourceImplJUnitTest {
     public void endResponse(Object request, long startTime) {}
 
     public void restarting(DistributedSystem ds, GemFireCache cache,
-        ClusterConfigurationService sharedConfig) {}
+        InternalClusterConfigurationService sharedConfig) {}
 
   }
 

--- a/geode-core/src/test/java/org/apache/geode/distributed/LocatorLauncherIntegrationTestCase.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/LocatorLauncherIntegrationTestCase.java
@@ -20,8 +20,8 @@ import static org.apache.geode.distributed.ConfigurationProperties.CLUSTER_CONFI
 import static org.apache.geode.distributed.ConfigurationProperties.DISABLE_AUTO_RECONNECT;
 import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
-import static org.apache.geode.distributed.internal.ClusterConfigurationService.CLUSTER_CONFIG_DISK_DIR_PREFIX;
 import static org.apache.geode.distributed.internal.DistributionConfig.GEMFIRE_PREFIX;
+import static org.apache.geode.distributed.internal.InternalClusterConfigurationService.CLUSTER_CONFIG_DISK_DIR_PREFIX;
 import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPorts;
 import static org.apache.geode.internal.DistributionLocator.TEST_OVERRIDE_DEFAULT_PORT_PROPERTY;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/CacheConfigIntegrationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/CacheConfigIntegrationTest.java
@@ -44,7 +44,7 @@ public class CacheConfigIntegrationTest {
     xmlFile = temporaryFolder.newFile("cache.xml");
     CacheConfig cacheConfig = new CacheConfig();
     cacheConfig.setVersion("1.0");
-    ClusterConfigurationService service = new ClusterConfigurationService();
+    InternalClusterConfigurationService service = new InternalClusterConfigurationService();
     String xml = service.marshall(cacheConfig);
     FileUtils.writeStringToFile(xmlFile, xml, "UTF-8");
 

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/InternalClusterConfigurationServiceTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/InternalClusterConfigurationServiceTest.java
@@ -26,9 +26,7 @@ import static org.mockito.Mockito.spy;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElementDecl;
 import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlSchema;
 import javax.xml.bind.annotation.XmlType;
 
 import org.junit.Before;
@@ -49,12 +47,12 @@ import org.apache.geode.test.junit.categories.UnitTest;
 public class InternalClusterConfigurationServiceTest {
   private String xml;
   private CacheConfig unmarshalled;
-  private ClusterConfigurationService service;
+  private InternalClusterConfigurationService service;
   private Configuration configuration;
 
   @Before
   public void setUp() throws Exception {
-    service = spy(ClusterConfigurationService.class);
+    service = spy(InternalClusterConfigurationService.class);
     configuration = new Configuration("cluster");
     doReturn(configuration).when(service).getConfiguration(any());
     doReturn(mock(Region.class)).when(service).getConfigurationRegion();

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/tcpserver/TcpServerJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/tcpserver/TcpServerJUnitTest.java
@@ -38,8 +38,8 @@ import org.junit.experimental.categories.Category;
 import org.apache.geode.DataSerializable;
 import org.apache.geode.cache.GemFireCache;
 import org.apache.geode.distributed.DistributedSystem;
-import org.apache.geode.distributed.internal.ClusterConfigurationService;
 import org.apache.geode.distributed.internal.DistributionConfigImpl;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.distributed.internal.PoolStatHelper;
 import org.apache.geode.internal.AvailablePort;
 import org.apache.geode.internal.cache.tier.sockets.TcpServerFactory;
@@ -183,7 +183,7 @@ public class TcpServerJUnitTest {
     }
 
     public void restarting(DistributedSystem ds, GemFireCache cache,
-        ClusterConfigurationService sharedConfig) {}
+        InternalClusterConfigurationService sharedConfig) {}
 
     public void endRequest(Object request, long startTime) {}
 
@@ -216,7 +216,7 @@ public class TcpServerJUnitTest {
     public void shutDown() {}
 
     public void restarting(DistributedSystem ds, GemFireCache cache,
-        ClusterConfigurationService sharedConfig) {}
+        InternalClusterConfigurationService sharedConfig) {}
 
     public void endRequest(Object request, long startTime) {}
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/extension/mock/MockExtensionCommands.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/extension/mock/MockExtensionCommands.java
@@ -27,7 +27,7 @@ import org.apache.geode.cache.Region;
 import org.apache.geode.cache.execute.Function;
 import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.distributed.DistributedMember;
-import org.apache.geode.distributed.internal.ClusterConfigurationService;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.distributed.internal.InternalLocator;
 import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.cache.InternalCache;
@@ -202,7 +202,8 @@ public class MockExtensionCommands implements CommandMarker {
 
     final Result result = ResultBuilder.buildResult(tabularResultData);
 
-    ClusterConfigurationService ccService = InternalLocator.getLocator().getSharedConfiguration();
+    InternalClusterConfigurationService ccService =
+        InternalLocator.getLocator().getSharedConfiguration();
     System.out.println("MockExtensionCommands: persisting xmlEntity=" + xmlEntity);
     if (null != xmlEntity.get()) {
       if (addXmlElement) {

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/AlterAsyncEventQueueCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/AlterAsyncEventQueueCommandTest.java
@@ -40,7 +40,7 @@ import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
 import org.apache.geode.cache.Region;
-import org.apache.geode.distributed.internal.ClusterConfigurationService;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.management.internal.configuration.domain.Configuration;
 import org.apache.geode.management.internal.configuration.utils.XmlUtils;
 import org.apache.geode.test.junit.categories.UnitTest;
@@ -54,13 +54,13 @@ public class AlterAsyncEventQueueCommandTest {
   public static GfshParserRule gfsh = new GfshParserRule();
 
   private AlterAsyncEventQueueCommand command;
-  private ClusterConfigurationService service;
+  private InternalClusterConfigurationService service;
   private Region<String, Configuration> configRegion;
 
   @Before
   public void before() throws Exception {
     command = spy(AlterAsyncEventQueueCommand.class);
-    service = mock(ClusterConfigurationService.class);
+    service = mock(InternalClusterConfigurationService.class);
     doReturn(service).when(command).getSharedConfiguration();
     configRegion = mock(Region.class);
     when(service.getConfigurationRegion()).thenReturn(configRegion);

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/AlterCompressorDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/AlterCompressorDUnitTest.java
@@ -29,7 +29,7 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 import org.apache.geode.cache.Region;
-import org.apache.geode.distributed.internal.ClusterConfigurationService;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.internal.cache.CachedDeserializable;
 import org.apache.geode.internal.cache.CachedDeserializableFactory;
 import org.apache.geode.internal.cache.EntryEventImpl;
@@ -129,7 +129,7 @@ public class AlterCompressorDUnitTest {
       // add the compressor to the region attributes and put it back in cluster config
       // this is just a hack to change the cache.xml so that when server restarts it restarts
       // with new region attributes
-      ClusterConfigurationService ccService =
+      InternalClusterConfigurationService ccService =
           ClusterStartupRule.getLocator().getSharedConfiguration();
       Configuration configuration = ccService.getConfiguration("dataStore");
       String modifiedXml =
@@ -170,7 +170,7 @@ public class AlterCompressorDUnitTest {
       // remove the compressor to the region attributes and put it back in cluster config
       // this is just a hack to change the cache.xml so that when server restarts it restarts
       // with new region attributes
-      ClusterConfigurationService ccService =
+      InternalClusterConfigurationService ccService =
           ClusterStartupRule.getLocator().getSharedConfiguration();
       Configuration configuration = ccService.getConfiguration("dataStore");
       String modifiedXml = removeCompressor(configuration.getCacheXmlContent());

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateAlterDestroyRegionCommandsDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateAlterDestroyRegionCommandsDUnitTest.java
@@ -55,7 +55,7 @@ import org.junit.experimental.categories.Category;
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.Region;
 import org.apache.geode.distributed.Locator;
-import org.apache.geode.distributed.internal.ClusterConfigurationService;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.distributed.internal.InternalLocator;
 import org.apache.geode.internal.AvailablePort;
 import org.apache.geode.internal.AvailablePortHelper;
@@ -180,7 +180,7 @@ public class CreateAlterDestroyRegionCommandsDUnitTest extends CliCommandTestBas
 
     // Make sure the region exists in the shared config
     Host.getHost(0).getVM(0).invoke(() -> {
-      ClusterConfigurationService sharedConfig =
+      InternalClusterConfigurationService sharedConfig =
           ((InternalLocator) Locator.getLocator()).getSharedConfiguration();
       try {
         assertTrue(
@@ -222,7 +222,7 @@ public class CreateAlterDestroyRegionCommandsDUnitTest extends CliCommandTestBas
 
     // Make sure the region was altered in the shared config
     Host.getHost(0).getVM(0).invoke(() -> {
-      ClusterConfigurationService sharedConfig =
+      InternalClusterConfigurationService sharedConfig =
           ((InternalLocator) Locator.getLocator()).getSharedConfiguration();
       try {
         assertTrue(sharedConfig.getConfiguration(groupName).getCacheXmlContent().contains("45635"));

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateAsyncEventQueueCommandDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateAsyncEventQueueCommandDUnitTest.java
@@ -21,7 +21,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import org.apache.geode.distributed.internal.ClusterConfigurationService;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.internal.cache.wan.MyAsyncEventListener;
 import org.apache.geode.management.internal.configuration.domain.Configuration;
 import org.apache.geode.test.dunit.IgnoredException;
@@ -110,7 +110,7 @@ public class CreateAsyncEventQueueCommandDUnitTest {
     gfsh.connectAndVerify(locator);
 
     locator.invoke(() -> {
-      ClusterConfigurationService service =
+      InternalClusterConfigurationService service =
           ClusterStartupRule.getLocator().getSharedConfiguration();
       assertThat(service.getConfiguration("cluster").getCacheXmlContent())
           .doesNotContain("async-event-queue");
@@ -120,7 +120,7 @@ public class CreateAsyncEventQueueCommandDUnitTest {
         .tableHasRowCount("Member", 1).tableHasColumnWithExactValuesInAnyOrder("Status", "Success");
 
     locator.invoke(() -> {
-      ClusterConfigurationService service =
+      InternalClusterConfigurationService service =
           ClusterStartupRule.getLocator().getSharedConfiguration();
       Configuration configuration = service.getConfiguration("cluster");
       configuration.getCacheXmlContent().contains("id=queue");

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateAsyncEventQueueCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateAsyncEventQueueCommandTest.java
@@ -45,7 +45,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import org.apache.geode.cache.execute.Function;
-import org.apache.geode.distributed.internal.ClusterConfigurationService;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.management.internal.cli.GfshParseResult;
 import org.apache.geode.management.internal.cli.functions.CliFunctionResult;
 import org.apache.geode.management.internal.configuration.domain.XmlEntity;
@@ -62,12 +62,12 @@ public class CreateAsyncEventQueueCommandTest {
   public static GfshParserRule gfsh = new GfshParserRule();
 
   private CreateAsyncEventQueueCommand command;
-  private ClusterConfigurationService service;
+  private InternalClusterConfigurationService service;
 
   @Before
   public void before() throws Exception {
     command = spy(CreateAsyncEventQueueCommand.class);
-    service = mock(ClusterConfigurationService.class);
+    service = mock(InternalClusterConfigurationService.class);
     doReturn(service).when(command).getSharedConfiguration();
   }
 

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateDefinedIndexesCommandDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateDefinedIndexesCommandDUnitTest.java
@@ -27,7 +27,7 @@ import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.query.QueryService;
 import org.apache.geode.distributed.Locator;
-import org.apache.geode.distributed.internal.ClusterConfigurationService;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.distributed.internal.InternalLocator;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
@@ -139,7 +139,7 @@ public class CreateDefinedIndexesCommandDUnitTest {
 
     locator.invoke(() -> {
       // Make sure the indexes exist in the cluster config
-      ClusterConfigurationService sharedConfig =
+      InternalClusterConfigurationService sharedConfig =
           ((InternalLocator) Locator.getLocator()).getSharedConfiguration();
       assertThat(sharedConfig.getConfiguration("cluster").getCacheXmlContent()).contains(index1Name,
           index2Name);
@@ -201,7 +201,7 @@ public class CreateDefinedIndexesCommandDUnitTest {
 
     locator.invoke(() -> {
       // Make sure the indexes exist in the cluster config
-      ClusterConfigurationService sharedConfig =
+      InternalClusterConfigurationService sharedConfig =
           ((InternalLocator) Locator.getLocator()).getSharedConfiguration();
       assertThat(sharedConfig.getConfiguration("group1").getCacheXmlContent()).contains(index2Name,
           index1Name);

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateDefinedIndexesCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateDefinedIndexesCommandTest.java
@@ -40,7 +40,7 @@ import org.mockito.Mockito;
 import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.cache.query.IndexType;
 import org.apache.geode.distributed.DistributedMember;
-import org.apache.geode.distributed.internal.ClusterConfigurationService;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.management.internal.cli.domain.IndexInfo;
 import org.apache.geode.management.internal.cli.functions.CliFunctionResult;
 import org.apache.geode.management.internal.cli.result.CommandResult;
@@ -86,7 +86,8 @@ public class CreateDefinedIndexesCommandTest {
   public void creationFailure() throws Exception {
     DistributedMember member = mock(DistributedMember.class);
     when(member.getId()).thenReturn("memberId");
-    ClusterConfigurationService mockService = mock(ClusterConfigurationService.class);
+    InternalClusterConfigurationService mockService =
+        mock(InternalClusterConfigurationService.class);
 
     doReturn(mockService).when(command).getSharedConfiguration();
     doReturn(Collections.singleton(member)).when(command).findMembers(any(), any());
@@ -106,7 +107,8 @@ public class CreateDefinedIndexesCommandTest {
     XmlEntity xmlEntity = mock(XmlEntity.class);
     DistributedMember member = mock(DistributedMember.class);
     when(member.getId()).thenReturn("memberId");
-    ClusterConfigurationService mockService = mock(ClusterConfigurationService.class);
+    InternalClusterConfigurationService mockService =
+        mock(InternalClusterConfigurationService.class);
 
     doReturn(mockService).when(command).getSharedConfiguration();
     doReturn(Collections.singleton(member)).when(command).findMembers(any(), any());
@@ -132,7 +134,8 @@ public class CreateDefinedIndexesCommandTest {
     when(member1.getId()).thenReturn("memberId_1");
     when(member2.getId()).thenReturn("memberId_2");
 
-    ClusterConfigurationService mockService = mock(ClusterConfigurationService.class);
+    InternalClusterConfigurationService mockService =
+        mock(InternalClusterConfigurationService.class);
     CliFunctionResult member1Region1Result =
         new CliFunctionResult(member1.getId(), xmlEntityRegion1);
     CliFunctionResult member1Region2Result =

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateGatewayReceiverCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateGatewayReceiverCommandTest.java
@@ -32,7 +32,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import org.apache.geode.distributed.internal.ClusterConfigurationService;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.management.internal.cli.GfshParseResult;
 import org.apache.geode.management.internal.cli.functions.CliFunctionResult;
@@ -50,14 +50,14 @@ public class CreateGatewayReceiverCommandTest {
   private CreateGatewayReceiverCommand command;
   private InternalCache cache;
   private List<CliFunctionResult> functionResults;
-  private ClusterConfigurationService ccService;
+  private InternalClusterConfigurationService ccService;
   private CliFunctionResult result1;
   private XmlEntity xmlEntity;
 
   @Before
   public void before() {
     command = spy(CreateGatewayReceiverCommand.class);
-    ccService = mock(ClusterConfigurationService.class);
+    ccService = mock(InternalClusterConfigurationService.class);
     xmlEntity = mock(XmlEntity.class);
     cache = mock(InternalCache.class);
     doReturn(cache).when(command).getCache();

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateGatewaySenderCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateGatewaySenderCommandTest.java
@@ -33,7 +33,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import org.apache.geode.distributed.internal.ClusterConfigurationService;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.management.internal.cli.functions.CliFunctionResult;
 import org.apache.geode.management.internal.configuration.domain.XmlEntity;
@@ -49,14 +49,14 @@ public class CreateGatewaySenderCommandTest {
   private CreateGatewaySenderCommand command;
   private InternalCache cache;
   private List<CliFunctionResult> functionResults;
-  private ClusterConfigurationService ccService;
+  private InternalClusterConfigurationService ccService;
   private CliFunctionResult result1, result2;
   private XmlEntity xmlEntity;
 
   @Before
   public void before() {
     command = spy(CreateGatewaySenderCommand.class);
-    ccService = mock(ClusterConfigurationService.class);
+    ccService = mock(InternalClusterConfigurationService.class);
     xmlEntity = mock(XmlEntity.class);
     cache = mock(InternalCache.class);
     doReturn(cache).when(command).getCache();

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateJndiBindingCommandDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateJndiBindingCommandDUnitTest.java
@@ -17,8 +17,6 @@ package org.apache.geode.management.internal.cli.commands;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
-import java.util.stream.Stream;
-
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -27,7 +25,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
-import org.apache.geode.distributed.internal.ClusterConfigurationService;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.internal.jndi.JNDIInvoker;
 import org.apache.geode.management.internal.configuration.domain.Configuration;
 import org.apache.geode.management.internal.configuration.utils.XmlUtils;
@@ -71,7 +69,7 @@ public class CreateJndiBindingCommandDUnitTest {
 
     // verify cluster config is updated
     locator.invoke(() -> {
-      ClusterConfigurationService ccService =
+      InternalClusterConfigurationService ccService =
           ClusterStartupRule.getLocator().getSharedConfiguration();
       Configuration configuration = ccService.getConfiguration("cluster");
       Document document = XmlUtils.createDocumentFromXml(configuration.getCacheXmlContent());

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateJndiBindingCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateJndiBindingCommandTest.java
@@ -46,7 +46,7 @@ import org.xml.sax.SAXException;
 
 import org.apache.geode.cache.Region;
 import org.apache.geode.distributed.DistributedMember;
-import org.apache.geode.distributed.internal.ClusterConfigurationService;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.datasource.ConfigProperty;
 import org.apache.geode.management.internal.cli.GfshParseResult;
@@ -105,7 +105,8 @@ public class CreateJndiBindingCommandTest {
   @Test
   public void returnsErrorIfBindingAlreadyExistsAndIfUnspecified()
       throws ParserConfigurationException, SAXException, IOException {
-    ClusterConfigurationService clusterConfigService = mock(ClusterConfigurationService.class);
+    InternalClusterConfigurationService clusterConfigService =
+        mock(InternalClusterConfigurationService.class);
     Element existingBinding = mock(Element.class);
 
     doReturn(clusterConfigService).when(command).getSharedConfiguration();
@@ -119,7 +120,8 @@ public class CreateJndiBindingCommandTest {
   @Test
   public void skipsIfBindingAlreadyExistsAndIfSpecified()
       throws ParserConfigurationException, SAXException, IOException {
-    ClusterConfigurationService clusterConfigService = mock(ClusterConfigurationService.class);
+    InternalClusterConfigurationService clusterConfigService =
+        mock(InternalClusterConfigurationService.class);
     Element existingBinding = mock(Element.class);
 
     doReturn(clusterConfigService).when(command).getSharedConfiguration();
@@ -134,7 +136,8 @@ public class CreateJndiBindingCommandTest {
   @Test
   public void skipsIfBindingAlreadyExistsAndIfSpecifiedTrue()
       throws ParserConfigurationException, SAXException, IOException {
-    ClusterConfigurationService clusterConfigService = mock(ClusterConfigurationService.class);
+    InternalClusterConfigurationService clusterConfigService =
+        mock(InternalClusterConfigurationService.class);
     Element existingBinding = mock(Element.class);
 
     doReturn(clusterConfigService).when(command).getSharedConfiguration();
@@ -149,7 +152,8 @@ public class CreateJndiBindingCommandTest {
   @Test
   public void returnsErrorIfBindingAlreadyExistsAndIfSpecifiedFalse()
       throws ParserConfigurationException, SAXException, IOException {
-    ClusterConfigurationService clusterConfigService = mock(ClusterConfigurationService.class);
+    InternalClusterConfigurationService clusterConfigService =
+        mock(InternalClusterConfigurationService.class);
     Element existingBinding = mock(Element.class);
 
     doReturn(clusterConfigService).when(command).getSharedConfiguration();
@@ -165,7 +169,8 @@ public class CreateJndiBindingCommandTest {
   public void updateXmlShouldClusterConfigurationWithJndiConfiguration()
       throws IOException, ParserConfigurationException, SAXException, TransformerException {
     Configuration clusterConfig = new Configuration("cluster");
-    ClusterConfigurationService clusterConfigService = mock(ClusterConfigurationService.class);
+    InternalClusterConfigurationService clusterConfigService =
+        mock(InternalClusterConfigurationService.class);
     Region configRegion = mock(Region.class);
 
     doReturn(configRegion).when(clusterConfigService).getConfigurationRegion();
@@ -252,7 +257,8 @@ public class CreateJndiBindingCommandTest {
   @Test
   public void whenNoMembersFoundAndClusterConfigRunningThenUpdateClusterConfig()
       throws IOException, ParserConfigurationException, SAXException, TransformerException {
-    ClusterConfigurationService clusterConfigService = mock(ClusterConfigurationService.class);
+    InternalClusterConfigurationService clusterConfigService =
+        mock(InternalClusterConfigurationService.class);
 
     doReturn(Collections.emptySet()).when(command).findMembers(any(), any());
     doReturn(null).when(clusterConfigService).getXmlElement(any(), any(), any(), any());
@@ -319,7 +325,8 @@ public class CreateJndiBindingCommandTest {
         "Tried creating jndi binding \"name\" on \"server1\"");
     List<CliFunctionResult> results = new ArrayList<>();
     results.add(result);
-    ClusterConfigurationService clusterConfigService = mock(ClusterConfigurationService.class);
+    InternalClusterConfigurationService clusterConfigService =
+        mock(InternalClusterConfigurationService.class);
 
     doReturn(members).when(command).findMembers(any(), any());
     doReturn(null).when(clusterConfigService).getXmlElement(any(), any(), any(), any());

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DestroyAsyncEventQueueCommandDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DestroyAsyncEventQueueCommandDUnitTest.java
@@ -23,7 +23,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import org.apache.geode.distributed.internal.ClusterConfigurationService;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.internal.cache.wan.MyAsyncEventListener;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.json.GfJsonException;
@@ -62,7 +62,7 @@ public class DestroyAsyncEventQueueCommandDUnitTest {
     gfsh.executeAndAssertThat("list async-event-queues").statusIsSuccess();
 
     locator.invoke(() -> {
-      ClusterConfigurationService service =
+      InternalClusterConfigurationService service =
           ClusterStartupRule.getLocator().getSharedConfiguration();
       Configuration config = service.getConfiguration("cluster");
       assertThat(config.getCacheXmlContent()).contains("id=\"queue1\"");
@@ -74,7 +74,7 @@ public class DestroyAsyncEventQueueCommandDUnitTest {
 
     // verify that aeq entry is deleted from cluster config
     locator.invoke(() -> {
-      ClusterConfigurationService service =
+      InternalClusterConfigurationService service =
           ClusterStartupRule.getLocator().getSharedConfiguration();
       Configuration config = service.getConfiguration("cluster");
       assertThat(config.getCacheXmlContent()).doesNotContain("id=\"queue1\"");
@@ -113,7 +113,7 @@ public class DestroyAsyncEventQueueCommandDUnitTest {
 
     // verify that aeq entry is deleted from cluster config
     locator.invoke(() -> {
-      ClusterConfigurationService service =
+      InternalClusterConfigurationService service =
           ClusterStartupRule.getLocator().getSharedConfiguration();
       Configuration config = service.getConfiguration("cluster");
       assertThat(config.getCacheXmlContent()).doesNotContain("id=\"queue1\"");
@@ -134,7 +134,7 @@ public class DestroyAsyncEventQueueCommandDUnitTest {
 
     // verify that aeq entry is deleted from cluster config
     locator.invoke(() -> {
-      ClusterConfigurationService service =
+      InternalClusterConfigurationService service =
           ClusterStartupRule.getLocator().getSharedConfiguration();
       Configuration config = service.getConfiguration("group1");
       assertThat(config.getCacheXmlContent()).doesNotContain("id=\"queue1\"");
@@ -154,7 +154,7 @@ public class DestroyAsyncEventQueueCommandDUnitTest {
 
     // verify that aeq entry is not deleted from cluster config
     locator.invoke(() -> {
-      ClusterConfigurationService service =
+      InternalClusterConfigurationService service =
           ClusterStartupRule.getLocator().getSharedConfiguration();
       Configuration config = service.getConfiguration("group1");
       assertThat(config.getCacheXmlContent()).contains("id=\"queue1\"");
@@ -204,7 +204,7 @@ public class DestroyAsyncEventQueueCommandDUnitTest {
 
     // verify that cluster config aeq entry for destroyed queue is deleted
     locator.invoke(() -> {
-      ClusterConfigurationService service =
+      InternalClusterConfigurationService service =
           ClusterStartupRule.getLocator().getSharedConfiguration();
       System.out.println("cluster config: " + service.getConfiguration("cluster"));
       Configuration config1 = service.getConfiguration("group1");

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DestroyAsyncEventQueueCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DestroyAsyncEventQueueCommandTest.java
@@ -36,7 +36,7 @@ import org.mockito.ArgumentCaptor;
 
 import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.distributed.DistributedMember;
-import org.apache.geode.distributed.internal.ClusterConfigurationService;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.management.internal.cli.functions.CliFunctionResult;
 import org.apache.geode.management.internal.cli.functions.DestroyAsyncEventQueueFunction;
@@ -51,7 +51,7 @@ public class DestroyAsyncEventQueueCommandTest {
   public static GfshParserRule gfsh = new GfshParserRule();
 
   private DestroyAsyncEventQueueCommand command;
-  private ClusterConfigurationService service;
+  private InternalClusterConfigurationService service;
   private Map<String, Configuration> configurationMap;
   private DistributedMember member1 = mock(DistributedMember.class);
   private DistributedMember member2 = mock(DistributedMember.class);

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DestroyGatewaySenderCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DestroyGatewaySenderCommandTest.java
@@ -32,7 +32,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import org.apache.geode.distributed.internal.ClusterConfigurationService;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.management.internal.cli.functions.CliFunctionResult;
 import org.apache.geode.management.internal.configuration.domain.XmlEntity;
@@ -49,14 +49,14 @@ public class DestroyGatewaySenderCommandTest {
   private DestroyGatewaySenderCommand command;
   private InternalCache cache;
   private List<CliFunctionResult> functionResults;
-  private ClusterConfigurationService ccService;
+  private InternalClusterConfigurationService ccService;
   private CliFunctionResult result1, result2;
   private XmlEntity xmlEntity;
 
   @Before
   public void before() throws Exception {
     command = spy(DestroyGatewaySenderCommand.class);
-    ccService = mock(ClusterConfigurationService.class);
+    ccService = mock(InternalClusterConfigurationService.class);
     xmlEntity = mock(XmlEntity.class);
     cache = mock(InternalCache.class);
     doReturn(cache).when(command).getCache();

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DestroyJndiBindingCommandDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DestroyJndiBindingCommandDUnitTest.java
@@ -25,7 +25,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
-import org.apache.geode.distributed.internal.ClusterConfigurationService;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.internal.jndi.JNDIInvoker;
 import org.apache.geode.management.internal.configuration.domain.Configuration;
 import org.apache.geode.management.internal.configuration.utils.XmlUtils;
@@ -72,7 +72,7 @@ public class DestroyJndiBindingCommandDUnitTest {
 
     // verify cluster config is updated
     locator.invoke(() -> {
-      ClusterConfigurationService ccService =
+      InternalClusterConfigurationService ccService =
           ClusterStartupRule.getLocator().getSharedConfiguration();
       Configuration configuration = ccService.getConfiguration("cluster");
       Document document = XmlUtils.createDocumentFromXml(configuration.getCacheXmlContent());

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DestroyJndiBindingCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DestroyJndiBindingCommandTest.java
@@ -25,7 +25,6 @@ import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -39,23 +38,17 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.mockito.ArgumentCaptor;
-import org.w3c.dom.Document;
 import org.w3c.dom.Element;
-import org.w3c.dom.Node;
 import org.xml.sax.SAXException;
 
 import org.apache.geode.cache.Region;
 import org.apache.geode.distributed.DistributedMember;
-import org.apache.geode.distributed.internal.ClusterConfigurationService;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.internal.cache.InternalCache;
-import org.apache.geode.internal.datasource.ConfigProperty;
-import org.apache.geode.management.internal.cli.GfshParseResult;
 import org.apache.geode.management.internal.cli.functions.CliFunctionResult;
 import org.apache.geode.management.internal.cli.functions.CreateJndiBindingFunction;
 import org.apache.geode.management.internal.cli.functions.DestroyJndiBindingFunction;
-import org.apache.geode.management.internal.cli.functions.JndiBindingConfiguration;
 import org.apache.geode.management.internal.configuration.domain.Configuration;
-import org.apache.geode.management.internal.configuration.utils.XmlUtils;
 import org.apache.geode.test.junit.categories.UnitTest;
 import org.apache.geode.test.junit.rules.GfshParserRule;
 
@@ -85,7 +78,8 @@ public class DestroyJndiBindingCommandTest {
   @Test
   public void returnsErrorIfBindingDoesNotExistAndIfExistsUnspecified()
       throws ParserConfigurationException, SAXException, IOException {
-    ClusterConfigurationService clusterConfigService = mock(ClusterConfigurationService.class);
+    InternalClusterConfigurationService clusterConfigService =
+        mock(InternalClusterConfigurationService.class);
     doReturn(clusterConfigService).when(command).getSharedConfiguration();
     doReturn(null).when(clusterConfigService).getXmlElement(any(), any(), any(), any());
     gfsh.executeAndAssertThat(command, COMMAND + " --name=name").statusIsError()
@@ -95,7 +89,8 @@ public class DestroyJndiBindingCommandTest {
   @Test
   public void skipsIfBindingDoesNotExistAndIfExistsSpecified()
       throws ParserConfigurationException, SAXException, IOException {
-    ClusterConfigurationService clusterConfigService = mock(ClusterConfigurationService.class);
+    InternalClusterConfigurationService clusterConfigService =
+        mock(InternalClusterConfigurationService.class);
     doReturn(clusterConfigService).when(command).getSharedConfiguration();
     doReturn(null).when(clusterConfigService).getXmlElement(any(), any(), any(), any());
     gfsh.executeAndAssertThat(command, COMMAND + " --name=name --if-exists").statusIsSuccess()
@@ -105,7 +100,8 @@ public class DestroyJndiBindingCommandTest {
   @Test
   public void skipsIfBindingDoesNotExistAndIfExistsSpecifiedTrue()
       throws ParserConfigurationException, SAXException, IOException {
-    ClusterConfigurationService clusterConfigService = mock(ClusterConfigurationService.class);
+    InternalClusterConfigurationService clusterConfigService =
+        mock(InternalClusterConfigurationService.class);
     doReturn(clusterConfigService).when(command).getSharedConfiguration();
     doReturn(null).when(clusterConfigService).getXmlElement(any(), any(), any(), any());
     gfsh.executeAndAssertThat(command, COMMAND + " --name=name --if-exists=true").statusIsSuccess()
@@ -115,7 +111,8 @@ public class DestroyJndiBindingCommandTest {
   @Test
   public void returnsErrorIfBindingDoesNotExistAndIfExistsSpecifiedFalse()
       throws ParserConfigurationException, SAXException, IOException {
-    ClusterConfigurationService clusterConfigService = mock(ClusterConfigurationService.class);
+    InternalClusterConfigurationService clusterConfigService =
+        mock(InternalClusterConfigurationService.class);
     doReturn(clusterConfigService).when(command).getSharedConfiguration();
     doReturn(null).when(clusterConfigService).getXmlElement(any(), any(), any(), any());
     gfsh.executeAndAssertThat(command, COMMAND + " --name=name --if-exists=false").statusIsError()
@@ -125,7 +122,8 @@ public class DestroyJndiBindingCommandTest {
   @Test
   public void removeJndiBindingFromXmlShouldRemoveBindingFromClusterConfiguration()
       throws IOException, ParserConfigurationException, SAXException, TransformerException {
-    ClusterConfigurationService clusterConfigService = mock(ClusterConfigurationService.class);
+    InternalClusterConfigurationService clusterConfigService =
+        mock(InternalClusterConfigurationService.class);
     Region configRegion = mock(Region.class);
 
     Configuration clusterConfig = new Configuration("cluster");
@@ -156,7 +154,8 @@ public class DestroyJndiBindingCommandTest {
   @Test
   public void removeJndiBindingFromXmlIsNoOpWhenNoBindingFoundInClusterConfiguration()
       throws IOException, ParserConfigurationException, SAXException, TransformerException {
-    ClusterConfigurationService clusterConfigService = mock(ClusterConfigurationService.class);
+    InternalClusterConfigurationService clusterConfigService =
+        mock(InternalClusterConfigurationService.class);
     Region configRegion = mock(Region.class);
     Configuration clusterConfig = new Configuration("cluster");
 
@@ -184,7 +183,8 @@ public class DestroyJndiBindingCommandTest {
   @Test
   public void whenNoMembersFoundAndClusterConfigRunningThenUpdateClusterConfig()
       throws IOException, ParserConfigurationException, SAXException, TransformerException {
-    ClusterConfigurationService clusterConfigService = mock(ClusterConfigurationService.class);
+    InternalClusterConfigurationService clusterConfigService =
+        mock(InternalClusterConfigurationService.class);
     Element existingBinding = mock(Element.class);
 
     doReturn(Collections.emptySet()).when(command).findMembers(any(), any());
@@ -244,7 +244,8 @@ public class DestroyJndiBindingCommandTest {
         new CliFunctionResult("server1", true, "Jndi binding \"name\" destroyed on \"server1\"");
     List<CliFunctionResult> results = new ArrayList<>();
     results.add(result);
-    ClusterConfigurationService clusterConfigService = mock(ClusterConfigurationService.class);
+    InternalClusterConfigurationService clusterConfigService =
+        mock(InternalClusterConfigurationService.class);
     Element existingBinding = mock(Element.class);
 
     doReturn(members).when(command).findMembers(any(), any());

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DestroyRegionCommandDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DestroyRegionCommandDUnitTest.java
@@ -28,7 +28,7 @@ import org.junit.experimental.categories.Category;
 
 import org.apache.geode.cache.Cache;
 import org.apache.geode.distributed.Locator;
-import org.apache.geode.distributed.internal.ClusterConfigurationService;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.distributed.internal.InternalLocator;
 import org.apache.geode.management.internal.configuration.domain.Configuration;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
@@ -112,7 +112,7 @@ public class DestroyRegionCommandDUnitTest {
     locator.waitTillRegionsAreReadyOnServers("/region1", 3);
 
     locator.invoke(() -> {
-      ClusterConfigurationService service =
+      InternalClusterConfigurationService service =
           ClusterStartupRule.getLocator().getSharedConfiguration();
       Configuration group1Config = service.getConfiguration("group1");
       assertThat(group1Config.getCacheXmlContent()).contains("<region name=\"region1\">\n"
@@ -128,7 +128,7 @@ public class DestroyRegionCommandDUnitTest {
 
     // verify that all cc entries are deleted, no matter what the scope is
     locator.invoke(() -> {
-      ClusterConfigurationService service =
+      InternalClusterConfigurationService service =
           ClusterStartupRule.getLocator().getSharedConfiguration();
       Configuration group1Config = service.getConfiguration("group1");
       assertThat(group1Config.getCacheXmlContent()).doesNotContain("region1");
@@ -150,7 +150,7 @@ public class DestroyRegionCommandDUnitTest {
 
     // Make sure the region exists in the cluster config
     locator.invoke(() -> {
-      ClusterConfigurationService sharedConfig =
+      InternalClusterConfigurationService sharedConfig =
           ((InternalLocator) Locator.getLocator()).getSharedConfiguration();
       assertThat(sharedConfig.getConfiguration("cluster").getCacheXmlContent())
           .contains("Customer");
@@ -162,7 +162,7 @@ public class DestroyRegionCommandDUnitTest {
 
     // make sure the region was removed from cluster config
     locator.invoke(() -> {
-      ClusterConfigurationService sharedConfig =
+      InternalClusterConfigurationService sharedConfig =
           ((InternalLocator) Locator.getLocator()).getSharedConfiguration();
       assertThat(sharedConfig.getConfiguration("cluster").getCacheXmlContent())
           .doesNotContain("Customer");

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DestroyRegionCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DestroyRegionCommandTest.java
@@ -35,7 +35,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import org.apache.geode.distributed.DistributedMember;
-import org.apache.geode.distributed.internal.ClusterConfigurationService;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.management.internal.cli.GfshParseResult;
 import org.apache.geode.management.internal.cli.functions.CliFunctionResult;
@@ -53,14 +53,14 @@ public class DestroyRegionCommandTest {
   private DestroyRegionCommand command;
   private CommandResult result;
   private CliFunctionResult result1, result2;
-  private ClusterConfigurationService ccService;
+  private InternalClusterConfigurationService ccService;
   XmlEntity xmlEntity;
 
   @Before
   public void before() throws Exception {
     xmlEntity = mock(XmlEntity.class);
     command = spy(DestroyRegionCommand.class);
-    ccService = mock(ClusterConfigurationService.class);
+    ccService = mock(InternalClusterConfigurationService.class);
     doReturn(ccService).when(command).getSharedConfiguration();
     doReturn(mock(InternalCache.class)).when(command).getCache();
 

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DiskStoreCommandsDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DiskStoreCommandsDUnitTest.java
@@ -33,7 +33,7 @@ import org.junit.rules.TemporaryFolder;
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.Region;
 import org.apache.geode.distributed.Locator;
-import org.apache.geode.distributed.internal.ClusterConfigurationService;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.distributed.internal.InternalLocator;
 import org.apache.geode.internal.cache.SnapshotTestUtil;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
@@ -193,7 +193,7 @@ public class DiskStoreCommandsDUnitTest {
 
   private boolean diskStoreExistsInClusterConfig(MemberVM jmxManager) {
     boolean result = jmxManager.invoke(() -> {
-      ClusterConfigurationService sharedConfig =
+      InternalClusterConfigurationService sharedConfig =
           ((InternalLocator) Locator.getLocator()).getSharedConfiguration();
       String xmlFromConfig;
       xmlFromConfig = sharedConfig.getConfiguration(GROUP).getCacheXmlContent();

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/GfshCommandJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/GfshCommandJUnitTest.java
@@ -27,7 +27,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import org.apache.geode.distributed.internal.ClusterConfigurationService;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.management.cli.Result;
 import org.apache.geode.management.internal.cli.exceptions.EntityNotFoundException;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
@@ -39,13 +39,13 @@ public class GfshCommandJUnitTest {
 
   private GfshCommand command;
   private Gfsh gfsh;
-  private ClusterConfigurationService clusterConfigurationService;
+  private InternalClusterConfigurationService clusterConfigurationService;
 
   @Before
   public void before() throws Exception {
     command = spy(GfshCommand.class);
     gfsh = mock(Gfsh.class);
-    clusterConfigurationService = mock(ClusterConfigurationService.class);
+    clusterConfigurationService = mock(InternalClusterConfigurationService.class);
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/IndexCommandsShareConfigurationDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/IndexCommandsShareConfigurationDUnitTest.java
@@ -41,7 +41,7 @@ import org.apache.geode.cache.RegionFactory;
 import org.apache.geode.cache.query.Index;
 import org.apache.geode.distributed.ConfigurationProperties;
 import org.apache.geode.distributed.Locator;
-import org.apache.geode.distributed.internal.ClusterConfigurationService;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.distributed.internal.InternalLocator;
 import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.internal.cache.InternalCache;
@@ -114,7 +114,7 @@ public class IndexCommandsShareConfigurationDUnitTest {
     assertTrue(indexIsListed());
 
     locator.invoke(() -> {
-      ClusterConfigurationService sharedConfig =
+      InternalClusterConfigurationService sharedConfig =
           ((InternalLocator) Locator.getLocator()).getSharedConfiguration();
       String xmlFromConfig;
       try {
@@ -132,7 +132,7 @@ public class IndexCommandsShareConfigurationDUnitTest {
     gfsh.executeAndAssertThat(createStringBuilder.toString()).statusIsSuccess();
 
     locator.invoke(() -> {
-      ClusterConfigurationService sharedConfig =
+      InternalClusterConfigurationService sharedConfig =
           ((InternalLocator) Locator.getLocator()).getSharedConfiguration();
       String xmlFromConfig;
       try {

--- a/geode-core/src/test/java/org/apache/geode/management/internal/configuration/ClusterConfig.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/configuration/ClusterConfig.java
@@ -39,7 +39,7 @@ import java.util.stream.Stream;
 import org.apache.commons.lang.StringUtils;
 
 import org.apache.geode.cache.Cache;
-import org.apache.geode.distributed.internal.ClusterConfigurationService;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.distributed.internal.InternalLocator;
 import org.apache.geode.internal.ClassPathLoader;
 import org.apache.geode.internal.DeployedJar;
@@ -94,7 +94,7 @@ public class ClusterConfig implements Serializable {
     // verify info exists in memory
     locatorVM.invoke(() -> {
       InternalLocator internalLocator = ClusterStartupRule.getLocator();
-      ClusterConfigurationService sc = internalLocator.getSharedConfiguration();
+      InternalClusterConfigurationService sc = internalLocator.getSharedConfiguration();
 
       // verify no extra configs exist in memory
       Set<String> actualGroupConfigs = sc.getConfigurationRegion().keySet();

--- a/geode-core/src/test/java/org/apache/geode/management/internal/configuration/ClusterConfigWithSecurityDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/configuration/ClusterConfigWithSecurityDUnitTest.java
@@ -30,7 +30,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import org.apache.geode.distributed.internal.ClusterConfigurationService;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.distributed.internal.InternalLocator;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
@@ -78,7 +78,7 @@ public class ClusterConfigWithSecurityDUnitTest {
     // the second locator should inherit the first locator's security props
     locator1.invoke(() -> {
       InternalLocator locator = ClusterStartupRule.getLocator();
-      ClusterConfigurationService sc = locator.getSharedConfiguration();
+      InternalClusterConfigurationService sc = locator.getSharedConfiguration();
       Properties clusterConfigProps = sc.getConfiguration("cluster").getGemfireProperties();
       assertThat(clusterConfigProps.getProperty(SECURITY_MANAGER))
           .isEqualTo(SimpleTestSecurityManager.class.getName());
@@ -98,7 +98,7 @@ public class ClusterConfigWithSecurityDUnitTest {
 
     locator0.invoke(() -> {
       InternalLocator locator = ClusterStartupRule.getLocator();
-      ClusterConfigurationService sc = locator.getSharedConfiguration();
+      InternalClusterConfigurationService sc = locator.getSharedConfiguration();
       Properties properties = sc.getConfiguration("cluster").getGemfireProperties();
       assertThat(properties.getProperty(MCAST_PORT)).isEqualTo("0");
       assertThat(properties.getProperty(LOG_FILE_SIZE_LIMIT)).isEqualTo("8000");

--- a/geode-core/src/test/java/org/apache/geode/management/internal/configuration/ClusterConfigurationServiceUsingDirDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/configuration/ClusterConfigurationServiceUsingDirDUnitTest.java
@@ -44,7 +44,7 @@ import org.junit.experimental.categories.Category;
 
 import org.apache.geode.cache.Region;
 import org.apache.geode.distributed.Locator;
-import org.apache.geode.distributed.internal.ClusterConfigurationService;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.distributed.internal.InternalLocator;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.cache.internal.JUnit4CacheTestCase;
@@ -65,7 +65,7 @@ public class ClusterConfigurationServiceUsingDirDUnitTest extends JUnit4CacheTes
           return;
         }
 
-        ClusterConfigurationService sharedConfig = locator.getSharedConfiguration();
+        InternalClusterConfigurationService sharedConfig = locator.getSharedConfiguration();
         if (sharedConfig != null) {
           sharedConfig.destroySharedConfiguration();
         }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/configuration/SharedConfigurationTestUtils.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/configuration/SharedConfigurationTestUtils.java
@@ -14,7 +14,7 @@
  */
 package org.apache.geode.management.internal.configuration;
 
-import org.apache.geode.distributed.internal.ClusterConfigurationService;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.distributed.internal.InternalLocator;
 import org.apache.geode.test.dunit.SerializableRunnable;
 import org.apache.geode.test.dunit.internal.JUnit4DistributedTestCase;
@@ -26,7 +26,7 @@ public class SharedConfigurationTestUtils {
     public void run() {
       InternalLocator locator = InternalLocator.getLocator();
       if (locator != null) {
-        ClusterConfigurationService sharedConfig = locator.getSharedConfiguration();
+        InternalClusterConfigurationService sharedConfig = locator.getSharedConfiguration();
         if (sharedConfig != null) {
           sharedConfig.destroySharedConfiguration();
         }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/configuration/utils/XmlUtilsAddNewNodeJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/configuration/utils/XmlUtilsAddNewNodeJUnitTest.java
@@ -38,7 +38,7 @@ import org.xml.sax.SAXException;
 
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.CacheFactory;
-import org.apache.geode.distributed.internal.ClusterConfigurationService;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.internal.cache.extension.Extension;
 import org.apache.geode.internal.cache.xmlcache.CacheXml;
 import org.apache.geode.management.internal.configuration.domain.XmlEntity;
@@ -48,7 +48,8 @@ import org.apache.geode.test.junit.categories.IntegrationTest;
 /**
  * Unit tests for {@link XmlUtils#addNewNode(Document, XmlEntity)} and
  * {@link XmlUtils#deleteNode(Document, XmlEntity)}. Simulates the
- * {@link ClusterConfigurationService} method of extracting {@link XmlEntity} from the new config
+ * {@link InternalClusterConfigurationService} method of extracting {@link XmlEntity} from the new
+ * config
  * and applying it to the current shared config.
  *
  *

--- a/geode-core/src/test/java/org/apache/geode/test/dunit/internal/JUnit4DistributedTestCase.java
+++ b/geode-core/src/test/java/org/apache/geode/test/dunit/internal/JUnit4DistributedTestCase.java
@@ -18,7 +18,7 @@ import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.LOG_FILE;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.apache.geode.distributed.ConfigurationProperties.STATISTIC_ARCHIVE_FILE;
-import static org.apache.geode.distributed.internal.ClusterConfigurationService.CLUSTER_CONFIG_DISK_DIR_PREFIX;
+import static org.apache.geode.distributed.internal.InternalClusterConfigurationService.CLUSTER_CONFIG_DISK_DIR_PREFIX;
 import static org.apache.geode.test.dunit.DistributedTestUtils.getAllDistributedSystemProperties;
 import static org.apache.geode.test.dunit.DistributedTestUtils.unregisterInstantiatorsInThisVM;
 import static org.apache.geode.test.dunit.Invoke.invokeInEveryVM;
@@ -27,7 +27,6 @@ import static org.apache.geode.test.dunit.LogWriterUtils.getLogWriter;
 import static org.junit.Assert.assertNotNull;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
@@ -42,7 +41,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 
-import org.apache.geode.admin.internal.AdminDistributedSystemImpl;
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.query.QueryTestUtils;

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/configuration/LuceneClusterConfigurationDUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/configuration/LuceneClusterConfigurationDUnitTest.java
@@ -40,7 +40,7 @@ import org.apache.geode.cache.lucene.LuceneServiceProvider;
 import org.apache.geode.cache.lucene.internal.cli.LuceneCliStrings;
 import org.apache.geode.cache.lucene.internal.repository.serializer.PrimitiveSerializer;
 import org.apache.geode.cache.lucene.internal.xml.LuceneXmlConstants;
-import org.apache.geode.distributed.internal.ClusterConfigurationService;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.distributed.internal.InternalLocator;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.util.CommandStringBuilder;
@@ -262,8 +262,9 @@ public class LuceneClusterConfigurationDUnitTest {
   SerializableRunnableIF verifyClusterConfiguration(boolean verifyIndexesExist) {
     return () -> {
       InternalLocator internalLocator = ClusterStartupRule.getLocator();
-      ClusterConfigurationService sc = internalLocator.getSharedConfiguration();
-      Configuration config = sc.getConfiguration(ClusterConfigurationService.CLUSTER_CONFIG);
+      InternalClusterConfigurationService sc = internalLocator.getSharedConfiguration();
+      Configuration config =
+          sc.getConfiguration(InternalClusterConfigurationService.CLUSTER_CONFIG);
       String xmlContent = config.getCacheXmlContent();
       String luceneIndex0Config = "<" + LuceneXmlConstants.PREFIX + ":" + LuceneXmlConstants.INDEX
           + " xmlns:lucene=\"" + LuceneXmlConstants.NAMESPACE + "\" " + LuceneXmlConstants.NAME

--- a/geode-web/src/test/java/org/apache/geode/management/internal/cli/commands/AlterRuntimeCommandDUnitTest.java
+++ b/geode-web/src/test/java/org/apache/geode/management/internal/cli/commands/AlterRuntimeCommandDUnitTest.java
@@ -29,8 +29,8 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 
-import org.apache.geode.distributed.internal.ClusterConfigurationService;
 import org.apache.geode.distributed.internal.DistributionConfig;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.logging.LogWriterImpl;
 import org.apache.geode.management.cli.Result;
@@ -1194,7 +1194,7 @@ public class AlterRuntimeCommandDUnitTest {
     gfsh.executeAndAssertThat(command).statusIsSuccess();
 
     locator.invoke(() -> {
-      ClusterConfigurationService sharedConfig =
+      InternalClusterConfigurationService sharedConfig =
           ClusterStartupRule.getLocator().getSharedConfiguration();
       Properties properties = sharedConfig.getConfiguration("Group1").getGemfireProperties();
       assertThat(properties.get(LOG_LEVEL)).isEqualTo("fine");


### PR DESCRIPTION
* rename the current ClusterConfigurationService to InternalClusterConfigurationService
* make a public interface and have the internal implementation implements it.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
