### PR TITLE
GEODE-2668: Add new command class for destroy gateway-receivers

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CommandAvailabilityIndicator.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CommandAvailabilityIndicator.java
@@ -51,7 +51,8 @@ public class CommandAvailabilityIndicator implements CommandMarker {
       CliStrings.STATUS_GATEWAYRECEIVER, CliStrings.LOAD_BALANCE_GATEWAYSENDER,
       CliStrings.DESTROY_GATEWAYSENDER, AlterAsyncEventQueueCommand.COMMAND_NAME,
       CreateJndiBindingCommand.CREATE_JNDIBINDING, DestroyJndiBindingCommand.DESTROY_JNDIBINDING,
-      DescribeJndiBindingCommand.DESCRIBE_JNDI_BINDING})
+      DescribeJndiBindingCommand.DESCRIBE_JNDI_BINDING,
+      DestroyGatewayReceiverCommand.DESTROY_GATEWAYRECEIVER})
   public boolean clientCommandsAvailable() {
     Gfsh gfsh = Gfsh.getCurrentInstance();
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyGatewayReceiverCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyGatewayReceiverCommand.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.management.internal.cli.commands;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.springframework.shell.core.annotation.CliCommand;
+import org.springframework.shell.core.annotation.CliOption;
+
+import org.apache.geode.cache.configuration.CacheConfig;
+import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
+import org.apache.geode.management.cli.CliMetaData;
+import org.apache.geode.management.cli.ConverterHint;
+import org.apache.geode.management.cli.Result;
+import org.apache.geode.management.internal.cli.exceptions.EntityNotFoundException;
+import org.apache.geode.management.internal.cli.functions.CliFunctionResult;
+import org.apache.geode.management.internal.cli.functions.DestroyGatewayReceiverFunction;
+import org.apache.geode.management.internal.cli.i18n.CliStrings;
+import org.apache.geode.management.internal.cli.result.CommandResult;
+import org.apache.geode.management.internal.cli.result.ResultBuilder;
+import org.apache.geode.management.internal.security.ResourceOperation;
+import org.apache.geode.security.ResourcePermission;
+
+public class DestroyGatewayReceiverCommand extends InternalGfshCommand {
+  public static final String DESTROY_GATEWAYRECEIVER = "destroy gateway-receiver";
+  public static final String DESTROY_GATEWAYRECEIVER__HELP =
+      "Destroy the Gateway Receiver on a member or members.";
+  public static final String DESTROY_GATEWAYRECEIVER__GROUP__HELP =
+      "Group(s) of members on which to destroy the Gateway Receiver.";
+  public static final String DESTROY_GATEWAYRECEIVER__MEMBER__HELP =
+      "Name/Id of the member on which to destroy the Gateway Receiver.";
+  public static final String GATEWAYRECIEVER_NOT_FOUND_ON_0 = "Gateway Receiver not found on {0}";
+
+  @CliCommand(value = DESTROY_GATEWAYRECEIVER, help = DESTROY_GATEWAYRECEIVER__HELP)
+  @CliMetaData(relatedTopic = CliStrings.TOPIC_GEODE_WAN)
+  @ResourceOperation(resource = ResourcePermission.Resource.CLUSTER,
+      operation = ResourcePermission.Operation.MANAGE, target = ResourcePermission.Target.GATEWAY)
+  public Result destroyGatewayReceiver(
+      @CliOption(key = {CliStrings.GROUP, CliStrings.GROUPS},
+          optionContext = ConverterHint.MEMBERGROUP,
+          help = DESTROY_GATEWAYRECEIVER__GROUP__HELP) String[] onGroups,
+      @CliOption(key = {CliStrings.MEMBER, CliStrings.MEMBERS},
+          optionContext = ConverterHint.MEMBERIDNAME,
+          help = DESTROY_GATEWAYRECEIVER__MEMBER__HELP) String[] onMember,
+      @CliOption(key = CliStrings.IFEXISTS, help = CliStrings.IFEXISTS_HELP,
+          specifiedDefaultValue = "true", unspecifiedDefaultValue = "false") boolean ifExists) {
+
+    boolean persisted = false;
+    Set<DistributedMember> members = getMembers(onGroups, onMember);
+
+    List<CliFunctionResult> functionResults =
+        executeAndGetFunctionResult(DestroyGatewayReceiverFunction.INSTANCE, ifExists, members);
+
+    CommandResult result = ResultBuilder.buildResult(functionResults);
+
+    // Only update the cluster config if the command is not executed on specific members.
+    InternalClusterConfigurationService service =
+        (InternalClusterConfigurationService) getConfigurationService();
+    if (onMember == null && result.getStatus().equals(Result.Status.OK) && service != null) {
+      if (onGroups == null) {
+        onGroups = new String[] {"cluster"};
+      }
+      Arrays.stream(onGroups).forEach(group -> service.updateCacheConfig(group, cc -> {
+        CacheConfig.GatewayReceiver receiver = cc.getGatewayReceiver();
+        if (receiver == null) {
+          throw new EntityNotFoundException(
+              CliStrings.format(GATEWAYRECIEVER_NOT_FOUND_ON_0, group), ifExists);
+
+        }
+        cc.setGatewayReceiver(null);
+        return cc;
+      }));
+      persisted = true;
+    }
+
+    result.setCommandPersisted(persisted);
+    return result;
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/DestroyGatewayReceiverFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/DestroyGatewayReceiverFunction.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.management.internal.cli.functions;
+
+import java.util.Set;
+
+import org.apache.logging.log4j.Logger;
+
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.execute.FunctionContext;
+import org.apache.geode.cache.execute.ResultSender;
+import org.apache.geode.cache.wan.GatewayReceiver;
+import org.apache.geode.internal.cache.execute.InternalFunction;
+import org.apache.geode.internal.logging.LogService;
+import org.apache.geode.management.internal.cli.CliUtil;
+
+public class DestroyGatewayReceiverFunction implements InternalFunction {
+  private static final Logger logger = LogService.getLogger();
+  private static final long serialVersionUID = 1490927519860899562L;
+  private static final String ID = DestroyGatewayReceiverFunction.class.getName();
+  public static DestroyGatewayReceiverFunction INSTANCE = new DestroyGatewayReceiverFunction();
+
+  @Override
+  public void execute(FunctionContext context) {
+    ResultSender<Object> resultSender = context.getResultSender();
+
+    Cache cache = context.getCache();
+    String memberNameOrId =
+        CliUtil.getMemberNameOrId(cache.getDistributedSystem().getDistributedMember());
+
+    boolean ifExists = (boolean) context.getArguments();
+    Set<GatewayReceiver> gatewayReceivers = cache.getGatewayReceivers();
+    if (gatewayReceivers == null || gatewayReceivers.isEmpty()) {
+      String message = "Gateway receiver not found.";
+      if (ifExists) {
+        resultSender
+            .lastResult(new CliFunctionResult(memberNameOrId, true, "Skipping: " + message));
+      } else {
+        resultSender.lastResult(new CliFunctionResult(memberNameOrId, false, message));
+      }
+      return;
+    }
+    for (GatewayReceiver receiver : cache.getGatewayReceivers()) {
+      try {
+        if (receiver.isRunning()) {
+          receiver.stop();
+        }
+        receiver.destroy();
+        resultSender.sendResult(new CliFunctionResult(memberNameOrId, true,
+            String.format("GatewayReceiver destroyed on \"%s\"", memberNameOrId)));
+      } catch (Exception e) {
+        logger.error(e.getMessage(), e);
+        resultSender.sendResult(new CliFunctionResult(memberNameOrId, e, ""));
+      }
+      resultSender.lastResult(-1);
+    }
+  }
+
+  @Override
+  public String getId() {
+    return ID;
+  }
+
+}

--- a/geode-core/src/main/resources/org/apache/geode/internal/sanctioned-geode-core-serializables.txt
+++ b/geode-core/src/main/resources/org/apache/geode/internal/sanctioned-geode-core-serializables.txt
@@ -534,6 +534,7 @@ org/apache/geode/management/internal/cli/functions/DestroyAsyncEventQueueFunctio
 org/apache/geode/management/internal/cli/functions/DestroyAsyncEventQueueFunctionArgs,true,1755045410754561928,id:java/lang/String,ifExists:boolean
 org/apache/geode/management/internal/cli/functions/DestroyDiskStoreFunction,true,1
 org/apache/geode/management/internal/cli/functions/DestroyDiskStoreFunctionArgs,true,2296397958405313306,id:java/lang/String,ifExists:boolean
+org/apache/geode/management/internal/cli/functions/DestroyGatewayReceiverFunction,true,1490927519860899562
 org/apache/geode/management/internal/cli/functions/DestroyIndexFunction,true,-868082551095130315
 org/apache/geode/management/internal/cli/functions/DestroyJndiBindingFunction,false
 org/apache/geode/management/internal/cli/functions/ExportConfigFunction,true,1

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DestroyGatewayReceiverCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DestroyGatewayReceiverCommandTest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.management.internal.cli.commands;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.distributed.internal.InternalClusterConfigurationService;
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
+import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.management.internal.cli.exceptions.UserErrorException;
+import org.apache.geode.management.internal.cli.functions.CliFunctionResult;
+import org.apache.geode.management.internal.cli.i18n.CliStrings;
+import org.apache.geode.management.internal.configuration.domain.XmlEntity;
+import org.apache.geode.test.junit.assertions.CommandResultAssert;
+import org.apache.geode.test.junit.categories.UnitTest;
+import org.apache.geode.test.junit.rules.GfshParserRule;
+
+@Category(UnitTest.class)
+public class DestroyGatewayReceiverCommandTest {
+  @ClassRule
+  public static GfshParserRule gfsh = new GfshParserRule();
+
+  private DestroyGatewayReceiverCommand command;
+  private InternalCache cache;
+  private List<CliFunctionResult> functionResults;
+  private InternalClusterConfigurationService ccService;
+  private CliFunctionResult result1;
+  private XmlEntity xmlEntity;
+
+  @Before
+  public void setUp() throws Exception {
+    command = spy(DestroyGatewayReceiverCommand.class);
+    ccService = mock(InternalClusterConfigurationService.class);
+    xmlEntity = mock(XmlEntity.class);
+    cache = mock(InternalCache.class);
+    doReturn(cache).when(command).getCache();
+    doReturn(ccService).when(command).getConfigurationService();
+    functionResults = new ArrayList<>();
+    doReturn(functionResults).when(command).executeAndGetFunctionResult(any(), any(),
+        any(Set.class));
+  }
+
+  @Test
+  public void noGroupOrMember_isError() {
+    doThrow(new UserErrorException(CliStrings.PROVIDE_EITHER_MEMBER_OR_GROUP_MESSAGE)).when(command)
+        .findMembers(null, null);
+    gfsh.executeAndAssertThat(command, "destroy gateway-receiver").statusIsError()
+        .containsOutput("provide either \\\"member\\\" or \\\"group\\\" option");
+  }
+
+  @Test
+  public void memberNoGroup_isOK() {
+    result1 = new CliFunctionResult("member1", xmlEntity, "result1");
+    functionResults.add(result1);
+    Set<DistributedMember> membersSet = new HashSet<>();
+    membersSet.add(new InternalDistributedMember("member1", 0));
+    doReturn(membersSet).when(command).findMembers(null, new String[] {"member1"});
+
+    CommandResultAssert resultAssert =
+        gfsh.executeAndAssertThat(command, "destroy gateway-receiver --member=\"member1\"");
+    resultAssert.statusIsSuccess().tableHasColumnWithValuesContaining("Status", "result1");
+  }
+
+  @Test
+  public void groupNoMember_isOK() {
+    result1 = new CliFunctionResult("member1", xmlEntity, "result1");
+    functionResults.add(result1);
+    Set<DistributedMember> membersSet = new HashSet<>();
+    membersSet.add(new InternalDistributedMember("member1", 0));
+    doReturn(membersSet).when(command).findMembers(new String[] {"group1"}, null);
+
+    CommandResultAssert resultAssert =
+        gfsh.executeAndAssertThat(command, "destroy gateway-receiver --group=\"group1\"");
+    resultAssert.statusIsSuccess().tableHasColumnWithValuesContaining("Status", "result1");
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/functions/DestroyGatewayReceiverFunctionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/functions/DestroyGatewayReceiverFunctionTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.management.internal.cli.functions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.ArgumentCaptor;
+
+import org.apache.geode.cache.execute.FunctionContext;
+import org.apache.geode.cache.execute.ResultSender;
+import org.apache.geode.distributed.DistributedSystem;
+import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.test.junit.categories.UnitTest;
+
+@Category(UnitTest.class)
+public class DestroyGatewayReceiverFunctionTest {
+  private DestroyGatewayReceiverFunction function;
+  private FunctionContext context;
+  private InternalCache cache;
+  private ResultSender resultSender;
+  private ArgumentCaptor<CliFunctionResult> resultCaptor;
+
+  @Before
+  public void setUp() throws Exception {
+    function = spy(DestroyGatewayReceiverFunction.class);
+    context = mock(FunctionContext.class);
+    cache = mock(InternalCache.class);
+    resultSender = mock(ResultSender.class);
+    resultCaptor = ArgumentCaptor.forClass(CliFunctionResult.class);
+    when(context.getCache()).thenReturn(cache);
+    when(context.getResultSender()).thenReturn(resultSender);
+    when(cache.getDistributedSystem()).thenReturn(mock(DistributedSystem.class));
+    when(context.getArguments()).thenReturn(false);
+  }
+
+  @Test
+  public void getGatewayReceiversNull_doesNotThrowException() {
+    when(cache.getGatewayReceivers()).thenReturn(null);
+    when(context.getArguments()).thenReturn(false);
+    function.execute(context);
+
+    verify(resultSender).lastResult(resultCaptor.capture());
+    CliFunctionResult result = resultCaptor.getValue();
+    assertThat(result.isSuccessful()).isFalse();
+    assertThat(result.getThrowable()).isNull();
+    assertThat(result.getMessage()).isEqualTo("Gateway receiver not found.");
+  }
+
+  @Test
+  public void getGatewayReceiversNotFound_ifExists_false() {
+    when(cache.getGatewayReceivers()).thenReturn(Collections.emptySet());
+    when(context.getArguments()).thenReturn(false);
+    function.execute(context);
+
+    verify(resultSender).lastResult(resultCaptor.capture());
+    CliFunctionResult result = resultCaptor.getValue();
+    assertThat(result.isSuccessful()).isFalse();
+    assertThat(result.getThrowable()).isNull();
+    assertThat(result.getMessage()).isEqualTo("Gateway receiver not found.");
+  }
+
+  @Test
+  public void getGatewayReceiversNotFound_ifExists_true() {
+    when(cache.getGatewayReceivers()).thenReturn(Collections.emptySet());
+    when(context.getArguments()).thenReturn(true);
+    function.execute(context);
+
+    verify(resultSender).lastResult(resultCaptor.capture());
+    CliFunctionResult result = resultCaptor.getValue();
+    assertThat(result.isSuccessful()).isTrue();
+    assertThat(result.getThrowable()).isNull();
+    assertThat(result.getMessage()).isEqualTo("Skipping: Gateway receiver not found.");
+  }
+}

--- a/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/wancommand/DestroyGatewayReceiverCommandDUnitTest.java
+++ b/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/wancommand/DestroyGatewayReceiverCommandDUnitTest.java
@@ -1,0 +1,359 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.wan.wancommand;
+
+import static org.apache.geode.distributed.ConfigurationProperties.DISTRIBUTED_SYSTEM_ID;
+import static org.apache.geode.distributed.ConfigurationProperties.GROUPS;
+import static org.apache.geode.internal.cache.wan.wancommand.WANCommandUtils.verifyReceiverCreationWithAttributes;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Properties;
+
+import org.apache.commons.lang.StringUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.cache.wan.GatewayReceiver;
+import org.apache.geode.management.internal.cli.commands.DestroyGatewayReceiverCommand;
+import org.apache.geode.management.internal.cli.i18n.CliStrings;
+import org.apache.geode.management.internal.cli.util.CommandStringBuilder;
+import org.apache.geode.test.dunit.rules.ClusterStartupRule;
+import org.apache.geode.test.dunit.rules.MemberVM;
+import org.apache.geode.test.junit.categories.DistributedTest;
+import org.apache.geode.test.junit.categories.GfshTest;
+import org.apache.geode.test.junit.categories.WanTest;
+import org.apache.geode.test.junit.rules.GfshCommandRule;
+import org.apache.geode.test.junit.rules.VMProvider;
+
+@Category({DistributedTest.class, WanTest.class, GfshTest.class})
+public class DestroyGatewayReceiverCommandDUnitTest {
+  private MemberVM locatorSite1;
+  private MemberVM server3, server4, server5;
+
+  @Rule
+  public ClusterStartupRule clusterStartupRule = new ClusterStartupRule(6);
+
+  @Rule
+  public GfshCommandRule gfsh = new GfshCommandRule();
+
+  @Before
+  public void before() throws Exception {
+    Properties props = new Properties();
+    props.setProperty(DISTRIBUTED_SYSTEM_ID, "" + 1);
+    locatorSite1 = clusterStartupRule.startLocatorVM(1, props);
+
+    // Connect Gfsh to locator.
+    gfsh.connectAndVerify(locatorSite1);
+  }
+
+  private MemberVM startServerWithGroups(int index, String groups, int locPort) {
+    Properties props = new Properties();
+    props.setProperty(GROUPS, groups);
+    return clusterStartupRule.startServerVM(index, props, locPort);
+  }
+
+
+  private String createGatewayReceiverCommand(String manualStart) {
+    return createGatewayReceiverCommand(manualStart, null);
+  }
+
+  private String createGatewayReceiverCommand(String manualStart, String memberOrGroup) {
+    CommandStringBuilder csb = new CommandStringBuilder(CliStrings.CREATE_GATEWAYRECEIVER)
+        .addOption(CliStrings.CREATE_GATEWAYRECEIVER__MANUALSTART, manualStart)
+        .addOption(CliStrings.CREATE_GATEWAYRECEIVER__BINDADDRESS, "localhost")
+        .addOption(CliStrings.CREATE_GATEWAYRECEIVER__STARTPORT, "10000")
+        .addOption(CliStrings.CREATE_GATEWAYRECEIVER__ENDPORT, "11000")
+        .addOption(CliStrings.CREATE_GATEWAYRECEIVER__MAXTIMEBETWEENPINGS, "100000")
+        .addOption(CliStrings.CREATE_GATEWAYRECEIVER__SOCKETBUFFERSIZE, "512000");
+    addOptionAndValue(csb, memberOrGroup);
+    return csb.toString();
+  }
+
+  private void addOptionAndValue(CommandStringBuilder csb, String optionAndValue) {
+    if (StringUtils.isNotBlank(optionAndValue)) {
+      String[] memberOption = optionAndValue.split(":");
+      if (memberOption.length == 1) {
+        csb.addOption(memberOption[0]);
+      } else {
+        csb.addOption(memberOption[0], memberOption[1]);
+      }
+    }
+  }
+
+  private void verifyConfigHasGatewayReceiver(String groupName) {
+    locatorSite1.invoke(() -> {
+      String sharedConfigXml = ClusterStartupRule.getLocator().getSharedConfiguration()
+          .getConfiguration(groupName).getCacheXmlContent();
+      assertThat(sharedConfigXml).contains("<gateway-receiver");
+    });
+  }
+
+  private void verifyConfigDoesNotHaveGatewayReceiver(String groupName) {
+    locatorSite1.invoke(() -> {
+      String sharedConfigXml = ClusterStartupRule.getLocator().getSharedConfiguration()
+          .getConfiguration(groupName).getCacheXmlContent();
+      // Null or emnpty XML doesn't have gateway-receiver element, so it's OK
+      if (StringUtils.isNotEmpty(sharedConfigXml)) {
+        assertThat(sharedConfigXml).doesNotContain("<gateway-receiver");
+      }
+    });
+  }
+
+  @Test
+  public void destroyStartedGatewayReceiverOnAllMembers() {
+    Integer locator1Port = locatorSite1.getPort();
+    server3 = clusterStartupRule.startServerVM(3, locator1Port);
+    server4 = clusterStartupRule.startServerVM(4, locator1Port);
+    server5 = clusterStartupRule.startServerVM(5, locator1Port);
+
+    gfsh.executeAndAssertThat(createGatewayReceiverCommand("false")).statusIsSuccess()
+        .tableHasColumnWithExactValuesInAnyOrder("Member", "server-3", "server-4", "server-5")
+        .tableHasColumnWithValuesContaining("Status",
+            "GatewayReceiver created on member \"server-3\"",
+            "GatewayReceiver created on member \"server-4\"",
+            "GatewayReceiver created on member \"server-5\"");
+
+    VMProvider
+        .invokeInEveryMember(
+            () -> verifyReceiverCreationWithAttributes(true, 10000, 11000, "localhost", 100000,
+                512000, null, GatewayReceiver.DEFAULT_HOSTNAME_FOR_SENDERS),
+            server3, server4, server5);
+
+    CommandStringBuilder csb =
+        new CommandStringBuilder(DestroyGatewayReceiverCommand.DESTROY_GATEWAYRECEIVER);
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess()
+        .doesNotContainOutput("change is not persisted")
+        .tableHasColumnWithExactValuesInAnyOrder("Member", "server-3", "server-4", "server-5");
+    VMProvider.invokeInEveryMember(WANCommandUtils::verifyReceiverDoesNotExist, server3, server4,
+        server5);
+  }
+
+  @Test
+  public void destroyStartedGatewayReceiver_destroysReceiverOnlyOnSpecificMembers() {
+    Integer locator1Port = locatorSite1.getPort();
+    server3 = clusterStartupRule.startServerVM(3, locator1Port);
+    server4 = clusterStartupRule.startServerVM(4, locator1Port);
+    server5 = clusterStartupRule.startServerVM(5, locator1Port);
+
+    gfsh.executeAndAssertThat(createGatewayReceiverCommand("false")).statusIsSuccess()
+        .tableHasColumnWithExactValuesInAnyOrder("Member", "server-3", "server-4", "server-5")
+        .tableHasColumnWithValuesContaining("Status",
+            "GatewayReceiver created on member \"server-3\"",
+            "GatewayReceiver created on member \"server-4\"",
+            "GatewayReceiver created on member \"server-5\"");
+    verifyConfigHasGatewayReceiver("cluster");
+
+    VMProvider
+        .invokeInEveryMember(
+            () -> verifyReceiverCreationWithAttributes(true, 10000, 11000, "localhost", 100000,
+                512000, null, GatewayReceiver.DEFAULT_HOSTNAME_FOR_SENDERS),
+            server3, server4, server5);
+
+    CommandStringBuilder csb =
+        new CommandStringBuilder(DestroyGatewayReceiverCommand.DESTROY_GATEWAYRECEIVER)
+            .addOption(CliStrings.MEMBER, server3.getName());
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess()
+        .containsOutput("change is not persisted")
+        .tableHasColumnWithExactValuesInAnyOrder("Member", "server-3");
+    verifyConfigHasGatewayReceiver("cluster");
+
+    VMProvider.invokeInEveryMember(WANCommandUtils::verifyReceiverDoesNotExist, server3);
+    VMProvider.invokeInEveryMember(() -> verifyReceiverCreationWithAttributes(true, 10000, 11000,
+        "localhost", 100000, 512000, null, GatewayReceiver.DEFAULT_HOSTNAME_FOR_SENDERS), server4,
+        server5);
+  }
+
+  @Test
+  public void destroyUnstartedGatewayReceiver_destroysReceiverOnlyOnSpecificMembers() {
+    Integer locator1Port = locatorSite1.getPort();
+    server3 = clusterStartupRule.startServerVM(3, locator1Port);
+    server4 = clusterStartupRule.startServerVM(4, locator1Port);
+    server5 = clusterStartupRule.startServerVM(5, locator1Port);
+
+    gfsh.executeAndAssertThat(createGatewayReceiverCommand("true")).statusIsSuccess()
+        .tableHasColumnWithExactValuesInAnyOrder("Member", "server-3", "server-4", "server-5")
+        .tableHasColumnWithValuesContaining("Status",
+            "GatewayReceiver created on member \"server-3\"",
+            "GatewayReceiver created on member \"server-4\"",
+            "GatewayReceiver created on member \"server-5\"");
+
+    VMProvider
+        .invokeInEveryMember(
+            () -> verifyReceiverCreationWithAttributes(false, 10000, 11000, "localhost", 100000,
+                512000, null, GatewayReceiver.DEFAULT_HOSTNAME_FOR_SENDERS),
+            server3, server4, server5);
+
+    CommandStringBuilder csb =
+        new CommandStringBuilder(DestroyGatewayReceiverCommand.DESTROY_GATEWAYRECEIVER)
+            .addOption(CliStrings.MEMBER, server3.getName());
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess()
+        .containsOutput("change is not persisted")
+        .tableHasColumnWithExactValuesInAnyOrder("Member", "server-3");
+    VMProvider.invokeInEveryMember(WANCommandUtils::verifyReceiverDoesNotExist, server3);
+    VMProvider.invokeInEveryMember(() -> verifyReceiverCreationWithAttributes(false, 10000, 11000,
+        "localhost", 100000, 512000, null, GatewayReceiver.DEFAULT_HOSTNAME_FOR_SENDERS), server4,
+        server5);
+  }
+
+  @Test
+  public void destroyWithoutGatewayReceivers_isError() {
+    Integer locator1Port = locatorSite1.getPort();
+    server3 = clusterStartupRule.startServerVM(3, locator1Port);
+    server4 = clusterStartupRule.startServerVM(4, locator1Port);
+    server5 = clusterStartupRule.startServerVM(5, locator1Port);
+
+    gfsh.executeAndAssertThat(
+        createGatewayReceiverCommand("false", CliStrings.MEMBER + ":server-4,server-5"))
+        .statusIsSuccess().tableHasColumnWithExactValuesInAnyOrder("Member", "server-4", "server-5")
+        .tableHasColumnWithValuesContaining("Status",
+            "GatewayReceiver created on member \"server-4\"",
+            "GatewayReceiver created on member \"server-5\"");
+    VMProvider.invokeInEveryMember(WANCommandUtils::verifyReceiverDoesNotExist, server3);
+
+    CommandStringBuilder csb =
+        new CommandStringBuilder(DestroyGatewayReceiverCommand.DESTROY_GATEWAYRECEIVER)
+            .addOption(CliStrings.MEMBER, server3.getName());
+    gfsh.executeAndAssertThat(csb.toString()).statusIsError()
+        .tableHasColumnWithExactValuesInAnyOrder("Member", "server-3");
+  }
+
+  @Test
+  public void destroyIfExistsWithoutGatewayReceivers_isSkipping() {
+    Integer locator1Port = locatorSite1.getPort();
+    server3 = clusterStartupRule.startServerVM(3, locator1Port);
+    server4 = clusterStartupRule.startServerVM(4, locator1Port);
+    server5 = clusterStartupRule.startServerVM(5, locator1Port);
+
+    VMProvider.invokeInEveryMember(WANCommandUtils::verifyReceiverDoesNotExist, server3, server4,
+        server5);
+
+    CommandStringBuilder csb =
+        new CommandStringBuilder(DestroyGatewayReceiverCommand.DESTROY_GATEWAYRECEIVER)
+            .addOption(CliStrings.IFEXISTS, "true").addOption(CliStrings.MEMBER, server3.getName());
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess()
+        .tableHasColumnWithExactValuesInAnyOrder("Member", "server-3")
+        .tableHasColumnWithValuesContaining("Status", "Skipping:");
+  }
+
+  @Test
+  public void destroyGatewayReceiverOnGroup_destroysReceiversOnAllGroupMembers() {
+    Integer locator1Port = locatorSite1.getPort();
+    server3 = startServerWithGroups(3, "Grp1", locator1Port);
+    server4 = startServerWithGroups(4, "Grp1", locator1Port);
+    server5 = startServerWithGroups(5, "Grp2", locator1Port);
+
+    gfsh.executeAndAssertThat(createGatewayReceiverCommand("false", CliStrings.GROUP + ":Grp1"))
+        .statusIsSuccess().tableHasColumnWithExactValuesInAnyOrder("Member", "server-3", "server-4")
+        .tableHasColumnWithValuesContaining("Status",
+            "GatewayReceiver created on member \"server-3\"",
+            "GatewayReceiver created on member \"server-4\"");
+    verifyConfigHasGatewayReceiver("Grp1");
+    verifyConfigDoesNotHaveGatewayReceiver("cluster");
+
+    VMProvider.invokeInEveryMember(() -> verifyReceiverCreationWithAttributes(true, 10000, 11000,
+        "localhost", 100000, 512000, null, GatewayReceiver.DEFAULT_HOSTNAME_FOR_SENDERS), server3,
+        server4);
+    VMProvider.invokeInEveryMember(WANCommandUtils::verifyReceiverDoesNotExist, server5);
+
+    CommandStringBuilder csb =
+        new CommandStringBuilder(DestroyGatewayReceiverCommand.DESTROY_GATEWAYRECEIVER)
+            .addOption(CliStrings.GROUP, "Grp1");
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess()
+        .doesNotContainOutput("change is not persisted")
+        .tableHasColumnWithExactValuesInAnyOrder("Member", "server-3", "server-4");
+    verifyConfigDoesNotHaveGatewayReceiver("Grp1");
+    verifyConfigDoesNotHaveGatewayReceiver("cluster");
+
+    VMProvider.invokeInEveryMember(WANCommandUtils::verifyReceiverDoesNotExist, server3, server4);
+  }
+
+  @Test
+  public void destroyGatewayReceiverOnListOfGroups_destroysReceiversOnMembersOfAllGroups() {
+    Integer locator1Port = locatorSite1.getPort();
+    server3 = startServerWithGroups(3, "Grp1", locator1Port);
+    server4 = startServerWithGroups(4, "Grp2", locator1Port);
+    server5 = startServerWithGroups(5, "Grp3", locator1Port);
+
+    gfsh.executeAndAssertThat(createGatewayReceiverCommand("false", CliStrings.GROUP + ":Grp1"))
+        .statusIsSuccess().tableHasColumnWithExactValuesInAnyOrder("Member", "server-3")
+        .tableHasColumnWithValuesContaining("Status",
+            "GatewayReceiver created on member \"server-3\"");
+    gfsh.executeAndAssertThat(createGatewayReceiverCommand("false", CliStrings.GROUP + ":Grp2"))
+        .statusIsSuccess().tableHasColumnWithExactValuesInAnyOrder("Member", "server-4")
+        .tableHasColumnWithValuesContaining("Status",
+            "GatewayReceiver created on member \"server-4\"");
+    verifyConfigHasGatewayReceiver("Grp1");
+    verifyConfigHasGatewayReceiver("Grp2");
+    verifyConfigDoesNotHaveGatewayReceiver("cluster");
+
+    VMProvider.invokeInEveryMember(() -> verifyReceiverCreationWithAttributes(true, 10000, 11000,
+        "localhost", 100000, 512000, null, GatewayReceiver.DEFAULT_HOSTNAME_FOR_SENDERS), server3,
+        server4);
+    VMProvider.invokeInEveryMember(WANCommandUtils::verifyReceiverDoesNotExist, server5);
+
+    CommandStringBuilder csb =
+        new CommandStringBuilder(DestroyGatewayReceiverCommand.DESTROY_GATEWAYRECEIVER)
+            .addOption(CliStrings.GROUP, "Grp1,Grp2");
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess()
+        .doesNotContainOutput("change is not persisted")
+        .tableHasColumnWithExactValuesInAnyOrder("Member", "server-3", "server-4");
+    verifyConfigDoesNotHaveGatewayReceiver("Grp1");
+    verifyConfigDoesNotHaveGatewayReceiver("Grp2");
+    verifyConfigDoesNotHaveGatewayReceiver("cluster");
+
+    VMProvider.invokeInEveryMember(WANCommandUtils::verifyReceiverDoesNotExist, server3, server4);
+  }
+
+  @Test
+  public void destroyGatewayReceiverOnListOfGroups_destroysReceiversListedGroups() {
+    Integer locator1Port = locatorSite1.getPort();
+    server3 = startServerWithGroups(3, "Grp1", locator1Port);
+    server4 = startServerWithGroups(4, "Grp2", locator1Port);
+    server5 = startServerWithGroups(5, "Grp3", locator1Port);
+
+    gfsh.executeAndAssertThat(createGatewayReceiverCommand("false", CliStrings.GROUP + ":Grp1"))
+        .statusIsSuccess().tableHasColumnWithExactValuesInAnyOrder("Member", "server-3")
+        .tableHasColumnWithValuesContaining("Status",
+            "GatewayReceiver created on member \"server-3\"");
+    gfsh.executeAndAssertThat(createGatewayReceiverCommand("false", CliStrings.GROUP + ":Grp2"))
+        .statusIsSuccess().tableHasColumnWithExactValuesInAnyOrder("Member", "server-4")
+        .tableHasColumnWithValuesContaining("Status",
+            "GatewayReceiver created on member \"server-4\"");
+    verifyConfigHasGatewayReceiver("Grp1");
+    verifyConfigHasGatewayReceiver("Grp2");
+    verifyConfigDoesNotHaveGatewayReceiver("cluster");
+
+    VMProvider.invokeInEveryMember(() -> verifyReceiverCreationWithAttributes(true, 10000, 11000,
+        "localhost", 100000, 512000, null, GatewayReceiver.DEFAULT_HOSTNAME_FOR_SENDERS), server3,
+        server4);
+    VMProvider.invokeInEveryMember(WANCommandUtils::verifyReceiverDoesNotExist, server5);
+
+    CommandStringBuilder csb =
+        new CommandStringBuilder(DestroyGatewayReceiverCommand.DESTROY_GATEWAYRECEIVER)
+            .addOption(CliStrings.GROUP, "Grp1");
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess()
+        .doesNotContainOutput("change is not persisted")
+        .tableHasColumnWithExactValuesInAnyOrder("Member", "server-3");
+    verifyConfigDoesNotHaveGatewayReceiver("Grp1");
+    verifyConfigHasGatewayReceiver("Grp2");
+    verifyConfigDoesNotHaveGatewayReceiver("cluster");
+
+    VMProvider.invokeInEveryMember(() -> verifyReceiverCreationWithAttributes(true, 10000, 11000,
+        "localhost", 100000, 512000, null, GatewayReceiver.DEFAULT_HOSTNAME_FOR_SENDERS), server4);
+    VMProvider.invokeInEveryMember(WANCommandUtils::verifyReceiverDoesNotExist, server3);
+  }
+}

--- a/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/wancommand/WANCommandUtils.java
+++ b/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/wancommand/WANCommandUtils.java
@@ -332,6 +332,11 @@ public class WANCommandUtils implements Serializable {
     }
   }
 
+  public static void verifyReceiverDoesNotExist() {
+    Set<GatewayReceiver> receivers = ClusterStartupRule.getCache().getGatewayReceivers();
+    assertThat(receivers.size()).isEqualTo(0);
+  }
+
   public static void validateMemberMXBeanProxy(final InternalDistributedMember member) {
     MemberMXBean memberMXBean = awaitMemberMXBeanProxy(member);
     assertThat(memberMXBean).isNotNull();


### PR DESCRIPTION
- New DUnit and unit tests for command and function classes
- Use new cluster configuration service instead of XmlEntity

This PR replaces PR#1706, which has conflicts with the current develop branch that prevent clean precheckin runs.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
