### PR TITLE
GEODE-2542: Extend timeouts from 10s to 30; cleanup

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/Assert.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/Assert.java
@@ -95,11 +95,6 @@ public class Assert {
       } else {
         ex = new InternalGemFireError();
       }
-      // org.apache.geode.internal.cache.GemFireCache gfc
-      // = org.apache.geode.internal.cache.GemFireCache.getInstance();
-      // if (gfc != null) {
-      // gfc.getLogger().info("DEBUG", ex);
-      // }
       throw ex;
     }
   }

--- a/geode-core/src/test/java/org/apache/geode/distributed/LocatorDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/LocatorDUnitTest.java
@@ -112,13 +112,6 @@ public class LocatorDUnitTest extends JUnit4DistributedTestCase {
 
   private static TestHook hook;
 
-  /**
-   * Creates a new <code>LocatorDUnitTest</code>
-   */
-  public LocatorDUnitTest() {
-    super();
-  }
-
   protected int port1;
   private int port2;
 

--- a/geode-core/src/test/java/org/apache/geode/distributed/LocatorUDPSecurityDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/LocatorUDPSecurityDUnitTest.java
@@ -22,7 +22,6 @@ import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_UDP_
 import java.util.Properties;
 
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -33,24 +32,13 @@ import org.apache.geode.test.dunit.DistributedTestUtils;
 import org.apache.geode.test.dunit.NetworkUtils;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.junit.categories.DistributedTest;
-import org.apache.geode.test.junit.categories.FlakyTest;
 import org.apache.geode.test.junit.categories.MembershipTest;
 
-@Category({DistributedTest.class, MembershipTest.class, FlakyTest.class}) // Flaky: GEODE-2542
+@Category({DistributedTest.class, MembershipTest.class})
 public class LocatorUDPSecurityDUnitTest extends LocatorDUnitTest {
-
-  public LocatorUDPSecurityDUnitTest() {}
-
   @Override
   protected void addDSProps(Properties p) {
     p.setProperty(SECURITY_UDP_DHALGO, "AES:128");
-  }
-
-  @Override
-  @Test
-  @Ignore // GEODE-3094
-  public void testMultipleLocatorsRestartingAtSameTimeWithMissingServers() throws Exception {
-    super.testMultipleLocatorsRestartingAtSameTimeWithMissingServers();
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/distributed/LocatorUDPSecurityDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/LocatorUDPSecurityDUnitTest.java
@@ -30,7 +30,6 @@ import org.apache.geode.GemFireConfigException;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.internal.AvailablePort;
 import org.apache.geode.test.dunit.DistributedTestUtils;
-import org.apache.geode.test.dunit.Host;
 import org.apache.geode.test.dunit.NetworkUtils;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.junit.categories.DistributedTest;
@@ -57,12 +56,11 @@ public class LocatorUDPSecurityDUnitTest extends LocatorDUnitTest {
   @Test
   public void testLocatorWithUDPSecurityButServer() throws Exception {
     disconnectAllFromDS();
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
+    VM vm0 = VM.getVM(0);
 
     final int port = AvailablePort.getRandomAvailablePort(AvailablePort.SOCKET);
     DistributedTestUtils.deleteLocatorStateFile(port1);
-    final String locators = NetworkUtils.getServerHostName(host) + "[" + port + "]";
+    final String locators = NetworkUtils.getServerHostName() + "[" + port + "]";
 
     vm0.invoke("Start locator " + locators, () -> startLocator(port));
     try {


### PR DESCRIPTION
There's not a whole lot going on here but I got mad at deprecated code and some no-longer-best-practices and decided to do some cleanup.

* Extend timeout to account for issues in CI
* Remove usage of Assert.fail()
* Don't use invoke try-catch-throw paradigm.
* Remove dead code

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?