### PR TITLE
GEODE-1279: Rename regression tests

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/cache/FinalStaticArrayShouldNotCauseSegFaultRegressionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/FinalStaticArrayShouldNotCauseSegFaultRegressionTest.java
@@ -26,8 +26,6 @@ import org.junit.experimental.categories.Category;
 import org.apache.geode.test.junit.categories.UnitTest;
 
 /**
- * Test case for Trac <a href="https://svn.gemstone.com/trac/gemfire/ticket/52289">#52289</a>.
- *
  * Asserts fixes for bug JDK-8076152 in JDK 1.8.0u20 to 1.8.0.u45.
  * http://bugs.java.com/bugdatabase/view_bug.do?bug_id=8076152
  *
@@ -38,45 +36,48 @@ import org.apache.geode.test.junit.categories.UnitTest;
  * This test and its corrections can be removed after the release of JDK 1.8.0u60 if we choose to
  * not support 1.8.0u20 - 1.8.0u45 inclusive.
  *
+ * <p>
+ * TRAC #52289: HotSpot SIGSEGV in C2 CompilerThread1 (LoadNode::Value(PhaseTransform*) const+0x202)
+ * with JDK 1.8.0_45
+ *
  * @since GemFire 8.2
  */
 @Category(UnitTest.class)
-public class FinalStaticArrayShouldNotCauseSegFaultTest {
+public class FinalStaticArrayShouldNotCauseSegFaultRegressionTest {
 
   @Test
-  public void test() throws IOException, ClassNotFoundException {
-    // Iterate enough to cause JIT to compile
-    // javax.print.attribute.EnumSyntax::readResolve
+  public void finalStaticArrayShouldNotCauseSegFault() throws Exception {
+    // Iterate enough to cause JIT to compile javax.print.attribute.EnumSyntax::readResolve
     for (int i = 0; i < 100_000; i++) {
-      // Must execute two or more subclasses with static final arrays of
-      // different types.
+      // Must execute two or more subclasses with static final arrays of different types.
       doEvictionAlgorithm();
       doEvictionAction();
     }
   }
 
-  protected void doEvictionAlgorithm() throws IOException, ClassNotFoundException {
-    final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    final ObjectOutputStream oos = new ObjectOutputStream(baos);
-    oos.writeObject(EvictionAlgorithm.NONE);
-    oos.close();
+  private void doEvictionAlgorithm() throws IOException, ClassNotFoundException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
-    final ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
-    final ObjectInputStream ois = new ObjectInputStream(bais);
-    ois.readObject();
-    ois.close();
+    try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+      oos.writeObject(EvictionAlgorithm.NONE);
+    }
+
+    try (ObjectInputStream ois =
+        new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
+      ois.readObject();
+    }
   }
 
-  protected void doEvictionAction() throws IOException, ClassNotFoundException {
-    final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    final ObjectOutputStream oos = new ObjectOutputStream(baos);
-    oos.writeObject(EvictionAction.NONE);
-    oos.close();
+  private void doEvictionAction() throws IOException, ClassNotFoundException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
-    final ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
-    final ObjectInputStream ois = new ObjectInputStream(bais);
-    ois.readObject();
-    ois.close();
+    try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+      oos.writeObject(EvictionAction.NONE);
+    }
+
+    try (ObjectInputStream ois =
+        new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
+      ois.readObject();
+    }
   }
-
 }

--- a/geode-core/src/test/java/org/apache/geode/cache/MembershipAttributesAreSerializableRegressionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/MembershipAttributesAreSerializableRegressionTest.java
@@ -14,7 +14,7 @@
  */
 package org.apache.geode.cache;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -31,7 +31,7 @@ import org.apache.geode.test.junit.categories.UnitTest;
  * Tests MembershipAttributes and SubscriptionAttributes to make sure they are Serializable
  */
 @Category({UnitTest.class, MembershipTest.class})
-public class MembershipAttributesAreSerializableTest {
+public class MembershipAttributesAreSerializableRegressionTest {
 
   /**
    * Assert that MembershipAttributes are serializable.
@@ -40,16 +40,19 @@ public class MembershipAttributesAreSerializableTest {
   public void testMembershipAttributesAreSerializable() throws Exception {
     String[] roles = {"a", "b", "c"};
     MembershipAttributes outMA = new MembershipAttributes(roles);
+
     ByteArrayOutputStream baos = new ByteArrayOutputStream(1000);
-    ObjectOutputStream oos = new ObjectOutputStream(baos);
-    oos.writeObject(outMA);
+    try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+      oos.writeObject(outMA);
+    }
 
     byte[] data = baos.toByteArray();
 
     ByteArrayInputStream bais = new ByteArrayInputStream(data);
-    ObjectInputStream ois = new ObjectInputStream(bais);
-    MembershipAttributes inMA = (MembershipAttributes) ois.readObject();
-    assertEquals(outMA, inMA);
+    try (ObjectInputStream ois = new ObjectInputStream(bais)) {
+      MembershipAttributes inMA = (MembershipAttributes) ois.readObject();
+      assertEquals(outMA, inMA);
+    }
   }
 
   /**
@@ -58,15 +61,18 @@ public class MembershipAttributesAreSerializableTest {
   @Test
   public void testSubscriptionAttributesAreSerializable() throws Exception {
     SubscriptionAttributes outSA = new SubscriptionAttributes();
+
     ByteArrayOutputStream baos = new ByteArrayOutputStream(1000);
-    ObjectOutputStream oos = new ObjectOutputStream(baos);
-    oos.writeObject(outSA);
+    try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+      oos.writeObject(outSA);
+    }
 
     byte[] data = baos.toByteArray();
 
     ByteArrayInputStream bais = new ByteArrayInputStream(data);
-    ObjectInputStream ois = new ObjectInputStream(bais);
-    SubscriptionAttributes inSA = (SubscriptionAttributes) ois.readObject();
-    assertEquals(outSA, inSA);
+    try (ObjectInputStream ois = new ObjectInputStream(bais)) {
+      SubscriptionAttributes inSA = (SubscriptionAttributes) ois.readObject();
+      assertEquals(outSA, inSA);
+    }
   }
 }


### PR DESCRIPTION
This PR simply adds "RegressionTest" to end of the name of two tests that were previously renamed for GEODE-1279:
```
commit 2f4f2b3f3b2efd2ff2cfa4c1e9dd52b645b7e52b (HEAD -> GEODE-1279-rename-tests, kirklund-fork/GEODE-1279-rename-tests)
Author: Kirk Lund <klund@apache.org>
Date:   Wed Apr 4 10:45:18 2018 -0700

    GEODE_1279: Rename MembershipAttributesAreSerializableRegressionTest
```
```
commit 71e95d017fdc2e00769bf559f343f11fd4567237
Author: Kirk Lund <klund@apache.org>
Date:   Wed Apr 4 10:40:59 2018 -0700

    GEODE-1279: Rename FinalStaticArrayShouldNotCauseSegFaultRegressionTest
```