### PR TITLE
GEODE-4913: gfsh start server cmd is not recognizing local properties…

### DIFF
--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/CreateConnectionCommandDUnitTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/CreateConnectionCommandDUnitTest.java
@@ -103,7 +103,7 @@ public class CreateConnectionCommandDUnitTest {
     locator.invoke(() -> {
       String xml = InternalLocator.getLocator().getSharedConfiguration().getConfiguration("cluster")
           .getCacheXmlContent();
-      assertThat(xml).doesNotContain("jdbc:connector-service");
+      assertThat(xml).isNull();
     });
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalClusterConfigurationService.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalClusterConfigurationService.java
@@ -239,10 +239,7 @@ public class InternalClusterConfigurationService implements ClusterConfiguration
         }
         String xmlContent = configuration.getCacheXmlContent();
         if (xmlContent == null || xmlContent.isEmpty()) {
-          StringWriter sw = new StringWriter();
-          PrintWriter pw = new PrintWriter(sw);
-          CacheXmlGenerator.generateDefault(pw);
-          xmlContent = sw.toString();
+          xmlContent = generateInitialXmlContent();
         }
         try {
           final Document doc = XmlUtils.createAndUpgradeDocumentFromXml(xmlContent);
@@ -866,13 +863,24 @@ public class InternalClusterConfigurationService implements ClusterConfiguration
     return unmarshaller;
   }
 
