### PR TITLE
GEODE-5069: Reduce direct exposure of GfJsonObject from CommandResult

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/json/GfJsonObject.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/json/GfJsonObject.java
@@ -14,10 +14,12 @@
  */
 package org.apache.geode.management.internal.cli.json;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 import org.json.JSONArray;
@@ -305,6 +307,17 @@ public class GfJsonObject {
     } catch (JSONException e) {
       throw new GfJsonException(e.getMessage());
     }
+  }
+
+  public List<String> getArrayValues(String key) {
+    List<String> result = new ArrayList<>();
+    JSONArray jsonArray = jsonObject.getJSONArray(key);
+
+    for (int i = 0; i < jsonArray.length(); i++) {
+      result.add(jsonArray.getString(i));
+    }
+
+    return result;
   }
 
   private static Object extractInternalForGfJsonOrReturnSame(Object value) {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/json/GfJsonObject.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/json/GfJsonObject.java
@@ -311,10 +311,12 @@ public class GfJsonObject {
 
   public List<String> getArrayValues(String key) {
     List<String> result = new ArrayList<>();
-    JSONArray jsonArray = jsonObject.getJSONArray(key);
+    if (jsonObject.has(key)) {
+      JSONArray jsonArray = jsonObject.getJSONArray(key);
 
-    for (int i = 0; i < jsonArray.length(); i++) {
-      result.add(jsonArray.getString(i));
+      for (int i = 0; i < jsonArray.length(); i++) {
+        result.add(jsonArray.getString(i));
+      }
     }
 
     return result;

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/result/CommandResult.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/result/CommandResult.java
@@ -18,13 +18,16 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Vector;
 import java.util.stream.Collectors;
 import java.util.zip.DataFormatException;
 
 import org.apache.logging.log4j.Logger;
 import org.json.JSONArray;
+import org.json.JSONObject;
 
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.management.cli.Result;
@@ -88,7 +91,7 @@ public class CommandResult implements Result {
     return ResultBuilder.getReadOnlyResultData(resultData);
   }
 
-  GfJsonObject getGfJsonObject() {
+  private GfJsonObject getGfJsonObject() {
     return gfJsonObject;
   }
 
@@ -442,14 +445,74 @@ public class CommandResult implements Result {
     return gfJsonObject.getJSONObject(ResultData.RESULT_CONTENT);
   }
 
+  public String getContentAsString() {
+    return getContent().toString();
+  }
+
+  public String getMessageFromContent() {
+    return getContent().getString("message");
+  }
+
+  public String getValueFromContent(String key) {
+    return getContent().get(key).toString();
+  }
+
+  public List<String> getListFromContent(String key) {
+    return getContent().getArrayValues(key);
+  }
+
+  public List<String> getColumnFromTableContent(String column, int... sectionAndTableIDs) {
+    List<String> ids =
+        Arrays.stream(sectionAndTableIDs).mapToObj(Integer::toString).collect(Collectors.toList());
+    return CommandResult.toList(
+        getTableContent(ids.toArray(new String[0])).getInternalJsonObject().getJSONArray(column));
+  }
+
+  public Map<String, List<String>> getMapFromTableContent(int... sectionAndTableIDs) {
+    Map<String, List<String>> result = new LinkedHashMap<>();
+
+    List<String> ids =
+        Arrays.stream(sectionAndTableIDs).mapToObj(Integer::toString).collect(Collectors.toList());
+    JSONObject table = getTableContent(ids.toArray(new String[0])).getInternalJsonObject();
+    for (String column : table.keySet()) {
+      result.put(column, CommandResult.toList(table.getJSONArray(column)));
+    }
+
+    return result;
+  }
+
+  public Map<String, List<String>> getMapFromTableContent(String... sectionAndTableIDs) {
+    Map<String, List<String>> result = new LinkedHashMap<>();
+
+    JSONObject table = getTableContent(sectionAndTableIDs).getInternalJsonObject();
+    for (String column : table.keySet()) {
+      result.put(column, CommandResult.toList(table.getJSONArray(column)));
+    }
+
+    return result;
+  }
+
+  public Map<String, String> getMapFromSection(String sectionID) {
+    Map<String, String> result = new LinkedHashMap<>();
+    GfJsonObject obj = getContent().getJSONObject("__sections__-" + sectionID);
+
+    Iterator<String> iter = obj.keys();
+    while (iter.hasNext()) {
+      String key = iter.next();
+      result.put(key, obj.getString(key));
+    }
+
+    return result;
+  }
+
   /**
    * The intent is that this method should be able to handle both ResultData as well as
    * CompositeResultData
    *
    * @return the extracted GfJsonObject table
    */
-  public GfJsonObject getTableContent() {
-    return getTableContent(0, 0);
+  private GfJsonObject getTableContent() {
+    return getTableContent("0", "0");
   }
 
   /**
@@ -457,7 +520,7 @@ public class CommandResult implements Result {
    * Some commands, such as 'describe region', may return command results with subsections, however.
    * Include these in order, e.g., getTableContent(sectionIndex, subsectionIndex, tableIndex);
    */
-  public GfJsonObject getTableContent(int... sectionAndTableIDs) {
+  private GfJsonObject getTableContent(String... sectionAndTableIDs) {
     GfJsonObject topLevelContent = getContent();
     // Most common is receiving exactly one section index and one table index.
     // Some results, however, will have subsections before the table listings.
@@ -465,14 +528,14 @@ public class CommandResult implements Result {
 
     GfJsonObject sectionObject = topLevelContent;
     for (int i = 0; i < sectionAndTableIDs.length - 1; i++) {
-      int idx = sectionAndTableIDs[i];
+      String idx = sectionAndTableIDs[i];
       sectionObject = sectionObject.getJSONObject("__sections__-" + idx);
       if (sectionObject == null) {
         return topLevelContent;
       }
     }
 
-    int tableId = sectionAndTableIDs[sectionAndTableIDs.length - 1];
+    String tableId = sectionAndTableIDs[sectionAndTableIDs.length - 1];
     GfJsonObject tableContent = sectionObject.getJSONObject("__tables__-" + tableId);
     if (tableContent == null) {
       return topLevelContent;

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateDefinedIndexesCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateDefinedIndexesCommandTest.java
@@ -69,7 +69,7 @@ public class CreateDefinedIndexesCommandTest {
   public void noDefinitions() throws Exception {
     result = gfshParser.executeCommandWithInstance(command, "create defined indexes");
     assertThat(result.getStatus()).isEqualTo(OK);
-    assertThat(result.getContent().toString()).contains("No indexes defined");
+    assertThat(result.getContentAsString()).contains("No indexes defined");
   }
 
   @Test
@@ -79,7 +79,7 @@ public class CreateDefinedIndexesCommandTest {
     doReturn(Collections.EMPTY_SET).when(command).findMembers(any(), any());
     result = gfshParser.executeCommandWithInstance(command, "create defined indexes");
     assertThat(result.getStatus()).isEqualTo(ERROR);
-    assertThat(result.getContent().toString()).contains("No Members Found");
+    assertThat(result.getContentAsString()).contains("No Members Found");
   }
 
   @Test
@@ -122,7 +122,7 @@ public class CreateDefinedIndexesCommandTest {
     assertThat(result.getStatus()).isEqualTo(OK);
     assertThat(result.failedToPersist()).isFalse();
     verify(command, Mockito.times(1)).persistClusterConfiguration(any(), any());
-    assertThat(result.getContent().toString()).contains("Indexes successfully created");
+    assertThat(result.getContentAsString()).contains("Indexes successfully created");
   }
 
   @Test
@@ -164,6 +164,6 @@ public class CreateDefinedIndexesCommandTest {
     // The command will receive 4 results from 2 members, but we need to persist only 2 (#regions)
     // of them.
     verify(command, Mockito.times(2)).persistClusterConfiguration(any(), any());
-    assertThat(result.getContent().toString()).contains("Indexes successfully created");
+    assertThat(result.getContentAsString()).contains("Indexes successfully created");
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateIndexCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateIndexCommandTest.java
@@ -64,14 +64,14 @@ public class CreateIndexCommandTest {
     result = gfshParser.executeCommandWithInstance(command,
         "create index --expression=abc --region=abc");
     assertThat(result.getStatus()).isEqualTo(ERROR);
-    assertThat(result.getContent().toString()).contains("Invalid command");
+    assertThat(result.getContentAsString()).contains("Invalid command");
   }
 
   @Test
   public void missingExpression() throws Exception {
     result = gfshParser.executeCommandWithInstance(command, "create index --name=abc --region=abc");
     assertThat(result.getStatus()).isEqualTo(ERROR);
-    assertThat(result.getContent().toString()).contains("Invalid command");
+    assertThat(result.getContentAsString()).contains("Invalid command");
   }
 
   @Test
@@ -79,7 +79,7 @@ public class CreateIndexCommandTest {
     result =
         gfshParser.executeCommandWithInstance(command, "create index --name=abc --expression=abc");
     assertThat(result.getStatus()).isEqualTo(ERROR);
-    assertThat(result.getContent().toString()).contains("Invalid command");
+    assertThat(result.getContentAsString()).contains("Invalid command");
   }
 
   @Test
@@ -87,7 +87,7 @@ public class CreateIndexCommandTest {
     result = gfshParser.executeCommandWithInstance(command,
         "create index --name=abc --expression=abc --region=abc --type=abc");
     assertThat(result.getStatus()).isEqualTo(ERROR);
-    assertThat(result.getContent().toString()).contains("Invalid command");
+    assertThat(result.getContentAsString()).contains("Invalid command");
   }
 
   @Test
@@ -96,7 +96,7 @@ public class CreateIndexCommandTest {
     result = gfshParser.executeCommandWithInstance(command,
         "create index --name=abc --expression=abc --region=abc --type=range");
     assertThat(result.getStatus()).isEqualTo(ERROR);
-    assertThat(result.getContent().toString()).contains("No Members Found");
+    assertThat(result.getContentAsString()).contains("No Members Found");
   }
 
   @Test
@@ -105,7 +105,7 @@ public class CreateIndexCommandTest {
     result = gfshParser.executeCommandWithInstance(command,
         "create index --name=abc --expression=abc --region=abc --type=hash");
     assertThat(result.getStatus()).isEqualTo(ERROR);
-    assertThat(result.getContent().toString()).contains("No Members Found");
+    assertThat(result.getContentAsString()).contains("No Members Found");
   }
 
   @Test
@@ -114,7 +114,7 @@ public class CreateIndexCommandTest {
     result = gfshParser.executeCommandWithInstance(command,
         "create index --name=abc --expression=abc --region=abc");
     assertThat(result.getStatus()).isEqualTo(ERROR);
-    assertThat(result.getContent().toString()).contains("No Members Found");
+    assertThat(result.getContentAsString()).contains("No Members Found");
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateRegionCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateRegionCommandTest.java
@@ -82,7 +82,7 @@ public class CreateRegionCommandTest {
   public void missingName() throws Exception {
     CommandResult result = parser.executeCommandWithInstance(command, "create region");
     assertThat(result.getStatus()).isEqualTo(Result.Status.ERROR);
-    assertThat(result.getContent().toString()).contains("Invalid command");
+    assertThat(result.getContentAsString()).contains("Invalid command");
   }
 
   @Test
@@ -90,7 +90,7 @@ public class CreateRegionCommandTest {
     CommandResult result =
         parser.executeCommandWithInstance(command, "create region --name=region");
     assertThat(result.getStatus()).isEqualTo(Result.Status.ERROR);
-    assertThat(result.getContent().toString())
+    assertThat(result.getContentAsString())
         .contains("One of \\\"type\\\" or \\\"template-region\\\" is required.");
   }
 
@@ -99,7 +99,7 @@ public class CreateRegionCommandTest {
     CommandResult result = parser.executeCommandWithInstance(command,
         "create region --name=region --type=REPLICATE --template-region=regionB");
     assertThat(result.getStatus()).isEqualTo(Result.Status.ERROR);
-    assertThat(result.getContent().toString())
+    assertThat(result.getContentAsString())
         .contains("Only one of type & template-region can be specified.");
   }
 
@@ -108,7 +108,7 @@ public class CreateRegionCommandTest {
     CommandResult result = parser.executeCommandWithInstance(command,
         "create region --name=region --type=REPLICATE --eviction-action=invalidAction");
     assertThat(result.getStatus()).isEqualTo(Result.Status.ERROR);
-    assertThat(result.getContent().toString())
+    assertThat(result.getContentAsString())
         .contains("eviction-action must be 'local-destroy' or 'overflow-to-disk'");
   }
 
@@ -117,7 +117,7 @@ public class CreateRegionCommandTest {
     CommandResult result = parser.executeCommandWithInstance(command,
         "create region --name=region --type=REPLICATE --eviction-max-memory=1000 --eviction-entry-count=200");
     assertThat(result.getStatus()).isEqualTo(Result.Status.ERROR);
-    assertThat(result.getContent().toString())
+    assertThat(result.getContentAsString())
         .contains("eviction-max-memory and eviction-entry-count cannot both be specified.");
   }
 
@@ -126,7 +126,7 @@ public class CreateRegionCommandTest {
     CommandResult result = parser.executeCommandWithInstance(command,
         "create region --name=region --type=REPLICATE --eviction-max-memory=1000");
     assertThat(result.getStatus()).isEqualTo(Result.Status.ERROR);
-    assertThat(result.getContent().toString()).contains("eviction-action must be specified.");
+    assertThat(result.getContentAsString()).contains("eviction-action must be specified.");
   }
 
   @Test
@@ -134,7 +134,7 @@ public class CreateRegionCommandTest {
     CommandResult result = parser.executeCommandWithInstance(command,
         "create region --name=region --type=REPLICATE --eviction-entry-count=1 --eviction-object-sizer=abc --eviction-action=local-destroy");
     assertThat(result.getStatus()).isEqualTo(Result.Status.ERROR);
-    assertThat(result.getContent().toString())
+    assertThat(result.getContentAsString())
         .contains("eviction-object-sizer cannot be specified with eviction-entry-count");
   }
 
@@ -147,7 +147,7 @@ public class CreateRegionCommandTest {
     CommandResult result = parser.executeCommandWithInstance(command,
         "create region --name=region --template-region=regionA");
     assertThat(result.getStatus()).isEqualTo(Result.Status.ERROR);
-    assertThat(result.getContent().toString())
+    assertThat(result.getContentAsString())
         .contains("Could not retrieve region attributes for given path");
   }
 
@@ -330,7 +330,7 @@ public class CreateRegionCommandTest {
     CommandResult result = parser.executeCommandWithInstance(command,
         "create region --name=region --type=REPLICATE --compressor=abc-def");
     assertThat(result.getStatus()).isEqualTo(Result.Status.ERROR);
-    assertThat(result.getContent().toString()).contains("abc-def is an invalid Compressor.");
+    assertThat(result.getContentAsString()).contains("abc-def is an invalid Compressor.");
   }
 
   @Test
@@ -338,7 +338,7 @@ public class CreateRegionCommandTest {
     CommandResult result = parser.executeCommandWithInstance(command,
         "create region --name=region --type=REPLICATE --key-type=abc-def");
     assertThat(result.getStatus()).isEqualTo(Result.Status.ERROR);
-    assertThat(result.getContent().toString()).contains("Invalid command");
+    assertThat(result.getContentAsString()).contains("Invalid command");
   }
 
   @Test
@@ -346,7 +346,7 @@ public class CreateRegionCommandTest {
     CommandResult result = parser.executeCommandWithInstance(command,
         "create region --name=region --type=REPLICATE --value-type=abc-def");
     assertThat(result.getStatus()).isEqualTo(Result.Status.ERROR);
-    assertThat(result.getContent().toString()).contains("Invalid command");
+    assertThat(result.getContentAsString()).contains("Invalid command");
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ListJndiBindingCommandDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ListJndiBindingCommandDUnitTest.java
@@ -17,6 +17,7 @@ package org.apache.geode.management.internal.cli.commands;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
 import java.util.Properties;
 
 import org.junit.BeforeClass;
@@ -26,9 +27,6 @@ import org.junit.experimental.categories.Category;
 
 import org.apache.geode.distributed.ConfigurationProperties;
 import org.apache.geode.management.internal.cli.functions.ListJndiBindingFunction;
-import org.apache.geode.management.internal.cli.json.GfJsonArray;
-import org.apache.geode.management.internal.cli.json.GfJsonException;
-import org.apache.geode.management.internal.cli.json.GfJsonObject;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.junit.assertions.CommandResultAssert;
@@ -60,7 +58,7 @@ public class ListJndiBindingCommandDUnitTest {
   }
 
   @Test
-  public void listJndiBinding() throws GfJsonException {
+  public void listJndiBinding() {
     gfsh.executeAndAssertThat(
         "create jndi-binding --name=jndi1 --type=SIMPLE --jdbc-driver-class=org.apache.derby.jdbc.EmbeddedDriver --connection-url=\"jdbc:derby:newDB;create=true\"")
         .statusIsSuccess().tableHasColumnOnlyWithValues("Member", "server-1");
@@ -74,10 +72,10 @@ public class ListJndiBindingCommandDUnitTest {
         .tableHasRowCount("Group Name", 1);
 
     // member table
-    GfJsonObject memberTableContent = commandResultAssert.getCommandResult().getTableContent(0, 1);
-    GfJsonArray jndi_names = memberTableContent.getJSONArray("JNDI Name");
-    assertThat(jndi_names.size()).isEqualTo(3);
-    assertThat(GfJsonArray.toStringArray(jndi_names)).containsExactlyInAnyOrder("java:jndi1",
-        "java:UserTransaction", "java:TransactionManager");
+    List<String> jndiNames =
+        commandResultAssert.getCommandResult().getColumnFromTableContent("JNDI Name", 0, 1);
+    assertThat(jndiNames.size()).isEqualTo(3);
+    assertThat(jndiNames).containsExactlyInAnyOrder("java:jndi1", "java:UserTransaction",
+        "java:TransactionManager");
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ShowMetricsJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ShowMetricsJUnitTest.java
@@ -38,7 +38,7 @@ public class ShowMetricsJUnitTest {
     CommandResult result =
         parser.executeCommandWithInstance(command, "show metrics --port=0 --region=regionA");
     assertThat(result.getStatus()).isEqualTo(Result.Status.ERROR);
-    assertThat(result.getContent().toString())
+    assertThat(result.getContentAsString())
         .contains("The --region and --port parameters are mutually exclusive");
   }
 
@@ -47,7 +47,7 @@ public class ShowMetricsJUnitTest {
     ShowMetricsCommand command = spy(ShowMetricsCommand.class);
     CommandResult result = parser.executeCommandWithInstance(command, "show metrics --port=0");
     assertThat(result.getStatus()).isEqualTo(Result.Status.ERROR);
-    assertThat(result.getContent().toString()).contains(
+    assertThat(result.getContentAsString()).contains(
         "If the --port parameter is specified, then the --member parameter must also be specified.");
   }
 
@@ -57,6 +57,6 @@ public class ShowMetricsJUnitTest {
     CommandResult result = parser.executeCommandWithInstance(command, "show metrics --port=abc");
     assertThat(result.getStatus()).isEqualTo(Result.Status.ERROR);
     // When relying on Spring's converters, any command that does not parse is "Invalid"
-    assertThat(result.getContent().toString()).contains("Invalid command");
+    assertThat(result.getContentAsString()).contains("Invalid command");
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/lifecycle/GfshStatusCommandsIntegrationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/lifecycle/GfshStatusCommandsIntegrationTest.java
@@ -56,14 +56,14 @@ public class GfshStatusCommandsIntegrationTest {
   public void statusLocatorWithBadPortReportsNotResponding() throws Exception {
     CommandResult result = gfsh.executeCommand("status locator --host=localhost --port="
         + String.valueOf(locator.getLocator().getPort() - 1));
-    assertThat(result.getContent().getString("message")).contains("not responding");
+    assertThat(result.getMessageFromContent()).contains("not responding");
   }
 
   @Test
   public void statusLocatorWithActivePortReportsOnline() throws Exception {
     CommandResult result = gfsh.executeCommand(
         "status locator --host=localhost --port=" + String.valueOf(locator.getLocator().getPort()));
-    assertThat(result.getContent().getString("message")).contains("is currently online");
+    assertThat(result.getMessageFromContent()).contains("is currently online");
   }
 
   @Test
@@ -71,7 +71,7 @@ public class GfshStatusCommandsIntegrationTest {
     File serverDir = new File(temporaryFolder.getRoot(), "serverDir");
     serverDir.mkdirs();
     CommandResult result = gfsh.executeCommand("status server");
-    assertThat(result.getContent().getString("message")).contains("not responding");
+    assertThat(result.getMessageFromContent()).contains("not responding");
   }
 
   @Test
@@ -79,6 +79,6 @@ public class GfshStatusCommandsIntegrationTest {
     File serverDir = new File(temporaryFolder.getRoot(), "serverDir");
     serverDir.mkdirs();
     CommandResult result = gfsh.executeCommand("status server --dir=" + serverDir.toString());
-    assertThat(result.getContent().getString("message")).contains("not responding");
+    assertThat(result.getMessageFromContent()).contains("not responding");
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/result/ResultBuilderTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/result/ResultBuilderTest.java
@@ -16,7 +16,9 @@ package org.apache.geode.management.internal.cli.result;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.json.JSONArray;
+import java.util.List;
+import java.util.Map;
+
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -29,108 +31,99 @@ public class ResultBuilderTest {
   @Test
   public void messageExistsForString() throws Exception {
     CommandResult result = (CommandResult) ResultBuilder.createInfoResult("test message");
-    assertThat(result.getContent().get("message")).isInstanceOf(JSONArray.class);
-    assertThat(result.getContent().get("message").toString()).isEqualTo("[\"test message\"]");
+    assertThat(result.getValueFromContent("message")).isEqualTo("[\"test message\"]");
   }
 
   @Test
   public void messageExistsForEmpty() throws Exception {
     CommandResult result = (CommandResult) ResultBuilder.createInfoResult("");
-    assertThat(result.getContent().get("message")).isInstanceOf(JSONArray.class);
-    assertThat(result.getContent().get("message").toString()).isEqualTo("[\"\"]");
+    assertThat(result.getValueFromContent("message")).isEqualTo("[\"\"]");
 
   }
 
   @Test
   public void messageExistsForNull() throws Exception {
     CommandResult result = (CommandResult) ResultBuilder.createInfoResult(null);
-    assertThat(result.getContent().get("message")).isInstanceOf(JSONArray.class);
-    assertThat(result.getContent().get("message").toString()).isEqualTo("[null]");
+    assertThat(result.getValueFromContent("message")).isEqualTo("[null]");
 
   }
 
   @Test
-  public void infoResultDataStructure() throws Exception {
+  public void infoResultDataStructure() {
     InfoResultData result = ResultBuilder.createInfoResultData();
     result.addLine("line 1");
     result.addLine("line 2");
-    result.setFooter("Feet!");
-    result.setHeader("Header");
-    CommandResult cmdResult = (CommandResult) ResultBuilder.buildResult(result);
+    result.setHeader("Heads");
+    result.setFooter("Tails");
+    CommandResult cmdResult = ResultBuilder.buildResult(result);
 
-    assertThat(cmdResult.getGfJsonObject().has("header")).isTrue();
-    assertThat(cmdResult.getGfJsonObject().has("content")).isTrue();
-    assertThat(cmdResult.getGfJsonObject().has("footer")).isTrue();
-
-    assertThat(cmdResult.getContent().has("message")).isTrue();
-
+    assertThat(cmdResult.getHeader()).isEqualTo("Heads");
+    assertThat(cmdResult.getListFromContent("message")).contains("line 1", "line 2");
+    assertThat(cmdResult.getFooter()).isEqualTo("Tails");
+    assertThat(cmdResult.getValueFromContent("message")).isNotEmpty();
     assertThat(cmdResult.getStatus()).isEqualTo(Result.Status.OK);
   }
 
   @Test
-  public void errorResultDataStructure() throws Exception {
+  public void errorResultDataStructure() {
     ErrorResultData result = ResultBuilder.createErrorResultData();
     result.addLine("line 1");
     result.addLine("line 2");
-    result.setFooter("Feet!");
-    result.setHeader("Header");
-    CommandResult cmdResult = (CommandResult) ResultBuilder.buildResult(result);
+    result.setHeader("Heads");
+    result.setFooter("Tails");
+    CommandResult cmdResult = ResultBuilder.buildResult(result);
 
-    assertThat(cmdResult.getGfJsonObject().has("header")).isTrue();
-    assertThat(cmdResult.getGfJsonObject().has("content")).isTrue();
-    assertThat(cmdResult.getGfJsonObject().has("footer")).isTrue();
+    assertThat(cmdResult.getHeader()).isEqualTo("Heads");
+    assertThat(cmdResult.getListFromContent("message")).contains("line 1", "line 2");
+    assertThat(cmdResult.getFooter()).isEqualTo("Tails");
 
-    assertThat(cmdResult.getContent().has("message")).isTrue();
+    assertThat(cmdResult.getValueFromContent("message")).isNotEmpty();
 
     assertThat(cmdResult.getStatus()).isEqualTo(Result.Status.ERROR);
   }
 
   @Test
-  public void tabularResultDataStructure() throws Exception {
+  public void tabularResultDataStructure() {
     TabularResultData result = ResultBuilder.createTabularResultData();
     result.accumulate("column1", "value11");
     result.accumulate("column1", "value12");
     result.accumulate("column2", "value21");
     result.accumulate("column2", "value22");
 
-    result.setFooter("Feet!");
-    result.setHeader("Header");
-    CommandResult cmdResult = (CommandResult) ResultBuilder.buildResult(result);
+    result.setHeader("Heads");
+    result.setFooter("Tails");
+    CommandResult cmdResult = ResultBuilder.buildResult(result);
 
-    assertThat(cmdResult.getGfJsonObject().has("header")).isTrue();
-    assertThat(cmdResult.getGfJsonObject().has("content")).isTrue();
-    assertThat(cmdResult.getGfJsonObject().has("footer")).isTrue();
+    assertThat(cmdResult.getHeader()).isEqualTo("Heads");
+    assertThat(cmdResult.getFooter()).isEqualTo("Tails");
 
-    assertThat(cmdResult.getContent().has("column1")).isTrue();
-    assertThat(cmdResult.getContent().has("column2")).isTrue();
-
-    assertThat(cmdResult.getContent().getJSONArray("column1").toString()).contains("value11");
-    assertThat(cmdResult.getContent().getJSONArray("column1").toString()).contains("value12");
-    assertThat(cmdResult.getContent().getJSONArray("column2").toString()).contains("value21");
-    assertThat(cmdResult.getContent().getJSONArray("column2").toString()).contains("value22");
+    assertThat(cmdResult.getListFromContent("column1")).contains("value11", "value12");
+    assertThat(cmdResult.getListFromContent("column2")).contains("value21", "value22");
   }
 
   @Test
-  public void compositeResultDataStructure() throws Exception {
+  public void compositeResultDataStructure() {
     CompositeResultData result = ResultBuilder.createCompositeResultData();
 
-    result.setFooter("Feet!");
-    result.setHeader("Header");
-
-    assertThat(result.getGfJsonObject().has("header")).isTrue();
-    assertThat(result.getGfJsonObject().has("content")).isTrue();
-    assertThat(result.getGfJsonObject().has("footer")).isTrue();
-
+    result.setHeader("Heads");
+    result.setFooter("Tails");
     // build up an example
     result.addSection().addData("section 0 key", "section 0 value");
     result.addSection().addTable().accumulate("table 1 column", "table 1 value");
 
-    result.addSection();
+    CommandResult cmdResult = ResultBuilder.buildResult(result);
 
+    assertThat(cmdResult.getHeader()).isEqualTo("Heads");
+    assertThat(cmdResult.getFooter()).isEqualTo("Tails");
+
+    assertThat(cmdResult.getMapFromSection("0").get("section 0 key")).isEqualTo("section 0 value");
+
+    Map<String, List<String>> table = cmdResult.getMapFromTableContent("1", "0");
+    assertThat(table.get("table 1 column")).contains("table 1 value");
   }
 
   @Test
-  public void errorCodeCorrectlyUpdated() throws Exception {
+  public void errorCodeCorrectlyUpdated() {
     String json =
         "{\"contentType\":\"table\",\"data\":{\"content\":{\"Member\":[\"server\"],\"Status\":[\"ERROR: Bad.\"]},\"footer\":\"\",\"header\":\"\",\"type-class\":\"org.apache.geode.management.internal.cli.CommandResponse.Data\"},\"debugInfo\":\"\",\"failedToPersist\":false,\"fileToDownload\":null,\"page\":\"1/1\",\"sender\":\"server\",\"status\":-1,\"tokenAccessor\":\"__NULL__\",\"type-class\":\"org.apache.geode.management.internal.cli.CommandResponse\",\"version\":\"1.3.0-SNAPSHOT\",\"when\":\"10/17/17 8:17 AM\"}";
 

--- a/geode-core/src/test/java/org/apache/geode/management/internal/configuration/ClusterConfigImportDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/configuration/ClusterConfigImportDUnitTest.java
@@ -80,7 +80,7 @@ public class ClusterConfigImportDUnitTest extends ClusterConfigTestBase {
         .executeCommand("import cluster-configuration --zip-file-name=" + clusterConfigZipPath);
 
     assertThat(result.getStatus()).isEqualTo(Result.Status.ERROR);
-    assertThat(result.getContent().toString()).contains("existing regions: " + regionName);
+    assertThat(result.getContentAsString()).contains("existing regions: " + regionName);
   }
 
   @Test
@@ -92,9 +92,9 @@ public class ClusterConfigImportDUnitTest extends ClusterConfigTestBase {
 
     CommandResult result = gfshConnector
         .executeCommand("import cluster-configuration --zip-file-name=" + clusterConfigZipPath);
-    assertThat(result.getContent().toString())
+    assertThat(result.getContentAsString())
         .contains("Successfully applied the imported cluster configuration on server-1");
-    assertThat(result.getContent().toString())
+    assertThat(result.getContentAsString())
         .contains("Successfully applied the imported cluster configuration on server-2");
     new ClusterConfig(CLUSTER).verify(server1);
     new ClusterConfig(CLUSTER, GROUP2).verify(server2);

--- a/geode-core/src/test/java/org/apache/geode/management/internal/security/GfshCommandsSecurityTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/security/GfshCommandsSecurityTest.java
@@ -137,7 +137,7 @@ public class GfshCommandsSecurityTest {
 
       // for permitted commands, if any error happens, it's not an Unauthorized error
       if (result.getStatus() == Result.Status.ERROR) {
-        assertThat(result.getContent().toString()).doesNotContain("not authorized");
+        assertThat(result.getContentAsString()).doesNotContain("not authorized");
       }
     }
 
@@ -152,7 +152,7 @@ public class GfshCommandsSecurityTest {
       // for some commands there are pre execution checks to check for user input error, will skip
       // those commands
       if (errorCode == ResultBuilder.ERRORCODE_USER_ERROR) {
-        LogService.getLogger().info("Skip user error: " + result.getContent());
+        LogService.getLogger().info("Skip user error: " + result.getContentAsString());
         continue;
       }
 
@@ -178,7 +178,7 @@ public class GfshCommandsSecurityTest {
     CommandResult result =
         gfshConnection.executeCommand("create disk-store --name=disk1 --dir=disk1");
 
-    assertThat(result.getContent().toString()).contains("not authorized for CLUSTER:MANAGE:DISK");
+    assertThat(result.getContentAsString()).contains("not authorized for CLUSTER:MANAGE:DISK");
   }
 
   @Test
@@ -195,7 +195,7 @@ public class GfshCommandsSecurityTest {
     CommandResult result =
         gfshConnection.executeCommand("create region --name=region2 --type=PARTITION_PERSISTENT");
 
-    assertThat(result.getContent().toString()).contains("not authorized for CLUSTER:WRITE:DISK");
+    assertThat(result.getContentAsString()).contains("not authorized for CLUSTER:WRITE:DISK");
   }
 
   @Test
@@ -204,7 +204,7 @@ public class GfshCommandsSecurityTest {
     CommandResult result =
         gfshConnection.executeCommand("create region --name=region2 --type=PARTITION_PERSISTENT");
 
-    assertThat(result.getContent().toString()).contains("not authorized for DATA:MANAGE");
+    assertThat(result.getContentAsString()).contains("not authorized for DATA:MANAGE");
   }
 
 }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/security/MultiGfshDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/security/MultiGfshDUnitTest.java
@@ -98,7 +98,7 @@ public class MultiGfshDUnitTest {
         // for some commands there are pre execution checks to check for user input error, will skip
         // those commands
         if (errorCode == ResultBuilder.ERRORCODE_USER_ERROR) {
-          LogService.getLogger().info("Skip user error: " + result.getContent());
+          LogService.getLogger().info("Skip user error: " + result.getContentAsString());
           continue;
         }
 

--- a/geode-core/src/test/java/org/apache/geode/test/junit/rules/GfshCommandRule.java
+++ b/geode-core/src/test/java/org/apache/geode/test/junit/rules/GfshCommandRule.java
@@ -20,10 +20,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.List;
 import java.util.function.Supplier;
 
 import org.apache.commons.lang.StringUtils;
-import org.json.JSONArray;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.Description;
 
@@ -227,16 +227,15 @@ public class GfshCommandRule extends DescribedExternalResource {
     } catch (InterruptedException e) {
       throw new RuntimeException(e);
     }
-    if (StringUtils.isBlank(gfsh.outputString) && result != null && result.getContent() != null) {
+    if (StringUtils.isBlank(gfsh.outputString) && result != null
+        && !result.getContentAsString().isEmpty()) {
       if (result.getStatus() == Result.Status.ERROR) {
         gfsh.outputString = result.toString();
       } else {
         // print out the message body as the command result
-        JSONArray messages = ((JSONArray) result.getContent().get("message"));
-        if (messages != null) {
-          for (int i = 0; i < messages.length(); i++) {
-            gfsh.outputString += messages.getString(i) + "\n";
-          }
+        List<String> messages = result.getListFromContent("message");
+        for (String line : messages) {
+          gfsh.outputString += line + "\n";
         }
       }
     }


### PR DESCRIPTION
- Methods getGfJsonObject() and getTableContent() are now private.
- getContent() is still public but only used by CommandResponseBuilder. This
  will change in subsequent PRs.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
