### PR TITLE
GEODE-4913: gfsh start server cmd is not recognizing local properties…

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateAsyncEventQueueCommandDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateAsyncEventQueueCommandDUnitTest.java
@@ -112,8 +112,7 @@ public class CreateAsyncEventQueueCommandDUnitTest {
     locator.invoke(() -> {
       ClusterConfigurationService service =
           ClusterStartupRule.getLocator().getSharedConfiguration();
-      assertThat(service.getConfiguration("cluster").getCacheXmlContent())
-          .doesNotContain("async-event-queue");
+      assertThat(service.getConfiguration("cluster").getCacheXmlContent()).isNull();
     });
 
     gfsh.executeAndAssertThat(VALID_COMMAND + " --id=queue").statusIsSuccess()

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateDefinedIndexesCommandDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateDefinedIndexesCommandDUnitTest.java
@@ -205,10 +205,7 @@ public class CreateDefinedIndexesCommandDUnitTest {
           ((InternalLocator) Locator.getLocator()).getSharedConfiguration();
       assertThat(sharedConfig.getConfiguration("group1").getCacheXmlContent()).contains(index2Name,
           index1Name);
-      assertThat(sharedConfig.getConfiguration("cluster").getCacheXmlContent())
-          .doesNotContain(index2Name);
-      assertThat(sharedConfig.getConfiguration("cluster").getCacheXmlContent())
-          .doesNotContain(index1Name);
+      assertThat(sharedConfig.getConfiguration("cluster").getCacheXmlContent()).isNullOrEmpty();
     });
   }
 }


### PR DESCRIPTION
… and cache.xml, instead using default

   Fixed DUnit test failures by reverting the test assertions as like earlier.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
