### PR TITLE
GEODE-577: Refactored QueryMonitorDUnitTest to use new rules

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/CompiledIteratorDef.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/CompiledIteratorDef.java
@@ -121,6 +121,8 @@ public class CompiledIteratorDef extends AbstractCompiledValue {
         throw re;
       } catch (NotAuthorizedException e) {
         throw e;
+      } catch (QueryExecutionCanceledException e) {
+        throw e;
       } catch (Exception e) {
         if (logger.isDebugEnabled()) {
           logger.debug("Exception while getting runtime iterator.", e);

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/QueryMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/QueryMonitor.java
@@ -213,7 +213,10 @@ public class QueryMonitor implements Runnable {
         boolean[] queryCompleted =
             ((DefaultQuery) queryTask.query).getQueryCompletedForMonitoring();
         synchronized (queryCompleted) {
-          if (!queryCompleted[0]) { // Check if the query is already completed.
+          if (!queryCompleted[0] && !((DefaultQuery) queryTask.query).isCqQuery()) { // Check if the
+                                                                                     // query is
+                                                                                     // already
+                                                                                     // completed.
             ((DefaultQuery) queryTask.query).setCanceled(true,
                 new QueryExecutionTimeoutException(
                     LocalizedStrings.QueryMonitor_LONG_RUNNING_QUERY_CANCELED

--- a/geode-core/src/test/java/org/apache/geode/cache/query/internal/index/EquiJoinIntegrationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/internal/index/EquiJoinIntegrationTest.java
@@ -178,7 +178,8 @@ public class EquiJoinIntegrationTest {
         new String[] {"select * from /region1 c, /region2 s where c.pkid=1 and c.pkid = s.pkid",
             "select * from /region1 c, /region2 s where c.pkid=1 and s.pkid = c.pkid",
             "select * from /region1 c, /region2 s where c.pkid = s.pkid and c.pkid=1",
-            "select * from /region1 c, /region2 s where s.pkid = c.pkid and c.pkid=1",};
+            "select * from /region1 c, /region2 s where s.pkid = c.pkid and c.pkid=1",
+            "select distinct * from /region1 c, /region2 s where s.pkid = c.pkid and c.pkid=1"};
 
     for (int i = 0; i < 1000; i++) {
       region1.put(i, new Customer(i, i));

--- a/geode-cq/src/test/java/org/apache/geode/internal/cache/ha/CQListGIIDUnitTest.java
+++ b/geode-cq/src/test/java/org/apache/geode/internal/cache/ha/CQListGIIDUnitTest.java
@@ -190,7 +190,6 @@ public class CQListGIIDUnitTest extends JUnit4DistributedTestCase {
     factory.setScope(Scope.DISTRIBUTED_ACK);
     factory.setDataPolicy(DataPolicy.REPLICATE);
     RegionAttributes attrs = factory.create();
-    // cache.createRegion(regionName, attrs);
     createRegion(regions[0], "root", attrs);
     createRegion(regions[1], "root", attrs);
     Thread.sleep(2000);


### PR DESCRIPTION
  * Modified product to have cq's ignore the query timeout - not sure if that was expected originally, from the tests it sounds like it shouldn't have been
  * Was wrapping cancelled exceptions in TypeMismatch exceptions under certain scenarios
  * Enabled ignored tests and removed flaky tag
  * Removed creating an instance of a different test inside this test case
  * Tests can be further pruned and refactored but this was a first step
  * Removed some queries combinations that shouldn't be the responsibility of the QueryMonitorDUnitTest to test

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
