### PR TITLE
GEODE-4913: gfsh start server cmd is not recognizing local properties…

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/ClusterConfigurationService.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/ClusterConfigurationService.java
@@ -176,6 +176,13 @@ public class ClusterConfigurationService {
     return sharedConfigDls;
   }
 
+  public String generateDefaultXml() {
+    StringWriter sw = new StringWriter();
+    PrintWriter pw = new PrintWriter(sw);
+    CacheXmlGenerator.generateDefault(pw);
+    return sw.toString();
+  }
+
   /**
    * Adds/replaces the xml entity in the shared configuration we don't need to trigger the change
    * listener for this modification, so it's ok to operate on the original configuration object
@@ -194,10 +201,7 @@ public class ClusterConfigurationService {
         }
         String xmlContent = configuration.getCacheXmlContent();
         if (xmlContent == null || xmlContent.isEmpty()) {
-          StringWriter sw = new StringWriter();
-          PrintWriter pw = new PrintWriter(sw);
-          CacheXmlGenerator.generateDefault(pw);
-          xmlContent = sw.toString();
+          xmlContent = generateDefaultXml();
         }
         try {
           final Document doc = XmlUtils.createAndUpgradeDocumentFromXml(xmlContent);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateJndiBindingCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateJndiBindingCommand.java
@@ -194,7 +194,11 @@ public class CreateJndiBindingCommand implements GfshCommand {
 
     Configuration config = getSharedConfiguration().getConfiguration("cluster");
 
-    Document document = XmlUtils.createDocumentFromXml(config.getCacheXmlContent());
+    String xmlContent = config.getCacheXmlContent();
+    if (xmlContent == null || xmlContent.isEmpty()) {
+      xmlContent = getSharedConfiguration().generateDefaultXml();
+    }
+    Document document = XmlUtils.createDocumentFromXml(xmlContent);
     NodeList jndiBindings = document.getElementsByTagName("jndi-binding");
 
     if (jndiBindings == null || jndiBindings.getLength() == 0) {
@@ -214,7 +218,11 @@ public class CreateJndiBindingCommand implements GfshCommand {
     // cluster group config should always be present
     Configuration config = getSharedConfiguration().getConfiguration("cluster");
 
-    Document document = XmlUtils.createDocumentFromXml(config.getCacheXmlContent());
+    String xmlContent = config.getCacheXmlContent();
+    if (xmlContent == null || xmlContent.isEmpty()) {
+      xmlContent = getSharedConfiguration().generateDefaultXml();
+    }
+    Document document = XmlUtils.createDocumentFromXml(xmlContent);
     Node cacheNode = document.getElementsByTagName("cache").item(0);
 
     NodeList jndiBindingsNode = document.getElementsByTagName("jndi-bindings");

--- a/geode-core/src/main/java/org/apache/geode/management/internal/configuration/domain/Configuration.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/configuration/domain/Configuration.java
@@ -73,14 +73,6 @@ public class Configuration implements DataSerializable {
     this.propertiesFileName = configName + ".properties";
     this.gemfireProperties = new Properties();
     this.jarNames = new HashSet<String>();
-    this.cacheXmlContent = generateInitialXmlContent();
-  }
-
-  private String generateInitialXmlContent() {
-    StringWriter sw = new StringWriter();
-    PrintWriter pw = new PrintWriter(sw);
-    CacheXmlGenerator.generateDefault(pw);
-    return sw.toString();
   }
 
   public String getCacheXmlContent() {

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/StartServerWithXmlDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/StartServerWithXmlDUnitTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.internal.cache;
+
+import static org.apache.geode.distributed.ConfigurationProperties.CACHE_XML_FILE;
+import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Properties;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.CacheFactory;
+import org.apache.geode.test.dunit.VM;
+import org.apache.geode.test.dunit.rules.ClusterStartupRule;
+import org.apache.geode.test.dunit.rules.MemberVM;
+import org.apache.geode.test.junit.categories.DistributedTest;
+import org.apache.geode.util.test.TestUtil;
+
+@Category(DistributedTest.class)
+public class StartServerWithXmlDUnitTest {
+
+  private VM server;
+  private MemberVM locator;
+
+  @Rule
+  public ClusterStartupRule cluster = new ClusterStartupRule();
+
+  @Before
+  public void before() throws Exception {
+    locator = cluster.startLocatorVM(0);
+
+    Properties props = new Properties();
+    String locators = "localhost[" + locator.getPort() + "]";
+    props.setProperty(LOCATORS, locators);
+    String cacheXmlPath = TestUtil.getResourcePath(getClass(), "CacheServerWithZeroPort.xml");
+    props.setProperty(CACHE_XML_FILE, cacheXmlPath);
+
+    server = cluster.getVM(1);
+
+    server.invoke(() -> {
+      CacheServerLauncher.setServerBindAddress("localhost");
+      CacheServerLauncher.setDisableDefaultServer(false);
+      CacheFactory cf = new CacheFactory(props);
+      Cache cache = cf.create();
+    });
+  }
+
+  @Test
+  public void startServerWithXMLNotToStartDefaultCacheServer() {
+    // Verify that when there is a declarative cache server then we dont launch default server
+    server.invoke(() -> {
+      assertThat(GemFireCacheImpl.getInstance().getCacheServers().size()).isEqualTo(1);
+    });
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateJndiBindingCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateJndiBindingCommandTest.java
@@ -16,6 +16,7 @@ package org.apache.geode.management.internal.cli.commands;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -166,6 +167,7 @@ public class CreateJndiBindingCommandTest {
     Region configRegion = mock(Region.class);
 
     doReturn(configRegion).when(clusterConfigService).getConfigurationRegion();
+    doCallRealMethod().when(clusterConfigService).generateDefaultXml();
     doReturn(null).when(configRegion).put(any(), any());
     doReturn(clusterConfig).when(clusterConfigService).getConfiguration("cluster");
     doReturn(Collections.emptySet()).when(command).findMembers(any(), any());
@@ -188,6 +190,7 @@ public class CreateJndiBindingCommandTest {
     ClusterConfigurationService clusterConfigService = mock(ClusterConfigurationService.class);
 
     doReturn(clusterConfig).when(clusterConfigService).getConfiguration("cluster");
+    doCallRealMethod().when(clusterConfigService).generateDefaultXml();
     doReturn(Collections.emptySet()).when(command).findMembers(any(), any());
     doReturn(clusterConfigService).when(command).getSharedConfiguration();
 
@@ -203,6 +206,7 @@ public class CreateJndiBindingCommandTest {
     Region configRegion = mock(Region.class);
 
     doReturn(configRegion).when(clusterConfigService).getConfigurationRegion();
+    doCallRealMethod().when(clusterConfigService).generateDefaultXml();
     doReturn(null).when(configRegion).put(any(), any());
     doReturn(clusterConfig).when(clusterConfigService).getConfiguration("cluster");
     doReturn(Collections.emptySet()).when(command).findMembers(any(), any());
@@ -225,6 +229,7 @@ public class CreateJndiBindingCommandTest {
     Region configRegion = mock(Region.class);
 
     doReturn(configRegion).when(clusterConfigService).getConfigurationRegion();
+    doCallRealMethod().when(clusterConfigService).generateDefaultXml();
     doReturn(null).when(configRegion).put(any(), any());
     doReturn(clusterConfig).when(clusterConfigService).getConfiguration("cluster");
     doReturn(Collections.emptySet()).when(command).findMembers(any(), any());

--- a/geode-core/src/test/resources/org/apache/geode/internal/cache/CacheServerWithZeroPort.xml
+++ b/geode-core/src/test/resources/org/apache/geode/internal/cache/CacheServerWithZeroPort.xml
@@ -15,8 +15,10 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-
-<!DOCTYPE cache PUBLIC "-//GemStone Systems, Inc.//GemFire Declarative Caching 7.0//EN" "http://www.gemstone.com/dtd/cache7_0.dtd">
-<cache>
-    <cache-server port="0" />
+<cache
+        xmlns="http://geode.apache.org/schema/cache"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://geode.apache.org/schema/cache http://geode.apache.org/schema/cache/cache-1.0.xsd"
+        version="1.0">
+    <cache-server port="0"/>
 </cache>

--- a/geode-core/src/test/resources/org/apache/geode/internal/cache/CacheServerWithZeroPort.xml
+++ b/geode-core/src/test/resources/org/apache/geode/internal/cache/CacheServerWithZeroPort.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!DOCTYPE cache PUBLIC "-//GemStone Systems, Inc.//GemFire Declarative Caching 7.0//EN" "http://www.gemstone.com/dtd/cache7_0.dtd">
+<cache>
+    <cache-server port="0" />
+</cache>


### PR DESCRIPTION
… and cache.xml, instead using default

  * Reverted having a default cluster xml, having a default xml
    in the cluster config caused a default cache server to be
    launched, which caused the sighted issue.

  * Instead cluster config is initialized only when needed.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
