### PR TITLE
GEODE-4860: make sure the extensions xsd is upgradable

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/internal/config/JAXBServiceTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/config/JAXBServiceTest.java
@@ -139,6 +139,23 @@ public class JAXBServiceTest {
     assertThat(newXml).isEqualTo(prettyXml);
   }
 
+  @Test
+  public void unmarshallIgnoresUnknownProperties() {
+    // say xml has a type attribute that is removed in the new version
+    String existingXML = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n"
+        + "<cache version=\"1.0\" xsi:schemaLocation=\"http://geode.apache.org/schema/cache "
+        + "http://geode.apache.org/schema/cache/cache-1.0.xsd\" "
+        + "xmlns=\"http://geode.apache.org/schema/cache\" "
+        + "xmlns:ns2=\"http://geode.apache.org/schema/CustomOne\" "
+        + "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n" + "    <ns2:custom-one>\n"
+        + "        <ns2:id>one</ns2:id>\n" + "        <ns2:type>onetype</ns2:type>\n"
+        + "        <ns2:value>onevalue</ns2:value>\n" + "    </ns2:custom-one>\n" + "</cache>";
+
+    CacheConfig cacheConfig = service.unMarshall(existingXML);
+    List elements = cacheConfig.getCustomCacheElements();
+    assertThat(elements.get(0)).isInstanceOf(ElementOne.class);
+  }
+
   public static void setBasicValues(CacheConfig cache) {
     cache.setCopyOnRead(true);
     CacheConfig.GatewayReceiver receiver = new CacheConfig.GatewayReceiver();


### PR DESCRIPTION
  JAXB ignores unknown properties during unmarshalling. Added a test
  to make sure that an xml can be unmarshalled while ignoring any
  unknown properties.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
