### PR TITLE
GEODE-4989 CQ reply message fromData method deserializes query results

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/CqEntry.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/CqEntry.java
@@ -92,7 +92,7 @@ public class CqEntry implements DataSerializableFixedID {
 
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
     this.key = InternalDataSerializer.readUserObject(in);
-    this.value = DataSerializer.readObject(in);
+    this.value = InternalDataSerializer.readUserObject(in);
   }
 
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/streaming/StreamingOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/streaming/StreamingOperation.java
@@ -554,17 +554,17 @@ public abstract class StreamingOperation {
               lowMemoryDetected = true;
               break;
             }
-            Object o = InternalDataSerializer.readUserObject(in);
+            Object theObject = DataSerializer.readObject(in);
             if (isQueryMessageProcessor && elementType != null && elementType.isStructType()) {
               boolean convertToStruct = isSenderAbove_8_1;
               if (convertToStruct && i == 0) {
-                convertToStruct = !(o instanceof PRQueryTraceInfo);
+                convertToStruct = !(theObject instanceof PRQueryTraceInfo);
               }
               if (convertToStruct) {
-                o = new StructImpl((StructTypeImpl) elementType, (Object[]) o);
+                theObject = new StructImpl((StructTypeImpl) elementType, (Object[]) theObject);
               }
             }
-            this.objectList.add(o);
+            this.objectList.add(theObject);
           }
           if (lowMemoryDetected) {
             isCanceled = true;

--- a/geode-core/src/main/java/org/apache/geode/pdx/internal/TypeRegistry.java
+++ b/geode-core/src/main/java/org/apache/geode/pdx/internal/TypeRegistry.java
@@ -95,6 +95,12 @@ public class TypeRegistry {
     }
   }
 
+  /**
+   * When this returns true pdx-read-serialized should be respected, which is the
+   * default. Setting this to false disables pdx-read-serialized while deserializing
+   * objects. This takes precendence over setPdxReadSerializedOverride, which affects
+   * the cache's setting of that attribute.
+   */
   public static boolean getPdxReadSerialized() {
     return disablePdxReadSerialized.get() == null;
   }

--- a/geode-core/src/test/java/org/apache/geode/cache/query/internal/QueryObjectSerializationJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/internal/QueryObjectSerializationJUnitTest.java
@@ -14,7 +14,7 @@
  */
 package org.apache.geode.cache.query.internal;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -32,9 +32,14 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import org.apache.geode.DataSerializer;
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.query.QueryService;
 import org.apache.geode.cache.query.types.ObjectType;
+import org.apache.geode.distributed.ConfigurationProperties;
 import org.apache.geode.internal.cache.CachePerfStats;
+import org.apache.geode.pdx.PdxSerializableDUnitTest;
+import org.apache.geode.pdx.internal.PdxInstanceImpl;
 import org.apache.geode.test.junit.categories.UnitTest;
 
 /**
@@ -130,6 +135,29 @@ public class QueryObjectSerializationJUnitTest implements Serializable {
     // SortedStructSet
     // SortedStructSet sssWithoutData = new SortedStructSet();
     // checkRoundTrip(sssWithoutData);
+  }
+
+  /**
+   * Ensure that a CqEntry respects pdx-read-serialized=true
+   */
+  @Test
+  public void testPdxReadSerializedWithCQEntry() throws IOException, ClassNotFoundException {
+    Cache cache = new CacheFactory().set(ConfigurationProperties.LOCATORS, "")
+        .set(ConfigurationProperties.MCAST_PORT, "0").setPdxReadSerialized(true).create();
+
+    try {
+      Object key = "APdxSerializableObject";
+      Object value = new PdxSerializableDUnitTest.TestPdxObject();
+      CqEntry entry = new CqEntry(key, value);
+      DataOutputStream out = getDataOutput();
+      DataSerializer.writeObject(entry, out);
+      out.flush();
+      DataInput in = getDataInput();
+      CqEntry newEntry = DataSerializer.readObject(in);
+      assertEquals(PdxInstanceImpl.class, newEntry.getValue().getClass());
+    } finally {
+      cache.close();
+    }
   }
 
   private static class SimpleObjectType implements ObjectType {


### PR DESCRIPTION
CqEntry was using DataSerializer.readObject() to read the entry's value
instead of InternalDataSerializer.readUserObject().  The latter is needed
to respect the setting of pdx-read-serialized in the query service's
StreamingReplyMessage.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
