### PR TITLE
GEODE-4943: Move isConnectedAndReady method to public class

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/cli/GfshCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/cli/GfshCommand.java
@@ -35,11 +35,18 @@ import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.exceptions.EntityNotFoundException;
 import org.apache.geode.management.internal.cli.functions.CliFunctionResult;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
+import org.apache.geode.management.internal.cli.shell.Gfsh;
 import org.apache.geode.security.ResourcePermission;
 
 @Experimental
 public abstract class GfshCommand implements CommandMarker {
   private InternalCache cache;
+
+  public boolean isConnectedAndReady() {
+    Gfsh gfsh = Gfsh.getCurrentInstance();
+    return gfsh != null && gfsh.isConnectedAndReady();
+  }
+
 
   public void authorize(ResourcePermission.Resource resource,
       ResourcePermission.Operation operation, ResourcePermission.Target target) {
@@ -169,9 +176,5 @@ public abstract class GfshCommand implements CommandMarker {
       Set<DistributedMember> targetMembers) {
     ResultCollector rc = executeFunction(function, args, targetMembers);
     return CliFunctionResult.cleanResults((List<?>) rc.getResult());
-  }
-
-  public Set<DistributedMember> findMembersWithAsyncEventQueue(String queueId) {
-    return CliUtil.getMembersWithAsyncEventQueue((InternalCache) getCache(), queueId);
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/management/cli/GfshCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/cli/GfshCommand.java
@@ -47,7 +47,6 @@ public abstract class GfshCommand implements CommandMarker {
     return gfsh != null && gfsh.isConnectedAndReady();
   }
 
-
   public void authorize(ResourcePermission.Resource resource,
       ResourcePermission.Operation operation, ResourcePermission.Target target) {
     cache.getSecurityService().authorize(resource, operation, target);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/InternalGfshCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/InternalGfshCommand.java
@@ -37,10 +37,6 @@ import org.apache.geode.management.internal.configuration.domain.XmlEntity;
 public abstract class InternalGfshCommand extends GfshCommand implements CommandMarker {
   public static final String EXPERIMENTAL = "(Experimental) ";
 
-  public boolean isConnectedAndReady() {
-    return getGfsh() != null && getGfsh().isConnectedAndReady();
-  }
-
   public void persistClusterConfiguration(Result result, Runnable runnable) {
     if (result == null) {
       throw new IllegalArgumentException("Result should not be null");

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/GfshCommandJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/GfshCommandJUnitTest.java
@@ -49,20 +49,6 @@ public class GfshCommandJUnitTest {
   }
 
   @Test
-  public void isConnectedAndReady() throws Exception {
-    when(command.getGfsh()).thenReturn(null);
-    assertThat(command.isConnectedAndReady()).isFalse();
-
-    when(command.getGfsh()).thenReturn(gfsh);
-    when(gfsh.isConnectedAndReady()).thenReturn(false);
-    assertThat(command.isConnectedAndReady()).isFalse();
-
-    when(command.getGfsh()).thenReturn(gfsh);
-    when(gfsh.isConnectedAndReady()).thenReturn(true);
-    assertThat(command.isConnectedAndReady()).isTrue();
-  }
-
-  @Test
   public void persistClusterConfiguration() throws Exception {
     when(command.getConfigurationService()).thenReturn(null);
     Result result = ResultBuilder.createInfoResult("info");


### PR DESCRIPTION
- Remove unnecessary findMembersWithAsyncEventQueue method which was
  inadvertently included.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
