### PR TITLE
GEODE-5086 Clarify docs: we need version 8 Java

### DIFF
--- a/geode-docs/getting_started/installation/install_standalone.html.md.erb
+++ b/geode-docs/getting_started/installation/install_standalone.html.md.erb
@@ -24,7 +24,7 @@ Build from source or use the ZIP or TAR distribution to install <%=vars.product_
 1.  Set the JAVA\_HOME environment variable.
 
     ``` pre
-    JAVA_HOME=/usr/java/jdk1.8.0_60
+    JAVA_HOME=/usr/java/jdk1.8.0_<%=vars.min_java_update%>
     export JAVA_HOME
     ```
 
@@ -54,7 +54,7 @@ Build from source or use the ZIP or TAR distribution to install <%=vars.product_
 1.  Set the JAVA\_HOME environment variable. For example:
 
     ``` pre
-    $ set JAVA_HOME="C:\Program Files\Java\jdk1.8.0_60" 
+    $ set JAVA_HOME="C:\Program Files\Java\jdk1.8.0_<%=vars.min_java_update%>" 
     ```
 
 2.  Install Gradle, version 2.3 or a more recent version.
@@ -97,14 +97,14 @@ Build from source or use the ZIP or TAR distribution to install <%=vars.product_
 3.  Set the JAVA\_HOME environment variable. On Linux/Unix platforms:
 
     ``` pre
-    JAVA_HOME=/usr/java/jdk1.8.0_60
+    JAVA_HOME=/usr/java/jdk1.8.0_<%=vars.min_java_update%>
     export JAVA_HOME
     ```
 
     On Windows platforms:
 
     ``` pre
-    set JAVA_HOME=c:\Program Files\Java\jdk1.8.0_60 
+    set JAVA_HOME="C:\Program Files\Java\jdk1.8.0_<%=vars.min_java_update%>"
     ```
 
 4.  Add the <%=vars.product_name%> scripts to your PATH environment variable. On Linux/Unix platforms:

--- a/geode-docs/getting_started/system_requirements/host_machine.html.md.erb
+++ b/geode-docs/getting_started/system_requirements/host_machine.html.md.erb
@@ -24,7 +24,7 @@ Host machines must meet a set of requirements for <%=vars.product_name_long%>.
 <a id="system_requirements__section_1E1F206FBC8B4A898A449E0699907A7A"></a>
 Each machine that will run <%=vars.product_name_long%> must meet the following requirements:
 
--   Java SE Development Kit 8 with update <%=vars.min_java_update%> or a more recent version.
+-   Java SE Development Kit 8 with update <%=vars.min_java_update%> or a more recent version 8 update.
 -   A system clock set to the correct time and a time synchronization service such as Network Time Protocol (NTP). Correct time stamps permit the following activities:
     -   Logs that are useful for troubleshooting. Synchronized time stamps ensure that log messages from different hosts can be merged to reproduce an accurate chronological history of a distributed run.
     -   Aggregate product-level and application-level time statistics. 


### PR DESCRIPTION
- Also updated a few places that called out a specific version 8
update, and changed them to use a variable instead of a specific
version

- Found a typo in a Windows set JAVA_HOME command.  It needed double quotes due to a space in the path name.

