### PR TITLE
GEODE-5085 authentication failure when auto-reconnecting

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfigImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfigImpl.java
@@ -2337,8 +2337,17 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
     securityPeerMembershipTimeout = (Integer) value;
   }
 
+  @Override
   public Properties getSecurityProps() {
-    return security;
+    Properties result = new Properties();
+    for (Object attName : security.keySet()) {
+      if (attName instanceof String) {
+        result.put(attName, getAttribute((String) attName));
+      } else {
+        result.put(attName, security.get(attName));
+      }
+    }
+    return result;
   }
 
   public String getSecurity(String attName) {

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfigImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfigImpl.java
@@ -2340,6 +2340,13 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
   @Override
   public Properties getSecurityProps() {
     Properties result = new Properties();
+    result.putAll(security);
+    return result;
+  }
+
+  @Override
+  public Properties toSecurityProperties() {
+    Properties result = new Properties();
     for (Object attName : security.keySet()) {
       if (attName instanceof String) {
         result.put(attName, getAttribute((String) attName));

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalDistributedSystem.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalDistributedSystem.java
@@ -2610,6 +2610,8 @@ public class InternalDistributedSystem extends DistributedSystem
 
     DistributionConfig oldConfig = ids.getConfig();
     Properties configProps = getProperties();
+    configProps.putAll(getSecurityProperties());
+
     int timeOut = oldConfig.getMaxWaitTimeForReconnect();
     int maxTries = oldConfig.getMaxNumReconnectTries();
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalDistributedSystem.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalDistributedSystem.java
@@ -2609,8 +2609,8 @@ public class InternalDistributedSystem extends DistributedSystem
     }
 
     DistributionConfig oldConfig = ids.getConfig();
-    Properties configProps = getProperties();
-    configProps.putAll(getSecurityProperties());
+    Properties configProps = this.config.toProperties();
+    configProps.putAll(this.config.toSecurityProperties());
 
     int timeOut = oldConfig.getMaxWaitTimeForReconnect();
     int maxTries = oldConfig.getMaxNumReconnectTries();

--- a/geode-core/src/main/java/org/apache/geode/internal/Config.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/Config.java
@@ -105,11 +105,18 @@ public interface Config {
   boolean sameAs(Config v);
 
   /**
-   * Converts the contents of this config to a property instance.
+   * Converts the non-secure contents of this config to a property instance.
    *
    * @since GemFire 3.5
    */
   Properties toProperties();
+
+  /**
+   * Converts the secure contents of this config to a property instance.
+   *
+   * @since Geode 1.6
+   */
+  Properties toSecurityProperties();
 
   /**
    * Writes this config to the specified file.

--- a/geode-core/src/test/java/org/apache/geode/cache30/ReconnectDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache30/ReconnectDUnitTest.java
@@ -46,6 +46,7 @@ import org.apache.geode.distributed.internal.ServerLocator;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.distributed.internal.membership.gms.MembershipManagerHelper;
 import org.apache.geode.distributed.internal.membership.gms.mgr.GMSMembershipManager;
+import org.apache.geode.examples.SimpleSecurityManager;
 import org.apache.geode.internal.AvailablePort;
 import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.internal.cache.GemFireCacheImpl;
@@ -111,7 +112,7 @@ public class ReconnectDUnitTest extends JUnit4CacheTestCase {
     finishCacheXml("MyDisconnect");
     // Cache cache = getCache();
     closeCache();
-    getSystem().disconnect();
+    basicGetSystem().disconnect();
     LogWriterUtils.getLogWriter().fine("Cache Closed ");
   }
 
@@ -127,6 +128,9 @@ public class ReconnectDUnitTest extends JUnit4CacheTestCase {
       dsProperties.put(MCAST_PORT, "0");
       dsProperties.put(MEMBER_TIMEOUT, "1000");
       dsProperties.put(LOG_LEVEL, LogWriterUtils.getDUnitLogLevel());
+      dsProperties.put(SECURITY_MANAGER, SimpleSecurityManager.class.getName());
+      dsProperties.put("security-username", "clusterManage");
+      dsProperties.put("security-password", "clusterManage");
       addDSProps(dsProperties);
     }
     return dsProperties;
@@ -632,7 +636,7 @@ public class ReconnectDUnitTest extends JUnit4CacheTestCase {
       Assert.fail("IOException during cache.xml generation to " + file, ex);
     }
     closeCache();
-    getSystem().disconnect();
+    basicGetSystem().disconnect();
 
     LogWriterUtils.getLogWriter().info("disconnected from the system...");
     Host host = Host.getHost(0);
@@ -644,7 +648,9 @@ public class ReconnectDUnitTest extends JUnit4CacheTestCase {
     SerializableRunnable roleLoss = new CacheSerializableRunnable("ROLERECONNECTTESTS") {
       public void run2() throws RuntimeException {
         LogWriterUtils.getLogWriter().info("####### STARTING THE REAL TEST ##########");
+
         locatorPort = locPort;
+        dsProperties = null;
         Properties props = getDistributedSystemProperties();
         props.put(CACHE_XML_FILE, xmlFileLoc + fileSeparator + "RoleReconnect-cache.xml");
         props.put(MAX_WAIT_TIME_RECONNECT, "200");
@@ -660,7 +666,7 @@ public class ReconnectDUnitTest extends JUnit4CacheTestCase {
         basicGetSystem().getLogWriter().info(
             "<ExpectedException action=add>" + "CacheClosedException" + "</ExpectedException");
         try {
-          getCache();
+          getCache(props);
           throw new RuntimeException("The test should throw a CancelException ");
         } catch (CancelException ignor) { // can be caused by role loss during intialization.
           LogWriterUtils.getLogWriter().info("Got Expected CancelException ");

--- a/geode-core/src/test/java/org/apache/geode/test/dunit/internal/JUnit4DistributedTestCase.java
+++ b/geode-core/src/test/java/org/apache/geode/test/dunit/internal/JUnit4DistributedTestCase.java
@@ -219,6 +219,23 @@ public abstract class JUnit4DistributedTestCase implements DistributedTestFixtur
         Properties activeProps = system.getProperties();
         for (Entry<Object, Object> entry : props.entrySet()) {
           String key = (String) entry.getKey();
+          if (key.startsWith("security-")) {
+            continue;
+          }
+          String value = (String) entry.getValue();
+          if (!value.equals(activeProps.getProperty(key))) {
+            needNewSystem = true;
+            getLogWriter().info("Forcing DS disconnect. For property " + key + " old value = "
+                + activeProps.getProperty(key) + " new value = " + value);
+            break;
+          }
+        }
+        activeProps = system.getSecurityProperties();
+        for (Entry<Object, Object> entry : props.entrySet()) {
+          String key = (String) entry.getKey();
+          if (!key.startsWith("security-")) {
+            continue;
+          }
           String value = (String) entry.getValue();
           if (!value.equals(activeProps.getProperty(key))) {
             needNewSystem = true;


### PR DESCRIPTION
Added DistributionConfig security properties to the props used to reconnect
to the distributed system.

Modified the getSecurityProps implementation to stop sharing the internal
state of the configuration object.  I found that things were being removed from the map returned by this method.

Added a new method, toSecurityProperties(), to convert values into external form for use in auto-reconnect. Security-log-level, for instance, was a number instead of the corresponding
level name.

Added a security manager to all of the ReconnectDUnitTest test cases.

---------------------------

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
