### PR TITLE
GEODE-4840: do not deserialize PdxInstances for remote gets

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
@@ -2200,7 +2200,7 @@ public class DistributedRegion extends LocalRegion implements InternalDistribute
       event = findOnServer(keyInfo, op, generateCallbacks, clientEvent);
       if (event == null) {
         event = createEventForLoad(keyInfo, generateCallbacks, requestingClient, op);
-        lastModified = findUsingSearchLoad(txState, localValue, clientEvent, keyInfo, event);
+        lastModified = findUsingSearchLoad(txState, localValue, clientEvent, keyInfo, event, preferCD);
       }
       // Update region with new value.
       if (event.hasNewValue() && !isMemoryThresholdReachedForLoad()) {
@@ -2320,7 +2320,7 @@ public class DistributedRegion extends LocalRegion implements InternalDistribute
   }
 
   private long findUsingSearchLoad(TXStateInterface txState, Object localValue,
-      EntryEventImpl clientEvent, final KeyInfo keyInfo, EntryEventImpl event) {
+      EntryEventImpl clientEvent, final KeyInfo keyInfo, EntryEventImpl event, boolean preferCD) {
     long lastModified = 0L;
     // If this event is because of a register interest call, don't invoke the CacheLoader
     boolean getForRegisterInterest = clientEvent != null && clientEvent.getOperation() != null
@@ -2330,7 +2330,7 @@ public class DistributedRegion extends LocalRegion implements InternalDistribute
       try {
         processor.initialize(this, keyInfo.getKey(), keyInfo.getCallbackArg());
         // processor fills in event
-        processor.doSearchAndLoad(event, txState, localValue);
+        processor.doSearchAndLoad(event, txState, localValue, preferCD);
         if (clientEvent != null && clientEvent.getVersionTag() == null) {
           clientEvent.setVersionTag(event.getVersionTag());
         }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
@@ -2200,7 +2200,8 @@ public class DistributedRegion extends LocalRegion implements InternalDistribute
       event = findOnServer(keyInfo, op, generateCallbacks, clientEvent);
       if (event == null) {
         event = createEventForLoad(keyInfo, generateCallbacks, requestingClient, op);
-        lastModified = findUsingSearchLoad(txState, localValue, clientEvent, keyInfo, event, preferCD);
+        lastModified =
+            findUsingSearchLoad(txState, localValue, clientEvent, keyInfo, event, preferCD);
       }
       // Update region with new value.
       if (event.hasNewValue() && !isMemoryThresholdReachedForLoad()) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
@@ -5311,7 +5311,7 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
   }
 
   @Override
-  public Object convertPdxInstanceIfNeeded(Object obj) {
+  public Object convertPdxInstanceIfNeeded(Object obj, boolean preferCD) {
     Object result = obj;
     if (!this.getPdxReadSerialized() && obj instanceof PdxInstance) {
       result = ((PdxInstance) obj).getObject();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
@@ -239,6 +239,7 @@ import org.apache.geode.pdx.PdxInstanceFactory;
 import org.apache.geode.pdx.PdxSerializer;
 import org.apache.geode.pdx.ReflectionBasedAutoSerializer;
 import org.apache.geode.pdx.internal.AutoSerializableManager;
+import org.apache.geode.pdx.internal.InternalPdxInstance;
 import org.apache.geode.pdx.internal.PdxInstanceFactoryImpl;
 import org.apache.geode.pdx.internal.TypeRegistry;
 import org.apache.geode.redis.GeodeRedisServer;
@@ -5313,8 +5314,18 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
   @Override
   public Object convertPdxInstanceIfNeeded(Object obj, boolean preferCD) {
     Object result = obj;
-    if (!this.getPdxReadSerialized() && obj instanceof PdxInstance) {
-      result = ((PdxInstance) obj).getObject();
+    if (obj instanceof InternalPdxInstance) {
+      InternalPdxInstance pdxInstance = (InternalPdxInstance) obj;
+      if (preferCD) {
+        try {
+          result = new PreferBytesCachedDeserializable(pdxInstance.toBytes());
+        } catch (IOException ignore) {
+          // Could not convert pdx to bytes here; it will be tried again later
+          // and an exception will be thrown there.
+        }
+      } else if (!this.getPdxReadSerialized()) {
+        result = ((PdxInstance) obj).getObject();
+      }
     }
     return result;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
@@ -5324,7 +5324,7 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
           // and an exception will be thrown there.
         }
       } else if (!this.getPdxReadSerialized()) {
-        result = ((PdxInstance) obj).getObject();
+        result = pdxInstance.getObject();
       }
     }
     return result;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/HARegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/HARegion.java
@@ -363,7 +363,7 @@ public class HARegion extends DistributedRegion {
     Assert.assertTrue(!hasServerProxy());
     CacheLoader loader = basicGetLoader();
     if (loader != null) {
-      value = callCacheLoader(loader, key, aCallbackArgument);
+      value = callCacheLoader(loader, key, aCallbackArgument, preferCD);
 
       if (value != null) {
         try {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCache.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCache.java
@@ -354,7 +354,7 @@ public interface InternalCache extends Cache, Extensible<Cache>, CacheTime {
    * @return either the original obj if no conversion was needed;
    *         or the result of calling PdxInstance.getObject on obj.
    */
-  Object convertPdxInstanceIfNeeded(Object obj);
+  Object convertPdxInstanceIfNeeded(Object obj, boolean preferCD);
 
   Boolean getPdxReadSerializedOverride();
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
@@ -2781,7 +2781,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
         CachePerfStats stats = getCachePerfStats();
         long statStart = stats.startLoad();
         try {
-          value = callCacheLoader(loader, key, aCallbackArgument);
+          value = callCacheLoader(loader, key, aCallbackArgument, preferCD);
         } finally {
           stats.endLoad(statStart);
         }
@@ -2869,11 +2869,11 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
 
   @SuppressWarnings({"rawtypes", "unchecked"})
   protected Object callCacheLoader(CacheLoader loader, final Object key,
-      final Object aCallbackArgument) {
+      final Object aCallbackArgument, boolean preferCD) {
     LoaderHelper loaderHelper = this.loaderHelperFactory.createLoaderHelper(key, aCallbackArgument,
         false /* netSearchAllowed */, true /* netloadAllowed */, null /* searcher */);
     Object result = loader.load(loaderHelper);
-    result = this.getCache().convertPdxInstanceIfNeeded(result);
+    result = this.getCache().convertPdxInstanceIfNeeded(result, preferCD);
     return result;
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/SearchLoadAndWriteProcessor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/SearchLoadAndWriteProcessor.java
@@ -432,7 +432,7 @@ public class SearchLoadAndWriteProcessor implements MembershipListener {
    * netSearch amongst selected peers if netSearch returns a blob, deserialize the blob and return
    * that as the result netSearch failed, so all we can do at this point is do a load return result
    * from load
-   * 
+   *
    * @param preferCD
    */
   private void searchAndLoad(EntryEventImpl event, TXStateInterface txState, Object localValue,

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/SearchLoadAndWriteProcessor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/SearchLoadAndWriteProcessor.java
@@ -164,17 +164,17 @@ public class SearchLoadAndWriteProcessor implements MembershipListener {
 
 
 
-  void doSearchAndLoad(EntryEventImpl event, TXStateInterface txState, Object localValue)
+  void doSearchAndLoad(EntryEventImpl event, TXStateInterface txState, Object localValue, boolean preferCD)
       throws CacheLoaderException, TimeoutException {
     this.requestInProgress = true;
     RegionAttributes attrs = region.getAttributes();
     Scope scope = attrs.getScope();
     CacheLoader loader = ((AbstractRegion) region).basicGetLoader();
     if (scope.isLocal()) {
-      Object obj = doLocalLoad(loader, false);
+      Object obj = doLocalLoad(loader, false, preferCD);
       event.setNewValue(obj);
     } else {
-      searchAndLoad(event, txState, localValue);
+      searchAndLoad(event, txState, localValue, preferCD);
     }
     this.requestInProgress = false;
     if (this.netSearch) {
@@ -432,8 +432,9 @@ public class SearchLoadAndWriteProcessor implements MembershipListener {
    * netSearch amongst selected peers if netSearch returns a blob, deserialize the blob and return
    * that as the result netSearch failed, so all we can do at this point is do a load return result
    * from load
+   * @param preferCD 
    */
-  private void searchAndLoad(EntryEventImpl event, TXStateInterface txState, Object localValue)
+  private void searchAndLoad(EntryEventImpl event, TXStateInterface txState, Object localValue, boolean preferCD)
       throws CacheLoaderException, TimeoutException {
 
     RegionAttributes attrs = region.getAttributes();
@@ -448,7 +449,7 @@ public class SearchLoadAndWriteProcessor implements MembershipListener {
           // If the tx view has it invalid or destroyed everywhere
           // then don't do a netsearch. We want to see the
           // transactional view.
-          load(event);
+          load(event, preferCD);
           return;
         }
       }
@@ -459,7 +460,7 @@ public class SearchLoadAndWriteProcessor implements MembershipListener {
     // know it was distributed. (Otherwise it would be a LOCAL_INVALID token)
     {
       if (localValue == Token.INVALID || dataPolicy.withReplication()) {
-        load(event);
+        load(event, preferCD);
         return;
       }
     }
@@ -469,7 +470,7 @@ public class SearchLoadAndWriteProcessor implements MembershipListener {
       // copy into local var to prevent race condition
       CacheLoader loader = ((AbstractRegion) region).basicGetLoader();
       if (loader != null) {
-        obj = doLocalLoad(loader, true);
+        obj = doLocalLoad(loader, true, preferCD);
         Assert.assertTrue(obj != Token.INVALID && obj != Token.LOCAL_INVALID);
         event.setNewValue(obj);
         this.isSerialized = false;
@@ -492,7 +493,7 @@ public class SearchLoadAndWriteProcessor implements MembershipListener {
       return;
     }
 
-    load(event);
+    load(event, preferCD);
   }
 
   /** perform a net-search, setting this.result to the object found in the search */
@@ -592,7 +593,7 @@ public class SearchLoadAndWriteProcessor implements MembershipListener {
     }
   }
 
-  private void load(EntryEventImpl event) throws CacheLoaderException, TimeoutException {
+  private void load(EntryEventImpl event, boolean preferCD) throws CacheLoaderException, TimeoutException {
     Object obj = null;
     RegionAttributes attrs = this.region.getAttributes();
     Scope scope = attrs.getScope();
@@ -600,7 +601,7 @@ public class SearchLoadAndWriteProcessor implements MembershipListener {
     Assert.assertTrue(scope.isDistributed());
 
     if ((loader != null) && (!scope.isGlobal())) {
-      obj = doLocalLoad(loader, false);
+      obj = doLocalLoad(loader, false, preferCD);
       event.setNewValue(obj);
       Assert.assertTrue(obj != Token.INVALID && obj != Token.LOCAL_INVALID);
       return;
@@ -652,7 +653,7 @@ public class SearchLoadAndWriteProcessor implements MembershipListener {
             }
           }
         } else {
-          obj = doLocalLoad(loader, false);
+          obj = doLocalLoad(loader, false, preferCD);
           Assert.assertTrue(obj != Token.INVALID && obj != Token.LOCAL_INVALID);
           event.setNewValue(obj);
         }
@@ -779,7 +780,7 @@ public class SearchLoadAndWriteProcessor implements MembershipListener {
   }
 
 
-  private Object doLocalLoad(CacheLoader loader, boolean netSearchAllowed)
+  private Object doLocalLoad(CacheLoader loader, boolean netSearchAllowed, boolean preferCD)
       throws CacheLoaderException {
     Object obj = null;
     if (loader != null && !this.attemptedLocalLoad) {
@@ -790,7 +791,7 @@ public class SearchLoadAndWriteProcessor implements MembershipListener {
       long statStart = stats.startLoad();
       try {
         obj = loader.load(loaderHelper);
-        obj = this.region.getCache().convertPdxInstanceIfNeeded(obj);
+        obj = this.region.getCache().convertPdxInstanceIfNeeded(obj, preferCD);
       } finally {
         stats.endLoad(statStart);
       }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/SearchLoadAndWriteProcessor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/SearchLoadAndWriteProcessor.java
@@ -164,8 +164,8 @@ public class SearchLoadAndWriteProcessor implements MembershipListener {
 
 
 
-  void doSearchAndLoad(EntryEventImpl event, TXStateInterface txState, Object localValue, boolean preferCD)
-      throws CacheLoaderException, TimeoutException {
+  void doSearchAndLoad(EntryEventImpl event, TXStateInterface txState, Object localValue,
+      boolean preferCD) throws CacheLoaderException, TimeoutException {
     this.requestInProgress = true;
     RegionAttributes attrs = region.getAttributes();
     Scope scope = attrs.getScope();
@@ -432,10 +432,11 @@ public class SearchLoadAndWriteProcessor implements MembershipListener {
    * netSearch amongst selected peers if netSearch returns a blob, deserialize the blob and return
    * that as the result netSearch failed, so all we can do at this point is do a load return result
    * from load
-   * @param preferCD 
+   * 
+   * @param preferCD
    */
-  private void searchAndLoad(EntryEventImpl event, TXStateInterface txState, Object localValue, boolean preferCD)
-      throws CacheLoaderException, TimeoutException {
+  private void searchAndLoad(EntryEventImpl event, TXStateInterface txState, Object localValue,
+      boolean preferCD) throws CacheLoaderException, TimeoutException {
 
     RegionAttributes attrs = region.getAttributes();
     Scope scope = attrs.getScope();
@@ -593,7 +594,8 @@ public class SearchLoadAndWriteProcessor implements MembershipListener {
     }
   }
 
-  private void load(EntryEventImpl event, boolean preferCD) throws CacheLoaderException, TimeoutException {
+  private void load(EntryEventImpl event, boolean preferCD)
+      throws CacheLoaderException, TimeoutException {
     Object obj = null;
     RegionAttributes attrs = this.region.getAttributes();
     Scope scope = attrs.getScope();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheCreation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheCreation.java
@@ -2346,7 +2346,7 @@ public class CacheCreation implements InternalCache {
   }
 
   @Override
-  public Object convertPdxInstanceIfNeeded(Object obj) {
+  public Object convertPdxInstanceIfNeeded(Object obj, boolean preferCD) {
     throw new UnsupportedOperationException(LocalizedStrings.SHOULDNT_INVOKE.toLocalizedString());
   }
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/DistributedRegionSearchLoadJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/DistributedRegionSearchLoadJUnitTest.java
@@ -142,7 +142,7 @@ public class DistributedRegionSearchLoadJUnitTest {
         }
         return null;
       }
-    }).when(proc).doSearchAndLoad(any(EntryEventImpl.class), anyObject(), anyObject());
+    }).when(proc).doSearchAndLoad(any(EntryEventImpl.class), anyObject(), anyObject(), anyBoolean());
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/DistributedRegionSearchLoadJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/DistributedRegionSearchLoadJUnitTest.java
@@ -142,7 +142,8 @@ public class DistributedRegionSearchLoadJUnitTest {
         }
         return null;
       }
-    }).when(proc).doSearchAndLoad(any(EntryEventImpl.class), anyObject(), anyObject(), anyBoolean());
+    }).when(proc).doSearchAndLoad(any(EntryEventImpl.class), anyObject(), anyObject(),
+        anyBoolean());
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/SearchLoadAndWriteProcessorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/SearchLoadAndWriteProcessorTest.java
@@ -159,7 +159,7 @@ public class SearchLoadAndWriteProcessorTest {
     t3.start();
 
     processor.initialize(lr, key, null);
-    processor.doSearchAndLoad(event, null, null);
+    processor.doSearchAndLoad(event, null, null, false);
 
     assertTrue(Arrays.equals((byte[]) event.getNewValue(), v2));
   }

--- a/geode-core/src/test/java/org/apache/geode/pdx/PdxInstanceLoaderIntegrationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/pdx/PdxInstanceLoaderIntegrationTest.java
@@ -31,6 +31,8 @@ import org.apache.geode.cache.CacheLoaderException;
 import org.apache.geode.cache.LoaderHelper;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.internal.cache.CachedDeserializable;
+import org.apache.geode.internal.cache.LocalRegion;
 import org.apache.geode.test.junit.categories.IntegrationTest;
 import org.apache.geode.test.junit.categories.SerializationTest;
 
@@ -73,5 +75,16 @@ public class PdxInstanceLoaderIntegrationTest {
         .setCacheLoader(new PdxInstanceLoader()).create("region");
     Object obj = region.get("key");
     assertThat(obj).isInstanceOf(PdxInstance.class);
+  }
+
+  @Test
+  public void loadOfPdxInstanceWithPreferCDReturnsCachedDeserializable() {
+    cache = new CacheFactory().set(MCAST_PORT, "0").setPdxReadSerialized(false).create();
+    LocalRegion region = (LocalRegion) cache.createRegionFactory(RegionShortcut.LOCAL)
+        .setCacheLoader(new PdxInstanceLoader()).create("region");
+
+    Object obj = region.get("key", null, true, true, true, null, null, false);
+
+    assertThat(obj).isInstanceOf(CachedDeserializable.class);
   }
 }


### PR DESCRIPTION
The preferCD flag is now passed down to convertPdxInstanceIfNeeded.

If preferCD is true then the caller wants the serialized form back
from the load and in that case the PdxInstances bytes are wrapped
in a PreferBytesCachedDeserializable and it is returned.

So now the PdxInstance will only be deserialized if a local get is
done and pdx-read-serialized is false.