### PR TITLE
GEODE-4859: Create a public version of GfshCommand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ out/
 *.orig
 geode-pulse/screenshots/
 /jpf.properties
+
+.git-together

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/AlterConnectionCommand.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/AlterConnectionCommand.java
@@ -25,9 +25,10 @@ import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.connectors.jdbc.internal.ConnectionConfigBuilder;
 import org.apache.geode.connectors.jdbc.internal.ConnectionConfiguration;
 import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.commands.GfshCommand;
+import org.apache.geode.management.internal.cli.commands.InternalGfshCommand;
 import org.apache.geode.management.internal.cli.functions.CliFunctionResult;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
@@ -37,7 +38,7 @@ import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
 @Experimental
-public class AlterConnectionCommand extends GfshCommand {
+public class AlterConnectionCommand extends InternalGfshCommand {
   static final String ALTER_JDBC_CONNECTION = "alter jdbc-connection";
   static final String ALTER_JDBC_CONNECTION__HELP =
       EXPERIMENTAL + "Alter properties for an existing jdbc connection.";
@@ -136,7 +137,8 @@ public class AlterConnectionCommand extends GfshCommand {
   private void updateClusterConfiguration(final Result result, final XmlEntity xmlEntity) {
     if (xmlEntity != null) {
       persistClusterConfiguration(result,
-          () -> getConfigurationService().addXmlEntity(xmlEntity, null));
+          () -> ((InternalClusterConfigurationService) getConfigurationService())
+              .addXmlEntity(xmlEntity, null));
     }
   }
 }

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/AlterMappingCommand.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/AlterMappingCommand.java
@@ -25,9 +25,10 @@ import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.connectors.jdbc.internal.RegionMapping;
 import org.apache.geode.connectors.jdbc.internal.RegionMappingBuilder;
 import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.commands.GfshCommand;
+import org.apache.geode.management.internal.cli.commands.InternalGfshCommand;
 import org.apache.geode.management.internal.cli.functions.CliFunctionResult;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
@@ -37,7 +38,7 @@ import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
 @Experimental
-public class AlterMappingCommand extends GfshCommand {
+public class AlterMappingCommand extends InternalGfshCommand {
   static final String ALTER_MAPPING = "alter jdbc-mapping";
   static final String ALTER_MAPPING__HELP =
       EXPERIMENTAL + "Alter properties for an existing jdbc mapping.";
@@ -145,7 +146,8 @@ public class AlterMappingCommand extends GfshCommand {
   private void updateClusterConfiguration(final Result result, final XmlEntity xmlEntity) {
     if (xmlEntity != null) {
       persistClusterConfiguration(result,
-          () -> getConfigurationService().addXmlEntity(xmlEntity, null));
+          () -> ((InternalClusterConfigurationService) getConfigurationService())
+              .addXmlEntity(xmlEntity, null));
     }
   }
 }

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/CreateConnectionCommand.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/CreateConnectionCommand.java
@@ -27,12 +27,13 @@ import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.connectors.jdbc.internal.ConnectionConfigBuilder;
 import org.apache.geode.connectors.jdbc.internal.ConnectionConfiguration;
 import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.Result;
 import org.apache.geode.management.internal.cli.AbstractCliAroundInterceptor;
 import org.apache.geode.management.internal.cli.GfshParseResult;
-import org.apache.geode.management.internal.cli.commands.GfshCommand;
+import org.apache.geode.management.internal.cli.commands.InternalGfshCommand;
 import org.apache.geode.management.internal.cli.functions.CliFunctionResult;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
@@ -42,7 +43,7 @@ import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
 @Experimental
-public class CreateConnectionCommand extends GfshCommand {
+public class CreateConnectionCommand extends InternalGfshCommand {
   private static final Logger logger = LogService.getLogger();
 
   static final String CREATE_CONNECTION = "create jdbc-connection";
@@ -143,7 +144,8 @@ public class CreateConnectionCommand extends GfshCommand {
   private void updateClusterConfiguration(final Result result, final XmlEntity xmlEntity) {
     if (xmlEntity != null) {
       persistClusterConfiguration(result,
-          () -> getConfigurationService().addXmlEntity(xmlEntity, null));
+          () -> ((InternalClusterConfigurationService) getConfigurationService())
+              .addXmlEntity(xmlEntity, null));
     }
   }
 

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/CreateMappingCommand.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/CreateMappingCommand.java
@@ -25,9 +25,10 @@ import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.connectors.jdbc.internal.RegionMapping;
 import org.apache.geode.connectors.jdbc.internal.RegionMappingBuilder;
 import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.commands.GfshCommand;
+import org.apache.geode.management.internal.cli.commands.InternalGfshCommand;
 import org.apache.geode.management.internal.cli.functions.CliFunctionResult;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
@@ -37,7 +38,7 @@ import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
 @Experimental
-public class CreateMappingCommand extends GfshCommand {
+public class CreateMappingCommand extends InternalGfshCommand {
   static final String CREATE_MAPPING = "create jdbc-mapping";
   static final String CREATE_MAPPING__HELP =
       EXPERIMENTAL + "Create a mapping for a region for use with a JDBC database connection.";
@@ -146,7 +147,8 @@ public class CreateMappingCommand extends GfshCommand {
   private void updateClusterConfiguration(final Result result, final XmlEntity xmlEntity) {
     if (xmlEntity != null) {
       persistClusterConfiguration(result,
-          () -> getConfigurationService().addXmlEntity(xmlEntity, null));
+          () -> ((InternalClusterConfigurationService) getConfigurationService())
+              .addXmlEntity(xmlEntity, null));
     }
   }
 }

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/DescribeConnectionCommand.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/DescribeConnectionCommand.java
@@ -32,7 +32,7 @@ import org.apache.geode.connectors.jdbc.internal.ConnectionConfiguration;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.commands.GfshCommand;
+import org.apache.geode.management.internal.cli.commands.InternalGfshCommand;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.CompositeResultData;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
@@ -41,7 +41,7 @@ import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
 @Experimental
-public class DescribeConnectionCommand extends GfshCommand {
+public class DescribeConnectionCommand extends InternalGfshCommand {
   static final String DESCRIBE_CONNECTION = "describe jdbc-connection";
   static final String DESCRIBE_CONNECTION__HELP =
       EXPERIMENTAL + "Describe the specified jdbc connection.";

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/DescribeMappingCommand.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/DescribeMappingCommand.java
@@ -32,7 +32,7 @@ import org.apache.geode.connectors.jdbc.internal.RegionMapping;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.commands.GfshCommand;
+import org.apache.geode.management.internal.cli.commands.InternalGfshCommand;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.CompositeResultData;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
@@ -41,7 +41,7 @@ import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
 @Experimental
-public class DescribeMappingCommand extends GfshCommand {
+public class DescribeMappingCommand extends InternalGfshCommand {
   static final String DESCRIBE_MAPPING = "describe jdbc-mapping";
   static final String DESCRIBE_MAPPING__HELP =
       EXPERIMENTAL + "Describe the specified jdbc mapping.";

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyConnectionCommand.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyConnectionCommand.java
@@ -23,9 +23,10 @@ import org.springframework.shell.core.annotation.CliOption;
 import org.apache.geode.annotations.Experimental;
 import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.commands.GfshCommand;
+import org.apache.geode.management.internal.cli.commands.InternalGfshCommand;
 import org.apache.geode.management.internal.cli.functions.CliFunctionResult;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
@@ -35,7 +36,7 @@ import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
 @Experimental
-public class DestroyConnectionCommand extends GfshCommand {
+public class DestroyConnectionCommand extends InternalGfshCommand {
   static final String DESTROY_CONNECTION = "destroy jdbc-connection";
   static final String DESTROY_CONNECTION__HELP =
       EXPERIMENTAL + "Destroy/Remove the specified jdbc connection.";
@@ -107,7 +108,8 @@ public class DestroyConnectionCommand extends GfshCommand {
   private void updateClusterConfiguration(final Result result, final XmlEntity xmlEntity) {
     if (xmlEntity != null) {
       persistClusterConfiguration(result,
-          () -> getConfigurationService().addXmlEntity(xmlEntity, null));
+          () -> ((InternalClusterConfigurationService) getConfigurationService())
+              .addXmlEntity(xmlEntity, null));
     }
   }
 }

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyMappingCommand.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyMappingCommand.java
@@ -23,9 +23,10 @@ import org.springframework.shell.core.annotation.CliOption;
 import org.apache.geode.annotations.Experimental;
 import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.commands.GfshCommand;
+import org.apache.geode.management.internal.cli.commands.InternalGfshCommand;
 import org.apache.geode.management.internal.cli.functions.CliFunctionResult;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
@@ -35,7 +36,7 @@ import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
 @Experimental
-public class DestroyMappingCommand extends GfshCommand {
+public class DestroyMappingCommand extends InternalGfshCommand {
   static final String DESTROY_MAPPING = "destroy jdbc-mapping";
   static final String DESTROY_MAPPING__HELP = EXPERIMENTAL + "Destroy the specified mapping.";
   static final String DESTROY_MAPPING__REGION_NAME = "region";
@@ -104,7 +105,8 @@ public class DestroyMappingCommand extends GfshCommand {
   private void updateClusterConfiguration(final Result result, final XmlEntity xmlEntity) {
     if (xmlEntity != null) {
       persistClusterConfiguration(result,
-          () -> getConfigurationService().addXmlEntity(xmlEntity, null));
+          () -> ((InternalClusterConfigurationService) getConfigurationService())
+              .addXmlEntity(xmlEntity, null));
     }
   }
 }

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/ListConnectionCommand.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/ListConnectionCommand.java
@@ -27,7 +27,7 @@ import org.apache.geode.connectors.jdbc.internal.ConnectionConfiguration;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.commands.GfshCommand;
+import org.apache.geode.management.internal.cli.commands.InternalGfshCommand;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.cli.result.TabularResultData;
@@ -35,7 +35,7 @@ import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
 @Experimental
-public class ListConnectionCommand extends GfshCommand {
+public class ListConnectionCommand extends InternalGfshCommand {
   static final String LIST_JDBC_CONNECTION = "list jdbc-connections";
   static final String LIST_JDBC_CONNECTION__HELP =
       EXPERIMENTAL + "Display jdbc connections for all members.";

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/ListMappingCommand.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/ListMappingCommand.java
@@ -27,7 +27,7 @@ import org.apache.geode.connectors.jdbc.internal.RegionMapping;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.commands.GfshCommand;
+import org.apache.geode.management.internal.cli.commands.InternalGfshCommand;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.cli.result.TabularResultData;
@@ -35,7 +35,7 @@ import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
 @Experimental
-public class ListMappingCommand extends GfshCommand {
+public class ListMappingCommand extends InternalGfshCommand {
   static final String LIST_MAPPING = "list jdbc-mappings";
   static final String LIST_MAPPING__HELP = EXPERIMENTAL + "Display jdbc mappings for all members.";
 

--- a/geode-core/src/main/java/org/apache/geode/management/cli/GfshCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/cli/GfshCommand.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.shiro.subject.Subject;
+import org.springframework.shell.core.CommandMarker;
 
 import org.apache.geode.annotations.Experimental;
 import org.apache.geode.cache.Cache;
@@ -37,7 +38,7 @@ import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.security.ResourcePermission;
 
 @Experimental
-public abstract class GfshCommand {
+public abstract class GfshCommand implements CommandMarker {
   private InternalCache cache;
 
   public void authorize(ResourcePermission.Resource resource,

--- a/geode-core/src/main/java/org/apache/geode/management/cli/GfshCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/cli/GfshCommand.java
@@ -12,16 +12,15 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.geode.management.internal.cli.commands;
+package org.apache.geode.management.cli;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 
 import org.apache.shiro.subject.Subject;
-import org.springframework.shell.core.CommandMarker;
 
+import org.apache.geode.annotations.Experimental;
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.execute.Execution;
 import org.apache.geode.cache.execute.Function;
@@ -29,74 +28,17 @@ import org.apache.geode.cache.execute.FunctionService;
 import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.distributed.ClusterConfigurationService;
 import org.apache.geode.distributed.DistributedMember;
-import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.distributed.internal.InternalLocator;
 import org.apache.geode.internal.cache.InternalCache;
-import org.apache.geode.management.ManagementService;
-import org.apache.geode.management.cli.Result;
 import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.exceptions.EntityNotFoundException;
 import org.apache.geode.management.internal.cli.functions.CliFunctionResult;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
-import org.apache.geode.management.internal.cli.shell.Gfsh;
-import org.apache.geode.management.internal.configuration.domain.XmlEntity;
 import org.apache.geode.security.ResourcePermission;
 
-/**
- * Encapsulates common functionality for implementing command classes for the Geode shell (gfsh).
- * this provides wrapper around the static methods in CliUtils for easy mock of the commands
- *
- * this class should not have much implementation of its own other then those tested in
- * GfshCommandJUnitTest
- */
-@SuppressWarnings("unused")
-public abstract class GfshCommand implements CommandMarker {
+@Experimental
+public abstract class GfshCommand {
   private InternalCache cache;
-
-  public void setCache(Cache cache) {
-    this.cache = (InternalCache) cache;
-  }
-
-  public Cache getCache() {
-    return cache;
-  }
-
-  public static final String EXPERIMENTAL = "(Experimental) ";
-
-  public boolean isConnectedAndReady() {
-    return getGfsh() != null && getGfsh().isConnectedAndReady();
-  }
-
-  public InternalClusterConfigurationService getConfigurationService() {
-    InternalLocator locator = InternalLocator.getLocator();
-    return locator == null ? null : locator.getSharedConfiguration();
-  }
-
-  public void persistClusterConfiguration(Result result, Runnable runnable) {
-    if (result == null) {
-      throw new IllegalArgumentException("Result should not be null");
-    }
-    InternalClusterConfigurationService sc = getConfigurationService();
-    if (sc == null) {
-      result.setCommandPersisted(false);
-    } else {
-      runnable.run();
-      result.setCommandPersisted(true);
-    }
-  }
-
-  public XmlEntity findXmlEntity(List<CliFunctionResult> functionResults) {
-    return functionResults.stream().filter(CliFunctionResult::isSuccessful)
-        .map(CliFunctionResult::getXmlEntity).filter(Objects::nonNull).findFirst().orElse(null);
-  }
-
-  public boolean isDebugging() {
-    return getGfsh() != null && getGfsh().getDebug();
-  }
-
-  public boolean isLogging() {
-    return getGfsh() != null;
-  }
 
   public void authorize(ResourcePermission.Resource resource,
       ResourcePermission.Operation operation, ResourcePermission.Target target) {
@@ -113,12 +55,21 @@ public abstract class GfshCommand implements CommandMarker {
     cache.getSecurityService().authorize(resource, operation, target, key);
   }
 
-  public Subject getSubject() {
-    return cache.getSecurityService().getSubject();
+  public Cache getCache() {
+    return cache;
   }
 
-  public Gfsh getGfsh() {
-    return Gfsh.getCurrentInstance();
+  public ClusterConfigurationService getConfigurationService() {
+    InternalLocator locator = InternalLocator.getLocator();
+    return locator == null ? null : locator.getSharedConfiguration();
+  }
+
+  public void setCache(Cache cache) {
+    this.cache = (InternalCache) cache;
+  }
+
+  public Subject getSubject() {
+    return cache.getSecurityService().getSubject();
   }
 
   /**
@@ -193,10 +144,6 @@ public abstract class GfshCommand implements CommandMarker {
       throw new EntityNotFoundException(CliStrings.NO_MEMBERS_FOUND_MESSAGE);
     }
     return matchingMembers;
-  }
-
-  public ManagementService getManagementService() {
-    return ManagementService.getExistingManagementService(getCache());
   }
 
   public Set<DistributedMember> findMembersForRegion(String regionPath) {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/CommandManager.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/CommandManager.java
@@ -37,7 +37,8 @@ import org.apache.geode.distributed.ConfigurationProperties;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.internal.ClassPathLoader;
 import org.apache.geode.internal.cache.InternalCache;
-import org.apache.geode.management.internal.cli.commands.GfshCommand;
+import org.apache.geode.management.cli.GfshCommand;
+import org.apache.geode.management.internal.cli.commands.InternalGfshCommand;
 import org.apache.geode.management.internal.cli.help.Helper;
 import org.apache.geode.management.internal.cli.shell.Gfsh;
 import org.apache.geode.management.internal.cli.util.ClasspathScanLoadHelper;
@@ -220,7 +221,7 @@ public class CommandManager {
     try {
       // geode's commands
       foundClasses = ClasspathScanLoadHelper.scanPackageForClassesImplementing(
-          GfshCommand.class.getPackage().getName(), CommandMarker.class);
+          InternalGfshCommand.class.getPackage().getName(), CommandMarker.class);
 
       for (Class<?> klass : foundClasses) {
         try {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/AlterAsyncEventQueueCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/AlterAsyncEventQueueCommand.java
@@ -51,7 +51,7 @@ import org.apache.geode.security.ResourcePermission;
  * this command currently only updates the cluster configuration. Requires server restart to pick up
  * the changes.
  */
-public class AlterAsyncEventQueueCommand extends GfshCommand {
+public class AlterAsyncEventQueueCommand extends InternalGfshCommand {
 
   static final String COMMAND_NAME = "alter async-event-queue";
   static final String ID = "id";
@@ -85,7 +85,8 @@ public class AlterAsyncEventQueueCommand extends GfshCommand {
 
     // need not check if any running servers has this async-event-queue. A server with this queue id
     // may be shutdown, but we still need to update Cluster Configuration.
-    InternalClusterConfigurationService service = getConfigurationService();
+    InternalClusterConfigurationService service =
+        (InternalClusterConfigurationService) getConfigurationService();
 
     if (service == null) {
       return ResultBuilder.createUserErrorResult("Cluster Configuration Service is not available. "

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/AlterOfflineDiskStoreCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/AlterOfflineDiskStoreCommand.java
@@ -29,7 +29,7 @@ import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ErrorResultData;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 
-public class AlterOfflineDiskStoreCommand extends GfshCommand {
+public class AlterOfflineDiskStoreCommand extends InternalGfshCommand {
   @CliCommand(value = CliStrings.ALTER_DISK_STORE, help = CliStrings.ALTER_DISK_STORE__HELP)
   @CliMetaData(shellOnly = true, relatedTopic = {CliStrings.TOPIC_GEODE_DISKSTORE})
   public Result alterOfflineDiskStore(

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/AlterRegionCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/AlterRegionCommand.java
@@ -26,6 +26,7 @@ import org.apache.geode.cache.CacheWriter;
 import org.apache.geode.cache.CustomExpiry;
 import org.apache.geode.cache.ExpirationAction;
 import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
@@ -40,7 +41,7 @@ import org.apache.geode.management.internal.configuration.domain.XmlEntity;
 import org.apache.geode.security.ResourcePermission.Operation;
 import org.apache.geode.security.ResourcePermission.Resource;
 
-public class AlterRegionCommand extends GfshCommand {
+public class AlterRegionCommand extends InternalGfshCommand {
   @CliCommand(value = CliStrings.ALTER_REGION, help = CliStrings.ALTER_REGION__HELP)
   @CliMetaData(relatedTopic = CliStrings.TOPIC_GEODE_REGION)
   public Result alterRegion(
@@ -137,7 +138,8 @@ public class AlterRegionCommand extends GfshCommand {
     XmlEntity xmlEntity = findXmlEntity(regionAlterResults);
     if (xmlEntity != null) {
       persistClusterConfiguration(result,
-          () -> getConfigurationService().addXmlEntity(xmlEntity, groups));
+          () -> ((InternalClusterConfigurationService) getConfigurationService())
+              .addXmlEntity(xmlEntity, groups));
     }
     return result;
   }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/AlterRuntimeConfigCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/AlterRuntimeConfigCommand.java
@@ -30,6 +30,7 @@ import org.springframework.shell.core.annotation.CliOption;
 
 import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.internal.cache.xmlcache.CacheXml;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.logging.log4j.LogLevel;
@@ -47,7 +48,7 @@ import org.apache.geode.management.internal.configuration.domain.XmlEntity;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class AlterRuntimeConfigCommand extends GfshCommand {
+public class AlterRuntimeConfigCommand extends InternalGfshCommand {
   private final AlterRuntimeConfigFunction alterRunTimeConfigFunction =
       new AlterRuntimeConfigFunction();
   private static Logger logger = LogService.getLogger();
@@ -216,7 +217,8 @@ public class AlterRuntimeConfigCommand extends GfshCommand {
       final XmlEntity xmlEntity = XmlEntity.builder().withType(CacheXml.CACHE)
           .withAttributes(rumTimeCacheAttributes).build();
       persistClusterConfiguration(result,
-          () -> getConfigurationService().modifyXmlAndProperties(properties, xmlEntity, group));
+          () -> ((InternalClusterConfigurationService) getConfigurationService())
+              .modifyXmlAndProperties(properties, xmlEntity, group));
       return result;
     } else {
       StringBuilder errorMessageBuilder = new StringBuilder();

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/BackupDiskStoreCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/BackupDiskStoreCommand.java
@@ -36,7 +36,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class BackupDiskStoreCommand extends GfshCommand {
+public class BackupDiskStoreCommand extends InternalGfshCommand {
   /**
    * Internally, we also verify the resource operation permissions CLUSTER:WRITE:DISK if the region
    * is persistent

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ChangeLogLevelCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ChangeLogLevelCommand.java
@@ -45,7 +45,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class ChangeLogLevelCommand extends GfshCommand {
+public class ChangeLogLevelCommand extends InternalGfshCommand {
   private static Logger logger = LogService.getLogger();
 
   @CliCommand(value = CliStrings.CHANGE_LOGLEVEL, help = CliStrings.CHANGE_LOGLEVEL__HELP)

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ClearDefinedIndexesCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ClearDefinedIndexesCommand.java
@@ -25,7 +25,7 @@ import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class ClearDefinedIndexesCommand extends GfshCommand {
+public class ClearDefinedIndexesCommand extends InternalGfshCommand {
   @CliCommand(value = CliStrings.CLEAR_DEFINED_INDEXES, help = CliStrings.CLEAR_DEFINED__HELP)
   @CliMetaData(relatedTopic = {CliStrings.TOPIC_GEODE_REGION, CliStrings.TOPIC_GEODE_DATA})
   @ResourceOperation(resource = ResourcePermission.Resource.CLUSTER,

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CloseDurableCQsCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CloseDurableCQsCommand.java
@@ -34,7 +34,7 @@ import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class CloseDurableCQsCommand extends GfshCommand {
+public class CloseDurableCQsCommand extends InternalGfshCommand {
   DurableClientCommandsResultBuilder builder = new DurableClientCommandsResultBuilder();
 
   @CliCommand(value = CliStrings.CLOSE_DURABLE_CQS, help = CliStrings.CLOSE_DURABLE_CQS__HELP)

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CloseDurableClientCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CloseDurableClientCommand.java
@@ -34,7 +34,7 @@ import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class CloseDurableClientCommand extends GfshCommand {
+public class CloseDurableClientCommand extends InternalGfshCommand {
   DurableClientCommandsResultBuilder builder = new DurableClientCommandsResultBuilder();
 
   @CliCommand(value = CliStrings.CLOSE_DURABLE_CLIENTS,

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CompactDiskStoreCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CompactDiskStoreCommand.java
@@ -45,7 +45,7 @@ import org.apache.geode.management.internal.messages.CompactRequest;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class CompactDiskStoreCommand extends GfshCommand {
+public class CompactDiskStoreCommand extends InternalGfshCommand {
   @CliCommand(value = CliStrings.COMPACT_DISK_STORE, help = CliStrings.COMPACT_DISK_STORE__HELP)
   @CliMetaData(relatedTopic = {CliStrings.TOPIC_GEODE_DISKSTORE})
   @ResourceOperation(resource = ResourcePermission.Resource.CLUSTER,

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CompactOfflineDiskStoreCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CompactOfflineDiskStoreCommand.java
@@ -38,7 +38,7 @@ import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.cli.shell.Gfsh;
 import org.apache.geode.management.internal.cli.util.DiskStoreCompacter;
 
-public class CompactOfflineDiskStoreCommand extends GfshCommand {
+public class CompactOfflineDiskStoreCommand extends InternalGfshCommand {
   @CliCommand(value = CliStrings.COMPACT_OFFLINE_DISK_STORE,
       help = CliStrings.COMPACT_OFFLINE_DISK_STORE__HELP)
   @CliMetaData(shellOnly = true, relatedTopic = {CliStrings.TOPIC_GEODE_DISKSTORE})

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ConfigurePDXCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ConfigurePDXCommand.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import org.springframework.shell.core.annotation.CliCommand;
 import org.springframework.shell.core.annotation.CliOption;
 
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.internal.cache.CacheConfig;
 import org.apache.geode.internal.cache.xmlcache.CacheCreation;
 import org.apache.geode.internal.cache.xmlcache.CacheXml;
@@ -38,7 +39,7 @@ import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.pdx.ReflectionBasedAutoSerializer;
 import org.apache.geode.security.ResourcePermission;
 
-public class ConfigurePDXCommand extends GfshCommand {
+public class ConfigurePDXCommand extends InternalGfshCommand {
 
   /**
    *
@@ -151,7 +152,8 @@ public class ConfigurePDXCommand extends GfshCommand {
     XmlEntity xmlEntity = createXmlEntity(cache);
     result = ResultBuilder.buildResult(ird);
     persistClusterConfiguration(result,
-        () -> getConfigurationService().addXmlEntity(xmlEntity, null));
+        () -> ((InternalClusterConfigurationService) getConfigurationService())
+            .addXmlEntity(xmlEntity, null));
     return result;
   }
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ConnectCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ConnectCommand.java
@@ -70,7 +70,7 @@ import org.apache.geode.management.internal.security.ResourceConstants;
 import org.apache.geode.management.internal.web.shell.HttpOperationInvoker;
 import org.apache.geode.security.AuthenticationFailedException;
 
-public class ConnectCommand extends GfshCommand {
+public class ConnectCommand extends InternalGfshCommand {
   // millis that connect --locator will wait for a response from the locator.
   static final int CONNECT_LOCATOR_TIMEOUT_MS = 60000; // see bug 45971
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CountDurableCQEventsCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CountDurableCQEventsCommand.java
@@ -34,7 +34,7 @@ import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class CountDurableCQEventsCommand extends GfshCommand {
+public class CountDurableCQEventsCommand extends InternalGfshCommand {
   DurableClientCommandsResultBuilder builder = new DurableClientCommandsResultBuilder();
 
   @CliCommand(value = CliStrings.COUNT_DURABLE_CQ_EVENTS,

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateAsyncEventQueueCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateAsyncEventQueueCommand.java
@@ -24,6 +24,7 @@ import org.springframework.shell.core.annotation.CliOption;
 
 import org.apache.geode.cache.asyncqueue.internal.AsyncEventQueueFactoryImpl;
 import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
 import org.apache.geode.management.internal.cli.functions.AsyncEventQueueFunctionArgs;
@@ -36,7 +37,7 @@ import org.apache.geode.management.internal.configuration.domain.XmlEntity;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class CreateAsyncEventQueueCommand extends GfshCommand {
+public class CreateAsyncEventQueueCommand extends InternalGfshCommand {
   @CliCommand(value = CliStrings.CREATE_ASYNC_EVENT_QUEUE,
       help = CliStrings.CREATE_ASYNC_EVENT_QUEUE__HELP)
   @ResourceOperation(resource = ResourcePermission.Resource.CLUSTER,
@@ -124,7 +125,8 @@ public class CreateAsyncEventQueueCommand extends GfshCommand {
     XmlEntity xmlEntity = findXmlEntity(results);
     if (xmlEntity != null) {
       persistClusterConfiguration(commandResult,
-          () -> getConfigurationService().addXmlEntity(xmlEntity, groups));
+          () -> ((InternalClusterConfigurationService) getConfigurationService())
+              .addXmlEntity(xmlEntity, groups));
     }
     return commandResult;
   }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateDefinedIndexesCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateDefinedIndexesCommand.java
@@ -27,6 +27,7 @@ import org.springframework.shell.core.annotation.CliOption;
 
 import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
@@ -40,7 +41,7 @@ import org.apache.geode.management.internal.configuration.domain.XmlEntity;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class CreateDefinedIndexesCommand extends GfshCommand {
+public class CreateDefinedIndexesCommand extends InternalGfshCommand {
   private static final CreateDefinedIndexesFunction createDefinedIndexesFunction =
       new CreateDefinedIndexesFunction();
 
@@ -153,7 +154,8 @@ public class CreateDefinedIndexesCommand extends GfshCommand {
 
     for (XmlEntity xmlEntity : xmlEntities) {
       persistClusterConfiguration(result,
-          () -> getConfigurationService().addXmlEntity(xmlEntity, group));
+          () -> ((InternalClusterConfigurationService) getConfigurationService())
+              .addXmlEntity(xmlEntity, group));
     }
 
     return result;

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateDiskStoreCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateDiskStoreCommand.java
@@ -23,6 +23,7 @@ import org.springframework.shell.core.annotation.CliCommand;
 import org.springframework.shell.core.annotation.CliOption;
 
 import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.internal.cache.DiskStoreAttributes;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
@@ -36,7 +37,7 @@ import org.apache.geode.management.internal.configuration.domain.XmlEntity;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class CreateDiskStoreCommand extends GfshCommand {
+public class CreateDiskStoreCommand extends InternalGfshCommand {
   @CliCommand(value = CliStrings.CREATE_DISK_STORE, help = CliStrings.CREATE_DISK_STORE__HELP)
   @CliMetaData(relatedTopic = {CliStrings.TOPIC_GEODE_DISKSTORE})
   @ResourceOperation(resource = ResourcePermission.Resource.CLUSTER,
@@ -119,7 +120,8 @@ public class CreateDiskStoreCommand extends GfshCommand {
 
     if (xmlEntity != null) {
       persistClusterConfiguration(result,
-          () -> getConfigurationService().addXmlEntity(xmlEntity, groups));
+          () -> ((InternalClusterConfigurationService) getConfigurationService())
+              .addXmlEntity(xmlEntity, groups));
     }
 
     return result;

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateGatewayReceiverCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateGatewayReceiverCommand.java
@@ -23,6 +23,7 @@ import org.springframework.shell.core.annotation.CliOption;
 
 import org.apache.geode.cache.wan.GatewayReceiver;
 import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
@@ -38,7 +39,7 @@ import org.apache.geode.management.internal.configuration.domain.XmlEntity;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class CreateGatewayReceiverCommand extends GfshCommand {
+public class CreateGatewayReceiverCommand extends InternalGfshCommand {
 
   @CliCommand(value = CliStrings.CREATE_GATEWAYRECEIVER,
       help = CliStrings.CREATE_GATEWAYRECEIVER__HELP)
@@ -102,7 +103,8 @@ public class CreateGatewayReceiverCommand extends GfshCommand {
     }
 
     // update cluster config
-    getConfigurationService().addXmlEntity(xmlEntity, onGroups);
+    ((InternalClusterConfigurationService) getConfigurationService()).addXmlEntity(xmlEntity,
+        onGroups);
     return result;
   }
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateGatewaySenderCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateGatewaySenderCommand.java
@@ -23,6 +23,7 @@ import org.springframework.shell.core.annotation.CliOption;
 
 import org.apache.geode.cache.wan.GatewaySender.OrderPolicy;
 import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.Version;
 import org.apache.geode.management.cli.CliMetaData;
@@ -40,7 +41,7 @@ import org.apache.geode.management.internal.configuration.domain.XmlEntity;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class CreateGatewaySenderCommand extends GfshCommand {
+public class CreateGatewaySenderCommand extends InternalGfshCommand {
   @CliCommand(value = CliStrings.CREATE_GATEWAYSENDER, help = CliStrings.CREATE_GATEWAYSENDER__HELP)
   @CliMetaData(relatedTopic = CliStrings.TOPIC_GEODE_WAN,
       interceptor = "org.apache.geode.management.internal.cli.commands.CreateGatewaySenderCommand$Interceptor")
@@ -143,7 +144,8 @@ public class CreateGatewaySenderCommand extends GfshCommand {
     }
 
     // update cluster config
-    getConfigurationService().addXmlEntity(xmlEntity, onGroups);
+    ((InternalClusterConfigurationService) getConfigurationService()).addXmlEntity(xmlEntity,
+        onGroups);
     return result;
   }
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateIndexCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateIndexCommand.java
@@ -23,6 +23,7 @@ import org.springframework.shell.core.annotation.CliOption;
 
 import org.apache.geode.cache.query.IndexType;
 import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
@@ -35,7 +36,7 @@ import org.apache.geode.management.internal.configuration.domain.XmlEntity;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class CreateIndexCommand extends GfshCommand {
+public class CreateIndexCommand extends InternalGfshCommand {
   private static final CreateIndexFunction createIndexFunction = new CreateIndexFunction();
 
   @CliCommand(value = CliStrings.CREATE_INDEX, help = CliStrings.CREATE_INDEX__HELP)
@@ -80,7 +81,8 @@ public class CreateIndexCommand extends GfshCommand {
 
     if (xmlEntity != null) {
       persistClusterConfiguration(result,
-          () -> getConfigurationService().addXmlEntity(xmlEntity, group));
+          () -> ((InternalClusterConfigurationService) getConfigurationService())
+              .addXmlEntity(xmlEntity, group));
     }
     return result;
   }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateJndiBindingCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateJndiBindingCommand.java
@@ -40,7 +40,7 @@ import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class CreateJndiBindingCommand extends GfshCommand {
+public class CreateJndiBindingCommand extends InternalGfshCommand {
   private static final Logger logger = LogService.getLogger();
 
   static final String CREATE_JNDIBINDING = "create jndi-binding";
@@ -147,7 +147,8 @@ public class CreateJndiBindingCommand extends GfshCommand {
 
     Result result;
     boolean persisted = false;
-    InternalClusterConfigurationService service = getConfigurationService();
+    InternalClusterConfigurationService service =
+        (InternalClusterConfigurationService) getConfigurationService();
 
     if (service != null) {
       CacheConfig cacheConfig = service.getCacheConfig("cluster");

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateRegionCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateRegionCommand.java
@@ -41,6 +41,7 @@ import org.apache.geode.cache.RegionAttributes;
 import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.i18n.LocalizedStrings;
 import org.apache.geode.management.DistributedRegionMXBean;
@@ -69,7 +70,7 @@ import org.apache.geode.management.internal.configuration.domain.XmlEntity;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class CreateRegionCommand extends GfshCommand {
+public class CreateRegionCommand extends InternalGfshCommand {
   @CliCommand(value = CliStrings.CREATE_REGION, help = CliStrings.CREATE_REGION__HELP)
   @CliMetaData(relatedTopic = CliStrings.TOPIC_GEODE_REGION,
       interceptor = "org.apache.geode.management.internal.cli.commands.CreateRegionCommand$Interceptor")
@@ -441,7 +442,8 @@ public class CreateRegionCommand extends GfshCommand {
     if (xmlEntity != null) {
       verifyDistributedRegionMbean(cache, regionPath);
       persistClusterConfiguration(result,
-          () -> getConfigurationService().addXmlEntity(xmlEntity, groups));
+          () -> ((InternalClusterConfigurationService) getConfigurationService())
+              .addXmlEntity(xmlEntity, groups));
     }
     return result;
   }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DebugCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DebugCommand.java
@@ -25,7 +25,7 @@ import org.apache.geode.management.internal.cli.result.ErrorResultData;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.cli.shell.Gfsh;
 
-public class DebugCommand extends GfshCommand {
+public class DebugCommand extends InternalGfshCommand {
   @CliCommand(value = {CliStrings.DEBUG}, help = CliStrings.DEBUG__HELP)
   @CliMetaData(shellOnly = true,
       relatedTopic = {CliStrings.TOPIC_GFSH, CliStrings.TOPIC_GEODE_DEBUG_UTIL})

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DefineIndexCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DefineIndexCommand.java
@@ -29,7 +29,7 @@ import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class DefineIndexCommand extends GfshCommand {
+public class DefineIndexCommand extends InternalGfshCommand {
   @CliCommand(value = CliStrings.DEFINE_INDEX, help = CliStrings.DEFINE_INDEX__HELP)
   @CliMetaData(relatedTopic = {CliStrings.TOPIC_GEODE_REGION, CliStrings.TOPIC_GEODE_DATA})
   // TODO : Add optionContext for indexName

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DeployCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DeployCommand.java
@@ -55,7 +55,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class DeployCommand extends GfshCommand {
+public class DeployCommand extends InternalGfshCommand {
   private final DeployFunction deployFunction = new DeployFunction();
 
   /**
@@ -136,7 +136,8 @@ public class DeployCommand extends GfshCommand {
     }
 
     Result result = ResultBuilder.buildResult(tabularData);
-    InternalClusterConfigurationService sc = getConfigurationService();
+    InternalClusterConfigurationService sc =
+        (InternalClusterConfigurationService) getConfigurationService();
     if (sc == null) {
       result.setCommandPersisted(false);
     } else {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeClientCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeClientCommand.java
@@ -43,7 +43,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class DescribeClientCommand extends GfshCommand {
+public class DescribeClientCommand extends InternalGfshCommand {
   @CliCommand(value = CliStrings.DESCRIBE_CLIENT, help = CliStrings.DESCRIBE_CLIENT__HELP)
   @CliMetaData(relatedTopic = {CliStrings.TOPIC_CLIENT})
   @ResourceOperation(resource = ResourcePermission.Resource.CLUSTER,

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeConfigCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeConfigCommand.java
@@ -40,7 +40,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class DescribeConfigCommand extends GfshCommand {
+public class DescribeConfigCommand extends InternalGfshCommand {
   private final GetMemberConfigInformationFunction getMemberConfigFunction =
       new GetMemberConfigInformationFunction();
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeConnectionCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeConnectionCommand.java
@@ -26,7 +26,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.cli.shell.Gfsh;
 import org.apache.geode.management.internal.cli.shell.OperationInvoker;
 
-public class DescribeConnectionCommand extends GfshCommand {
+public class DescribeConnectionCommand extends InternalGfshCommand {
   @CliCommand(value = {CliStrings.DESCRIBE_CONNECTION}, help = CliStrings.DESCRIBE_CONNECTION__HELP)
   @CliMetaData(shellOnly = true, relatedTopic = {CliStrings.TOPIC_GFSH, CliStrings.TOPIC_GEODE_JMX})
   public Result describeConnection() {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeDiskStoreCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeDiskStoreCommand.java
@@ -37,7 +37,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class DescribeDiskStoreCommand extends GfshCommand {
+public class DescribeDiskStoreCommand extends InternalGfshCommand {
   @CliCommand(value = CliStrings.DESCRIBE_DISK_STORE, help = CliStrings.DESCRIBE_DISK_STORE__HELP)
   @CliMetaData(relatedTopic = {CliStrings.TOPIC_GEODE_DISKSTORE})
   @ResourceOperation(resource = ResourcePermission.Resource.CLUSTER,

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeJndiBindingCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeJndiBindingCommand.java
@@ -33,7 +33,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class DescribeJndiBindingCommand extends GfshCommand {
+public class DescribeJndiBindingCommand extends InternalGfshCommand {
   private static final Logger logger = LogService.getLogger();
 
   private static final String DESCRIBE_JNDI_BINDING = "describe jndi-binding";
@@ -49,7 +49,8 @@ public class DescribeJndiBindingCommand extends GfshCommand {
     Result result = null;
     TabularResultData tabularData = ResultBuilder.createTabularResultData();
 
-    InternalClusterConfigurationService ccService = getConfigurationService();
+    InternalClusterConfigurationService ccService =
+        (InternalClusterConfigurationService) getConfigurationService();
     if (ccService != null) {
       CacheConfig cacheConfig = ccService.getCacheConfig("cluster");
       List<JndiBindingsType.JndiBinding> jndiBindings = cacheConfig.getJndiBindings();

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeMemberCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeMemberCommand.java
@@ -38,7 +38,7 @@ import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class DescribeMemberCommand extends GfshCommand {
+public class DescribeMemberCommand extends InternalGfshCommand {
   private static final GetMemberInformationFunction getMemberInformation =
       new GetMemberInformationFunction();
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeOfflineDiskStoreCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeOfflineDiskStoreCommand.java
@@ -30,7 +30,7 @@ import org.apache.geode.management.cli.Result;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 
-public class DescribeOfflineDiskStoreCommand extends GfshCommand {
+public class DescribeOfflineDiskStoreCommand extends InternalGfshCommand {
   @CliCommand(value = CliStrings.DESCRIBE_OFFLINE_DISK_STORE,
       help = CliStrings.DESCRIBE_OFFLINE_DISK_STORE__HELP)
   @CliMetaData(shellOnly = true, relatedTopic = {CliStrings.TOPIC_GEODE_DISKSTORE})

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeRegionCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeRegionCommand.java
@@ -44,7 +44,7 @@ import org.apache.geode.management.internal.cli.util.RegionAttributesNames;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class DescribeRegionCommand extends GfshCommand {
+public class DescribeRegionCommand extends InternalGfshCommand {
   public static final Logger logger = LogService.getLogger();
 
   private static final GetRegionDescriptionFunction getRegionDescription =

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyAsyncEventQueueCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyAsyncEventQueueCommand.java
@@ -24,6 +24,7 @@ import org.springframework.shell.core.annotation.CliCommand;
 import org.springframework.shell.core.annotation.CliOption;
 
 import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
 import org.apache.geode.management.internal.cli.functions.CliFunctionResult;
@@ -35,7 +36,7 @@ import org.apache.geode.management.internal.configuration.domain.XmlEntity;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class DestroyAsyncEventQueueCommand extends GfshCommand {
+public class DestroyAsyncEventQueueCommand extends InternalGfshCommand {
   public static final String DESTROY_ASYNC_EVENT_QUEUE = "destroy async-event-queue";
   public static final String DESTROY_ASYNC_EVENT_QUEUE__HELP = "destroy an Async Event Queue";
   public static final String DESTROY_ASYNC_EVENT_QUEUE__ID = "id";
@@ -72,7 +73,8 @@ public class DestroyAsyncEventQueueCommand extends GfshCommand {
     XmlEntity xmlEntity = findXmlEntity(functionResults);
     if (xmlEntity != null) {
       persistClusterConfiguration(commandResult,
-          () -> getConfigurationService().deleteXmlEntity(xmlEntity, onGroups));
+          () -> ((InternalClusterConfigurationService) getConfigurationService())
+              .deleteXmlEntity(xmlEntity, onGroups));
     }
     return commandResult;
   }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyDiskStoreCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyDiskStoreCommand.java
@@ -22,6 +22,7 @@ import org.springframework.shell.core.annotation.CliCommand;
 import org.springframework.shell.core.annotation.CliOption;
 
 import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
@@ -34,7 +35,7 @@ import org.apache.geode.management.internal.configuration.domain.XmlEntity;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class DestroyDiskStoreCommand extends GfshCommand {
+public class DestroyDiskStoreCommand extends InternalGfshCommand {
   @CliCommand(value = CliStrings.DESTROY_DISK_STORE, help = CliStrings.DESTROY_DISK_STORE__HELP)
   @CliMetaData(relatedTopic = {CliStrings.TOPIC_GEODE_DISKSTORE})
   @ResourceOperation(resource = ResourcePermission.Resource.CLUSTER,
@@ -64,7 +65,8 @@ public class DestroyDiskStoreCommand extends GfshCommand {
 
     if (xmlEntity != null) {
       persistClusterConfiguration(result,
-          () -> getConfigurationService().deleteXmlEntity(xmlEntity, groups));
+          () -> ((InternalClusterConfigurationService) getConfigurationService())
+              .deleteXmlEntity(xmlEntity, groups));
     }
 
     return result;

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyFunctionCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyFunctionCommand.java
@@ -41,7 +41,7 @@ import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class DestroyFunctionCommand extends GfshCommand {
+public class DestroyFunctionCommand extends InternalGfshCommand {
   @CliCommand(value = CliStrings.DESTROY_FUNCTION, help = CliStrings.DESTROY_FUNCTION__HELP)
   @CliMetaData(relatedTopic = {CliStrings.TOPIC_GEODE_FUNCTION},
       interceptor = "org.apache.geode.management.internal.cli.commands.DestroyFunctionCommand$Interceptor")

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyGatewaySenderCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyGatewaySenderCommand.java
@@ -23,6 +23,7 @@ import org.springframework.shell.core.annotation.CliCommand;
 import org.springframework.shell.core.annotation.CliOption;
 
 import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
@@ -37,7 +38,7 @@ import org.apache.geode.management.internal.configuration.domain.XmlEntity;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class DestroyGatewaySenderCommand extends GfshCommand {
+public class DestroyGatewaySenderCommand extends InternalGfshCommand {
   private static final Logger logger = LogService.getLogger();
 
   @CliCommand(value = CliStrings.DESTROY_GATEWAYSENDER,
@@ -81,7 +82,8 @@ public class DestroyGatewaySenderCommand extends GfshCommand {
     }
 
     // update cluster config
-    getConfigurationService().deleteXmlEntity(xmlEntity, onGroups);
+    ((InternalClusterConfigurationService) getConfigurationService()).deleteXmlEntity(xmlEntity,
+        onGroups);
     return result;
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyIndexCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyIndexCommand.java
@@ -23,6 +23,7 @@ import org.springframework.shell.core.annotation.CliCommand;
 import org.springframework.shell.core.annotation.CliOption;
 
 import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.internal.lang.StringUtils;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
@@ -36,7 +37,7 @@ import org.apache.geode.management.internal.configuration.domain.XmlEntity;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class DestroyIndexCommand extends GfshCommand {
+public class DestroyIndexCommand extends InternalGfshCommand {
   private static final DestroyIndexFunction destroyIndexFunction = new DestroyIndexFunction();
 
   @CliCommand(value = CliStrings.DESTROY_INDEX, help = CliStrings.DESTROY_INDEX__HELP)
@@ -82,7 +83,8 @@ public class DestroyIndexCommand extends GfshCommand {
 
     if (xmlEntity != null) {
       persistClusterConfiguration(result,
-          () -> getConfigurationService().deleteXmlEntity(xmlEntity, group));
+          () -> ((InternalClusterConfigurationService) getConfigurationService())
+              .deleteXmlEntity(xmlEntity, group));
     }
     return result;
   }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyJndiBindingCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyJndiBindingCommand.java
@@ -35,7 +35,7 @@ import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class DestroyJndiBindingCommand extends GfshCommand {
+public class DestroyJndiBindingCommand extends InternalGfshCommand {
   static final String DESTROY_JNDIBINDING = "destroy jndi-binding";
   static final String DESTROY_JNDIBINDING__HELP =
       "Destroy a jndi binding that holds the configuration for the XA datasource.";
@@ -55,7 +55,8 @@ public class DestroyJndiBindingCommand extends GfshCommand {
 
     Result result;
     boolean persisted = false;
-    InternalClusterConfigurationService service = getConfigurationService();
+    InternalClusterConfigurationService service =
+        (InternalClusterConfigurationService) getConfigurationService();
     if (service != null) {
       service.updateCacheConfig("cluster", cc -> {
         List<JndiBindingsType.JndiBinding> bindings = cc.getJndiBindings();

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyRegionCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyRegionCommand.java
@@ -21,6 +21,7 @@ import org.springframework.shell.core.annotation.CliCommand;
 import org.springframework.shell.core.annotation.CliOption;
 
 import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
@@ -34,7 +35,7 @@ import org.apache.geode.management.internal.configuration.domain.XmlEntity;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class DestroyRegionCommand extends GfshCommand {
+public class DestroyRegionCommand extends InternalGfshCommand {
   @CliCommand(value = {CliStrings.DESTROY_REGION}, help = CliStrings.DESTROY_REGION__HELP)
   @CliMetaData(relatedTopic = CliStrings.TOPIC_GEODE_REGION)
   @ResourceOperation(resource = ResourcePermission.Resource.DATA,
@@ -70,7 +71,8 @@ public class DestroyRegionCommand extends GfshCommand {
     // if at least one member returns with successful deletion, we will need to update cc
     if (xmlEntity != null) {
       persistClusterConfiguration(result,
-          () -> getConfigurationService().deleteXmlEntity(xmlEntity, null));
+          () -> ((InternalClusterConfigurationService) getConfigurationService())
+              .deleteXmlEntity(xmlEntity, null));
     }
     return result;
   }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DisconnectCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DisconnectCommand.java
@@ -26,7 +26,7 @@ import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.cli.shell.Gfsh;
 import org.apache.geode.management.internal.cli.shell.OperationInvoker;
 
-public class DisconnectCommand extends GfshCommand {
+public class DisconnectCommand extends InternalGfshCommand {
   @CliCommand(value = {CliStrings.DISCONNECT}, help = CliStrings.DISCONNECT__HELP)
   @CliMetaData(shellOnly = true, relatedTopic = {CliStrings.TOPIC_GFSH, CliStrings.TOPIC_GEODE_JMX,
       CliStrings.TOPIC_GEODE_MANAGER})

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/EchoCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/EchoCommand.java
@@ -28,7 +28,7 @@ import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.cli.shell.Gfsh;
 
-public class EchoCommand extends GfshCommand {
+public class EchoCommand extends InternalGfshCommand {
   @CliCommand(value = {CliStrings.ECHO}, help = CliStrings.ECHO__HELP)
   @CliMetaData(shellOnly = true, relatedTopic = {CliStrings.TOPIC_GFSH})
   public Result echo(@CliOption(key = {CliStrings.ECHO__STR, ""}, specifiedDefaultValue = "",

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExecuteFunctionCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExecuteFunctionCommand.java
@@ -39,7 +39,7 @@ import org.apache.geode.management.internal.cli.result.CompositeResultData;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.cli.result.TabularResultData;
 
-public class ExecuteFunctionCommand extends GfshCommand {
+public class ExecuteFunctionCommand extends InternalGfshCommand {
   @CliCommand(value = CliStrings.EXECUTE_FUNCTION, help = CliStrings.EXECUTE_FUNCTION__HELP)
   @CliMetaData(relatedTopic = {CliStrings.TOPIC_GEODE_FUNCTION},
       interceptor = "org.apache.geode.management.internal.cli.commands.ExecuteFunctionCommand$ExecuteFunctionCommandInterceptor")

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExecuteScriptCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExecuteScriptCommand.java
@@ -27,7 +27,7 @@ import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.cli.shell.Gfsh;
 
-public class ExecuteScriptCommand extends GfshCommand {
+public class ExecuteScriptCommand extends InternalGfshCommand {
   @CliCommand(value = {CliStrings.RUN}, help = CliStrings.RUN__HELP)
   @CliMetaData(shellOnly = true, relatedTopic = {CliStrings.TOPIC_GFSH})
   public Result executeScript(

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExitCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExitCommand.java
@@ -22,7 +22,7 @@ import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.shell.Gfsh;
 
-public class ExitCommand extends GfshCommand {
+public class ExitCommand extends InternalGfshCommand {
   @CliCommand(value = {CliStrings.EXIT, "quit"}, help = CliStrings.EXIT__HELP)
   @CliMetaData(shellOnly = true, relatedTopic = {CliStrings.TOPIC_GFSH})
   public ExitShellRequest exit() {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExportConfigCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExportConfigCommand.java
@@ -41,7 +41,7 @@ import org.apache.geode.management.internal.cli.shell.Gfsh;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class ExportConfigCommand extends GfshCommand {
+public class ExportConfigCommand extends InternalGfshCommand {
   private final ExportConfigFunction exportConfigFunction = new ExportConfigFunction();
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExportDataCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExportDataCommand.java
@@ -36,7 +36,7 @@ import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.security.ResourcePermission.Operation;
 import org.apache.geode.security.ResourcePermission.Resource;
 
-public class ExportDataCommand extends GfshCommand {
+public class ExportDataCommand extends InternalGfshCommand {
   private final ExportDataFunction exportDataFunction = new ExportDataFunction();
 
   @CliCommand(value = CliStrings.EXPORT_DATA, help = CliStrings.EXPORT_DATA__HELP)

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExportImportClusterConfigurationCommands.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExportImportClusterConfigurationCommands.java
@@ -64,7 +64,7 @@ import org.apache.geode.security.ResourcePermission.Resource;
  * Commands for the cluster configuration
  */
 @SuppressWarnings("unused")
-public class ExportImportClusterConfigurationCommands extends GfshCommand {
+public class ExportImportClusterConfigurationCommands extends InternalGfshCommand {
 
   @CliCommand(value = {CliStrings.EXPORT_SHARED_CONFIG},
       help = CliStrings.EXPORT_SHARED_CONFIG__HELP)

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExportLogsCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExportLogsCommand.java
@@ -49,7 +49,7 @@ import org.apache.geode.management.internal.configuration.utils.ZipUtils;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class ExportLogsCommand extends GfshCommand {
+public class ExportLogsCommand extends InternalGfshCommand {
 
   private static final Logger logger = LogService.getLogger();
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExportOfflineDiskStoreCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExportOfflineDiskStoreCommand.java
@@ -28,7 +28,7 @@ import org.apache.geode.management.internal.cli.LogWrapper;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 
-public class ExportOfflineDiskStoreCommand extends GfshCommand {
+public class ExportOfflineDiskStoreCommand extends InternalGfshCommand {
   @CliCommand(value = CliStrings.EXPORT_OFFLINE_DISK_STORE,
       help = CliStrings.EXPORT_OFFLINE_DISK_STORE__HELP)
   @CliMetaData(shellOnly = true, relatedTopic = {CliStrings.TOPIC_GEODE_DISKSTORE})

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExportStackTraceCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExportStackTraceCommand.java
@@ -46,7 +46,7 @@ import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class ExportStackTraceCommand extends GfshCommand {
+public class ExportStackTraceCommand extends InternalGfshCommand {
   public static final String STACK_TRACE_FOR_MEMBER = "*** Stack-trace for member ";
   private final GetStackTracesFunction getStackTracesFunction = new GetStackTracesFunction();
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/GCCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/GCCommand.java
@@ -26,7 +26,6 @@ import org.springframework.shell.core.annotation.CliOption;
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.execute.Function;
 import org.apache.geode.distributed.DistributedMember;
-import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
@@ -40,7 +39,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class GCCommand extends GfshCommand {
+public class GCCommand extends InternalGfshCommand {
   @CliCommand(value = CliStrings.GC, help = CliStrings.GC__HELP)
   @CliMetaData(relatedTopic = {CliStrings.TOPIC_GEODE_DEBUG_UTIL})
   @ResourceOperation(resource = ResourcePermission.Resource.CLUSTER,

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/GetCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/GetCommand.java
@@ -39,7 +39,7 @@ import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.security.ResourcePermission.Operation;
 import org.apache.geode.security.ResourcePermission.Resource;
 
-public class GetCommand extends GfshCommand {
+public class GetCommand extends InternalGfshCommand {
   @CliMetaData(relatedTopic = {CliStrings.TOPIC_GEODE_DATA, CliStrings.TOPIC_GEODE_REGION})
   @CliCommand(value = {CliStrings.GET}, help = CliStrings.GET__HELP)
   public Result get(

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/GfshHelpCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/GfshHelpCommand.java
@@ -26,7 +26,7 @@ import org.apache.geode.management.internal.cli.CommandManagerAware;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 
-public class GfshHelpCommand extends GfshCommand implements CommandManagerAware {
+public class GfshHelpCommand extends InternalGfshCommand implements CommandManagerAware {
   private CommandManager commandManager = null;
 
   public void setCommandManager(CommandManager commandManager) {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/GfshHintCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/GfshHintCommand.java
@@ -26,7 +26,7 @@ import org.apache.geode.management.internal.cli.CommandManagerAware;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 
-public class GfshHintCommand extends GfshCommand implements CommandManagerAware {
+public class GfshHintCommand extends InternalGfshCommand implements CommandManagerAware {
   private CommandManager commandManager = null;
 
   public void setCommandManager(CommandManager commandManager) {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/HistoryCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/HistoryCommand.java
@@ -34,7 +34,7 @@ import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.cli.shell.Gfsh;
 import org.apache.geode.management.internal.cli.shell.jline.GfshHistory;
 
-public class HistoryCommand extends GfshCommand {
+public class HistoryCommand extends InternalGfshCommand {
   @CliCommand(value = CliStrings.HISTORY, help = CliStrings.HISTORY__HELP)
   @CliMetaData(shellOnly = true, relatedTopic = {CliStrings.TOPIC_GFSH})
   public Result history(

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ImportDataCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ImportDataCommand.java
@@ -34,7 +34,7 @@ import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.security.ResourcePermission.Operation;
 import org.apache.geode.security.ResourcePermission.Resource;
 
-public class ImportDataCommand extends GfshCommand {
+public class ImportDataCommand extends InternalGfshCommand {
   private final ImportDataFunction importDataFunction = new ImportDataFunction();
 
   @CliCommand(value = CliStrings.IMPORT_DATA, help = CliStrings.IMPORT_DATA__HELP)

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/InternalGfshCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/InternalGfshCommand.java
@@ -17,6 +17,8 @@ package org.apache.geode.management.internal.cli.commands;
 import java.util.List;
 import java.util.Objects;
 
+import org.springframework.shell.core.CommandMarker;
+
 import org.apache.geode.management.ManagementService;
 import org.apache.geode.management.cli.GfshCommand;
 import org.apache.geode.management.cli.Result;
@@ -32,7 +34,7 @@ import org.apache.geode.management.internal.configuration.domain.XmlEntity;
  * GfshCommandJUnitTest
  */
 @SuppressWarnings("unused")
-public abstract class InternalGfshCommand extends GfshCommand {
+public abstract class InternalGfshCommand extends GfshCommand implements CommandMarker {
   public static final String EXPERIMENTAL = "(Experimental) ";
 
   public boolean isConnectedAndReady() {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/InternalGfshCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/InternalGfshCommand.java
@@ -17,8 +17,6 @@ package org.apache.geode.management.internal.cli.commands;
 import java.util.List;
 import java.util.Objects;
 
-import org.springframework.shell.core.CommandMarker;
-
 import org.apache.geode.management.ManagementService;
 import org.apache.geode.management.cli.GfshCommand;
 import org.apache.geode.management.cli.Result;
@@ -34,7 +32,7 @@ import org.apache.geode.management.internal.configuration.domain.XmlEntity;
  * GfshCommandJUnitTest
  */
 @SuppressWarnings("unused")
-public abstract class InternalGfshCommand extends GfshCommand implements CommandMarker {
+public abstract class InternalGfshCommand extends GfshCommand {
   public static final String EXPERIMENTAL = "(Experimental) ";
 
   public boolean isConnectedAndReady() {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/InternalGfshCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/InternalGfshCommand.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.management.internal.cli.commands;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.springframework.shell.core.CommandMarker;
+
+import org.apache.geode.management.ManagementService;
+import org.apache.geode.management.cli.GfshCommand;
+import org.apache.geode.management.cli.Result;
+import org.apache.geode.management.internal.cli.functions.CliFunctionResult;
+import org.apache.geode.management.internal.cli.shell.Gfsh;
+import org.apache.geode.management.internal.configuration.domain.XmlEntity;
+
+/**
+ * Encapsulates common functionality for implementing command classes for the Geode shell (gfsh).
+ * this provides wrapper around the static methods in CliUtils for easy mock of the commands
+ *
+ * this class should not have much implementation of its own other then those tested in
+ * GfshCommandJUnitTest
+ */
+@SuppressWarnings("unused")
+public abstract class InternalGfshCommand extends GfshCommand implements CommandMarker {
+  public static final String EXPERIMENTAL = "(Experimental) ";
+
+  public boolean isConnectedAndReady() {
+    return getGfsh() != null && getGfsh().isConnectedAndReady();
+  }
+
+  public void persistClusterConfiguration(Result result, Runnable runnable) {
+    if (result == null) {
+      throw new IllegalArgumentException("Result should not be null");
+    }
+    if (getConfigurationService() == null) {
+      result.setCommandPersisted(false);
+    } else {
+      runnable.run();
+      result.setCommandPersisted(true);
+    }
+  }
+
+  public XmlEntity findXmlEntity(List<CliFunctionResult> functionResults) {
+    return functionResults.stream().filter(CliFunctionResult::isSuccessful)
+        .map(CliFunctionResult::getXmlEntity).filter(Objects::nonNull).findFirst().orElse(null);
+  }
+
+  public boolean isDebugging() {
+    return getGfsh() != null && getGfsh().getDebug();
+  }
+
+  public boolean isLogging() {
+    return getGfsh() != null;
+  }
+
+  public Gfsh getGfsh() {
+    return Gfsh.getCurrentInstance();
+  }
+
+  public ManagementService getManagementService() {
+    return ManagementService.getExistingManagementService(getCache());
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListAsyncEventQueuesCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListAsyncEventQueuesCommand.java
@@ -36,7 +36,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class ListAsyncEventQueuesCommand extends GfshCommand {
+public class ListAsyncEventQueuesCommand extends InternalGfshCommand {
   @CliCommand(value = CliStrings.LIST_ASYNC_EVENT_QUEUES,
       help = CliStrings.LIST_ASYNC_EVENT_QUEUES__HELP)
   @ResourceOperation(resource = ResourcePermission.Resource.CLUSTER,

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListClientCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListClientCommand.java
@@ -36,7 +36,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class ListClientCommand extends GfshCommand {
+public class ListClientCommand extends InternalGfshCommand {
   @CliCommand(value = CliStrings.LIST_CLIENTS, help = CliStrings.LIST_CLIENT__HELP)
   @CliMetaData(relatedTopic = {CliStrings.TOPIC_CLIENT})
   @ResourceOperation(resource = ResourcePermission.Resource.CLUSTER,

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListDeployedCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListDeployedCommand.java
@@ -35,7 +35,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class ListDeployedCommand extends GfshCommand {
+public class ListDeployedCommand extends InternalGfshCommand {
   private final ListDeployedFunction listDeployedFunction = new ListDeployedFunction();
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListDiskStoresCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListDiskStoresCommand.java
@@ -38,7 +38,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class ListDiskStoresCommand extends GfshCommand {
+public class ListDiskStoresCommand extends InternalGfshCommand {
   @CliCommand(value = CliStrings.LIST_DISK_STORE, help = CliStrings.LIST_DISK_STORE__HELP)
   @CliMetaData(relatedTopic = {CliStrings.TOPIC_GEODE_DISKSTORE})
   @ResourceOperation(resource = ResourcePermission.Resource.CLUSTER,

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListDurableClientCQsCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListDurableClientCQsCommand.java
@@ -38,7 +38,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class ListDurableClientCQsCommand extends GfshCommand {
+public class ListDurableClientCQsCommand extends InternalGfshCommand {
   DurableClientCommandsResultBuilder builder = new DurableClientCommandsResultBuilder();
 
   @CliCommand(value = CliStrings.LIST_DURABLE_CQS, help = CliStrings.LIST_DURABLE_CQS__HELP)

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListFunctionCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListFunctionCommand.java
@@ -37,7 +37,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class ListFunctionCommand extends GfshCommand {
+public class ListFunctionCommand extends InternalGfshCommand {
   private final ListFunctionFunction listFunctionFunction = new ListFunctionFunction();
 
   @CliCommand(value = CliStrings.LIST_FUNCTION, help = CliStrings.LIST_FUNCTION__HELP)

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListGatewayCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListGatewayCommand.java
@@ -40,7 +40,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class ListGatewayCommand extends GfshCommand {
+public class ListGatewayCommand extends InternalGfshCommand {
   @CliCommand(value = CliStrings.LIST_GATEWAY, help = CliStrings.LIST_GATEWAY__HELP)
   @CliMetaData(relatedTopic = CliStrings.TOPIC_GEODE_WAN)
   @ResourceOperation(resource = ResourcePermission.Resource.CLUSTER,

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListIndexCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListIndexCommand.java
@@ -38,7 +38,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class ListIndexCommand extends GfshCommand {
+public class ListIndexCommand extends InternalGfshCommand {
   @CliCommand(value = CliStrings.LIST_INDEX, help = CliStrings.LIST_INDEX__HELP)
   @CliMetaData(relatedTopic = {CliStrings.TOPIC_GEODE_REGION, CliStrings.TOPIC_GEODE_DATA})
   @ResourceOperation(resource = ResourcePermission.Resource.CLUSTER,

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListJndiBindingCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListJndiBindingCommand.java
@@ -37,7 +37,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class ListJndiBindingCommand extends GfshCommand {
+public class ListJndiBindingCommand extends InternalGfshCommand {
   private static final Logger logger = LogService.getLogger();
 
   private static final String LIST_JNDIBINDING = "list jndi-binding";
@@ -54,7 +54,8 @@ public class ListJndiBindingCommand extends GfshCommand {
     TabularResultData configTable = null;
     TabularResultData memberTable = null;
 
-    InternalClusterConfigurationService ccService = getConfigurationService();
+    InternalClusterConfigurationService ccService =
+        (InternalClusterConfigurationService) getConfigurationService();
     if (ccService != null) {
       configTable = resultSection.addTable();
       configTable.setHeader("Configured JNDI bindings: ");

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListMembersCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListMembersCommand.java
@@ -33,7 +33,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class ListMembersCommand extends GfshCommand {
+public class ListMembersCommand extends InternalGfshCommand {
   @CliCommand(value = {CliStrings.LIST_MEMBER}, help = CliStrings.LIST_MEMBER__HELP)
   @CliMetaData(relatedTopic = CliStrings.TOPIC_GEODE_SERVER)
   @ResourceOperation(resource = ResourcePermission.Resource.CLUSTER,

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListRegionCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListRegionCommand.java
@@ -41,7 +41,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class ListRegionCommand extends GfshCommand {
+public class ListRegionCommand extends InternalGfshCommand {
   private static final GetRegionsFunction getRegionsFunction = new GetRegionsFunction();
 
   @CliCommand(value = {CliStrings.LIST_REGION}, help = CliStrings.LIST_REGION__HELP)

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/LoadBalanceGatewaySenderCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/LoadBalanceGatewaySenderCommand.java
@@ -35,7 +35,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class LoadBalanceGatewaySenderCommand extends GfshCommand {
+public class LoadBalanceGatewaySenderCommand extends InternalGfshCommand {
 
   @CliCommand(value = CliStrings.LOAD_BALANCE_GATEWAYSENDER,
       help = CliStrings.LOAD_BALANCE_GATEWAYSENDER__HELP)

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/LocateEntryCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/LocateEntryCommand.java
@@ -35,7 +35,7 @@ import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.security.ResourcePermission.Operation;
 import org.apache.geode.security.ResourcePermission.Resource;
 
-public class LocateEntryCommand extends GfshCommand {
+public class LocateEntryCommand extends InternalGfshCommand {
   @CliMetaData(relatedTopic = {CliStrings.TOPIC_GEODE_DATA, CliStrings.TOPIC_GEODE_REGION})
   @CliCommand(value = {CliStrings.LOCATE_ENTRY}, help = CliStrings.LOCATE_ENTRY__HELP)
   public Result locateEntry(

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/NetstatCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/NetstatCommand.java
@@ -47,7 +47,7 @@ import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class NetstatCommand extends GfshCommand {
+public class NetstatCommand extends InternalGfshCommand {
   private static final String NETSTAT_FILE_REQUIRED_EXTENSION = ".txt";
 
   @CliCommand(value = CliStrings.NETSTAT, help = CliStrings.NETSTAT__HELP)

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/PDXRenameCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/PDXRenameCommand.java
@@ -31,7 +31,7 @@ import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.pdx.internal.EnumInfo;
 import org.apache.geode.pdx.internal.PdxType;
 
-public class PDXRenameCommand extends GfshCommand {
+public class PDXRenameCommand extends InternalGfshCommand {
   @CliCommand(value = CliStrings.PDX_RENAME, help = CliStrings.PDX_RENAME__HELP)
   @CliMetaData(shellOnly = true, relatedTopic = {CliStrings.TOPIC_GEODE_DISKSTORE})
   public Result pdxRename(@CliOption(key = CliStrings.PDX_RENAME_OLD, mandatory = true,

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/PauseGatewaySenderCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/PauseGatewaySenderCommand.java
@@ -35,7 +35,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class PauseGatewaySenderCommand extends GfshCommand {
+public class PauseGatewaySenderCommand extends InternalGfshCommand {
 
   @CliCommand(value = CliStrings.PAUSE_GATEWAYSENDER, help = CliStrings.PAUSE_GATEWAYSENDER__HELP)
   @CliMetaData(relatedTopic = CliStrings.TOPIC_GEODE_WAN)

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/PutCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/PutCommand.java
@@ -38,7 +38,7 @@ import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.security.ResourcePermission.Operation;
 import org.apache.geode.security.ResourcePermission.Resource;
 
-public class PutCommand extends GfshCommand {
+public class PutCommand extends InternalGfshCommand {
   @CliMetaData(relatedTopic = {CliStrings.TOPIC_GEODE_DATA, CliStrings.TOPIC_GEODE_REGION})
   @CliCommand(value = {CliStrings.PUT}, help = CliStrings.PUT__HELP)
   public Result put(

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/QueryCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/QueryCommand.java
@@ -50,7 +50,7 @@ import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.security.ResourcePermission.Operation;
 import org.apache.geode.security.ResourcePermission.Resource;
 
-public class QueryCommand extends GfshCommand {
+public class QueryCommand extends InternalGfshCommand {
   private static final Logger logger = LogService.getLogger();
 
   @CliCommand(value = "query", help = CliStrings.QUERY__HELP)

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/RebalanceCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/RebalanceCommand.java
@@ -60,7 +60,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class RebalanceCommand extends GfshCommand {
+public class RebalanceCommand extends InternalGfshCommand {
   @CliCommand(value = CliStrings.REBALANCE, help = CliStrings.REBALANCE__HELP)
   @CliMetaData(relatedTopic = {CliStrings.TOPIC_GEODE_DATA, CliStrings.TOPIC_GEODE_REGION})
   @ResourceOperation(resource = ResourcePermission.Resource.DATA,

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/RemoveCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/RemoveCommand.java
@@ -39,7 +39,7 @@ import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.security.ResourcePermission.Operation;
 import org.apache.geode.security.ResourcePermission.Resource;
 
-public class RemoveCommand extends GfshCommand {
+public class RemoveCommand extends InternalGfshCommand {
   public static final String REGION_NOT_FOUND = "Region <%s> not found in any of the members";
 
   @CliMetaData(relatedTopic = {CliStrings.TOPIC_GEODE_DATA, CliStrings.TOPIC_GEODE_REGION})

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ResumeGatewaySenderCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ResumeGatewaySenderCommand.java
@@ -35,7 +35,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class ResumeGatewaySenderCommand extends GfshCommand {
+public class ResumeGatewaySenderCommand extends InternalGfshCommand {
 
   @CliCommand(value = CliStrings.RESUME_GATEWAYSENDER, help = CliStrings.RESUME_GATEWAYSENDER__HELP)
   @CliMetaData(relatedTopic = CliStrings.TOPIC_GEODE_WAN)

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/RevokeMissingDiskStoreCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/RevokeMissingDiskStoreCommand.java
@@ -28,7 +28,7 @@ import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class RevokeMissingDiskStoreCommand extends GfshCommand {
+public class RevokeMissingDiskStoreCommand extends InternalGfshCommand {
   @CliCommand(value = CliStrings.REVOKE_MISSING_DISK_STORE,
       help = CliStrings.REVOKE_MISSING_DISK_STORE__HELP)
   @CliMetaData(relatedTopic = {CliStrings.TOPIC_GEODE_DISKSTORE})

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/SetVariableCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/SetVariableCommand.java
@@ -24,7 +24,7 @@ import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ErrorResultData;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 
-public class SetVariableCommand extends GfshCommand {
+public class SetVariableCommand extends InternalGfshCommand {
   @CliCommand(value = {CliStrings.SET_VARIABLE}, help = CliStrings.SET_VARIABLE__HELP)
   @CliMetaData(shellOnly = true, relatedTopic = {CliStrings.TOPIC_GFSH})
   public Result setVariable(

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ShCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ShCommand.java
@@ -31,7 +31,7 @@ import org.apache.geode.management.internal.cli.result.InfoResultData;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.cli.shell.Gfsh;
 
-public class ShCommand extends GfshCommand {
+public class ShCommand extends InternalGfshCommand {
   @CliCommand(value = {CliStrings.SH}, help = CliStrings.SH__HELP)
   @CliMetaData(shellOnly = true, relatedTopic = {CliStrings.TOPIC_GFSH})
   public Result sh(

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ShowDeadlockCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ShowDeadlockCommand.java
@@ -35,7 +35,7 @@ import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class ShowDeadlockCommand extends GfshCommand {
+public class ShowDeadlockCommand extends InternalGfshCommand {
   @CliCommand(value = CliStrings.SHOW_DEADLOCK, help = CliStrings.SHOW_DEADLOCK__HELP)
   @CliMetaData(relatedTopic = {CliStrings.TOPIC_GEODE_DEBUG_UTIL})
   @ResourceOperation(resource = ResourcePermission.Resource.CLUSTER,

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ShowLogCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ShowLogCommand.java
@@ -20,7 +20,6 @@ import javax.management.ObjectName;
 import org.springframework.shell.core.annotation.CliCommand;
 import org.springframework.shell.core.annotation.CliOption;
 
-import org.apache.geode.cache.Cache;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.management.MemberMXBean;
 import org.apache.geode.management.cli.CliMetaData;
@@ -35,7 +34,7 @@ import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class ShowLogCommand extends GfshCommand {
+public class ShowLogCommand extends InternalGfshCommand {
   @CliCommand(value = CliStrings.SHOW_LOG, help = CliStrings.SHOW_LOG_HELP)
   @CliMetaData(relatedTopic = {CliStrings.TOPIC_GEODE_DEBUG_UTIL})
   @ResourceOperation(resource = ResourcePermission.Resource.CLUSTER,

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ShowMetricsCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ShowMetricsCommand.java
@@ -52,7 +52,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class ShowMetricsCommand extends GfshCommand {
+public class ShowMetricsCommand extends InternalGfshCommand {
   enum Category {
     cache,
     cacheserver,

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ShowMissingDiskStoreCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ShowMissingDiskStoreCommand.java
@@ -41,7 +41,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class ShowMissingDiskStoreCommand extends GfshCommand {
+public class ShowMissingDiskStoreCommand extends InternalGfshCommand {
   @CliCommand(value = CliStrings.SHOW_MISSING_DISK_STORE,
       help = CliStrings.SHOW_MISSING_DISK_STORE__HELP)
   @CliMetaData(relatedTopic = {CliStrings.TOPIC_GEODE_DISKSTORE})

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ShutdownCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ShutdownCommand.java
@@ -46,7 +46,7 @@ import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class ShutdownCommand extends GfshCommand {
+public class ShutdownCommand extends InternalGfshCommand {
   private static final String DEFAULT_TIME_OUT = "10";
   private static final Logger logger = LogService.getLogger();
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/SleepCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/SleepCommand.java
@@ -24,7 +24,7 @@ import org.apache.geode.management.internal.cli.LogWrapper;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 
-public class SleepCommand extends GfshCommand {
+public class SleepCommand extends InternalGfshCommand {
   @CliCommand(value = {CliStrings.SLEEP}, help = CliStrings.SLEEP__HELP)
   @CliMetaData(shellOnly = true, relatedTopic = {CliStrings.TOPIC_GFSH})
   public Result sleep(@CliOption(key = {CliStrings.SLEEP__TIME}, unspecifiedDefaultValue = "3",

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartGatewayReceiverCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartGatewayReceiverCommand.java
@@ -35,7 +35,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class StartGatewayReceiverCommand extends GfshCommand {
+public class StartGatewayReceiverCommand extends InternalGfshCommand {
 
   @CliCommand(value = CliStrings.START_GATEWAYRECEIVER,
       help = CliStrings.START_GATEWAYRECEIVER__HELP)

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartGatewaySenderCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartGatewaySenderCommand.java
@@ -45,7 +45,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class StartGatewaySenderCommand extends GfshCommand {
+public class StartGatewaySenderCommand extends InternalGfshCommand {
 
   @CliCommand(value = CliStrings.START_GATEWAYSENDER, help = CliStrings.START_GATEWAYSENDER__HELP)
   @CliMetaData(relatedTopic = CliStrings.TOPIC_GEODE_WAN)

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartLocatorCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartLocatorCommand.java
@@ -55,7 +55,7 @@ import org.apache.geode.management.internal.cli.util.HostUtils;
 import org.apache.geode.management.internal.configuration.utils.ClusterConfigurationStatusRetriever;
 import org.apache.geode.security.AuthenticationFailedException;
 
-public class StartLocatorCommand extends GfshCommand {
+public class StartLocatorCommand extends InternalGfshCommand {
   @CliCommand(value = CliStrings.START_LOCATOR, help = CliStrings.START_LOCATOR__HELP)
   @CliMetaData(shellOnly = true,
       relatedTopic = {CliStrings.TOPIC_GEODE_LOCATOR, CliStrings.TOPIC_GEODE_LIFECYCLE})

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartMemberUtils.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartMemberUtils.java
@@ -139,7 +139,7 @@ public class StartMemberUtils {
     }
   }
 
-  static void addCurrentLocators(GfshCommand gfshCommand, final List<String> commandLine,
+  static void addCurrentLocators(InternalGfshCommand gfshCommand, final List<String> commandLine,
       final Properties gemfireProperties) throws MalformedObjectNameException {
     if (StringUtils.isBlank(gemfireProperties.getProperty(LOCATORS))) {
       String currentLocators = getCurrentLocators(gfshCommand);
@@ -150,7 +150,7 @@ public class StartMemberUtils {
     }
   }
 
-  private static String getCurrentLocators(GfshCommand gfshCommand)
+  private static String getCurrentLocators(InternalGfshCommand gfshCommand)
       throws MalformedObjectNameException {
     String delimitedLocators = "";
     try {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartServerCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartServerCommand.java
@@ -46,7 +46,7 @@ import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.cli.shell.Gfsh;
 import org.apache.geode.management.internal.security.ResourceConstants;
 
-public class StartServerCommand extends GfshCommand {
+public class StartServerCommand extends InternalGfshCommand {
   private static final String SERVER_TERM_NAME = "Server";
 
   @CliCommand(value = CliStrings.START_SERVER, help = CliStrings.START_SERVER__HELP)

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StatusClusterConfigServiceCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StatusClusterConfigServiceCommand.java
@@ -37,7 +37,7 @@ import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission.Operation;
 import org.apache.geode.security.ResourcePermission.Resource;
 
-public class StatusClusterConfigServiceCommand extends GfshCommand {
+public class StatusClusterConfigServiceCommand extends InternalGfshCommand {
   private static final FetchSharedConfigurationStatusFunction fetchSharedConfigStatusFunction =
       new FetchSharedConfigurationStatusFunction();
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StatusGatewayReceiverCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StatusGatewayReceiverCommand.java
@@ -36,7 +36,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class StatusGatewayReceiverCommand extends GfshCommand {
+public class StatusGatewayReceiverCommand extends InternalGfshCommand {
   @CliCommand(value = CliStrings.STATUS_GATEWAYRECEIVER,
       help = CliStrings.STATUS_GATEWAYRECEIVER__HELP)
   @CliMetaData(relatedTopic = CliStrings.TOPIC_GEODE_WAN)

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StatusGatewaySenderCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StatusGatewaySenderCommand.java
@@ -36,7 +36,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class StatusGatewaySenderCommand extends GfshCommand {
+public class StatusGatewaySenderCommand extends InternalGfshCommand {
   @CliCommand(value = CliStrings.STATUS_GATEWAYSENDER, help = CliStrings.STATUS_GATEWAYSENDER__HELP)
   @CliMetaData(relatedTopic = CliStrings.TOPIC_GEODE_WAN)
   @ResourceOperation(resource = ResourcePermission.Resource.CLUSTER,

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StopGatewayReceiverCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StopGatewayReceiverCommand.java
@@ -35,7 +35,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class StopGatewayReceiverCommand extends GfshCommand {
+public class StopGatewayReceiverCommand extends InternalGfshCommand {
   @CliCommand(value = CliStrings.STOP_GATEWAYRECEIVER, help = CliStrings.STOP_GATEWAYRECEIVER__HELP)
   @CliMetaData(relatedTopic = CliStrings.TOPIC_GEODE_WAN)
   @ResourceOperation(resource = ResourcePermission.Resource.CLUSTER,

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StopGatewaySenderCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StopGatewaySenderCommand.java
@@ -25,7 +25,6 @@ import org.springframework.shell.core.annotation.CliOption;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.management.GatewaySenderMXBean;
-import org.apache.geode.management.ManagementService;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
@@ -36,7 +35,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class StopGatewaySenderCommand extends GfshCommand {
+public class StopGatewaySenderCommand extends InternalGfshCommand {
 
   @CliCommand(value = CliStrings.STOP_GATEWAYSENDER, help = CliStrings.STOP_GATEWAYSENDER__HELP)
   @CliMetaData(relatedTopic = CliStrings.TOPIC_GEODE_WAN)

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/UndeployCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/UndeployCommand.java
@@ -24,6 +24,7 @@ import org.springframework.shell.core.annotation.CliOption;
 import org.apache.geode.SystemFailure;
 import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
@@ -36,7 +37,7 @@ import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class UndeployCommand extends GfshCommand {
+public class UndeployCommand extends InternalGfshCommand {
   private final UndeployFunction undeployFunction = new UndeployFunction();
 
   /**
@@ -99,7 +100,8 @@ public class UndeployCommand extends GfshCommand {
       Result result = ResultBuilder.buildResult(tabularData);
       if (tabularData.getStatus().equals(Result.Status.OK)) {
         persistClusterConfiguration(result,
-            () -> getConfigurationService().removeJars(jars, groups));
+            () -> ((InternalClusterConfigurationService) getConfigurationService()).removeJars(jars,
+                groups));
       }
       return result;
     } catch (VirtualMachineError e) {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/UpgradeOfflineDiskStoreCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/UpgradeOfflineDiskStoreCommand.java
@@ -38,7 +38,7 @@ import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.cli.shell.Gfsh;
 import org.apache.geode.management.internal.cli.util.DiskStoreUpgrader;
 
-public class UpgradeOfflineDiskStoreCommand extends GfshCommand {
+public class UpgradeOfflineDiskStoreCommand extends InternalGfshCommand {
   @CliCommand(value = CliStrings.UPGRADE_OFFLINE_DISK_STORE,
       help = CliStrings.UPGRADE_OFFLINE_DISK_STORE__HELP)
   @CliMetaData(shellOnly = true, relatedTopic = {CliStrings.TOPIC_GEODE_DISKSTORE})

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ValidateDiskStoreCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ValidateDiskStoreCommand.java
@@ -34,7 +34,7 @@ import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.cli.util.DiskStoreValidater;
 
-public class ValidateDiskStoreCommand extends GfshCommand {
+public class ValidateDiskStoreCommand extends InternalGfshCommand {
   @CliCommand(value = CliStrings.VALIDATE_DISK_STORE, help = CliStrings.VALIDATE_DISK_STORE__HELP)
   @CliMetaData(shellOnly = true, relatedTopic = {CliStrings.TOPIC_GEODE_DISKSTORE})
   public Result validateDiskStore(

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/VersionCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/VersionCommand.java
@@ -24,7 +24,7 @@ import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.cli.shell.Gfsh;
 
-public class VersionCommand extends GfshCommand {
+public class VersionCommand extends InternalGfshCommand {
   @CliCommand(value = {CliStrings.VERSION}, help = CliStrings.VERSION__HELP)
   @CliMetaData(shellOnly = true, relatedTopic = {CliStrings.TOPIC_GFSH})
   public Result version(@CliOption(key = {CliStrings.VERSION__FULL}, specifiedDefaultValue = "true",

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/lifecycle/StartJConsoleCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/lifecycle/StartJConsoleCommand.java
@@ -34,7 +34,7 @@ import org.apache.geode.internal.util.IOUtils;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.Result;
 import org.apache.geode.management.internal.cli.GfshParser;
-import org.apache.geode.management.internal.cli.commands.GfshCommand;
+import org.apache.geode.management.internal.cli.commands.InternalGfshCommand;
 import org.apache.geode.management.internal.cli.converters.ConnectionEndpointConverter;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
@@ -42,7 +42,7 @@ import org.apache.geode.management.internal.cli.shell.JmxOperationInvoker;
 import org.apache.geode.management.internal.cli.util.ConnectionEndpoint;
 import org.apache.geode.management.internal.cli.util.JdkTool;
 
-public class StartJConsoleCommand extends GfshCommand {
+public class StartJConsoleCommand extends InternalGfshCommand {
 
   @CliCommand(value = CliStrings.START_JCONSOLE, help = CliStrings.START_JCONSOLE__HELP)
   @CliMetaData(shellOnly = true, relatedTopic = {CliStrings.TOPIC_GEODE_MANAGER,

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/lifecycle/StartJVisualVMCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/lifecycle/StartJVisualVMCommand.java
@@ -29,13 +29,13 @@ import org.apache.geode.internal.lang.StringUtils;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.Result;
 import org.apache.geode.management.internal.cli.GfshParser;
-import org.apache.geode.management.internal.cli.commands.GfshCommand;
+import org.apache.geode.management.internal.cli.commands.InternalGfshCommand;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.InfoResultData;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.cli.util.JdkTool;
 
-public class StartJVisualVMCommand extends GfshCommand {
+public class StartJVisualVMCommand extends InternalGfshCommand {
   @CliCommand(value = CliStrings.START_JVISUALVM, help = CliStrings.START_JVISUALVM__HELP)
   @CliMetaData(shellOnly = true, relatedTopic = {CliStrings.TOPIC_GEODE_MANAGER,
       CliStrings.TOPIC_GEODE_JMX, CliStrings.TOPIC_GEODE_M_AND_M})

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/lifecycle/StartPulseCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/lifecycle/StartPulseCommand.java
@@ -30,12 +30,12 @@ import org.apache.geode.internal.lang.StringUtils;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.Result;
 import org.apache.geode.management.internal.ManagementConstants;
-import org.apache.geode.management.internal.cli.commands.GfshCommand;
+import org.apache.geode.management.internal.cli.commands.InternalGfshCommand;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.cli.shell.OperationInvoker;
 
-public class StartPulseCommand extends GfshCommand {
+public class StartPulseCommand extends InternalGfshCommand {
 
   @CliCommand(value = CliStrings.START_PULSE, help = CliStrings.START_PULSE__HELP)
   @CliMetaData(shellOnly = true, relatedTopic = {CliStrings.TOPIC_GEODE_MANAGER,

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/lifecycle/StartVsdCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/lifecycle/StartVsdCommand.java
@@ -36,12 +36,12 @@ import org.apache.geode.internal.lang.SystemUtils;
 import org.apache.geode.internal.util.IOUtils;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.commands.GfshCommand;
+import org.apache.geode.management.internal.cli.commands.InternalGfshCommand;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.InfoResultData;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 
-public class StartVsdCommand extends GfshCommand {
+public class StartVsdCommand extends InternalGfshCommand {
   @CliCommand(value = CliStrings.START_VSD, help = CliStrings.START_VSD__HELP)
   @CliMetaData(shellOnly = true,
       relatedTopic = {CliStrings.TOPIC_GEODE_M_AND_M, CliStrings.TOPIC_GEODE_STATISTICS})

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/lifecycle/StatusLocatorCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/lifecycle/StatusLocatorCommand.java
@@ -29,13 +29,13 @@ import org.apache.geode.management.MemberMXBean;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.commands.GfshCommand;
+import org.apache.geode.management.internal.cli.commands.InternalGfshCommand;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.InfoResultData;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.configuration.utils.ClusterConfigurationStatusRetriever;
 
-public class StatusLocatorCommand extends GfshCommand {
+public class StatusLocatorCommand extends InternalGfshCommand {
   @CliCommand(value = CliStrings.STATUS_LOCATOR, help = CliStrings.STATUS_LOCATOR__HELP)
   @CliMetaData(shellOnly = true,
       relatedTopic = {CliStrings.TOPIC_GEODE_LOCATOR, CliStrings.TOPIC_GEODE_LIFECYCLE})

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/lifecycle/StatusServerCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/lifecycle/StatusServerCommand.java
@@ -28,11 +28,11 @@ import org.apache.geode.management.MemberMXBean;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.commands.GfshCommand;
+import org.apache.geode.management.internal.cli.commands.InternalGfshCommand;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 
-public class StatusServerCommand extends GfshCommand {
+public class StatusServerCommand extends InternalGfshCommand {
 
   @CliCommand(value = CliStrings.STATUS_SERVER, help = CliStrings.STATUS_SERVER__HELP)
   @CliMetaData(shellOnly = true,

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/lifecycle/StopLocatorCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/lifecycle/StopLocatorCommand.java
@@ -30,12 +30,12 @@ import org.apache.geode.management.MemberMXBean;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.commands.GfshCommand;
+import org.apache.geode.management.internal.cli.commands.InternalGfshCommand;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.cli.shell.Gfsh;
 
-public class StopLocatorCommand extends GfshCommand {
+public class StopLocatorCommand extends InternalGfshCommand {
   private static final long WAITING_FOR_STOP_TO_MAKE_PID_GO_AWAY_TIMEOUT_MILLIS = 30 * 1000;
 
   @CliCommand(value = CliStrings.STOP_LOCATOR, help = CliStrings.STOP_LOCATOR__HELP)

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/lifecycle/StopServerCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/lifecycle/StopServerCommand.java
@@ -29,12 +29,12 @@ import org.apache.geode.management.MemberMXBean;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.internal.cli.commands.GfshCommand;
+import org.apache.geode.management.internal.cli.commands.InternalGfshCommand;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.cli.shell.Gfsh;
 
-public class StopServerCommand extends GfshCommand {
+public class StopServerCommand extends InternalGfshCommand {
   private static final long WAITING_FOR_STOP_TO_MAKE_PID_GO_AWAY_TIMEOUT_MILLIS = 30 * 1000;
 
   @CliCommand(value = CliStrings.STOP_SERVER, help = CliStrings.STOP_SERVER__HELP)

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/AlterDiskStoreJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/AlterDiskStoreJUnitTest.java
@@ -22,6 +22,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import org.apache.geode.management.cli.GfshCommand;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.util.CommandStringBuilder;
 import org.apache.geode.test.junit.categories.UnitTest;

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CommandAvailabilityIndicatorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CommandAvailabilityIndicatorTest.java
@@ -26,6 +26,7 @@ import org.springframework.shell.core.CommandMarker;
 import org.springframework.shell.core.annotation.CliCommand;
 
 import org.apache.geode.management.cli.CliMetaData;
+import org.apache.geode.management.cli.GfshCommand;
 import org.apache.geode.management.internal.cli.CommandManager;
 import org.apache.geode.test.junit.categories.UnitTest;
 
@@ -44,7 +45,6 @@ public class CommandAvailabilityIndicatorTest {
         continue;
       }
 
-      GfshCommand gfshCommand = (GfshCommand) commandMarker;
       for (Method method : commandMarker.getClass().getMethods()) {
         CliCommand cliCommand = method.getAnnotation(CliCommand.class);
         CliMetaData cliMetaData = method.getAnnotation(CliMetaData.class);

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DescribeConnectionCommandIntegrationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DescribeConnectionCommandIntegrationTest.java
@@ -26,21 +26,8 @@ import org.apache.geode.test.junit.rules.GfshCommandRule;
 import org.apache.geode.test.junit.rules.GfshCommandRule.PortType;
 import org.apache.geode.test.junit.rules.LocatorStarterRule;
 
-/**
- * The GfshCommandJUnitTest class is a test suite of test cases testing the contract and
- * functionality of the GfshCommand class for implementing GemFire shell (Gfsh) commands.
- *
- * @see org.apache.geode.management.cli.GfshCommand
- * @see org.jmock.Expectations
- * @see org.jmock.Mockery
- * @see org.jmock.lib.legacy.ClassImposteriser
- * @see org.junit.Assert
- * @see org.junit.Test
- * @since GemFire 7.0
- */
-
 @Category(IntegrationTest.class)
-public class DescribeConnectionCommandJUnitTest {
+public class DescribeConnectionCommandIntegrationTest {
   public static Logger logger = LogService.getLogger();
 
   @ClassRule

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DescribeConnectionCommandJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DescribeConnectionCommandJUnitTest.java
@@ -30,7 +30,7 @@ import org.apache.geode.test.junit.rules.LocatorStarterRule;
  * The GfshCommandJUnitTest class is a test suite of test cases testing the contract and
  * functionality of the GfshCommand class for implementing GemFire shell (Gfsh) commands.
  *
- * @see org.apache.geode.management.internal.cli.commands.GfshCommand
+ * @see org.apache.geode.management.cli.GfshCommand
  * @see org.jmock.Expectations
  * @see org.jmock.Mockery
  * @see org.jmock.lib.legacy.ClassImposteriser

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/GfshCommandJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/GfshCommandJUnitTest.java
@@ -37,13 +37,13 @@ import org.apache.geode.test.junit.categories.UnitTest;
 @Category(UnitTest.class)
 public class GfshCommandJUnitTest {
 
-  private GfshCommand command;
+  private InternalGfshCommand command;
   private Gfsh gfsh;
   private InternalClusterConfigurationService clusterConfigurationService;
 
   @Before
   public void before() throws Exception {
-    command = spy(GfshCommand.class);
+    command = spy(InternalGfshCommand.class);
     gfsh = mock(Gfsh.class);
     clusterConfigurationService = mock(InternalClusterConfigurationService.class);
   }

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexCommands.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexCommands.java
@@ -39,13 +39,14 @@ import org.apache.geode.cache.lucene.internal.cli.functions.LuceneListIndexFunct
 import org.apache.geode.cache.lucene.internal.cli.functions.LuceneSearchIndexFunction;
 import org.apache.geode.cache.lucene.internal.security.LucenePermission;
 import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.execute.AbstractExecution;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
 import org.apache.geode.management.internal.cli.CliUtil;
-import org.apache.geode.management.internal.cli.commands.GfshCommand;
+import org.apache.geode.management.internal.cli.commands.InternalGfshCommand;
 import org.apache.geode.management.internal.cli.exceptions.UserErrorException;
 import org.apache.geode.management.internal.cli.functions.CliFunctionResult;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
@@ -62,12 +63,12 @@ import org.apache.geode.security.ResourcePermission.Resource;
  * The LuceneIndexCommands class encapsulates all Geode shell (Gfsh) commands related to Lucene
  * indexes defined in Geode.
  *
- * @see GfshCommand
+ * @see InternalGfshCommand
  * @see LuceneIndexDetails
  * @see LuceneListIndexFunction
  */
 @SuppressWarnings("unused")
-public class LuceneIndexCommands extends GfshCommand {
+public class LuceneIndexCommands extends InternalGfshCommand {
   private static final LuceneCreateIndexFunction createIndexFunction =
       new LuceneCreateIndexFunction();
   private static final LuceneDescribeIndexFunction describeIndexFunction =
@@ -199,7 +200,8 @@ public class LuceneIndexCommands extends GfshCommand {
     result = ResultBuilder.buildResult(tabularResult);
     if (xmlEntity != null) {
       persistClusterConfiguration(result, () -> {
-        getConfigurationService().addXmlEntity(xmlEntity, null);
+        ((InternalClusterConfigurationService) getConfigurationService()).addXmlEntity(xmlEntity,
+            null);
       });
     }
     return result;
@@ -292,7 +294,8 @@ public class LuceneIndexCommands extends GfshCommand {
     if (xmlEntity != null) {
       persistClusterConfiguration(result, () -> {
         // Delete the xml entity to remove the index(es) in all groups
-        getConfigurationService().deleteXmlEntity(xmlEntity, null);
+        ((InternalClusterConfigurationService) getConfigurationService()).deleteXmlEntity(xmlEntity,
+            null);
       });
     }
 


### PR DESCRIPTION
* Added public GfshCommand abstract class
* InternalGfshCommand extends the public class
* CommandManager sets cache to GfshCommand

Signed-off-by: Jens Deppe <jdeppe@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
