### PR TITLE
GEODE-5035: Explicitly pass java.io.tmpdir to JVMs invoked by Gradle.

### DIFF
--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -105,7 +105,7 @@ subprojects {
     useJUnit {
       includeCategories 'org.apache.geode.test.junit.categories.UnitTest'
     }
-    
+
     doFirst {
       TestPropertiesWriter.writeTestProperties(buildDir, name)
     }
@@ -122,7 +122,7 @@ subprojects {
       TestPropertiesWriter.writeTestProperties(buildDir, name)
     }
   }
-  
+
   task distributedTest(type:Test) {
     useJUnit {
       includeCategories 'org.apache.geode.test.junit.categories.DistributedTest'
@@ -130,12 +130,12 @@ subprojects {
     }
     forkEvery 1
   }
-  
+
   task flakyTest(type:Test) {
     useJUnit {
       includeCategories 'org.apache.geode.test.junit.categories.FlakyTest'
     }
-    
+
     forkEvery 1
     doFirst {
       TestPropertiesWriter.writeTestProperties(buildDir, name)
@@ -345,15 +345,15 @@ subprojects {
         //force tests to be run every time by
         //saying the results are never up to date
         outputs.upToDateWhen { false }
-    
+
         def resultsDir = TestPropertiesWriter.testResultsDir(buildDir, test.name)
         workingDir resultsDir.absolutePath
-        
+
         reports.html.destination = file "$buildDir/reports/$name"
         testLogging {
           exceptionFormat = 'full'
         }
-        
+
         maxHeapSize '768m'
 //        jvmArgs = ['-XX:+HeapDumpOnOutOfMemoryError', '-ea',"-XX:+PrintGC", "-XX:+PrintGCDetails","-XX:+PrintGCTimeStamps"]
         jvmArgs = ['-XX:+HeapDumpOnOutOfMemoryError', '-ea']
@@ -371,6 +371,12 @@ subprojects {
         def log4jLocation = System.getProperty('log4j.configurationFile')
         if (log4jLocation != null) {
           systemProperty 'log4j.configurationFile', log4jLocation
+        }
+
+        // The distributed tests seem to need to use /tmp directly,
+        // so exclude them from using the supplied temp directory.
+        if (! test.name.contains("distributed")) {
+          systemProperty 'java.io.tmpdir', System.getProperty('java.io.tmpdir')
         }
 
         def eol = System.getProperty('line.separator')


### PR DESCRIPTION
- Exclude distributed tests from using java.io.tmpdir as they appear
  to need /tmp.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [n/a] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
