### PR TITLE
GEODE-3237: Loading cluster configuration from a dir that does not ha…

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartLocatorCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartLocatorCommand.java
@@ -268,6 +268,11 @@ public class StartLocatorCommand extends InternalGfshCommand {
 
     InfoResultData infoResultData = ResultBuilder.createInfoResultData();
 
+    // add a warning for deprecating --load-cluster-config-from-dir
+    infoResultData.addLine("Warning: Option --load-cluster-config-from-dir is deprecated, use '"
+        + CliStrings.IMPORT_SHARED_CONFIG
+        + "' command instead to import any existing configuration.\n");
+
     if (asyncStart) {
       infoResultData.addLine(
           String.format(CliStrings.ASYNC_PROCESS_LAUNCH_MESSAGE, CliStrings.LOCATOR_TERM_NAME));

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartLocatorCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartLocatorCommand.java
@@ -268,10 +268,11 @@ public class StartLocatorCommand extends InternalGfshCommand {
 
     InfoResultData infoResultData = ResultBuilder.createInfoResultData();
 
-    // add a warning for deprecating --load-cluster-config-from-dir
-    infoResultData.addLine("Warning: Option --load-cluster-config-from-dir is deprecated, use '"
-        + CliStrings.IMPORT_SHARED_CONFIG
-        + "' command instead to import any existing configuration.\n");
+    if (loadSharedConfigurationFromDirectory) {
+      infoResultData.addLine("Warning: Option --load-cluster-config-from-dir is deprecated, use '"
+          + CliStrings.IMPORT_SHARED_CONFIG
+          + "' command instead to import any existing configuration.\n");
+    }
 
     if (asyncStart) {
       infoResultData.addLine(

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/i18n/CliStrings.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/i18n/CliStrings.java
@@ -2410,7 +2410,7 @@ public class CliStrings {
   public static final String START_LOCATOR__LOAD__SHARED_CONFIGURATION__FROM__FILESYSTEM =
       "load-cluster-configuration-from-dir";
   public static final String START_LOCATOR__LOAD__SHARED_CONFIGURATION__FROM__FILESYSTEM__HELP =
-      "Deprecated: Since Geode 1.7, use import cluster-configuration command instead. When \" "
+      "Deprecated: Since Geode 1.6, use import cluster-configuration command instead. When \" "
           + START_LOCATOR__LOAD__SHARED_CONFIGURATION__FROM__FILESYSTEM
           + " \" is set to true, the locator loads the cluster configuration from the \""
           + InternalClusterConfigurationService.CLUSTER_CONFIG_ARTIFACTS_DIR_NAME + "\" directory.";

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/i18n/CliStrings.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/i18n/CliStrings.java
@@ -2410,7 +2410,8 @@ public class CliStrings {
   public static final String START_LOCATOR__LOAD__SHARED_CONFIGURATION__FROM__FILESYSTEM =
       "load-cluster-configuration-from-dir";
   public static final String START_LOCATOR__LOAD__SHARED_CONFIGURATION__FROM__FILESYSTEM__HELP =
-      "When \" " + START_LOCATOR__LOAD__SHARED_CONFIGURATION__FROM__FILESYSTEM
+      "Deprecated: Since Geode 1.7, use import cluster-configuration command instead. When \" "
+          + START_LOCATOR__LOAD__SHARED_CONFIGURATION__FROM__FILESYSTEM
           + " \" is set to true, the locator loads the cluster configuration from the \""
           + InternalClusterConfigurationService.CLUSTER_CONFIG_ARTIFACTS_DIR_NAME + "\" directory.";
   public static final String START_LOCATOR__CLUSTER__CONFIG__DIR = "cluster-config-dir";


### PR DESCRIPTION
…ve complete CC will throw NPE

    command option --load-cluster-config-from-dir is deprecated and a warning
    is added to the gfsh command output in case if its used.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
