### PR TITLE
GEODE-4972: Move VersionManager to geode-old-versions module

### DIFF
--- a/extensions/geode-modules-tomcat8/build.gradle
+++ b/extensions/geode-modules-tomcat8/build.gradle
@@ -41,6 +41,7 @@ dependencies {
   testCompile project(path: ':geode-junit')
   testCompile files(project(':geode-core').sourceSets.test.output)
   testCompile files(project(':extensions/geode-modules').sourceSets.test.output)
+  testCompile files(project(':geode-old-versions').sourceSets.main.output)
 
   eclipse.classpath.file {
     whenMerged { classpath ->

--- a/geode-core/build.gradle
+++ b/geode-core/build.gradle
@@ -131,7 +131,8 @@ dependencies {
   jcaCompile sourceSets.main.output
 
   testCompile project(':geode-junit')
-  testCompile project(':geode-old-versions')
+
+  testCompile files(project(':geode-old-versions').sourceSets.main.output)
 
   // Test Dependencies
   // External

--- a/geode-old-client-support/build.gradle
+++ b/geode-old-client-support/build.gradle
@@ -22,4 +22,5 @@ dependencies {
     testCompile project(':geode-junit')
 
     testCompile files(project(':geode-core').sourceSets.test.output)
+    testCompile files(project(':geode-old-versions').sourceSets.main.output)
 }

--- a/geode-old-versions/build.gradle
+++ b/geode-old-versions/build.gradle
@@ -20,6 +20,10 @@ disableMavenPublishing()
 
 project.ext.installs = new Properties();
 
+dependencies {
+  testCompile project(":geode-junit")
+}
+
 def addOldVersion(def source, def geodeVersion, def downloadInstall) {
   sourceSets.create(source, {
     compileClasspath += configurations.provided

--- a/geode-old-versions/src/main/java/org/apache/geode/test/dunit/standalone/VersionManager.java
+++ b/geode-old-versions/src/main/java/org/apache/geode/test/dunit/standalone/VersionManager.java
@@ -26,15 +26,13 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.function.BiConsumer;
 
-import org.apache.geode.test.dunit.Host;
-
 /**
  * VersionManager loads the class-paths for all of the releases of Geode configured for
  * backward-compatibility testing in the geode-core build.gradle file.
  * <p>
  * Tests may use these versions in launching VMs to run older clients or servers.
  *
- * @see Host#getVM(String, int)
+ * see Host.getVM(String, int)
  */
 public class VersionManager {
   public static final String CURRENT_VERSION = "000";

--- a/geode-old-versions/src/test/java/org/apache/geode/test/dunit/standalone/VersionManagerJUnitTest.java
+++ b/geode-old-versions/src/test/java/org/apache/geode/test/dunit/standalone/VersionManagerJUnitTest.java
@@ -14,7 +14,6 @@
  */
 package org.apache.geode.test.dunit.standalone;
 
-import static org.apache.geode.internal.Assert.assertTrue;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.Assert;
@@ -45,6 +44,6 @@ public class VersionManagerJUnitTest {
   @Test
   public void managerIsAbleToFindVersions() throws Exception {
     VersionManager instance = VersionManager.getInstance();
-    assertTrue(instance.getVersionsWithoutCurrent().size() > 0);
+    Assert.assertTrue(instance.getVersionsWithoutCurrent().size() > 0);
   }
 }

--- a/geode-protobuf/build.gradle
+++ b/geode-protobuf/build.gradle
@@ -27,4 +27,5 @@ dependencies {
     testCompile 'org.powermock:powermock-api-mockito:' + project.'powermock.version'
 
     compile 'com.google.protobuf:protobuf-java:' + project.'protobuf-java.version'
+    testCompile files(project(':geode-old-versions').sourceSets.main.output)
 }

--- a/geode-web/build.gradle
+++ b/geode-web/build.gradle
@@ -59,6 +59,7 @@ dependencies {
   testCompile 'com.pholser:junit-quickcheck-guava:' + project.'junit-quickcheck.version'
 
   testRuntime files(war.destinationDir)
+  testCompile files(project(':geode-old-versions').sourceSets.main.output)
 }
 
 //Remove the gradle output directories from the eclipse classpath. These


### PR DESCRIPTION
- This will facilitate other modules being able to use VersionManager;
  specifically geode-junit.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
