### PR TITLE
GEODE-4995 ClusterStartupRule is inefficient when shutting down the c…

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/test/dunit/rules/ClusterStartupRule.java
+++ b/geode-core/src/test/java/org/apache/geode/test/dunit/rules/ClusterStartupRule.java
@@ -127,6 +127,7 @@ public class ClusterStartupRule extends ExternalResource implements Serializable
       MemberStarterRule.disconnectDSIfAny();
 
       // stop all the clientsVM before stop all the memberVM
+      occupiedVMs.values().forEach(x -> x.stopVMIfNotLocator(true));
       occupiedVMs.values().forEach(x -> x.stopVM(true));
 
       // delete any file under root dir

--- a/geode-core/src/test/java/org/apache/geode/test/junit/rules/VMProvider.java
+++ b/geode-core/src/test/java/org/apache/geode/test/junit/rules/VMProvider.java
@@ -30,6 +30,15 @@ public abstract class VMProvider {
 
   public abstract VM getVM();
 
+  public void stopVMIfNotLocator(boolean cleanWorkingDir) {
+    getVM().invoke(() -> {
+      if (!org.apache.geode.distributed.Locator.hasLocator()) {
+        ClusterStartupRule.stopElementInsideVM();
+        MemberStarterRule.disconnectDSIfAny();
+      }
+    });
+  }
+
   public void stopVM(boolean cleanWorkingDir) {
     getVM().invoke(() -> {
       ClusterStartupRule.stopElementInsideVM();


### PR DESCRIPTION
…luster

modified after() to shut down non-locators before shutting down locators,
allowing membership coordination to stay in the locator instead of
causing cascading movement of the role.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
