### PR TITLE
GEODE-5104 - Output git SHA when updating passing reference file.

### DIFF
--- a/ci/scripts/update-passing-ref.sh
+++ b/ci/scripts/update-passing-ref.sh
@@ -25,4 +25,7 @@ DESTINATION_URL=gs://${PUBLIC_BUCKET}/${MAINTENANCE_VERSION}/passing.txt
 pushd ${REPOSITORY_DIR}
 git rev-parse HEAD > ${LOCAL_FILE}
 popd
+echo "Updating passing reference file for ${MAINTENANCE_VERSION} to the following SHA:"
+cat ${LOCAL_FILE}
 gsutil -q -m cp ${LOCAL_FILE} ${DESTINATION_URL}
+gsutil setmeta -h "Cache-Control:no-cache" ${DESTINATION_URL}


### PR DESCRIPTION
When we update the passing reference file, display the SHA, and ensure the file isn't cached.


Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ X ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ X ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ X ] Is your initial contribution a single, squashed commit?

- [ X ] Does `gradlew build` run cleanly?

- [ N/A ] Have you written or updated unit tests to verify your changes?

- [ N/A ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
