### PR TITLE
GEODE-5090: Lucene query doesn't hang on bucket loss

### DIFF
--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/LuceneDUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/LuceneDUnitTest.java
@@ -55,11 +55,21 @@ public abstract class LuceneDUnitTest extends JUnit4CacheTestCase {
     regionTestType.createDataStore(getCache(), REGION_NAME);
   }
 
+  protected void createDataStore(RegionTestableType regionTestType) {
+    regionTestType.createDataStore(getCache(), REGION_NAME);
+  }
+
   protected void initAccessor(SerializableRunnableIF createIndex, RegionTestableType regionTestType)
       throws Exception {
     createIndex.run();
     regionTestType.createAccessor(getCache(), REGION_NAME);
   }
+
+  protected void createAccessor(RegionTestableType regionTestType) {
+    regionTestType.createAccessor(getCache(), REGION_NAME);
+  }
+
+
 
   protected void initDataStore(RegionTestableType regionTestType) throws Exception {
     regionTestType.createDataStore(getCache(), REGION_NAME);

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/LuceneQueriesReindexDUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/LuceneQueriesReindexDUnitTest.java
@@ -17,13 +17,19 @@ package org.apache.geode.cache.lucene;
 import static org.apache.geode.cache.lucene.test.LuceneTestUtilities.INDEX_NAME;
 import static org.apache.geode.cache.lucene.test.LuceneTestUtilities.REGION_NAME;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.concurrent.TimeUnit;
 
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
+import org.awaitility.Awaitility;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import org.apache.geode.cache.PartitionedRegionStorageException;
+import org.apache.geode.cache.execute.EmptyRegionFunctionException;
 import org.apache.geode.cache.lucene.internal.LuceneIndexFactoryImpl;
 import org.apache.geode.test.dunit.AsyncInvocation;
 import org.apache.geode.test.dunit.SerializableRunnableIF;
@@ -51,7 +57,91 @@ public class LuceneQueriesReindexDUnitTest extends LuceneQueriesAccessorBase {
     LuceneIndexFactoryImpl indexFactory =
         (LuceneIndexFactoryImpl) luceneService.createIndexFactory().addField("text");
     indexFactory.create(INDEX_NAME, REGION_NAME, true);
-  };
+  }
+
+  @Test
+  @Parameters(method = "getListOfRegionTestTypes")
+  public void luceneQueryExecutedWithReindexWhenAllBucketsAreLostShouldNotCauseAHang(
+      RegionTestableType regionTestType) throws Exception {
+    dataStore1.invoke(() -> createDataStore(regionTestType));
+    dataStore2.invoke(() -> createDataStore(regionTestType));
+    accessor.invoke(() -> createAccessor(regionTestType));
+
+
+    putDataInRegion(accessor);
+    dataStore1.invoke(() -> Awaitility.await().atMost(1, TimeUnit.MINUTES)
+        .until(() -> assertTrue(getCache().getRegion(REGION_NAME).size() == 3)));
+
+    // re-index stored data
+    AsyncInvocation ai1 = dataStore1.invokeAsync(() -> {
+      recreateIndex();
+    });
+
+    AsyncInvocation ai2 = dataStore2.invokeAsync(() -> {
+      recreateIndex();
+    });
+    AsyncInvocation ai3 = accessor.invokeAsync(() -> {
+      recreateIndex();
+    });
+
+    ai1.join();
+    ai2.join();
+    ai3.join();
+
+    ai1.checkException();
+    ai2.checkException();
+    ai3.checkException();
+
+    waitForFlushBeforeExecuteTextSearch(accessor, 60000);
+    executeTextSearch(accessor);
+
+    dataStore1.invoke(() -> closeCache());
+    dataStore2.invoke(() -> closeCache());
+    executeQueryAndValidateNoHang(regionTestType);
+  }
+
+  private void executeQueryAndValidateNoHang(RegionTestableType regionTestType) {
+    try {
+      executeTextSearch(accessor);
+      fail();
+    } catch (Exception exception) {
+      // Should not be expecting a hang
+      if (regionTestType == RegionTestableType.FIXED_PARTITION
+          && !(exception.getCause() instanceof EmptyRegionFunctionException)) {
+        fail();
+      } else if (regionTestType != RegionTestableType.FIXED_PARTITION
+          && !(exception.getCause() instanceof PartitionedRegionStorageException)) {
+        fail();
+      }
+    }
+  }
+
+  @Test
+  @Parameters(method = "getListOfRegionTestTypes")
+  public void luceneQueryExecutedWhenAllBucketsAreLostShouldNotCauseAHang(
+      RegionTestableType regionTestType) throws Exception {
+    SerializableRunnableIF createIndex = () -> {
+      LuceneService luceneService = LuceneServiceProvider.get(getCache());
+      luceneService.createIndexFactory().addField("text").create(INDEX_NAME, REGION_NAME);
+    };
+    dataStore1.invoke(() -> initDataStore(createIndex, regionTestType));
+    dataStore2.invoke(() -> initDataStore(createIndex, regionTestType));
+    accessor.invoke(() -> initAccessor(createIndex, regionTestType));
+
+
+    putDataInRegion(accessor);
+    dataStore1.invoke(() -> Awaitility.await().atMost(1, TimeUnit.MINUTES)
+        .until(() -> assertTrue(getCache().getRegion(REGION_NAME).size() == 3)));
+
+
+    waitForFlushBeforeExecuteTextSearch(accessor, 60000);
+    executeTextSearch(accessor);
+
+    dataStore1.invoke(() -> closeCache());
+    dataStore2.invoke(() -> closeCache());
+    executeQueryAndValidateNoHang(regionTestType);
+  }
+
 
   @Test
   @Parameters(method = "getListOfRegionTestTypes")


### PR DESCRIPTION
	* Created a DUnit test which ensures that a lucene query doesn't hang when a lucene query is executed but all buckets are lost.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
