### PR TITLE
GEODE-5043: Buffering protobuf output to avoid multiple packet sends

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/OriginalServerConnection.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/OriginalServerConnection.java
@@ -47,6 +47,8 @@ public class OriginalServerConnection extends ServerConnection {
       SecurityService securityService) {
     super(socket, internalCache, helper, stats, hsTimeout, socketBufferSize, communicationModeStr,
         communicationMode, acceptor, securityService);
+
+    initStreams(socket, socketBufferSize, stats);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ProtobufServerConnection.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ProtobufServerConnection.java
@@ -15,10 +15,10 @@
 
 package org.apache.geode.internal.cache.tier.sockets;
 
+import java.io.BufferedOutputStream;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 
@@ -41,6 +41,7 @@ public class ProtobufServerConnection extends ServerConnection {
   private final ClientProtocolProcessor protocolProcessor;
   private boolean cleanedUp;
   private ClientProxyMembershipID clientProxyMembershipID;
+  private final BufferedOutputStream output;
 
   /**
    * Creates a new <code>ProtobufServerConnection</code> that processes messages received from an
@@ -49,11 +50,12 @@ public class ProtobufServerConnection extends ServerConnection {
   public ProtobufServerConnection(Socket socket, InternalCache c, CachedRegionHelper helper,
       CacheServerStats stats, int hsTimeout, int socketBufferSize, String communicationModeStr,
       byte communicationMode, Acceptor acceptor, ClientProtocolProcessor clientProtocolProcessor,
-      SecurityService securityService) {
+      SecurityService securityService) throws IOException {
     super(socket, c, helper, stats, hsTimeout, socketBufferSize, communicationModeStr,
         communicationMode, acceptor, securityService);
     this.protocolProcessor = clientProtocolProcessor;
 
+    this.output = new BufferedOutputStream(socket.getOutputStream(), socketBufferSize);
     setClientProxyMembershipId();
 
     doHandShake(CommunicationMode.ProtobufClientServerProtocol.getModeNumber(), 0);
@@ -64,12 +66,12 @@ public class ProtobufServerConnection extends ServerConnection {
     Socket socket = this.getSocket();
     try {
       InputStream inputStream = socket.getInputStream();
-      OutputStream outputStream = socket.getOutputStream();
 
       InternalCache cache = getCache();
       cache.setReadSerializedForCurrentThread(true);
       try {
-        protocolProcessor.processMessage(inputStream, outputStream);
+        protocolProcessor.processMessage(inputStream, output);
+        output.flush();
       } finally {
         cache.setReadSerializedForCurrentThread(false);
       }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ProtobufServerConnection.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ProtobufServerConnection.java
@@ -70,8 +70,11 @@ public class ProtobufServerConnection extends ServerConnection {
       InternalCache cache = getCache();
       cache.setReadSerializedForCurrentThread(true);
       try {
-        protocolProcessor.processMessage(inputStream, output);
-        output.flush();
+        try {
+          protocolProcessor.processMessage(inputStream, output);
+        } finally {
+          output.flush();
+        }
       } finally {
         cache.setReadSerializedForCurrentThread(false);
       }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ServerConnection.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ServerConnection.java
@@ -289,8 +289,9 @@ public abstract class ServerConnection implements Runnable {
 
     final boolean isDebugEnabled = logger.isDebugEnabled();
     try {
-
-      initStreams(socket, socketBufferSize, stats);
+      theSocket = socket;
+      theSocket.setSendBufferSize(socketBufferSize);
+      theSocket.setReceiveBufferSize(socketBufferSize);
 
       if (isDebugEnabled) {
         logger.debug(
@@ -1480,12 +1481,8 @@ public abstract class ServerConnection implements Runnable {
     }
   }
 
-
-  private void initStreams(Socket s, int socketBufferSize, MessageStats msgStats) {
+  protected void initStreams(Socket s, int socketBufferSize, MessageStats msgStats) {
     try {
-      theSocket = s;
-      theSocket.setSendBufferSize(socketBufferSize);
-      theSocket.setReceiveBufferSize(socketBufferSize);
       if (getAcceptor().isSelector()) {
         // set it on the message to null. This causes Message
         // to fetch it from a thread local. That way we only need

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ServerConnectionFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ServerConnectionFactory.java
@@ -78,7 +78,7 @@ public class ServerConnectionFactory {
   private ServerConnection createProtobufServerConnection(Socket socket, InternalCache cache,
       CachedRegionHelper helper, CacheServerStats stats, int hsTimeout, int socketBufferSize,
       String communicationModeStr, byte communicationMode, Acceptor acceptor,
-      SecurityService securityService) {
+      SecurityService securityService) throws IOException {
     ClientProtocolService service =
         getClientProtocolService(cache.getDistributedSystem(), acceptor.getServerName());
 

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/cache/tier/sockets/OutputCapturingServerConnectionTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/cache/tier/sockets/OutputCapturingServerConnectionTest.java
@@ -25,7 +25,6 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
-import java.net.UnknownHostException;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -76,7 +75,7 @@ public class OutputCapturingServerConnectionTest {
 
   private ProtobufServerConnection getServerConnection(Socket socketMock,
       ClientProtocolProcessor clientProtocolProcessorMock, AcceptorImpl acceptorStub)
-      throws UnknownHostException {
+      throws IOException {
     ClientHealthMonitor clientHealthMonitorMock = mock(ClientHealthMonitor.class);
     when(acceptorStub.getClientHealthMonitor()).thenReturn(clientHealthMonitorMock);
     InetSocketAddress inetSocketAddressStub = InetSocketAddress.createUnresolved("localhost", 9071);
@@ -89,7 +88,7 @@ public class OutputCapturingServerConnectionTest {
     CachedRegionHelper cachedRegionHelper = mock(CachedRegionHelper.class);
     when(cachedRegionHelper.getCache()).thenReturn(cache);
     return new ProtobufServerConnection(socketMock, cache, cachedRegionHelper,
-        mock(CacheServerStats.class), 0, 0, "",
+        mock(CacheServerStats.class), 0, 1024, "",
         CommunicationMode.ProtobufClientServerProtocol.getModeNumber(), acceptorStub,
         clientProtocolProcessorMock, mock(SecurityService.class));
   }

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/cache/tier/sockets/OutputCapturingServerConnectionTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/cache/tier/sockets/OutputCapturingServerConnectionTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -51,6 +52,8 @@ public class OutputCapturingServerConnectionTest {
     Socket socketMock = mock(Socket.class);
     when(socketMock.getInetAddress()).thenReturn(InetAddress.getByName("localhost"));
     when(socketMock.isClosed()).thenReturn(true);
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    when(socketMock.getOutputStream()).thenReturn(outputStream);
 
     AcceptorImpl acceptorStub = mock(AcceptorImpl.class);
     ClientProtocolProcessor clientProtocolProcessor = mock(ClientProtocolProcessor.class);

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/cache/tier/sockets/ProtobufServerConnectionTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/cache/tier/sockets/ProtobufServerConnectionTest.java
@@ -22,11 +22,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
-import java.net.UnknownHostException;
 
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -71,7 +71,7 @@ public class ProtobufServerConnectionTest {
   }
 
   @Test
-  public void testClientHealthMonitorRegistration() throws UnknownHostException {
+  public void testClientHealthMonitorRegistration() throws IOException {
     AcceptorImpl acceptorStub = mock(AcceptorImpl.class);
 
     ClientProtocolProcessor clientProtocolProcessor = mock(ClientProtocolProcessor.class);
@@ -94,7 +94,7 @@ public class ProtobufServerConnectionTest {
   }
 
   @Test
-  public void testDoOneMessageNotifiesClientHealthMonitor() throws UnknownHostException {
+  public void testDoOneMessageNotifiesClientHealthMonitor() throws IOException {
     AcceptorImpl acceptorStub = mock(AcceptorImpl.class);
     ClientProtocolProcessor clientProtocolProcessor = mock(ClientProtocolProcessor.class);
 
@@ -117,7 +117,7 @@ public class ProtobufServerConnectionTest {
 
   private ProtobufServerConnection getServerConnection(Socket socketMock,
       ClientProtocolProcessor clientProtocolProcessorMock, AcceptorImpl acceptorStub)
-      throws UnknownHostException {
+      throws IOException {
     clientHealthMonitorMock = mock(ClientHealthMonitor.class);
     when(acceptorStub.getClientHealthMonitor()).thenReturn(clientHealthMonitorMock);
     InetSocketAddress inetSocketAddressStub = InetSocketAddress.createUnresolved("localhost", 9071);
@@ -130,15 +130,16 @@ public class ProtobufServerConnectionTest {
     CachedRegionHelper cachedRegionHelper = mock(CachedRegionHelper.class);
     when(cachedRegionHelper.getCache()).thenReturn(cache);
     return new ProtobufServerConnection(socketMock, cache, cachedRegionHelper,
-        mock(CacheServerStats.class), 0, 0, "",
+        mock(CacheServerStats.class), 0, 1024, "",
         CommunicationMode.ProtobufClientServerProtocol.getModeNumber(), acceptorStub,
         clientProtocolProcessorMock, mock(SecurityService.class));
   }
 
   private ProtobufServerConnection getServerConnection(
       ClientProtocolProcessor clientProtocolProcessorMock, AcceptorImpl acceptorStub)
-      throws UnknownHostException {
+      throws IOException {
     Socket socketMock = mock(Socket.class);
+    when(socketMock.getOutputStream()).thenReturn(new ByteArrayOutputStream());
     return getServerConnection(socketMock, clientProtocolProcessorMock, acceptorStub);
   }
 }


### PR DESCRIPTION
Based on the stats all protobuf requests and responses were being sent
as two packets. Using a BufferedOutputStream to make sure we only send 1
packet

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
