### PR TITLE
GEODE-5055: Handle index creation in progress.

### DIFF
--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/PartitionedRepositoryManager.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/PartitionedRepositoryManager.java
@@ -77,6 +77,12 @@ public class PartitionedRepositoryManager implements RepositoryManager {
   @Override
   public Collection<IndexRepository> getRepositories(RegionFunctionContext ctx)
       throws BucketNotFoundException {
+    return getRepositories(ctx, false);
+  }
+
+  @Override
+  public Collection<IndexRepository> getRepositories(RegionFunctionContext ctx,
+      boolean waitForRepository) throws BucketNotFoundException {
     Region<Object, Object> region = ctx.getDataSet();
     Set<Integer> buckets = ((InternalRegionFunctionContext) ctx).getLocalBucketSet(region);
     ArrayList<IndexRepository> repos = new ArrayList<IndexRepository>(buckets.size());
@@ -86,7 +92,8 @@ public class PartitionedRepositoryManager implements RepositoryManager {
         throw new BucketNotFoundException(
             "User bucket was not found for region " + region + "bucket id " + bucketId);
       } else {
-        if (index.isIndexAvailable(userBucket.getId()) || userBucket.isEmpty()) {
+        if (index.isIndexAvailable(userBucket.getId()) || userBucket.isEmpty()
+            || waitForRepository) {
           repos.add(getRepository(userBucket.getId()));
         } else {
           waitingThreadPoolFromDM.execute(() -> {

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/repository/RepositoryManager.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/repository/RepositoryManager.java
@@ -41,6 +41,19 @@ public interface RepositoryManager {
       throws BucketNotFoundException;
 
   /**
+   * Returns a collection of {@link IndexRepository} instances hosting index data of the input list
+   * of bucket ids. The bucket needs to be present on this member.
+   *
+   * The method will wait till the index is ready to be used if the waitOnRetry boolean is set to
+   * true
+   *
+   * @return a collection of {@link IndexRepository} instances
+   * @throws BucketNotFoundException if any of the requested buckets is not found on this member
+   */
+  Collection<IndexRepository> getRepositories(RegionFunctionContext context, boolean waitOnRetry)
+      throws BucketNotFoundException;
+
+  /**
    * Closes this {@link RepositoryManager}
    */
   void close();

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/distributed/LuceneQueryFunctionJUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/distributed/LuceneQueryFunctionJUnitTest.java
@@ -94,7 +94,7 @@ public class LuceneQueryFunctionJUnitTest {
     when(mockContext.getDataSet()).thenReturn(mockRegion);
     when(mockContext.getArguments()).thenReturn(searchArgs);
     when(mockContext.getResultSender()).thenReturn(mockResultSender);
-    when(mockRepoManager.getRepositories(eq(mockContext))).thenReturn(repos);
+    when(mockRepoManager.getRepositories(eq(mockContext), eq(false))).thenReturn(repos);
     doAnswer(invocation -> {
       IndexResultCollector collector = invocation.getArgument(2);
       collector.collect(r1_1.getKey(), r1_1.getScore());
@@ -136,7 +136,7 @@ public class LuceneQueryFunctionJUnitTest {
     when(mockContext.getDataSet()).thenReturn(mockRegion);
     when(mockContext.getArguments()).thenReturn(searchArgs);
     when(mockContext.getResultSender()).thenReturn(mockResultSender);
-    when(mockRepoManager.getRepositories(eq(mockContext))).thenReturn(repos);
+    when(mockRepoManager.getRepositories(eq(mockContext), eq(false))).thenReturn(repos);
 
     doAnswer(invocation -> {
       IndexResultCollector collector = invocation.getArgument(2);
@@ -177,7 +177,7 @@ public class LuceneQueryFunctionJUnitTest {
     when(mockContext.getArguments()).thenReturn(searchArgs);
     when(mockContext.getResultSender()).thenReturn(mockResultSender);
     repos.remove(0);
-    when(mockRepoManager.getRepositories(eq(mockContext))).thenReturn(repos);
+    when(mockRepoManager.getRepositories(eq(mockContext), eq(false))).thenReturn(repos);
     when(mockManager.newCollector(eq("repo2"))).thenReturn(mockCollector);
     when(mockManager.reduce(any(Collection.class))).thenAnswer(invocation -> {
       Collection<IndexResultCollector> collectors = invocation.getArgument(0);
@@ -208,7 +208,7 @@ public class LuceneQueryFunctionJUnitTest {
     when(mockContext.getDataSet()).thenReturn(mockRegion);
     when(mockContext.getArguments()).thenReturn(searchArgs);
     when(mockContext.getResultSender()).thenReturn(mockResultSender);
-    when(mockRepoManager.getRepositories(eq(mockContext))).thenReturn(repos);
+    when(mockRepoManager.getRepositories(eq(mockContext), eq(false))).thenReturn(repos);
     doThrow(IOException.class).when(mockRepository1).query(eq(query),
         eq(LuceneQueryFactory.DEFAULT_LIMIT), any(IndexResultCollector.class));
 
@@ -285,7 +285,8 @@ public class LuceneQueryFunctionJUnitTest {
     when(mockContext.getDataSet()).thenReturn(mockRegion);
     when(mockContext.getArguments()).thenReturn(searchArgs);
     LuceneQueryFunction function = new LuceneQueryFunction();
-    when(mockRepoManager.getRepositories(eq(mockContext))).thenThrow(new CacheClosedException());
+    when(mockRepoManager.getRepositories(eq(mockContext), eq(false)))
+        .thenThrow(new CacheClosedException());
     function.execute(mockContext);
   }
 


### PR DESCRIPTION
	* If all the servers are above the 1.6.0 version then the LuceneIndexCreationInProgressException will be propogated up to the servers
	* If there are servers which are lower than 1.6.0 then get repository will be re-executed but it will wait till the indexes are available.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
