### PR TITLE
GEODE-5024: Use debug version of gradle-dockerized-test-plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ buildscript {
     maven { url "https://plugins.gradle.org/m2/" }
     maven { url "https://dl.bintray.com/palantir/releases" }
     jcenter()
+    maven { url "http://geode-maven.s3-website-us-west-2.amazonaws.com" }
   }
 
   dependencies {
@@ -28,7 +29,7 @@ buildscript {
     classpath 'org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.0.1'
     classpath "com.diffplug.spotless:spotless-plugin-gradle:3.10.0"
     classpath "me.champeau.gradle:jmh-gradle-plugin:0.3.1"
-    classpath "com.pedjak.gradle.plugins:dockerized-test:0.5.4"
+    classpath "com.pedjak.gradle.plugins:dockerized-test:0.5.6-SNAPSHOT"
     classpath 'com.github.ben-manes:gradle-versions-plugin:0.17.0'
   }
 }


### PR DESCRIPTION
- This version is forked at
  github.com/jdeppe-pivotal/gradle-dockerized-test-plugin and the artifacts
  have been published to s3://geode-maven.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
