### PR TITLE
GEODE-3563: use a timeout for newly created sockets in TcpConduit.run()

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/TcpServer.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/TcpServer.java
@@ -345,7 +345,6 @@ public class TcpServer {
       }
       handler.shutDown();
       synchronized (this) {
-        // this.shutDown = true;
         this.notifyAll();
       }
     }
@@ -360,7 +359,7 @@ public class TcpServer {
       long startTime = DistributionStats.getStatTime();
       DataInputStream input = null;
       try {
-        getSocketCreator().configureServerSSLSocket(socket, READ_TIMEOUT);
+        getSocketCreator().startHandshakeIfSocketIsSSL(socket, READ_TIMEOUT);
 
         try {
           input = new DataInputStream(socket.getInputStream());

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/TcpServer.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/TcpServer.java
@@ -360,9 +360,7 @@ public class TcpServer {
       long startTime = DistributionStats.getStatTime();
       DataInputStream input = null;
       try {
-
-        socket.setSoTimeout(READ_TIMEOUT);
-        getSocketCreator().configureServerSSLSocket(socket);
+        getSocketCreator().configureServerSSLSocket(socket, READ_TIMEOUT);
 
         try {
           input = new DataInputStream(socket.getInputStream());

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/AcceptorImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/AcceptorImpl.java
@@ -1549,8 +1549,7 @@ public class AcceptorImpl implements Acceptor, Runnable, CommBufferPool {
   }
 
   private CommunicationMode getCommunicationModeForNonSelector(Socket socket) throws IOException {
-    socket.setSoTimeout(this.acceptTimeout);
-    this.socketCreator.configureServerSSLSocket(socket);
+    this.socketCreator.configureServerSSLSocket(socket, this.acceptTimeout);
     byte communicationModeByte = (byte) socket.getInputStream().read();
     if (communicationModeByte == -1) {
       throw new EOFException();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/AcceptorImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/AcceptorImpl.java
@@ -1549,7 +1549,7 @@ public class AcceptorImpl implements Acceptor, Runnable, CommBufferPool {
   }
 
   private CommunicationMode getCommunicationModeForNonSelector(Socket socket) throws IOException {
-    this.socketCreator.configureServerSSLSocket(socket, this.acceptTimeout);
+    this.socketCreator.startHandshakeIfSocketIsSSL(socket, this.acceptTimeout);
     byte communicationModeByte = (byte) socket.getInputStream().read();
     if (communicationModeByte == -1) {
       throw new EOFException();

--- a/geode-core/src/main/java/org/apache/geode/internal/net/SocketCreator.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/SocketCreator.java
@@ -968,8 +968,11 @@ public class SocketCreator {
 
   /**
    * Will be a server socket... this one simply registers the listeners.
+   *
+   * @param timeout the socket's timeout will be set to this.
    */
-  public void configureServerSSLSocket(Socket socket) throws IOException {
+  public void configureServerSSLSocket(Socket socket, int timeout) throws IOException {
+    socket.setSoTimeout(timeout);
     if (socket instanceof SSLSocket) {
       SSLSocket sslSocket = (SSLSocket) socket;
       try {
@@ -990,6 +993,7 @@ public class SocketCreator {
               ex);
           throw ex;
         }
+        // else ignore
       }
     }
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/net/SocketCreator.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/SocketCreator.java
@@ -971,8 +971,9 @@ public class SocketCreator {
    *
    * @param timeout the socket's timeout will be set to this (in milliseconds).
    */
-  public void configureServerSSLSocket(Socket socket, int timeout) throws IOException {
+  public void startHandshakeIfSocketIsSSL(Socket socket, int timeout) throws IOException {
     socket.setSoTimeout(timeout);
+
     if (socket instanceof SSLSocket) {
       SSLSocket sslSocket = (SSLSocket) socket;
       try {

--- a/geode-core/src/main/java/org/apache/geode/internal/net/SocketCreator.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/SocketCreator.java
@@ -969,7 +969,7 @@ public class SocketCreator {
   /**
    * Will be a server socket... this one simply registers the listeners.
    *
-   * @param timeout the socket's timeout will be set to this.
+   * @param timeout the socket's timeout will be set to this (in milliseconds).
    */
   public void configureServerSSLSocket(Socket socket, int timeout) throws IOException {
     socket.setSoTimeout(timeout);

--- a/geode-core/src/main/java/org/apache/geode/internal/tcp/TCPConduit.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/tcp/TCPConduit.java
@@ -598,9 +598,8 @@ public class TCPConduit implements Runnable {
               LocalizedStrings.TCPConduit_UNABLE_TO_SHUT_DOWN_LISTENER_WITHIN_0_MS_UNABLE_TO_INTERRUPT_SOCKET_ACCEPT_DUE_TO_JDK_BUG_GIVING_UP,
               Integer.valueOf(LISTENER_CLOSE_TIMEOUT)));
         }
-      } catch (IOException e) {
-      } catch (InterruptedException e) {
-        // Ignore, we're trying to stop already.
+      } catch (IOException | InterruptedException e) {
+        // we're already trying to shutdown, ignore
       } finally {
         this.hsPool.shutdownNow();
       }
@@ -689,7 +688,7 @@ public class TCPConduit implements Runnable {
                 ex);
             break;
           }
-          socketCreator.configureServerSSLSocket(othersock, idleConnectionTimeout);
+          socketCreator.startHandshakeIfSocketIsSSL(othersock, idleConnectionTimeout);
         }
         if (stopped) {
           try {

--- a/geode-core/src/test/java/org/apache/geode/internal/net/DummySocketCreator.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/net/DummySocketCreator.java
@@ -35,8 +35,8 @@ public class DummySocketCreator extends SocketCreator {
   }
 
   @Override
-  public void configureServerSSLSocket(Socket socket) throws IOException {
-    this.socketSoTimeouts.add(socket.getSoTimeout());
+  public void configureServerSSLSocket(Socket socket, int timeout) throws IOException {
+    this.socketSoTimeouts.add(timeout);
     throw new SSLException("This is a test SSLException");
   }
 

--- a/geode-core/src/test/java/org/apache/geode/internal/net/DummySocketCreator.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/net/DummySocketCreator.java
@@ -35,12 +35,8 @@ public class DummySocketCreator extends SocketCreator {
   }
 
   @Override
-  public void configureServerSSLSocket(Socket socket, int timeout) throws IOException {
+  public void startHandshakeIfSocketIsSSL(Socket socket, int timeout) throws IOException {
     this.socketSoTimeouts.add(timeout);
     throw new SSLException("This is a test SSLException");
-  }
-
-  public List<Integer> getSocketSoTimeouts() {
-    return socketSoTimeouts;
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/net/SSLSocketIntegrationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/net/SSLSocketIntegrationTest.java
@@ -209,7 +209,7 @@ public class SSLSocketIntegrationTest {
       Awaitility.await("connect to server socket").atMost(30, TimeUnit.SECONDS).until(() -> {
         try {
           Socket clientSocket = socketCreator.connectForClient(
-              SocketCreator.getLocalHost().getHostAddress(), serverSocketPort, 2000);
+              SocketCreator.getLocalHost().getHostAddress(), serverSocketPort, 500);
           clientSocket.close();
           System.err.println(
               "client successfully connected to server but should not have been able to do so");
@@ -254,7 +254,8 @@ public class SSLSocketIntegrationTest {
     Thread serverThread = new Thread(new MyThreadGroup(this.testName.getMethodName()), () -> {
       try {
         Socket socket = serverSocket.accept();
-        SocketCreatorFactory.getSocketCreatorForComponent(CLUSTER).configureServerSSLSocket(socket);
+        SocketCreatorFactory.getSocketCreatorForComponent(CLUSTER).configureServerSSLSocket(socket,
+            15000);
         ObjectInputStream ois = new ObjectInputStream(socket.getInputStream());
         messageFromClient.set((String) ois.readObject());
       } catch (IOException | ClassNotFoundException e) {

--- a/geode-core/src/test/java/org/apache/geode/internal/net/SSLSocketIntegrationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/net/SSLSocketIntegrationTest.java
@@ -254,8 +254,8 @@ public class SSLSocketIntegrationTest {
     Thread serverThread = new Thread(new MyThreadGroup(this.testName.getMethodName()), () -> {
       try {
         Socket socket = serverSocket.accept();
-        SocketCreatorFactory.getSocketCreatorForComponent(CLUSTER).configureServerSSLSocket(socket,
-            15000);
+        SocketCreatorFactory.getSocketCreatorForComponent(CLUSTER)
+            .startHandshakeIfSocketIsSSL(socket, 15000);
         ObjectInputStream ois = new ObjectInputStream(socket.getInputStream());
         messageFromClient.set((String) ois.readObject());
       } catch (IOException | ClassNotFoundException e) {

--- a/geode-core/src/test/java/org/apache/geode/internal/net/SocketCreatorJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/net/SocketCreatorJUnitTest.java
@@ -14,6 +14,13 @@
  */
 package org.apache.geode.internal.net;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.Socket;
+
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -35,6 +42,17 @@ public class SocketCreatorJUnitTest {
     // GEODE-3393: This would fail with java.io.FileNotFoundException: $USER_HOME/.keystore
     new SocketCreator(testSSLConfig);
 
+  }
+
+  @Test
+  public void testConfigureServerSSLSocketSetsSoTimeout() throws Exception {
+    final SocketCreator socketCreator = new SocketCreator(mock(SSLConfig.class));
+    final Socket socket = mock(Socket.class);
+
+    final int timeout = 1938236;
+    socketCreator.configureServerSSLSocket(socket, timeout);
+
+    verify(socket).setSoTimeout(timeout);
   }
 
   private String getSingleKeyKeystore() {

--- a/geode-core/src/test/java/org/apache/geode/internal/net/SocketCreatorJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/net/SocketCreatorJUnitTest.java
@@ -17,7 +17,6 @@ package org.apache.geode.internal.net;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import java.net.Socket;
 
@@ -50,7 +49,7 @@ public class SocketCreatorJUnitTest {
     final Socket socket = mock(Socket.class);
 
     final int timeout = 1938236;
-    socketCreator.configureServerSSLSocket(socket, timeout);
+    socketCreator.startHandshakeIfSocketIsSSL(socket, timeout);
 
     verify(socket).setSoTimeout(timeout);
   }


### PR DESCRIPTION
Also close newly accepted sockets in TcpConduit.run() if SSL configuration fails (or any other IOException).

I'm not sure the best way to test the `run()` method itself, so I haven't attempted it here. l'm not sure what the best way to do that is and leaks are hard to test in general. Let me know if you have ideas.