+  private String generateInitialXmlContent() {
+    StringWriter sw = new StringWriter();
+    PrintWriter pw = new PrintWriter(sw);
+    CacheXmlGenerator.generateDefault(pw);
+    return sw.toString();
+  }
+
   @Override
   public CacheConfig getCacheConfig(String group,
       Class<? extends CacheElement>... additionalBindClass) {
     if (group == null) {
       group = CLUSTER_CONFIG;
     }
-    return unMarshall(getConfiguration(group).getCacheXmlContent(), additionalBindClass);
+    String xmlContent = getConfiguration(group).getCacheXmlContent();
+    if (xmlContent == null || xmlContent.isEmpty()) {
+      xmlContent = generateInitialXmlContent();
+    }
+    return unMarshall(xmlContent, additionalBindClass);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/management/internal/configuration/domain/Configuration.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/configuration/domain/Configuration.java
@@ -73,14 +73,6 @@ public class Configuration implements DataSerializable {
     this.propertiesFileName = configName + ".properties";
     this.gemfireProperties = new Properties();
     this.jarNames = new HashSet<String>();
-    this.cacheXmlContent = generateInitialXmlContent();
-  }
-
-  private String generateInitialXmlContent() {
-    StringWriter sw = new StringWriter();
-    PrintWriter pw = new PrintWriter(sw);
-    CacheXmlGenerator.generateDefault(pw);
-    return sw.toString();
   }
 
   public String getCacheXmlContent() {

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/StartServerWithXmlDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/StartServerWithXmlDUnitTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.internal.cache;
+
+import static org.apache.geode.distributed.ConfigurationProperties.CACHE_XML_FILE;
+import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.CacheFactory;
+import org.apache.geode.cache.server.CacheServer;
+import org.apache.geode.distributed.ServerLauncher;
+import org.apache.geode.distributed.ServerLauncherIntegrationTest;
+import org.apache.geode.distributed.internal.DistributionConfig;
+import org.apache.geode.distributed.internal.InternalDistributedSystem;
+import org.apache.geode.internal.cache.CacheServerLauncher;
+import org.apache.geode.internal.cache.GemFireCacheImpl;
+import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.test.dunit.VM;
+import org.apache.geode.test.dunit.rules.ClusterStartupRule;
+import org.apache.geode.test.dunit.rules.MemberVM;
+import org.apache.geode.test.junit.categories.DistributedTest;
+import org.apache.geode.test.junit.rules.GfshCommandRule;
+import org.apache.geode.test.junit.rules.LocatorStarterRule;
+import org.apache.geode.test.junit.rules.Server;
+import org.apache.geode.test.junit.rules.ServerStarterRule;
+import org.apache.geode.util.test.TestUtil;
+
+@Category(DistributedTest.class)
+public class StartServerWithXmlDUnitTest {
+
+  private VM server;
+  private MemberVM locator;
+
+  @Rule
+  public ClusterStartupRule cluster = new ClusterStartupRule();
+
+  @Before
+  public void before() throws Exception {
+    locator = cluster.startLocatorVM(0);
+
+    Properties props = new Properties();
+    String locators = "localhost[" + locator.getPort() + "]";
+    props.setProperty(LOCATORS, locators);
+    String cacheXmlPath = TestUtil.getResourcePath(getClass(), "CacheServerWithZeroPort.xml");
+    props.setProperty(CACHE_XML_FILE, cacheXmlPath);
+
+    server = cluster.getVM(1);
+
+    server.invoke(() -> {
+      CacheServerLauncher.setServerBindAddress("localhost");
+      CacheServerLauncher.setDisableDefaultServer(false);
+      CacheFactory cf = new CacheFactory(props);
+      Cache cache = cf.create();
+    });
+  }
+
+  @Test
+  public void startServerWithXMLNotToStartDefaultCacheServer() {
+    // Verify that when there is a declarative cache server then we dont launch default server
+    server.invoke(() -> {
+      assertThat(GemFireCacheImpl.getInstance().getCacheServers().size()).isEqualTo(1);
+    });
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateAsyncEventQueueCommandDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateAsyncEventQueueCommandDUnitTest.java
@@ -112,8 +112,7 @@ public class CreateAsyncEventQueueCommandDUnitTest {
     locator.invoke(() -> {
       InternalClusterConfigurationService service =
           ClusterStartupRule.getLocator().getSharedConfiguration();
-      assertThat(service.getConfiguration("cluster").getCacheXmlContent())
-          .doesNotContain("async-event-queue");
+      assertThat(service.getConfiguration("cluster").getCacheXmlContent()).isNull();
     });
 
     gfsh.executeAndAssertThat(VALID_COMMAND + " --id=queue").statusIsSuccess()

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateDefinedIndexesCommandDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateDefinedIndexesCommandDUnitTest.java
@@ -205,10 +205,7 @@ public class CreateDefinedIndexesCommandDUnitTest {
           ((InternalLocator) Locator.getLocator()).getSharedConfiguration();
       assertThat(sharedConfig.getConfiguration("group1").getCacheXmlContent()).contains(index2Name,
           index1Name);
-      assertThat(sharedConfig.getConfiguration("cluster").getCacheXmlContent())
-          .doesNotContain(index2Name);
-      assertThat(sharedConfig.getConfiguration("cluster").getCacheXmlContent())
-          .doesNotContain(index1Name);
+      assertThat(sharedConfig.getConfiguration("cluster").getCacheXmlContent()).isNullOrEmpty();
     });
   }
 }

--- a/geode-core/src/test/resources/org/apache/geode/internal/cache/CacheServerWithZeroPort.xml
+++ b/geode-core/src/test/resources/org/apache/geode/internal/cache/CacheServerWithZeroPort.xml
@@ -15,8 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-
-<!DOCTYPE cache PUBLIC "-//GemStone Systems, Inc.//GemFire Declarative Caching 7.0//EN" "http://www.gemstone.com/dtd/cache7_0.dtd">
-<cache>
-    <cache-server port="0" />
+<cache
+        xmlns="http://geode.apache.org/schema/cache"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://geode.apache.org/schema/cache http://geode.apache.org/schema/cache/cache-1.0.xsd"
+        version="1.0">
+    <cache-server port="0"/>
 </cache>

--- a/geode-core/src/test/resources/org/apache/geode/internal/cache/CacheServerWithZeroPort.xml
+++ b/geode-core/src/test/resources/org/apache/geode/internal/cache/CacheServerWithZeroPort.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!DOCTYPE cache PUBLIC "-//GemStone Systems, Inc.//GemFire Declarative Caching 7.0//EN" "http://www.gemstone.com/dtd/cache7_0.dtd">
+<cache>
+    <cache-server port="0" />
+</cache>


### PR DESCRIPTION
… and cache.xml, instead using default

  * Reverted having a default cluster xml, having a default xml
    in the cluster config caused a default cache server to be
    launched, which caused the sighted issue.

  * Instead cluster config is initialized only when needed.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
