### PR TITLE
GEODE-5130 - docker-image get needed

### DIFF
--- a/ci/pipelines/geode-build/base.yml
+++ b/ci/pipelines/geode-build/base.yml
@@ -178,6 +178,7 @@ jobs:
       passed: [AcceptanceTest, DistributedTest, IntegrationTest]
       trigger: true
     - get: geode-ci
+    - get: docker-geode-build-image
     - task: updatepassingref
       image: docker-geode-build-image
       config:


### PR DESCRIPTION
Update UpdatePassingRef to fetch docker image before running.

Signed-off-by: Sean Goller <sgoller@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
