### PR TITLE
GEODE-5155 hang recovering transaction state for crashed server

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXCommitMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXCommitMessage.java
@@ -104,7 +104,7 @@ public class TXCommitMessage extends PooledDistributionMessage
   private transient boolean wasProcessed;
   private transient boolean isProcessing;
   private transient boolean dontProcess;
-  private transient boolean departureNoticed = false;
+  private transient volatile boolean departureNoticed = false;
   private transient boolean lockNeedsUpdate = false;
   private transient boolean ackRequired = true;
   /**
@@ -1943,15 +1943,20 @@ public class TXCommitMessage extends PooledDistributionMessage
   public void quorumLost(DistributionManager distributionManager,
       Set<InternalDistributedMember> failures, List<InternalDistributedMember> remaining) {}
 
+  /** return true if the member initiating this transaction has left the cluster */
+  public boolean isDepartureNoticed() {
+    return departureNoticed;
+  }
+
   @Override
   public void memberDeparted(DistributionManager distributionManager,
       final InternalDistributedMember id, boolean crashed) {
+
     if (!getSender().equals(id)) {
       return;
     }
     this.dm.removeMembershipListener(this);
 
-    ThreadGroup group = LoggingThreadGroup.createThreadGroup("TXCommitMessage Threads", logger);
     synchronized (this) {
       if (isProcessing() || this.departureNoticed) {
         if (logger.isDebugEnabled()) {
@@ -1962,6 +1967,8 @@ public class TXCommitMessage extends PooledDistributionMessage
       }
       this.departureNoticed = true;
     }
+
+    ThreadGroup group = LoggingThreadGroup.createThreadGroup("TXCommitMessage Threads", logger);
 
     // Send message to fellow FarSiders (aka recipients), if any, to
     // determine if any one of them have received a CommitProcessMessage

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXFarSideCMTracker.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXFarSideCMTracker.java
@@ -162,23 +162,23 @@ public class TXFarSideCMTracker {
    * departed/ing Originator (this will most likely be called nearly the same time as
    * commitProcessReceived
    */
-  public void waitToProcess(TXLockId lk, DistributionManager dm) {
-    waitForMemberToDepart(lk.getMemberId(), dm);
-    final TXCommitMessage mess;
+  public void waitToProcess(TXLockId lockId, DistributionManager dm) {
+    waitForMemberToDepart(lockId.getMemberId(), dm);
+    final TXCommitMessage commitMessage;
     synchronized (this.txInProgress) {
-      mess = (TXCommitMessage) this.txInProgress.get(lk);
+      commitMessage = (TXCommitMessage) this.txInProgress.get(lockId);
     }
-    if (mess != null) {
-      synchronized (mess) {
+    if (commitMessage != null) {
+      synchronized (commitMessage) {
         // tx in progress, we must wait until its done
-        while (!(mess.wasProcessed() || mess.isDepartureNoticed())) {
+        while (!(commitMessage.wasProcessed() || commitMessage.isDepartureNoticed())) {
           try {
-            mess.wait(100);
+            commitMessage.wait(100);
           } catch (InterruptedException ie) {
             Thread.currentThread().interrupt();
             logger.error(LocalizedMessage.create(
                 LocalizedStrings.TxFarSideTracker_WAITING_TO_COMPLETE_ON_MESSAGE_0_CAUGHT_AN_INTERRUPTED_EXCEPTION,
-                mess), ie);
+                commitMessage), ie);
             break;
           }
         }
@@ -186,7 +186,7 @@ public class TXFarSideCMTracker {
     } else {
       // tx may have completed
       for (int i = this.txHistory.length - 1; i >= 0; --i) {
-        if (lk.equals(this.txHistory[i])) {
+        if (lockId.equals(this.txHistory[i])) {
           return;
         }
       }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXFarSideCMTracker.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXFarSideCMTracker.java
@@ -171,7 +171,7 @@ public class TXFarSideCMTracker {
     if (mess != null) {
       synchronized (mess) {
         // tx in progress, we must wait until its done
-        while (!mess.wasProcessed() || mess.isDepartureNoticed()) {
+        while (!(mess.wasProcessed() || mess.isDepartureNoticed())) {
           try {
             mess.wait(100);
           } catch (InterruptedException ie) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXFarSideCMTracker.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXFarSideCMTracker.java
@@ -171,9 +171,9 @@ public class TXFarSideCMTracker {
     if (mess != null) {
       synchronized (mess) {
         // tx in progress, we must wait until its done
-        while (!mess.wasProcessed()) {
+        while (!mess.wasProcessed() || mess.isDepartureNoticed()) {
           try {
-            mess.wait();
+            mess.wait(100);
           } catch (InterruptedException ie) {
             Thread.currentThread().interrupt();
             logger.error(LocalizedMessage.create(


### PR DESCRIPTION
I modified the test to hit the issue ~ 70% of the time.  The fix is to
check to see if the message was removed due to a memberDeparted event.
When that happens a departureNoticed flag was being set in TXCommitMessage
but the wait loop in the transaction tracker wasn't checking this flag.

Note: the first two commits address the problem & correct an error in the original fix.  The third commit renamed some variables for readability.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
