### PR TITLE
GEODE-5047: list lucene index result modified

### DIFF
--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/LuceneIndex.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/LuceneIndex.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import org.apache.lucene.analysis.Analyzer;
 
 
+
 /**
  * <p>
  * LuceneIndex represents the Lucene index created over the data stored in Apache Geode regions. The
@@ -82,5 +83,13 @@ public interface LuceneIndex {
    * Return the {@link LuceneSerializer} associated with this index
    */
   LuceneSerializer getLuceneSerializer();
+
+  /**
+   * Returns a boolean value to indicate if reindexing is in progress.
+   *
+   * @Return a boolean value indicating indexing progress
+   */
+
+  boolean isIndexingInProgress();
 
 }

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneRawIndex.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneRawIndex.java
@@ -55,4 +55,9 @@ public class LuceneRawIndex extends LuceneIndexImpl {
   public boolean isIndexAvailable(int id) {
     return true;
   }
+
+  @Override
+  public boolean isIndexingInProgress() {
+    return false;
+  }
 }

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexCommands.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexCommands.java
@@ -123,10 +123,12 @@ public class LuceneIndexCommands extends InternalGfshCommand {
         indexData.accumulate("Indexed Fields", indexDetails.getSearchableFieldNamesString());
         indexData.accumulate("Field Analyzer", indexDetails.getFieldAnalyzersString());
         indexData.accumulate("Serializer", indexDetails.getSerializerString());
-        indexData.accumulate("Status", indexDetails.getInitialized() ? "Initialized" : "Defined");
+        indexData.accumulate("Status", indexDetails.getStatus().toString());
 
         if (stats) {
-          if (!indexDetails.getInitialized()) {
+          LuceneIndexStatus luceneIndexStatus = indexDetails.getStatus();
+          if (luceneIndexStatus == LuceneIndexStatus.NOT_INITIALIZED
+              || luceneIndexStatus == LuceneIndexStatus.INDEXING_IN_PROGRESS) {
             indexData.accumulate("Query Executions", "NA");
             indexData.accumulate("Updates", "NA");
             indexData.accumulate("Commits", "NA");

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexStatus.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexStatus.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache.lucene.internal.cli;
+
+public enum LuceneIndexStatus {
+  NOT_INITIALIZED, INITIALIZED, INDEXING_IN_PROGRESS
+
+}

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/cli/functions/LuceneListIndexFunction.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/cli/functions/LuceneListIndexFunction.java
@@ -27,6 +27,7 @@ import org.apache.geode.cache.lucene.internal.LuceneIndexCreationProfile;
 import org.apache.geode.cache.lucene.internal.LuceneIndexImpl;
 import org.apache.geode.cache.lucene.internal.LuceneServiceImpl;
 import org.apache.geode.cache.lucene.internal.cli.LuceneIndexDetails;
+import org.apache.geode.cache.lucene.internal.cli.LuceneIndexStatus;
 import org.apache.geode.internal.InternalEntity;
 import org.apache.geode.internal.cache.execute.InternalFunction;
 
@@ -56,12 +57,18 @@ public class LuceneListIndexFunction implements InternalFunction {
     final Cache cache = context.getCache();
     final String serverName = cache.getDistributedSystem().getDistributedMember().getName();
     LuceneServiceImpl service = (LuceneServiceImpl) LuceneServiceProvider.get(cache);
-    for (LuceneIndex index : service.getAllIndexes()) {
-      indexDetailsSet.add(new LuceneIndexDetails((LuceneIndexImpl) index, serverName));
-    }
-
     for (LuceneIndexCreationProfile profile : service.getAllDefinedIndexes()) {
-      indexDetailsSet.add(new LuceneIndexDetails(profile, serverName));
+      indexDetailsSet
+          .add(new LuceneIndexDetails(profile, serverName, LuceneIndexStatus.NOT_INITIALIZED));
+    }
+    for (LuceneIndex index : service.getAllIndexes()) {
+      LuceneIndexStatus initialized;
+      if (index.isIndexingInProgress()) {
+        initialized = LuceneIndexStatus.INDEXING_IN_PROGRESS;
+      } else {
+        initialized = LuceneIndexStatus.INITIALIZED;
+      }
+      indexDetailsSet.add(new LuceneIndexDetails((LuceneIndexImpl) index, serverName, initialized));
     }
     context.getResultSender().lastResult(indexDetailsSet);
   }

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/xml/LuceneIndexCreation.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/xml/LuceneIndexCreation.java
@@ -28,7 +28,6 @@ import org.apache.lucene.analysis.standard.StandardAnalyzer;
 
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.Region;
-import org.apache.geode.cache.lucene.LuceneIndex;
 import org.apache.geode.cache.lucene.LuceneIndexExistsException;
 import org.apache.geode.cache.lucene.LuceneSerializer;
 import org.apache.geode.cache.lucene.LuceneServiceProvider;
@@ -39,7 +38,7 @@ import org.apache.geode.internal.cache.xmlcache.XmlGenerator;
 import org.apache.geode.internal.i18n.LocalizedStrings;
 import org.apache.geode.internal.logging.LogService;
 
-public class LuceneIndexCreation implements LuceneIndex, Extension<Region<?, ?>> {
+public class LuceneIndexCreation implements Extension<Region<?, ?>> {
   private Region region;
   private String name;
   private Set<String> fieldNames = new LinkedHashSet<String>();
@@ -61,7 +60,6 @@ public class LuceneIndexCreation implements LuceneIndex, Extension<Region<?, ?>>
     this.fieldAnalyzers = fieldAnalyzers;
   }
 
-  @Override
   public Map<String, Analyzer> getFieldAnalyzers() {
     if (this.fieldAnalyzers == null) {
       this.fieldAnalyzers = new HashMap<>();
@@ -77,12 +75,10 @@ public class LuceneIndexCreation implements LuceneIndex, Extension<Region<?, ?>>
     return fieldNames.toArray(new String[fieldNames.size()]);
   }
 
-  @Override
   public String getRegionPath() {
     return region.getFullPath();
   }
 
-  @Override
   public LuceneSerializer getLuceneSerializer() {
     return this.luceneSerializer;
   }

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/xml/LuceneIndexXmlGenerator.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/xml/LuceneIndexXmlGenerator.java
@@ -29,7 +29,6 @@ import org.xml.sax.SAXException;
 import org.xml.sax.helpers.AttributesImpl;
 
 import org.apache.geode.cache.Region;
-import org.apache.geode.cache.lucene.LuceneIndex;
 import org.apache.geode.cache.lucene.LuceneSerializer;
 import org.apache.geode.internal.cache.xmlcache.CacheXmlGenerator;
 import org.apache.geode.internal.cache.xmlcache.XmlGenerator;
@@ -38,9 +37,9 @@ import org.apache.geode.internal.cache.xmlcache.XmlGeneratorUtils;
 public class LuceneIndexXmlGenerator implements XmlGenerator<Region<?, ?>> {
   private static final AttributesImpl EMPTY = new AttributesImpl();
 
-  private final LuceneIndex index;
+  private final LuceneIndexCreation index;
 
-  public LuceneIndexXmlGenerator(LuceneIndex index) {
+  public LuceneIndexXmlGenerator(LuceneIndexCreation index) {
     this.index = index;
   }
 

--- a/geode-lucene/src/main/resources/org/apache/geode/internal/sanctioned-geode-lucene-serializables.txt
+++ b/geode-lucene/src/main/resources/org/apache/geode/internal/sanctioned-geode-lucene-serializables.txt
@@ -2,9 +2,10 @@ org/apache/geode/cache/lucene/LuceneIndexDestroyedException,false,indexName:java
 org/apache/geode/cache/lucene/LuceneIndexExistsException,false,indexName:java/lang/String,regionPath:java/lang/String
 org/apache/geode/cache/lucene/LuceneIndexNotFoundException,false,indexName:java/lang/String,regionPath:java/lang/String
 org/apache/geode/cache/lucene/LuceneQueryException,false
+org/apache/geode/cache/lucene/internal/cli/LuceneIndexStatus,false
 org/apache/geode/cache/lucene/internal/cli/LuceneDestroyIndexInfo,false,definedDestroyOnly:boolean
 org/apache/geode/cache/lucene/internal/cli/LuceneFunctionSerializable,false,indexName:java/lang/String,regionPath:java/lang/String
-org/apache/geode/cache/lucene/internal/cli/LuceneIndexDetails,true,1,fieldAnalyzers:java/util/Map,indexStats:java/util/Map,initialized:boolean,searchableFieldNames:java/lang/String[],serializer:java/lang/String,serverName:java/lang/String
+org/apache/geode/cache/lucene/internal/cli/LuceneIndexDetails,true,1,fieldAnalyzers:java/util/Map,indexStats:java/util/Map,searchableFieldNames:java/lang/String[],serializer:java/lang/String,serverName:java/lang/String,status:org/apache/geode/cache/lucene/internal/cli/LuceneIndexStatus
 org/apache/geode/cache/lucene/internal/cli/LuceneIndexInfo,true,1,fieldAnalyzers:java/lang/String[],searchableFieldNames:java/lang/String[],serializer:java/lang/String
 org/apache/geode/cache/lucene/internal/cli/LuceneQueryInfo,true,1,defaultField:java/lang/String,keysOnly:boolean,limit:int,queryString:java/lang/String
 org/apache/geode/cache/lucene/internal/cli/LuceneSearchResults,false,exceptionFlag:boolean,exceptionMessage:java/lang/String,key:java/lang/String,score:float,value:java/lang/String

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexCommandsDUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexCommandsDUnitTest.java
@@ -130,7 +130,7 @@ public class LuceneIndexCommandsDUnitTest implements Serializable {
     csb.addOption(LuceneCliStrings.LUCENE_LIST_INDEX__STATS, "true");
 
     gfsh.executeAndAssertThat(csb.toString())
-        .tableHasColumnWithExactValuesInAnyOrder("Status", "Defined")
+        .tableHasColumnWithExactValuesInAnyOrder("Status", "NOT_INITIALIZED")
         .tableHasColumnWithExactValuesInAnyOrder("Index Name", INDEX_NAME);
   }
 
@@ -149,7 +149,7 @@ public class LuceneIndexCommandsDUnitTest implements Serializable {
 
     gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess()
         .tableHasColumnWithExactValuesInAnyOrder("Index Name", INDEX_NAME)
-        .tableHasColumnWithExactValuesInAnyOrder("Status", "Initialized")
+        .tableHasColumnWithExactValuesInAnyOrder("Status", "INITIALIZED")
         .tableHasColumnWithExactValuesInAnyOrder("Region Path", "/region")
         .tableHasColumnWithExactValuesInAnyOrder("Query Executions", "1")
         .tableHasColumnWithExactValuesInAnyOrder("Documents", "2");

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexCommandsJUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexCommandsJUnitTest.java
@@ -113,11 +113,12 @@ public class LuceneIndexCommandsJUnitTest {
     fieldAnalyzers.put("field3", null);
     LuceneSerializer serializer = new HeterogeneousLuceneSerializer();
     final LuceneIndexDetails indexDetails1 = createIndexDetails("memberFive", "/Employees",
-        searchableFields, fieldAnalyzers, true, serverName, serializer);
-    final LuceneIndexDetails indexDetails2 = createIndexDetails("memberSix", "/Employees",
-        searchableFields, fieldAnalyzers, false, serverName, serializer);
+        searchableFields, fieldAnalyzers, LuceneIndexStatus.INITIALIZED, serverName, serializer);
+    final LuceneIndexDetails indexDetails2 =
+        createIndexDetails("memberSix", "/Employees", searchableFields, fieldAnalyzers,
+            LuceneIndexStatus.NOT_INITIALIZED, serverName, serializer);
     final LuceneIndexDetails indexDetails3 = createIndexDetails("memberTen", "/Employees",
-        searchableFields, fieldAnalyzers, true, serverName, serializer);
+        searchableFields, fieldAnalyzers, LuceneIndexStatus.INITIALIZED, serverName, serializer);
 
     final List<Set<LuceneIndexDetails>> results = new ArrayList<>();
 
@@ -142,7 +143,7 @@ public class LuceneIndexCommandsJUnitTest {
             "{field1=StandardAnalyzer, field2=KeywordAnalyzer}",
             "{field1=StandardAnalyzer, field2=KeywordAnalyzer}"),
         data.retrieveAllValues("Field Analyzer"));
-    assertEquals(Arrays.asList("Initialized", "Defined", "Initialized"),
+    assertEquals(Arrays.asList("INITIALIZED", "NOT_INITIALIZED", "INITIALIZED"),
         data.retrieveAllValues("Status"));
   }
 
@@ -161,12 +162,15 @@ public class LuceneIndexCommandsJUnitTest {
     fieldAnalyzers.put("field2", new KeywordAnalyzer());
     fieldAnalyzers.put("field3", null);
     LuceneSerializer serializer = new HeterogeneousLuceneSerializer();
-    final LuceneIndexDetails indexDetails1 = createIndexDetails("memberFive", "/Employees",
-        searchableFields, fieldAnalyzers, mockIndexStats1, true, serverName, serializer);
-    final LuceneIndexDetails indexDetails2 = createIndexDetails("memberSix", "/Employees",
-        searchableFields, fieldAnalyzers, mockIndexStats2, true, serverName, serializer);
-    final LuceneIndexDetails indexDetails3 = createIndexDetails("memberTen", "/Employees",
-        searchableFields, fieldAnalyzers, mockIndexStats3, true, serverName, serializer);
+    final LuceneIndexDetails indexDetails1 =
+        createIndexDetails("memberFive", "/Employees", searchableFields, fieldAnalyzers,
+            mockIndexStats1, LuceneIndexStatus.INITIALIZED, serverName, serializer);
+    final LuceneIndexDetails indexDetails2 =
+        createIndexDetails("memberSix", "/Employees", searchableFields, fieldAnalyzers,
+            mockIndexStats2, LuceneIndexStatus.INITIALIZED, serverName, serializer);
+    final LuceneIndexDetails indexDetails3 =
+        createIndexDetails("memberTen", "/Employees", searchableFields, fieldAnalyzers,
+            mockIndexStats3, LuceneIndexStatus.INITIALIZED, serverName, serializer);
 
     final List<Set<LuceneIndexDetails>> results = new ArrayList<>();
 
@@ -248,7 +252,7 @@ public class LuceneIndexCommandsJUnitTest {
     final List<LuceneIndexDetails> indexDetails = new ArrayList<>();
     LuceneSerializer serializer = new HeterogeneousLuceneSerializer();
     indexDetails.add(createIndexDetails("memberFive", "/Employees", searchableFields,
-        fieldAnalyzers, mockIndexStats, true, serverName, serializer));
+        fieldAnalyzers, mockIndexStats, LuceneIndexStatus.INITIALIZED, serverName, serializer));
 
     doReturn(mockResultCollector).when(commands).executeFunctionOnRegion(
         isA(LuceneDescribeIndexFunction.class), any(LuceneIndexInfo.class), eq(true));
@@ -263,7 +267,7 @@ public class LuceneIndexCommandsJUnitTest {
         data.retrieveAllValues("Indexed Fields"));
     assertEquals(Collections.singletonList("{field1=StandardAnalyzer, field2=KeywordAnalyzer}"),
         data.retrieveAllValues("Field Analyzer"));
-    assertEquals(Collections.singletonList("Initialized"), data.retrieveAllValues("Status"));
+    assertEquals(Collections.singletonList("INITIALIZED"), data.retrieveAllValues("Status"));
     assertEquals(Collections.singletonList("1"), data.retrieveAllValues("Query Executions"));
     assertEquals(Collections.singletonList("10"), data.retrieveAllValues("Commits"));
     assertEquals(Collections.singletonList("5"), data.retrieveAllValues("Updates"));
@@ -629,15 +633,15 @@ public class LuceneIndexCommandsJUnitTest {
 
   private LuceneIndexDetails createIndexDetails(final String indexName, final String regionPath,
       final String[] searchableFields, final Map<String, Analyzer> fieldAnalyzers,
-      LuceneIndexStats indexStats, boolean status, final String serverName,
+      LuceneIndexStats indexStats, LuceneIndexStatus status, final String serverName,
       LuceneSerializer serializer) {
     return new LuceneIndexDetails(indexName, regionPath, searchableFields, fieldAnalyzers,
         indexStats, status, serverName, serializer);
   }
 
   private LuceneIndexDetails createIndexDetails(final String indexName, final String regionPath,
-      final String[] searchableFields, final Map<String, Analyzer> fieldAnalyzers, boolean status,
-      final String serverName, LuceneSerializer serializer) {
+      final String[] searchableFields, final Map<String, Analyzer> fieldAnalyzers,
+      LuceneIndexStatus status, final String serverName, LuceneSerializer serializer) {
     return new LuceneIndexDetails(indexName, regionPath, searchableFields, fieldAnalyzers, null,
         status, serverName, serializer);
   }

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/cli/functions/LuceneListIndexFunctionJUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/cli/functions/LuceneListIndexFunctionJUnitTest.java
@@ -14,11 +14,14 @@
  */
 package org.apache.geode.cache.lucene.internal.cli.functions;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
@@ -34,10 +37,14 @@ import org.apache.geode.cache.execute.FunctionContext;
 import org.apache.geode.cache.execute.ResultSender;
 import org.apache.geode.cache.lucene.LuceneIndex;
 import org.apache.geode.cache.lucene.internal.InternalLuceneService;
-import org.apache.geode.cache.lucene.internal.LuceneIndexImpl;
+import org.apache.geode.cache.lucene.internal.LuceneIndexForPartitionedRegion;
 import org.apache.geode.cache.lucene.internal.LuceneServiceImpl;
 import org.apache.geode.cache.lucene.internal.cli.LuceneIndexDetails;
+import org.apache.geode.cache.lucene.internal.cli.LuceneIndexStatus;
+import org.apache.geode.internal.cache.BucketRegion;
 import org.apache.geode.internal.cache.GemFireCacheImpl;
+import org.apache.geode.internal.cache.PartitionedRegion;
+import org.apache.geode.internal.cache.PartitionedRegionDataStore;
 import org.apache.geode.test.fake.Fakes;
 import org.apache.geode.test.junit.categories.LuceneTest;
 import org.apache.geode.test.junit.categories.UnitTest;
@@ -46,11 +53,12 @@ import org.apache.geode.test.junit.categories.UnitTest;
 
 public class LuceneListIndexFunctionJUnitTest {
 
+
   @Test
   @SuppressWarnings("unchecked")
-  public void testExecute() throws Throwable {
+  public void executeListLuceneIndexWhenReindexingInProgress() {
     GemFireCacheImpl cache = Fakes.cache();
-    final String serverName = "mockServer";
+    final String serverName = "mockedServer";
     LuceneServiceImpl service = mock(LuceneServiceImpl.class);
     when(cache.getService(InternalLuceneService.class)).thenReturn(service);
 
@@ -59,17 +67,36 @@ public class LuceneListIndexFunctionJUnitTest {
     when(context.getResultSender()).thenReturn(resultSender);
     when(context.getCache()).thenReturn(cache);
 
-    LuceneIndexImpl index1 = getMockLuceneIndex("index1");
-    LuceneIndexImpl index2 = getMockLuceneIndex("index2");
+    LuceneIndexForPartitionedRegion index1 = getMockLuceneIndex("index1");
 
-    TreeSet expectedResult = new TreeSet();
-    expectedResult.add(new LuceneIndexDetails(index1, serverName));
-    expectedResult.add(new LuceneIndexDetails(index2, serverName));
+    PartitionedRegion userRegion = mock(PartitionedRegion.class);
+    when(cache.getRegion(index1.getRegionPath())).thenReturn(userRegion);
+
+    PartitionedRegionDataStore userRegionDataStore = mock(PartitionedRegionDataStore.class);
+    when(userRegion.getDataStore()).thenReturn(userRegionDataStore);
+
+    BucketRegion userBucket = mock(BucketRegion.class);
+    when(userRegionDataStore.getLocalBucketById(1)).thenReturn(userBucket);
+
+    when(userBucket.isEmpty()).thenReturn(false);
 
     ArrayList<LuceneIndex> allIndexes = new ArrayList();
     allIndexes.add(index1);
-    allIndexes.add(index2);
     when(service.getAllIndexes()).thenReturn(allIndexes);
+
+    PartitionedRegion mockFileRegion = mock(PartitionedRegion.class);
+    when(index1.getFileAndChunkRegion()).thenReturn(mockFileRegion);
+
+    PartitionedRegionDataStore mockPartitionedRegionDataStore =
+        mock(PartitionedRegionDataStore.class);
+    when(mockFileRegion.getDataStore()).thenReturn(mockPartitionedRegionDataStore);
+
+    Set<Integer> bucketSet = new HashSet<>();
+    bucketSet.add(1);
+
+    when(mockPartitionedRegionDataStore.getAllLocalPrimaryBucketIds()).thenReturn(bucketSet);
+
+    when(index1.isIndexAvailable(1)).thenReturn(false);
 
     LuceneListIndexFunction function = new LuceneListIndexFunction();
     function.execute(context);
@@ -78,17 +105,21 @@ public class LuceneListIndexFunctionJUnitTest {
     verify(resultSender).lastResult(resultCaptor.capture());
     Set<String> result = resultCaptor.getValue();
 
-    assertEquals(2, result.size());
+    TreeSet expectedResult = new TreeSet();
+    expectedResult
+        .add(new LuceneIndexDetails(index1, serverName, LuceneIndexStatus.INDEXING_IN_PROGRESS));
+
+    assertEquals(1, result.size());
     assertEquals(expectedResult, result);
+
   }
 
-  private LuceneIndexImpl getMockLuceneIndex(final String indexName) {
+  private LuceneIndexForPartitionedRegion getMockLuceneIndex(final String indexName) {
+    LuceneIndexForPartitionedRegion index = mock(LuceneIndexForPartitionedRegion.class);
     String[] searchableFields = {"field1", "field2"};
     Map<String, Analyzer> fieldAnalyzers = new HashMap<>();
     fieldAnalyzers.put("field1", new StandardAnalyzer());
     fieldAnalyzers.put("field2", new KeywordAnalyzer());
-
-    LuceneIndexImpl index = mock(LuceneIndexImpl.class);
     when(index.getName()).thenReturn(indexName);
     when(index.getRegionPath()).thenReturn("/region");
     when(index.getFieldNames()).thenReturn(searchableFields);

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/configuration/LuceneClusterConfigurationDUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/configuration/LuceneClusterConfigurationDUnitTest.java
@@ -240,8 +240,8 @@ public class LuceneClusterConfigurationDUnitTest {
     // Verify all members have indexes
     csb = new CommandStringBuilder(LuceneCliStrings.LUCENE_LIST_INDEX);
     gfshConnector.executeAndAssertThat(csb.toString()).statusIsSuccess()
-        .tableHasColumnWithExactValuesInExactOrder("Status", "Initialized", "Initialized",
-            "Initialized");
+        .tableHasColumnWithExactValuesInExactOrder("Status", "INITIALIZED", "INITIALIZED",
+            "INITIALIZED");
   }
 
   MemberVM createServer(Properties properties, int index) throws Exception {

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/xml/LuceneIndexXmlGeneratorJUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/xml/LuceneIndexXmlGeneratorJUnitTest.java
@@ -28,7 +28,6 @@ import org.mockito.ArgumentCaptor;
 import org.xml.sax.Attributes;
 import org.xml.sax.ContentHandler;
 
-import org.apache.geode.cache.lucene.LuceneIndex;
 import org.apache.geode.cache.lucene.LuceneSerializer;
 import org.apache.geode.internal.cache.xmlcache.CacheXmlGenerator;
 import org.apache.geode.internal.cache.xmlcache.Declarable2;
@@ -43,7 +42,7 @@ public class LuceneIndexXmlGeneratorJUnitTest {
    */
   @Test
   public void generateWithFields() throws Exception {
-    LuceneIndex index = mock(LuceneIndex.class);
+    LuceneIndexCreation index = mock(LuceneIndexCreation.class);
     when(index.getName()).thenReturn("index");
     String[] fields = new String[] {"field1", "field2"};
     when(index.getFieldNames()).thenReturn(fields);
@@ -79,7 +78,7 @@ public class LuceneIndexXmlGeneratorJUnitTest {
    */
   @Test
   public void generateWithSerializer() throws Exception {
-    LuceneIndex index = mock(LuceneIndex.class);
+    LuceneIndexCreation index = mock(LuceneIndexCreation.class);
     LuceneSerializer mySerializer =
         mock(LuceneSerializer.class, withSettings().extraInterfaces(Declarable2.class));
     Properties props = new Properties();


### PR DESCRIPTION
	* list lucene index gfsh command will now display on of three states
	* NOT_INITIALIZED if the index is present in only in defined map
	* INITIALIZED if the index is present in the index map
	* INDEXING_IN_PROGRESS if the index creation is in progress.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
