### PR TITLE
GEODE-4856: Public API for retrieving/persisting Cluster Configuration

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/configuration/CacheConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/configuration/CacheConfig.java
@@ -327,6 +327,12 @@ public class CacheConfig {
   @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
   protected String version;
 
+  public CacheConfig() {}
+
+  public CacheConfig(String version) {
+    this.version = version;
+  }
+
   /**
    * Gets the value of the cacheTransactionManager property.
    *

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalClusterConfigurationService.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalClusterConfigurationService.java
@@ -834,10 +834,16 @@ public class InternalClusterConfigurationService implements ClusterConfiguration
     if (group == null) {
       group = CLUSTER_CONFIG;
     }
-    String xmlContent = getConfiguration(group).getCacheXmlContent();
-    if (xmlContent == null || xmlContent.isEmpty()) {
-      xmlContent = generateInitialXmlContent();
+    Configuration configuration = getConfiguration(group);
+    if (configuration == null) {
+      return null;
     }
+    String xmlContent = configuration.getCacheXmlContent();
+    // group existed, so we should create a blank one to start with
+    if (xmlContent == null || xmlContent.isEmpty()) {
+      return null;
+    }
+
     return jaxbService.unMarshall(xmlContent);
   }
 
@@ -849,12 +855,18 @@ public class InternalClusterConfigurationService implements ClusterConfiguration
     lockSharedConfiguration();
     try {
       CacheConfig cacheConfig = getCacheConfig(group);
+      if (cacheConfig == null) {
+        cacheConfig = new CacheConfig("1.0");
+      }
       cacheConfig = mutator.apply(cacheConfig);
       if (cacheConfig == null) {
         // mutator returns a null config, indicating no change needs to be persisted
         return;
       }
       Configuration configuration = getConfiguration(group);
+      if (configuration == null) {
+        configuration = new Configuration(group);
+      }
       configuration.setCacheXmlContent(jaxbService.marshall(cacheConfig));
       getConfigurationRegion().put(group, configuration);
     } finally {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateJndiBindingCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateJndiBindingCommand.java
@@ -152,12 +152,14 @@ public class CreateJndiBindingCommand extends InternalGfshCommand {
 
     if (service != null) {
       CacheConfig cacheConfig = service.getCacheConfig("cluster");
-      JndiBindingsType.JndiBinding existing =
-          service.findIdentifiable(cacheConfig.getJndiBindings(), jndiName);
-      if (existing != null) {
-        throw new EntityExistsException(
-            CliStrings.format("Jndi binding with jndi-name \"{0}\" already exists.", jndiName),
-            ifNotExists);
+      if (cacheConfig != null) {
+        JndiBindingsType.JndiBinding existing =
+            service.findIdentifiable(cacheConfig.getJndiBindings(), jndiName);
+        if (existing != null) {
+          throw new EntityExistsException(
+              CliStrings.format("Jndi binding with jndi-name \"{0}\" already exists.", jndiName),
+              ifNotExists);
+        }
       }
 
       service.updateCacheConfig("cluster", config -> {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeJndiBindingCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeJndiBindingCommand.java
@@ -55,6 +55,10 @@ public class DescribeJndiBindingCommand extends InternalGfshCommand {
         (InternalClusterConfigurationService) getConfigurationService();
     if (ccService != null) {
       CacheConfig cacheConfig = ccService.getCacheConfig("cluster");
+      if (cacheConfig == null) {
+        return ResultBuilder
+            .createUserErrorResult(String.format("JNDI binding : %s not found", bindingName));
+      }
       List<JndiBindingsType.JndiBinding> jndiBindings = cacheConfig.getJndiBindings();
 
       if (jndiBindings.stream().noneMatch(b -> b.getJndiName().equals(bindingName)

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExportImportClusterConfigurationCommands.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ExportImportClusterConfigurationCommands.java
@@ -149,13 +149,16 @@ public class ExportImportClusterConfigurationCommands extends InternalGfshComman
       Set<String> groupNames = sc.getConfigurationRegion().keySet();
       for (String groupName : groupNames) {
         CacheConfig cacheConfig = sc.getCacheConfig(groupName);
-        if (cacheConfig.getRegion().size() > 0 || cacheConfig.getAsyncEventQueue().size() > 0
-            || cacheConfig.getDiskStore().size() > 0
-            || cacheConfig.getCustomCacheElements().size() > 0
-            || cacheConfig.getJndiBindings().size() > 0 || cacheConfig.getGatewayReceiver() != null
-            || cacheConfig.getGatewaySender().size() > 0) {
-          return ResultBuilder.createGemFireErrorResult(
-              "Running servers have existing cluster configuration applied already.");
+        if (cacheConfig != null) {
+          if (cacheConfig.getRegion().size() > 0 || cacheConfig.getAsyncEventQueue().size() > 0
+              || cacheConfig.getDiskStore().size() > 0
+              || cacheConfig.getCustomCacheElements().size() > 0
+              || cacheConfig.getJndiBindings().size() > 0
+              || cacheConfig.getGatewayReceiver() != null
+              || cacheConfig.getGatewaySender().size() > 0) {
+            return ResultBuilder.createGemFireErrorResult(
+                "Running servers have existing cluster configuration applied already.");
+          }
         }
       }
 


### PR DESCRIPTION
  fixed a bug in getCacheConfig and updateCacheConfig
  to support non-existing group

Signed-off-by: Jinmei Liao <jiliao@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
