### PR TITLE
GEODE-4822 The second server instance startup error: Could not create…

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/DSFIDFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/DSFIDFactory.java
@@ -413,6 +413,7 @@ import org.apache.geode.management.internal.configuration.messages.Configuration
 import org.apache.geode.pdx.internal.CheckTypeRegistryState;
 import org.apache.geode.pdx.internal.EnumId;
 import org.apache.geode.pdx.internal.EnumInfo;
+import org.apache.geode.pdx.internal.PdxInstanceImpl;
 
 /**
  * Factory for instances of DataSerializableFixedID instances. Note that this class implements
@@ -944,68 +945,73 @@ public class DSFIDFactory implements DataSerializableFixedID {
    * data input.
    */
   public static Object create(int dsfid, DataInput in) throws IOException, ClassNotFoundException {
-    switch (dsfid) {
-      case REGION:
-        return (DataSerializableFixedID) DataSerializer.readRegion(in);
-      case END_OF_STREAM_TOKEN:
-        return Token.END_OF_STREAM;
-      case DLOCK_REMOTE_TOKEN:
-        return DLockRemoteToken.createFromDataInput(in);
-      case TRANSACTION_ID:
-        return TXId.createFromData(in);
-      case INTEREST_RESULT_POLICY:
-        return readInterestResultPolicy(in);
-      case UNDEFINED:
-        return readUndefined(in);
-      case RESULTS_BAG:
-        return readResultsBag(in);
-      case TOKEN_INVALID:
-        return Token.INVALID;
-      case TOKEN_LOCAL_INVALID:
-        return Token.LOCAL_INVALID;
-      case TOKEN_DESTROYED:
-        return Token.DESTROYED;
-      case TOKEN_REMOVED:
-        return Token.REMOVED_PHASE1;
-      case TOKEN_REMOVED2:
-        return Token.REMOVED_PHASE2;
-      case TOKEN_TOMBSTONE:
-        return Token.TOMBSTONE;
-      case NULL_TOKEN:
-        return readNullToken(in);
-      case CONFIGURATION_RESPONSE:
-        return readConfigurationResponse(in);
-      case PR_DESTROY_ON_DATA_STORE_MESSAGE:
-        return readDestroyOnDataStore(in);
-      default:
-        final Constructor<?> cons;
-        if (dsfid >= Byte.MIN_VALUE && dsfid <= Byte.MAX_VALUE) {
-          cons = dsfidMap[dsfid + Byte.MAX_VALUE + 1];
-        } else {
-          cons = (Constructor<?>) dsfidMap2.get(dsfid);
-        }
-        if (cons != null) {
-          try {
-            Object ds = cons.newInstance((Object[]) null);
-            InternalDataSerializer.invokeFromData(ds, in);
-            return ds;
-          } catch (InstantiationException ie) {
-            throw new IOException(ie.getMessage(), ie);
-          } catch (IllegalAccessException iae) {
-            throw new IOException(iae.getMessage(), iae);
-          } catch (InvocationTargetException ite) {
-            Throwable targetEx = ite.getTargetException();
-            if (targetEx instanceof IOException) {
-              throw (IOException) targetEx;
-            } else if (targetEx instanceof ClassNotFoundException) {
-              throw (ClassNotFoundException) targetEx;
-            } else {
-              throw new IOException(ite.getMessage(), targetEx);
+    boolean readSerializedOverride = PdxInstanceImpl.getPdxReadSerialized();
+    PdxInstanceImpl.setPdxReadSerialized(false);
+    try {
+      switch (dsfid) {
+        case REGION:
+          return (DataSerializableFixedID) DataSerializer.readRegion(in);
+        case END_OF_STREAM_TOKEN:
+          return Token.END_OF_STREAM;
+        case DLOCK_REMOTE_TOKEN:
+          return DLockRemoteToken.createFromDataInput(in);
+        case TRANSACTION_ID:
+          return TXId.createFromData(in);
+        case INTEREST_RESULT_POLICY:
+          return readInterestResultPolicy(in);
+        case UNDEFINED:
+          return readUndefined(in);
+        case RESULTS_BAG:
+          return readResultsBag(in);
+        case TOKEN_INVALID:
+          return Token.INVALID;
+        case TOKEN_LOCAL_INVALID:
+          return Token.LOCAL_INVALID;
+        case TOKEN_DESTROYED:
+          return Token.DESTROYED;
+        case TOKEN_REMOVED:
+          return Token.REMOVED_PHASE1;
+        case TOKEN_REMOVED2:
+          return Token.REMOVED_PHASE2;
+        case TOKEN_TOMBSTONE:
+          return Token.TOMBSTONE;
+        case NULL_TOKEN:
+          return readNullToken(in);
+        case CONFIGURATION_RESPONSE:
+          return readConfigurationResponse(in);
+        case PR_DESTROY_ON_DATA_STORE_MESSAGE:
+          return readDestroyOnDataStore(in);
+        default:
+          final Constructor<?> cons;
+          if (dsfid >= Byte.MIN_VALUE && dsfid <= Byte.MAX_VALUE) {
+            cons = dsfidMap[dsfid + Byte.MAX_VALUE + 1];
+          } else {
+            cons = (Constructor<?>) dsfidMap2.get(dsfid);
+          }
+          if (cons != null) {
+            try {
+              Object ds = cons.newInstance((Object[]) null);
+              InternalDataSerializer.invokeFromData(ds, in);
+              return ds;
+            } catch (InstantiationException ie) {
+              throw new IOException(ie.getMessage(), ie);
+            } catch (IllegalAccessException iae) {
+              throw new IOException(iae.getMessage(), iae);
+            } catch (InvocationTargetException ite) {
+              Throwable targetEx = ite.getTargetException();
+              if (targetEx instanceof IOException) {
+                throw (IOException) targetEx;
+              } else if (targetEx instanceof ClassNotFoundException) {
+                throw (ClassNotFoundException) targetEx;
+              } else {
+                throw new IOException(ite.getMessage(), targetEx);
+              }
             }
           }
-        }
-        throw new DSFIDNotFoundException("Unknown DataSerializableFixedID: " + dsfid, dsfid);
-
+          throw new DSFIDNotFoundException("Unknown DataSerializableFixedID: " + dsfid, dsfid);
+      }
+    } finally {
+      PdxInstanceImpl.setPdxReadSerialized(readSerializedOverride);
     }
   }
 

--- a/geode-core/src/test/java/org/apache/geode/pdx/PdxSerializerRegressionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/pdx/PdxSerializerRegressionTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.pdx;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.test.dunit.DistributedTestUtils;
+import org.apache.geode.test.dunit.rules.ClusterStartupRule;
+import org.apache.geode.test.dunit.rules.MemberVM;
+import org.apache.geode.test.junit.categories.DistributedTest;
+import org.apache.geode.test.junit.categories.SerializationTest;
+
+@Category({DistributedTest.class, SerializationTest.class})
+public class PdxSerializerRegressionTest {
+  @Rule
+  public transient ClusterStartupRule startupRule = new ClusterStartupRule();
+
+
+  /**
+   * A PdxSerializer may PDX-serialize any object it chooses, even JDK classes used in
+   * Geode messaging. This caused initial image transfer for the _PR partition region
+   * metadata to fail when pdx-read-serialized was set to true due to a class-cast
+   * exception when a PdxInstance was returned by DataSerializer.readObject() instead
+   * of the expected collection of PartitionConfig objects.
+   */
+  @Test
+  public void serializerHandlingSetDoesNotBreakInitialImageTransferForPRRegistry() {
+    MemberVM server1 = startupRule.startServerVM(1,
+        x -> x.withConnectionToLocator(DistributedTestUtils.getLocatorPort())
+            .withPDXReadSerialized().withPdxSerializer(new TestSerializer()));
+    createRegion(server1, RegionShortcut.PARTITION);
+    MemberVM server2 = startupRule.startServerVM(2,
+        x -> x.withConnectionToLocator(DistributedTestUtils.getLocatorPort())
+            .withPDXReadSerialized().withPdxSerializer(new TestSerializer()));
+    createRegion(server2, RegionShortcut.PARTITION);
+    assertThat((boolean) server1.invoke(() -> {
+      return TestSerializer.serializerInvoked;
+    })).isTrue();
+    assertThat((boolean) server2.invoke(() -> {
+      return TestSerializer.serializerInvoked;
+    })).isTrue();
+  }
+
+  private void createRegion(MemberVM vm, RegionShortcut regionShortcut) {
+    vm.invoke("create region", () -> {
+      ClusterStartupRule.getCache().createRegionFactory(regionShortcut)
+          .addAsyncEventQueueId("queue1").create("region");
+    });
+  }
+
+  static class TestSerializer implements PdxSerializer, Serializable {
+    static boolean serializerInvoked;
+
+    @Override
+    public boolean toData(Object o, PdxWriter out) {
+      if (o.getClass().getName().equals("java.util.Collections$UnmodifiableSet")) {
+        serializerInvoked = true;
+        System.out.println("TestSerializer is serializing a Set");
+        Set set = (Set<Object>) o;
+        out.writeInt("size", set.size());
+        int elementIndex = 0;
+        for (Object element : set) {
+          out.writeObject("element" + (elementIndex++), element);
+        }
+        return true;
+      }
+      return false;
+    }
+
+    @Override
+    public Object fromData(Class<?> clazz, PdxReader in) {
+      if (clazz.getName().equals("java.util.Collections$UnmodifiableSet")) {
+        System.out.println("TestSerializer is deserializing a Set");
+        int size = in.readInt("size");
+        Set result = new HashSet(size);
+        for (int elementIndex = 0; elementIndex < size; elementIndex++) {
+          result.add(in.readObject("element" + elementIndex));
+        }
+        return Collections.unmodifiableSet(result);
+      }
+      return null;
+    }
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/test/junit/rules/VMProvider.java
+++ b/geode-core/src/test/java/org/apache/geode/test/junit/rules/VMProvider.java
@@ -41,6 +41,10 @@ public abstract class VMProvider {
     getVM().invoke(runnable);
   }
 
+  public void invoke(final String runnableName, final SerializableRunnableIF runnable) {
+    getVM().invoke(runnableName, runnable);
+  }
+
   public <T> T invoke(final SerializableCallableIF<T> callable) {
     return getVM().invoke(callable);
   }


### PR DESCRIPTION
… an instance of PartitionRegionConfig

Modified deserialization of DataSerializableFixedID objects to ignore the
pdx-read-serialized setting.



Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
