### PR TITLE
GEODE-4922: handle Date conversion

### DIFF
--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/JdbcLoaderIntegrationTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/JdbcLoaderIntegrationTest.java
@@ -84,11 +84,6 @@ public class JdbcLoaderIntegrationTest {
         + " (id varchar(10) primary key not null, name varchar(10), age int)");
   }
 
-  private void createEmployeeTableWithQuotes() throws Exception {
-    statement.execute("Create Table \"" + REGION_TABLE_NAME
-        + "\" (\"id\" varchar(10) primary key not null, \"name\" varchar(10), \"age\" int, \"Age\" int)");
-  }
-
   private void createClassWithSupportedPdxFieldsTable() throws Exception {
     statement.execute("Create Table " + REGION_TABLE_NAME
         + " (id varchar(10) primary key not null, " + "aboolean smallint, " + "abyte smallint, "
@@ -223,7 +218,7 @@ public class JdbcLoaderIntegrationTest {
     ps.setObject(i++, classWithSupportedPdxFields.getAfloat());
     ps.setObject(i++, classWithSupportedPdxFields.getAdouble());
     ps.setObject(i++, classWithSupportedPdxFields.getAstring());
-    ps.setObject(i++, classWithSupportedPdxFields.getAdate());
+    ps.setObject(i++, new java.sql.Timestamp(classWithSupportedPdxFields.getAdate().getTime()));
     ps.setObject(i++, classWithSupportedPdxFields.getAnobject());
     ps.setObject(i++, classWithSupportedPdxFields.getAbytearray());
     ps.setObject(i++, new Character(classWithSupportedPdxFields.getAchar()).toString());


### PR DESCRIPTION
When writing a java.util.Date the column type will be used
to convert it to a java.sql.Date, java.sql.Time, or java.sql.Timestamp.
When reading a pdx DATE field, the column type will be used to
decide if getDate, getTime, or getTimestamp is called.
When reading a pdx OBJECT field, if getObject returns an instance of
java.sql.Date, java.sql.Time, or java.sql.Timestamp then it will be
converted to java.util.Date and that will be stored in the pdx field.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
