### PR TITLE
GEODE-4885: launch DUnit from before instead of constructor

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/management/JMXMBeanDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/JMXMBeanDUnitTest.java
@@ -48,9 +48,9 @@ import javax.rmi.ssl.SslRMIClientSocketFactory;
 import com.google.common.collect.Maps;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.RuleChain;
 
@@ -58,6 +58,7 @@ import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.internal.security.SecurableCommunicationChannel;
 import org.apache.geode.test.dunit.rules.CleanupDUnitVMsRule;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
+import org.apache.geode.test.dunit.rules.DistributedTestRule;
 import org.apache.geode.test.junit.categories.DistributedTest;
 import org.apache.geode.test.junit.rules.MBeanServerConnectionRule;
 import org.apache.geode.util.test.TestUtil;
@@ -68,22 +69,29 @@ import org.apache.geode.util.test.TestUtil;
  * ssl settings cleanly.
  */
 @Category(DistributedTest.class)
-@SuppressWarnings({"serial", "unused"})
+@SuppressWarnings("serial")
 public class JMXMBeanDUnitTest implements Serializable {
 
-  private ClusterStartupRule lsRule = new ClusterStartupRule();
-  private transient MBeanServerConnectionRule jmxConnector = new MBeanServerConnectionRule();
-  private transient RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
-  private transient CleanupDUnitVMsRule cleanupDUnitVMsRule = new CleanupDUnitVMsRule();
-
-  @Rule
-  public transient RuleChain ruleChain = RuleChain.outerRule(cleanupDUnitVMsRule)
-      .around(restoreSystemProperties).around(lsRule).around(jmxConnector);
+  private static Properties legacySSLProperties;
+  private static Properties sslProperties;
+  private static Properties sslPropertiesWithMultiKey;
+  private static String singleKeystore;
+  private static String multiKeystore;
+  private static String multiKeyTruststore;
 
   private int jmxPort;
-  private Properties locatorProperties = null;
-  private static Properties legacySSLProperties, sslProperties, sslPropertiesWithMultiKey;
-  private static String singleKeystore, multiKeystore, multiKeyTruststore;
+  private Properties locatorProperties;
+
+  @ClassRule
+  public static DistributedTestRule distributedTestRule = new DistributedTestRule();
+
+  private transient CleanupDUnitVMsRule cleanupDUnitVMsRule = new CleanupDUnitVMsRule();
+  private ClusterStartupRule lsRule = new ClusterStartupRule();
+  private transient MBeanServerConnectionRule jmxConnector = new MBeanServerConnectionRule();
+
+  @Rule
+  public transient RuleChain ruleChain =
+      RuleChain.outerRule(cleanupDUnitVMsRule).around(lsRule).around(jmxConnector);
 
   @BeforeClass
   public static void beforeClass() {
@@ -153,7 +161,6 @@ public class JMXMBeanDUnitTest implements Serializable {
     lsRule.startLocatorVM(0, locatorProperties);
     remotelyValidateJmxConnection(false);
   }
-
 
   @Test
   public void testJMXOverSSLWithMultiKey() throws Exception {

--- a/geode-core/src/test/java/org/apache/geode/test/dunit/rules/ClusterStartupRule.java
+++ b/geode-core/src/test/java/org/apache/geode/test/dunit/rules/ClusterStartupRule.java
@@ -95,7 +95,6 @@ public class ClusterStartupRule extends ExternalResource implements Serializable
 
   public ClusterStartupRule(final int vmCount) {
     this.vmCount = vmCount;
-    DUnitLauncher.launchIfNeeded();
   }
 
   public static ClientCache getClientCache() {
@@ -112,6 +111,7 @@ public class ClusterStartupRule extends ExternalResource implements Serializable
 
   @Override
   protected void before() throws Throwable {
+    DUnitLauncher.launchIfNeeded();
     for (int i = 0; i < vmCount; i++) {
       Host.getHost(0).getVM(i);
     }

--- a/geode-cq/src/test/java/org/apache/geode/security/ClientCQAuthDUnitTest.java
+++ b/geode-cq/src/test/java/org/apache/geode/security/ClientCQAuthDUnitTest.java
@@ -12,7 +12,6 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package org.apache.geode.security;
 
 import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_MANAGER;
@@ -20,6 +19,7 @@ import static org.apache.geode.security.SecurityTestUtil.assertNotAuthorized;
 import static org.apache.geode.security.SecurityTestUtil.createClientCache;
 import static org.apache.geode.security.SecurityTestUtil.createProxyRegion;
 
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -42,17 +42,26 @@ import org.apache.geode.test.junit.rules.ServerStarterRule;
 @Category({DistributedTest.class, SecurityTest.class})
 public class ClientCQAuthDUnitTest {
 
+  private static final String REGION_NAME = "AuthRegion";
+
+  private VM client1;
+  private VM client2;
+  private VM client3;
+
   @Rule
   public ClusterStartupRule startupRule = new ClusterStartupRule();
-  private static String REGION_NAME = "AuthRegion";
-  private final VM client1 = startupRule.getVM(1);
-  private final VM client2 = startupRule.getVM(2);
-  private final VM client3 = startupRule.getVM(3);
 
   @Rule
   public ServerStarterRule server = new ServerStarterRule()
       .withProperty(SECURITY_MANAGER, SimpleTestSecurityManager.class.getName())
       .withRegion(RegionShortcut.REPLICATE, REGION_NAME);
+
+  @Before
+  public void setUp() {
+    client1 = startupRule.getVM(1);
+    client2 = startupRule.getVM(2);
+    client3 = startupRule.getVM(3);
+  }
 
   @Test
   public void verifyCQPermissions() {


### PR DESCRIPTION
Move dunit launch from constructor to before in ClusterStartupRule.

Precheckin is still running but I did confirm that these tests pass by running them individually:
* org.apache.geode.management.internal.cli.commands.ShowLogCommandDUnitTest
* org.apache.geode.internal.cache.rollingupgrade.RollingUpgradeDUnitTest
* org.apache.geode.security.ClientAuthenticationPart2DUnitTest
* org.apache.geode.cache.lucene.LuceneCommandsSecurityDUnitTest
* org.apache.geode.management.internal.configuration.ClusterConfigurationIndexWithFromClauseDUnitTest
* org.apache.geode.internal.cache.tier.sockets.ClientServerMiscBCDUnitTest
* org.apache.geode.cache.lucene.LuceneSearchWithRollingUpgradeDUnit
* org.apache.geode.cache.wan.WANRollingUpgradeDUnitTest
* org.apache.geode.internal.cache.rollingupgrade.RollingUpgrade2DUnitTest
* org.apache.geode.security.ClientAuthenticationDUnitTest
* org.apache.geode.security.ClientAuthorizationCQDUnitTest
* org.apache.geode.internal.cache.TxCommitMessageBackwardCompatibilityDUnitTest