### PR TITLE
GEODE-5080: Ensure that reconnect sequence has started

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/management/internal/configuration/ClusterConfigLocatorRestartDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/configuration/ClusterConfigLocatorRestartDUnitTest.java
@@ -43,6 +43,19 @@ public class ClusterConfigLocatorRestartDUnitTest {
   @Rule
   public GfshCommandRule gfsh = new GfshCommandRule();
 
+  public static class TestDisconnectListener implements InternalDistributedSystem.DisconnectListener {
+    static int disconnectCount;
+
+    public TestDisconnectListener() {
+      disconnectCount = 0;
+    }
+
+    @Override
+    public void onDisconnect(InternalDistributedSystem sys) {
+      disconnectCount += 1;
+    }
+  }
+
   @Test
   public void serverRestartsAfterLocatorReconnects() throws Exception {
     IgnoredException.addIgnoredException("org.apache.geode.ForcedDisconnectException: for testing");
@@ -53,6 +66,8 @@ public class ClusterConfigLocatorRestartDUnitTest {
 
     rule.startServerVM(1, props, locator0.getPort());
     MemberVM server2 = rule.startServerVM(2, props, locator0.getPort());
+
+    addDisconnectListener(locator0);
 
     server2.invokeAsync(() -> MembershipManagerHelper
         .crashDistributedSystem(InternalDistributedSystem.getConnectedInstance()));
@@ -100,8 +115,6 @@ public class ClusterConfigLocatorRestartDUnitTest {
     server3.invokeAsync(() -> MembershipManagerHelper
         .crashDistributedSystem(InternalDistributedSystem.getConnectedInstance()));
 
-    waitForLocatorToReconnect(locator1);
-
     rule.startServerVM(4, locator1.getPort(), locator0.getPort());
 
     gfsh.connectAndVerify(locator1);
@@ -111,7 +124,20 @@ public class ClusterConfigLocatorRestartDUnitTest {
             .tableHasColumnOnlyWithValues("Name", "locator-1", "server-2", "server-3", "server-4"));
   }
 
+  private void addDisconnectListener(MemberVM member) {
+    member.invoke(() -> {
+      InternalDistributedSystem ds =
+          (InternalDistributedSystem) InternalLocator.getLocator().getDistributedSystem();
+      ds.addDisconnectListener(new TestDisconnectListener());
+    });
+  }
+
   private void waitForLocatorToReconnect(MemberVM locator) {
+    // Ensure that disconnect/reconnect sequence starts otherwise in the next await we might end up
+    // with the initial locator instead of a newly created one.
+    Awaitility.waitAtMost(30, TimeUnit.SECONDS).until(() -> locator.invoke(() ->
+        TestDisconnectListener.disconnectCount > 0));
+
     Awaitility.waitAtMost(30, TimeUnit.SECONDS).until(() -> locator.invoke(() -> {
       InternalLocator intLocator = InternalLocator.getLocator();
       return intLocator != null && intLocator.isSharedConfigurationRunning();


### PR DESCRIPTION
- This fixes a race where, during a reconnect, we might still pick up the old locator instead of a new,
  fresh instance.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
