### PR TITLE
GEODE-4827: null check for the cache.

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/FilterProfile.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/FilterProfile.java
@@ -831,6 +831,11 @@ public class FilterProfile implements DataSerializableFixedID {
    */
   void processRegisterCq(String serverCqName, ServerCQ ServerCQ, boolean addToCqMap,
       GemFireCacheImpl cache) {
+    if (cache == null) {
+      logger.info("Error while initializing the CQs with FilterProfile for CQ " + serverCqName
+          + ", Error : Cache has been closed.");
+      return;
+    }
     ServerCQ cq = (ServerCQ) ServerCQ;
     try {
       CqService cqService = cache.getCqService();


### PR DESCRIPTION
	* While the servers are shutting down, getInstance may result in a null cache.
	* This may result in NPE.
	* NULL checks are added.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
