### PR TITLE
GEODE-4919: Alter region will update PRConfig

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionRegionConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionRegionConfig.java
@@ -89,6 +89,10 @@ public class PartitionRegionConfig extends ExternalizableDSFID implements Versio
 
   private ArrayList<String> partitionListenerClassNames = new ArrayList<String>();
 
+  public void setGatewaySenderIds(Set<String> gatewaySenderIds) {
+    this.gatewaySenderIds = Collections.unmodifiableSet(gatewaySenderIds);
+  }
+
   private Set<String> gatewaySenderIds = Collections.emptySet();
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache;
 
+import static java.util.stream.Collectors.toSet;
 import static org.apache.geode.internal.lang.SystemUtils.getLineSeparator;
 
 import java.io.IOException;
@@ -1225,6 +1226,27 @@ public class PartitionedRegion extends LocalRegion
     }
   }
 
+  public void updatePRConfigWithNewSetOfGatewaySenders(Set<String> gatewaySendersToAdd) {
+    PartitionRegionHelper.assignBucketsToPartitions(this);
+    PartitionRegionConfig prConfig = this.prRoot.get(getRegionIdentifier());
+    prConfig.setGatewaySenderIds(gatewaySendersToAdd);
+    updatePRConfig(prConfig, false);
+  }
+
+  public void updatePRConfigWithNewGatewaySender(String aeqId) {
+    PartitionRegionHelper.assignBucketsToPartitions(this);
+    PartitionRegionConfig prConfig = this.prRoot.get(getRegionIdentifier());
+    Set<String> newGateWayIds;
+    if (prConfig.getGatewaySenderIds() != null) {
+      newGateWayIds = new HashSet<>(prConfig.getGatewaySenderIds());
+    } else {
+      newGateWayIds = new HashSet<>();
+    }
+    newGateWayIds.add(aeqId);
+    prConfig.setGatewaySenderIds(newGateWayIds);
+    updatePRConfig(prConfig, false);
+  }
+
   public void removeGatewaySenderId(String gatewaySenderId) {
     super.removeGatewaySenderId(gatewaySenderId);
     new UpdateAttributesProcessor(this).distribute();
@@ -1347,7 +1369,7 @@ public class PartitionedRegion extends LocalRegion
       prConfig = this.prRoot.get(getRegionIdentifier());
 
       if (prConfig == null) {
-        validateParalleGatewaySenderIds();
+        validateParallelGatewaySenderIds();
         this.partitionedRegionId = generatePRId(getSystem());
         prConfig = new PartitionRegionConfig(this.partitionedRegionId, this.getFullPath(),
             prAttribs, this.getScope(), getAttributes().getEvictionAttributes(),
@@ -1454,10 +1476,35 @@ public class PartitionedRegion extends LocalRegion
     }
   }
 
-  public void validateParalleGatewaySenderIds() throws PRLocallyDestroyedException {
-    for (String senderId : this.getParallelGatewaySenderIds()) {
+  public void validateParallelGatewaySenderIds() throws PRLocallyDestroyedException {
+    validateParallelGatewaySenderIds(this.getParallelGatewaySenderIds());
+  }
+
+  /*
+   * filterOutNonParallelGatewaySenders takes in a set of gateway sender IDs and returns
+   * a set of parallel gateway senders present in the input set.
+   */
+  public Set<String> filterOutNonParallelGatewaySenders(Set<String> senderIds) {
+    Set<String> allParallelSenders = cache.getAllGatewaySenders().parallelStream()
+        .filter(GatewaySender::isParallel).map(GatewaySender::getId).collect(toSet());
+    Set<String> parallelSenders = new HashSet<>();
+    senderIds.parallelStream().forEach(gatewaySenderId -> {
+      if (allParallelSenders.contains(gatewaySenderId)) {
+        parallelSenders.add(gatewaySenderId);
+      }
+    });
+    return parallelSenders;
+  }
+
+  public void validateParallelGatewaySenderIds(Set<String> parallelGatewaySenderIds)
+      throws PRLocallyDestroyedException {
+    for (String senderId : parallelGatewaySenderIds) {
       for (PartitionRegionConfig config : this.prRoot.values()) {
         if (config.getGatewaySenderIds().contains(senderId)) {
+          if (this.getFullPath().equals(config.getFullPath())) {
+            // The sender is already attached to this region
+            continue;
+          }
           Map<String, PartitionedRegion> colocationMap =
               ColocationHelper.getAllColocationRegions(this);
           if (!colocationMap.isEmpty()) {
@@ -9922,7 +9969,6 @@ public class PartitionedRegion extends LocalRegion
     Set<Integer> allBuckets = userPR.getDataStore().getAllLocalBucketIds();
     Set<Integer> allBucketsClone = new HashSet<Integer>();
     allBucketsClone.addAll(allBuckets);
-
     while (allBucketsClone.size() != 0) {
       logger.debug(
           "Need to wait until partitionedRegionQueue <<{}>> is loaded with all the buckets",

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneServiceImpl.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneServiceImpl.java
@@ -24,8 +24,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.Logger;
@@ -228,6 +226,7 @@ public class LuceneServiceImpl implements InternalLuceneService {
         analyzer, fieldAnalyzers, serializer));
 
     String aeqId = LuceneServiceImpl.getUniqueIndexName(indexName, regionPath);
+    region.updatePRConfigWithNewGatewaySender(aeqId);
     LuceneIndexImpl luceneIndex = beforeDataRegionCreated(indexName, regionPath,
         region.getAttributes(), analyzer, fieldAnalyzers, aeqId, serializer, fields);
 

--- a/geode-wan/src/test/java/org/apache/geode/management/internal/configuration/WANClusterConfigurationDUnitTest.java
+++ b/geode-wan/src/test/java/org/apache/geode/management/internal/configuration/WANClusterConfigurationDUnitTest.java
@@ -20,8 +20,11 @@ import static org.apache.geode.test.dunit.Assert.assertTrue;
 import static org.apache.geode.test.dunit.IgnoredException.addIgnoredException;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
+import org.awaitility.Awaitility;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -29,7 +32,12 @@ import org.junit.experimental.categories.Category;
 
 import org.apache.geode.cache.wan.GatewayReceiver;
 import org.apache.geode.cache.wan.GatewaySender;
+import org.apache.geode.management.ManagementService;
+import org.apache.geode.management.cli.Result;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
+import org.apache.geode.management.internal.cli.result.CommandResult;
+import org.apache.geode.management.internal.cli.result.CompositeResultData;
+import org.apache.geode.management.internal.cli.result.TabularResultData;
 import org.apache.geode.management.internal.cli.util.CommandStringBuilder;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
@@ -56,6 +64,390 @@ public class WANClusterConfigurationDUnitTest {
   public void before() throws Exception {
     locator = clusterStartupRule.startLocatorVM(3);
   }
+
+  @Test
+  public void whenAlteringNoncolocatedRegionsWithTheSameParallelSenderIdThenFailure()
+      throws Exception {
+    addIgnoredException("could not get remote locator");
+    addIgnoredException("cannot have the same parallel gateway sender id");
+
+    MemberVM locator = clusterStartupRule.startLocatorVM(0);
+    MemberVM server1 = clusterStartupRule.startServerVM(1, locator.getPort());
+    MemberVM server2 = clusterStartupRule.startServerVM(2, locator.getPort());
+
+    // Connect Gfsh to locator.
+    gfsh.connectAndVerify(locator);
+
+    CommandStringBuilder csb = new CommandStringBuilder(CliStrings.CREATE_GATEWAYSENDER);
+    csb.addOption(CliStrings.CREATE_GATEWAYSENDER__ID, "ny");
+    csb.addOption(CliStrings.CREATE_GATEWAYSENDER__PARALLEL, "true");
+    csb.addOption(CliStrings.CREATE_GATEWAYSENDER__REMOTEDISTRIBUTEDSYSTEMID, "2");
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+
+    csb = new CommandStringBuilder(CliStrings.CREATE_REGION);
+    csb.addOption(CliStrings.CREATE_REGION__REGION, "test1");
+    csb.addOption(CliStrings.CREATE_REGION__REGIONSHORTCUT, "PARTITION_REDUNDANT");
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+
+    csb = new CommandStringBuilder(CliStrings.CREATE_REGION);
+    csb.addOption(CliStrings.CREATE_REGION__REGION, "test2");
+    csb.addOption(CliStrings.CREATE_REGION__REGIONSHORTCUT, "PARTITION_REDUNDANT");
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+
+    csb = new CommandStringBuilder(CliStrings.ALTER_REGION);
+    csb.addOption(CliStrings.ALTER_REGION__REGION, "test1");
+    csb.addOption(CliStrings.ALTER_REGION__GATEWAYSENDERID, "ny");
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+
+    csb = new CommandStringBuilder(CliStrings.ALTER_REGION);
+    csb.addOption(CliStrings.ALTER_REGION__REGION, "test2");
+    csb.addOption(CliStrings.ALTER_REGION__GATEWAYSENDERID, "ny");
+    gfsh.executeAndAssertThat(csb.toString()).statusIsError();
+  }
+
+  @Test
+  public void whenAlteringOneRegionsWithDifferentParallelSenderIdThenSuccess() throws Exception {
+    addIgnoredException("could not get remote locator");
+    addIgnoredException("cannot have the same parallel gateway sender id");
+
+    MemberVM locator = clusterStartupRule.startLocatorVM(0);
+    MemberVM server1 = clusterStartupRule.startServerVM(1, locator.getPort());
+    MemberVM server2 = clusterStartupRule.startServerVM(2, locator.getPort());
+
+    // Connect Gfsh to locator.
+    gfsh.connectAndVerify(locator);
+
+    CommandStringBuilder csb = new CommandStringBuilder(CliStrings.CREATE_GATEWAYSENDER);
+    csb.addOption(CliStrings.CREATE_GATEWAYSENDER__ID, "ny");
+    csb.addOption(CliStrings.CREATE_GATEWAYSENDER__PARALLEL, "true");
+    csb.addOption(CliStrings.CREATE_GATEWAYSENDER__REMOTEDISTRIBUTEDSYSTEMID, "2");
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+
+    csb = new CommandStringBuilder(CliStrings.CREATE_GATEWAYSENDER);
+    csb.addOption(CliStrings.CREATE_GATEWAYSENDER__ID, "ln");
+    csb.addOption(CliStrings.CREATE_GATEWAYSENDER__PARALLEL, "true");
+    csb.addOption(CliStrings.CREATE_GATEWAYSENDER__REMOTEDISTRIBUTEDSYSTEMID, "2");
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+
+    csb = new CommandStringBuilder(CliStrings.CREATE_REGION);
+    csb.addOption(CliStrings.CREATE_REGION__REGION, "test1");
+    csb.addOption(CliStrings.CREATE_REGION__REGIONSHORTCUT, "PARTITION_REDUNDANT");
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+
+    csb = new CommandStringBuilder(CliStrings.ALTER_REGION);
+    csb.addOption(CliStrings.ALTER_REGION__REGION, "test1");
+    csb.addOption(CliStrings.ALTER_REGION__GATEWAYSENDERID, "ny,ln");
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+  }
+
+  @Test
+  public void whenAlteringOneRegionsWithDifferentParallelSenderIdsAfterItWasAlreadySetWithOneOfTheNewSenderThenSuccess()
+      throws Exception {
+    addIgnoredException("could not get remote locator");
+    addIgnoredException("cannot have the same parallel gateway sender id");
+
+    MemberVM locator = clusterStartupRule.startLocatorVM(0);
+    MemberVM server1 = clusterStartupRule.startServerVM(1, locator.getPort());
+    MemberVM server2 = clusterStartupRule.startServerVM(2, locator.getPort());
+
+    // Connect Gfsh to locator.
+    gfsh.connectAndVerify(locator);
+
+    CommandStringBuilder csb = new CommandStringBuilder(CliStrings.CREATE_GATEWAYSENDER);
+    csb.addOption(CliStrings.CREATE_GATEWAYSENDER__ID, "ny");
+    csb.addOption(CliStrings.CREATE_GATEWAYSENDER__PARALLEL, "true");
+    csb.addOption(CliStrings.CREATE_GATEWAYSENDER__REMOTEDISTRIBUTEDSYSTEMID, "2");
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+
+    csb = new CommandStringBuilder(CliStrings.CREATE_GATEWAYSENDER);
+    csb.addOption(CliStrings.CREATE_GATEWAYSENDER__ID, "ln");
+    csb.addOption(CliStrings.CREATE_GATEWAYSENDER__PARALLEL, "true");
+    csb.addOption(CliStrings.CREATE_GATEWAYSENDER__REMOTEDISTRIBUTEDSYSTEMID, "2");
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+
+    csb = new CommandStringBuilder(CliStrings.CREATE_REGION);
+    csb.addOption(CliStrings.CREATE_REGION__REGION, "test1");
+    csb.addOption(CliStrings.CREATE_REGION__REGIONSHORTCUT, "PARTITION_REDUNDANT");
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+
+    csb = new CommandStringBuilder(CliStrings.ALTER_REGION);
+    csb.addOption(CliStrings.ALTER_REGION__REGION, "test1");
+    csb.addOption(CliStrings.ALTER_REGION__GATEWAYSENDERID, "ny");
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+
+    csb = new CommandStringBuilder(CliStrings.ALTER_REGION);
+    csb.addOption(CliStrings.ALTER_REGION__REGION, "test1");
+    csb.addOption(CliStrings.ALTER_REGION__GATEWAYSENDERID, "ny,ln");
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+  }
+
+
+  @Test
+  public void whenAlteringOneRegionsWithDifferentParallelSenderIdAfterItWasAlreadyCreatedWithDifferentSenderThenSuccess()
+      throws Exception {
+    addIgnoredException("could not get remote locator");
+    addIgnoredException("cannot have the same parallel gateway sender id");
+    addIgnoredException("Could not execute \"list gateways\"");
+    MemberVM locator = clusterStartupRule.startLocatorVM(0);
+    MemberVM server1 = clusterStartupRule.startServerVM(1, locator.getPort());
+    MemberVM server2 = clusterStartupRule.startServerVM(2, locator.getPort());
+
+    // Connect Gfsh to locator.
+    gfsh.connectAndVerify(locator);
+
+    CommandStringBuilder csb = new CommandStringBuilder(CliStrings.CREATE_GATEWAYSENDER);
+    csb.addOption(CliStrings.CREATE_GATEWAYSENDER__ID, "ny");
+    csb.addOption(CliStrings.CREATE_GATEWAYSENDER__PARALLEL, "true");
+    csb.addOption(CliStrings.CREATE_GATEWAYSENDER__REMOTEDISTRIBUTEDSYSTEMID, "2");
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+
+    csb = new CommandStringBuilder(CliStrings.CREATE_GATEWAYSENDER);
+    csb.addOption(CliStrings.CREATE_GATEWAYSENDER__ID, "ln");
+    csb.addOption(CliStrings.CREATE_GATEWAYSENDER__PARALLEL, "true");
+    csb.addOption(CliStrings.CREATE_GATEWAYSENDER__REMOTEDISTRIBUTEDSYSTEMID, "2");
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+
+    waitTillAllGatewaySendersAreReady();
+
+    csb = new CommandStringBuilder(CliStrings.CREATE_REGION);
+    csb.addOption(CliStrings.CREATE_REGION__REGION, "test1");
+    csb.addOption(CliStrings.CREATE_REGION__GATEWAYSENDERID, "ny");
+    csb.addOption(CliStrings.CREATE_REGION__REGIONSHORTCUT, "PARTITION_REDUNDANT");
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+
+    csb = new CommandStringBuilder(CliStrings.ALTER_REGION);
+    csb.addOption(CliStrings.ALTER_REGION__REGION, "test1");
+    csb.addOption(CliStrings.ALTER_REGION__GATEWAYSENDERID, "ln");
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+  }
+
+  private void waitTillAllGatewaySendersAreReady() {
+    Awaitility.await().atMost(1, TimeUnit.MINUTES).until(() -> {
+      CommandStringBuilder csb2 = new CommandStringBuilder(CliStrings.LIST_GATEWAY);
+      CommandResult cmdResult = gfsh.executeCommand(csb2.toString());
+      assertThat(cmdResult).isNotNull();
+      assertThat(cmdResult.getStatus()).isSameAs(Result.Status.OK);
+      TabularResultData tableSenderResultData = ((CompositeResultData) cmdResult.getResultData())
+          .retrieveSection(CliStrings.SECTION_GATEWAY_SENDER)
+          .retrieveTable(CliStrings.TABLE_GATEWAY_SENDER);
+      List<String> senders =
+          tableSenderResultData.retrieveAllValues(CliStrings.RESULT_GATEWAY_SENDER_ID);
+      assertThat(senders).hasSize(4);
+    });
+  }
+
+
+  @Test
+  public void whenAlteringOneRegionsWithDifferentParallelSenderIdAfterItWasSetWithOneSenderThenSuccess()
+      throws Exception {
+    addIgnoredException("could not get remote locator");
+    addIgnoredException("cannot have the same parallel gateway sender id");
+
+    MemberVM locator = clusterStartupRule.startLocatorVM(0);
+    MemberVM server1 = clusterStartupRule.startServerVM(1, locator.getPort());
+    MemberVM server2 = clusterStartupRule.startServerVM(2, locator.getPort());
+
+    // Connect Gfsh to locator.
+    gfsh.connectAndVerify(locator);
+
+    CommandStringBuilder csb = new CommandStringBuilder(CliStrings.CREATE_GATEWAYSENDER);
+    csb.addOption(CliStrings.CREATE_GATEWAYSENDER__ID, "ny");
+    csb.addOption(CliStrings.CREATE_GATEWAYSENDER__PARALLEL, "true");
+    csb.addOption(CliStrings.CREATE_GATEWAYSENDER__REMOTEDISTRIBUTEDSYSTEMID, "2");
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+
+    csb = new CommandStringBuilder(CliStrings.CREATE_GATEWAYSENDER);
+    csb.addOption(CliStrings.CREATE_GATEWAYSENDER__ID, "ln");
+    csb.addOption(CliStrings.CREATE_GATEWAYSENDER__PARALLEL, "true");
+    csb.addOption(CliStrings.CREATE_GATEWAYSENDER__REMOTEDISTRIBUTEDSYSTEMID, "2");
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+
+    csb = new CommandStringBuilder(CliStrings.CREATE_REGION);
+    csb.addOption(CliStrings.CREATE_REGION__REGION, "test1");
+    csb.addOption(CliStrings.CREATE_REGION__REGIONSHORTCUT, "PARTITION_REDUNDANT");
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+
+    csb = new CommandStringBuilder(CliStrings.ALTER_REGION);
+    csb.addOption(CliStrings.ALTER_REGION__REGION, "test1");
+    csb.addOption(CliStrings.ALTER_REGION__GATEWAYSENDERID, "ny");
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+
+    csb = new CommandStringBuilder(CliStrings.ALTER_REGION);
+    csb.addOption(CliStrings.ALTER_REGION__REGION, "test1");
+    csb.addOption(CliStrings.ALTER_REGION__GATEWAYSENDERID, "ln");
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+  }
+
+  @Test
+  public void whenAlteringNoncolocatedRegionsWithTheSameSerialSenderIdThenSuccess()
+      throws Exception {
+    addIgnoredException("could not get remote locator");
+    addIgnoredException("cannot have the same parallel gateway sender id");
+
+    MemberVM locator = clusterStartupRule.startLocatorVM(0);
+    MemberVM server1 = clusterStartupRule.startServerVM(1, locator.getPort());
+    MemberVM server2 = clusterStartupRule.startServerVM(2, locator.getPort());
+
+    // Connect Gfsh to locator.
+    gfsh.connectAndVerify(locator);
+
+    CommandStringBuilder csb = new CommandStringBuilder(CliStrings.CREATE_GATEWAYSENDER);
+    csb.addOption(CliStrings.CREATE_GATEWAYSENDER__ID, "ny");
+    csb.addOption(CliStrings.CREATE_GATEWAYSENDER__REMOTEDISTRIBUTEDSYSTEMID, "2");
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+
+    csb = new CommandStringBuilder(CliStrings.CREATE_REGION);
+    csb.addOption(CliStrings.CREATE_REGION__REGION, "test1");
+    csb.addOption(CliStrings.CREATE_REGION__REGIONSHORTCUT, "PARTITION_REDUNDANT");
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+
+    csb = new CommandStringBuilder(CliStrings.CREATE_REGION);
+    csb.addOption(CliStrings.CREATE_REGION__REGION, "test2");
+    csb.addOption(CliStrings.CREATE_REGION__REGIONSHORTCUT, "PARTITION_REDUNDANT");
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+
+    csb = new CommandStringBuilder(CliStrings.ALTER_REGION);
+    csb.addOption(CliStrings.ALTER_REGION__REGION, "test1");
+    csb.addOption(CliStrings.ALTER_REGION__GATEWAYSENDERID, "ny");
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+
+    csb = new CommandStringBuilder(CliStrings.ALTER_REGION);
+    csb.addOption(CliStrings.ALTER_REGION__REGION, "test2");
+    csb.addOption(CliStrings.ALTER_REGION__GATEWAYSENDERID, "ny");
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+  }
+
+  @Test
+  public void whenAlteringNoncolocatedRegionsWithDifferentSerialGatewayIDThenSuccess()
+      throws Exception {
+    addIgnoredException("could not get remote locator");
+    addIgnoredException("cannot have the same parallel gateway sender id");
+
+    MemberVM locator = clusterStartupRule.startLocatorVM(0);
+    MemberVM server1 = clusterStartupRule.startServerVM(1, locator.getPort());
+    MemberVM server2 = clusterStartupRule.startServerVM(2, locator.getPort());
+
+    // Connect Gfsh to locator.
+    gfsh.connectAndVerify(locator);
+
+    CommandStringBuilder csb = new CommandStringBuilder(CliStrings.CREATE_GATEWAYSENDER);
+    csb.addOption(CliStrings.CREATE_GATEWAYSENDER__ID, "ny");
+    csb.addOption(CliStrings.CREATE_GATEWAYSENDER__REMOTEDISTRIBUTEDSYSTEMID, "2");
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+
+    csb = new CommandStringBuilder(CliStrings.CREATE_GATEWAYSENDER);
+    csb.addOption(CliStrings.CREATE_GATEWAYSENDER__ID, "ln");
+    csb.addOption(CliStrings.CREATE_GATEWAYSENDER__REMOTEDISTRIBUTEDSYSTEMID, "2");
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+
+    csb = new CommandStringBuilder(CliStrings.CREATE_REGION);
+    csb.addOption(CliStrings.CREATE_REGION__REGION, "test1");
+    csb.addOption(CliStrings.CREATE_REGION__REGIONSHORTCUT, "PARTITION_REDUNDANT");
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+
+    csb = new CommandStringBuilder(CliStrings.CREATE_REGION);
+    csb.addOption(CliStrings.CREATE_REGION__REGION, "test2");
+    csb.addOption(CliStrings.CREATE_REGION__REGIONSHORTCUT, "PARTITION_REDUNDANT");
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+
+    csb = new CommandStringBuilder(CliStrings.ALTER_REGION);
+    csb.addOption(CliStrings.ALTER_REGION__REGION, "test1");
+    csb.addOption(CliStrings.ALTER_REGION__GATEWAYSENDERID, "ny");
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+
+    csb = new CommandStringBuilder(CliStrings.ALTER_REGION);
+    csb.addOption(CliStrings.ALTER_REGION__REGION, "test2");
+    csb.addOption(CliStrings.ALTER_REGION__GATEWAYSENDERID, "ln");
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+  }
+
+
+  @Test
+  public void whenAlteringNoncolocatedRegionsWithDifferentParallelGatewayIDThenSuccess()
+      throws Exception {
+    addIgnoredException("could not get remote locator");
+    addIgnoredException("cannot have the same parallel gateway sender id");
+
+    MemberVM locator = clusterStartupRule.startLocatorVM(0);
+    MemberVM server1 = clusterStartupRule.startServerVM(1, locator.getPort());
+    MemberVM server2 = clusterStartupRule.startServerVM(2, locator.getPort());
+
+    // Connect Gfsh to locator.
+    gfsh.connectAndVerify(locator);
+
+    CommandStringBuilder csb = new CommandStringBuilder(CliStrings.CREATE_GATEWAYSENDER);
+    csb.addOption(CliStrings.CREATE_GATEWAYSENDER__ID, "ny");
+    csb.addOption(CliStrings.CREATE_GATEWAYSENDER__PARALLEL, "true");
+    csb.addOption(CliStrings.CREATE_GATEWAYSENDER__REMOTEDISTRIBUTEDSYSTEMID, "2");
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+
+    csb = new CommandStringBuilder(CliStrings.CREATE_GATEWAYSENDER);
+    csb.addOption(CliStrings.CREATE_GATEWAYSENDER__ID, "ln");
+    csb.addOption(CliStrings.CREATE_GATEWAYSENDER__PARALLEL, "true");
+    csb.addOption(CliStrings.CREATE_GATEWAYSENDER__REMOTEDISTRIBUTEDSYSTEMID, "2");
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+
+    csb = new CommandStringBuilder(CliStrings.CREATE_REGION);
+    csb.addOption(CliStrings.CREATE_REGION__REGION, "test1");
+    csb.addOption(CliStrings.CREATE_REGION__REGIONSHORTCUT, "PARTITION_REDUNDANT");
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+
+    csb = new CommandStringBuilder(CliStrings.CREATE_REGION);
+    csb.addOption(CliStrings.CREATE_REGION__REGION, "test2");
+    csb.addOption(CliStrings.CREATE_REGION__REGIONSHORTCUT, "PARTITION_REDUNDANT");
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+
+    csb = new CommandStringBuilder(CliStrings.ALTER_REGION);
+    csb.addOption(CliStrings.ALTER_REGION__REGION, "test1");
+    csb.addOption(CliStrings.ALTER_REGION__GATEWAYSENDERID, "ny");
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+
+    csb = new CommandStringBuilder(CliStrings.ALTER_REGION);
+    csb.addOption(CliStrings.ALTER_REGION__REGION, "test2");
+    csb.addOption(CliStrings.ALTER_REGION__GATEWAYSENDERID, "ln");
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+  }
+
+  @Test
+  public void whenAlteringColocatedRegionsWithSameParallelGatewayIDThenSuccess() throws Exception {
+    addIgnoredException("could not get remote locator");
+    addIgnoredException("cannot have the same parallel gateway sender id");
+
+    MemberVM locator = clusterStartupRule.startLocatorVM(0);
+    MemberVM server1 = clusterStartupRule.startServerVM(1, locator.getPort());
+    MemberVM server2 = clusterStartupRule.startServerVM(2, locator.getPort());
+
+    // Connect Gfsh to locator.
+    gfsh.connectAndVerify(locator);
+
+    CommandStringBuilder csb = new CommandStringBuilder(CliStrings.CREATE_GATEWAYSENDER);
+    csb.addOption(CliStrings.CREATE_GATEWAYSENDER__ID, "ny");
+    csb.addOption(CliStrings.CREATE_GATEWAYSENDER__PARALLEL, "true");
+    csb.addOption(CliStrings.CREATE_GATEWAYSENDER__REMOTEDISTRIBUTEDSYSTEMID, "2");
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+
+    csb = new CommandStringBuilder(CliStrings.CREATE_REGION);
+    csb.addOption(CliStrings.CREATE_REGION__REGION, "test1");
+    csb.addOption(CliStrings.CREATE_REGION__REGIONSHORTCUT, "PARTITION_REDUNDANT");
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+
+    csb = new CommandStringBuilder(CliStrings.CREATE_REGION);
+    csb.addOption(CliStrings.CREATE_REGION__REGION, "test2");
+    csb.addOption(CliStrings.CREATE_REGION__COLOCATEDWITH, "test1");
+    csb.addOption(CliStrings.CREATE_REGION__REGIONSHORTCUT, "PARTITION_REDUNDANT");
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+
+    csb = new CommandStringBuilder(CliStrings.ALTER_REGION);
+    csb.addOption(CliStrings.ALTER_REGION__REGION, "test1");
+    csb.addOption(CliStrings.ALTER_REGION__GATEWAYSENDERID, "ny");
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+
+    csb = new CommandStringBuilder(CliStrings.ALTER_REGION);
+    csb.addOption(CliStrings.ALTER_REGION__REGION, "test2");
+    csb.addOption(CliStrings.ALTER_REGION__GATEWAYSENDERID, "ny");
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+  }
+
 
   @Test
   public void testCreateGatewaySenderReceiver() throws Exception {


### PR DESCRIPTION
              * Alter region to add a new gateway sender will update the PartitionRegionConfig
              * This will  allow validateParallelGatewaySenderIds to be executed in alter region command and not just create region
              * This will prevent gateway senders to be added to non colocated regions

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
