### PR TITLE
GEODE-3523 AutoConnectionSourceDUnitTest: testDynamicallyFindLocators failed

### DIFF
--- a/geode-assembly/src/test/java/org/apache/geode/rest/internal/web/controllers/RestAPIsAndInterOpsDUnitTest.java
+++ b/geode-assembly/src/test/java/org/apache/geode/rest/internal/web/controllers/RestAPIsAndInterOpsDUnitTest.java
@@ -67,7 +67,6 @@ import org.apache.geode.cache.client.internal.LocatorTestBase;
 import org.apache.geode.cache.server.CacheServer;
 import org.apache.geode.cache.server.ServerLoadProbe;
 import org.apache.geode.distributed.DistributedSystem;
-import org.apache.geode.internal.AvailablePort;
 import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.cache.InternalCache;
@@ -619,12 +618,11 @@ public class RestAPIsAndInterOpsDUnitTest extends LocatorTestBase {
     VM client = host.getVM(3);
 
     // start locator
-    int locatorPort = AvailablePort.getRandomAvailablePort(AvailablePort.SOCKET);
-    final String locatorHostName = NetworkUtils.getServerHostName(locator.getHost());
-    locator.invoke(() -> startLocator(locatorHostName, locatorPort, ""));
+    final String hostName = NetworkUtils.getServerHostName();
+    int locatorPort = locator.invoke(() -> startLocator(hostName, ""));
 
     // find locators
-    String locators = locatorHostName + "[" + locatorPort + "]";
+    String locators = hostName + "[" + locatorPort + "]";
 
     // start manager (peer cache)
     manager.invoke(() -> startManager(/* groups */null, locators, new String[] {REGION_NAME},
@@ -637,7 +635,7 @@ public class RestAPIsAndInterOpsDUnitTest extends LocatorTestBase {
             locators, new String[] {REGION_NAME}, CacheServer.DEFAULT_LOAD_PROBE));
 
     // create a client cache
-    client.invoke(() -> createClientCache(locatorHostName, locatorPort));
+    client.invoke(() -> createClientCache(hostName, locatorPort));
 
     // create region in Manager, peer cache and Client cache nodes
     manager.invoke(() -> createRegion());

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/ClientTxCommitShouldNotHangRegressionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/ClientTxCommitShouldNotHangRegressionTest.java
@@ -30,7 +30,6 @@ import org.apache.geode.cache.client.ClientCacheFactory;
 import org.apache.geode.cache.client.ClientRegionShortcut;
 import org.apache.geode.cache.client.PoolManager;
 import org.apache.geode.cache.client.internal.LocatorTestBase;
-import org.apache.geode.internal.AvailablePort;
 import org.apache.geode.test.dunit.NetworkUtils;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.junit.categories.DistributedTest;
@@ -116,12 +115,11 @@ public class ClientTxCommitShouldNotHangRegressionTest extends LocatorTestBase {
     region1Name = uniqueName + "_R1";
     region2Name = uniqueName + "_R2";
 
-    hostName = NetworkUtils.getServerHostName(getHost(0));
-    locatorPort = AvailablePort.getRandomAvailablePort(AvailablePort.SOCKET);
+    hostName = NetworkUtils.getServerHostName();
 
-    locator.invoke("Start locator", () -> startLocator(hostName, locatorPort, ""));
+    locatorPort = locator.invoke("Start locator", () -> startLocator(hostName, ""));
 
-    String locators = getLocatorString(getHost(0), locatorPort);
+    String locators = getLocatorString(hostName, locatorPort);
 
     server1.invoke("Start server",
         () -> startBridgeServer(new String[] {region1Name}, locators, new String[] {region1Name}));

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/FireAndForgetFunctionOnAllServersDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/FireAndForgetFunctionOnAllServersDUnitTest.java
@@ -28,7 +28,6 @@ import org.apache.geode.cache.client.internal.PoolImpl;
 import org.apache.geode.cache.execute.Execution;
 import org.apache.geode.cache.execute.Function;
 import org.apache.geode.cache.execute.FunctionService;
-import org.apache.geode.internal.AvailablePort;
 import org.apache.geode.internal.cache.functions.FireAndForgetFunctionOnAllServers;
 import org.apache.geode.test.dunit.Assert;
 import org.apache.geode.test.dunit.Host;
@@ -66,13 +65,12 @@ public class FireAndForgetFunctionOnAllServersDUnitTest extends LocatorTestBase 
     VM server2 = host.getVM(2);
     VM client = host.getVM(3);
 
-    final int locatorPort = AvailablePort.getRandomAvailablePort(AvailablePort.SOCKET);
-    final String locatorHost = NetworkUtils.getServerHostName(host);
+    final String locatorHost = NetworkUtils.getServerHostName();
 
     // Step 1. Start a locator and one cache server.
-    locator.invoke("Start Locator", () -> startLocator(locatorHost, locatorPort, ""));
+    final int locatorPort = locator.invoke("Start Locator", () -> startLocator(locatorHost, ""));
 
-    String locString = getLocatorString(host, locatorPort);
+    String locString = getLocatorString(locatorHost, locatorPort);
 
     // Step 2. Start a server and create a replicated region "R1".
     server1.invoke("Start BridgeServer",

--- a/geode-wan/src/test/java/org/apache/geode/cache/wan/GatewayReceiverAutoConnectionSourceDUnitTest.java
+++ b/geode-wan/src/test/java/org/apache/geode/cache/wan/GatewayReceiverAutoConnectionSourceDUnitTest.java
@@ -28,7 +28,6 @@ import org.apache.geode.cache.client.internal.AutoConnectionSourceImpl;
 import org.apache.geode.cache.client.internal.LocatorTestBase;
 import org.apache.geode.cache.client.internal.PoolImpl;
 import org.apache.geode.distributed.internal.ServerLocation;
-import org.apache.geode.internal.AvailablePort;
 import org.apache.geode.test.dunit.Host;
 import org.apache.geode.test.dunit.NetworkUtils;
 import org.apache.geode.test.dunit.SerializableRunnable;
@@ -75,10 +74,10 @@ public class GatewayReceiverAutoConnectionSourceDUnitTest extends LocatorTestBas
     VM vm1 = host.getVM(1);
     VM vm2 = host.getVM(2);
 
-    int locatorPort = AvailablePort.getRandomAvailablePort(AvailablePort.SOCKET);
-    startLocatorInVM(vm0, locatorPort, "");
+    String hostName = NetworkUtils.getServerHostName();
+    int locatorPort = startLocatorInVM(vm0, hostName, "");
 
-    String locators = NetworkUtils.getServerHostName(vm0.getHost()) + "[" + locatorPort + "]";
+    String locators = getLocatorString(hostName, locatorPort);
 
     int serverPort = startBridgeServerInVM(vm1, serverGroups, locators, true);
 


### PR DESCRIPTION
Refactored the test into two smaller tests, one that tests that a client
discovers another locator and another that tests that a client discovers
that a locator has gone away.

I did some general updating of the code in this class to
- replace SerializableCallable/Runnables with lambdas
- replace wait-loops with Awaitility
- replace use of AvailablePortHelper with wildcard binds
- replace ignoring of Exceptions with checks for the correct exception class
- replaced heavy use of deprecated methods with their non-deprecated versions

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
