### PR TITLE
GEODE-5109: Adding reindex op to lucene profile.

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
@@ -10433,6 +10433,10 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
     return this.isUsedForParallelGatewaySenderQueue;
   }
 
+  public void removeCacheServiceProfile(String profileID) {
+    this.cacheServiceProfiles.remove(profileID);
+  }
+
   public AbstractGatewaySender getSerialGatewaySender() {
     return this.serialGatewaySender;
   }

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/LuceneServiceImplJUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/LuceneServiceImplJUnitTest.java
@@ -158,6 +158,11 @@ public class LuceneServiceImplJUnitTest {
   private class TestLuceneServiceImpl extends LuceneServiceImpl {
 
     @Override
+    protected void validateLuceneIndexProfile(PartitionedRegion region) {
+
+    }
+
+    @Override
     public void afterDataRegionCreated(InternalLuceneIndex index) {
       PartitionedRegion userRegion =
           (PartitionedRegion) index.getCache().getRegion(index.getRegionPath());

--- a/geode-lucene/src/test/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
+++ b/geode-lucene/src/test/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
@@ -2,9 +2,9 @@ org/apache/geode/cache/lucene/internal/DestroyLuceneIndexMessage,2
 fromData,32
 toData,32
 org/apache/geode/cache/lucene/internal/LuceneIndexCreationProfile,4
-fromData,14
+fromData,25
 fromDataPre_GEODE_1_4_0_0,41
-toData,14
+toData,25
 toDataPre_GEODE_1_4_0_0,41
 org/apache/geode/cache/lucene/internal/LuceneResultStructImpl,2
 fromData,27


### PR DESCRIPTION
	* If reindex operation is in process, it sets a boolean in the LuceneIndexCreationProfile
	* When the remote member gets the profile and sees that the remote member is reindexing, it will not send a missing profile error.
	* This allows the remote member to create the index even if the index is not present in the local member.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
