### PR TITLE
GEODE-5183 require toData/fromData methods to correspond to a known version

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/StartupMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/StartupMessage.java
@@ -364,7 +364,7 @@ public class StartupMessage extends HighPriorityDistributionMessage implements A
   /**
    * Notes a problem that occurs while invoking {@link #fromData}.
    */
-  private void fromDataProblem(String s) {
+  private void recordFromDataProblem(String s) {
     if (this.fromDataProblems == null) {
       this.fromDataProblems = new StringBuffer();
     }
@@ -392,7 +392,7 @@ public class StartupMessage extends HighPriorityDistributionMessage implements A
           InternalDataSerializer.register(cName, false, null, null, id);
         }
       } catch (IllegalArgumentException ex) {
-        fromDataProblem(
+        recordFromDataProblem(
             LocalizedStrings.StartupMessage_ILLEGALARGUMENTEXCEPTION_WHILE_REGISTERING_A_DATASERIALIZER_0
                 .toLocalizedString(ex));
       }
@@ -409,7 +409,7 @@ public class StartupMessage extends HighPriorityDistributionMessage implements A
           InternalInstantiator.register(instantiatorClassName, instantiatedClassName, id, false);
         }
       } catch (IllegalArgumentException ex) {
-        fromDataProblem(
+        recordFromDataProblem(
             LocalizedStrings.StartupMessage_ILLEGALARGUMENTEXCEPTION_WHILE_REGISTERING_AN_INSTANTIATOR_0
                 .toLocalizedString(ex));
       }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/StartupResponseMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/StartupResponseMessage.java
@@ -193,15 +193,6 @@ public class StartupResponseMessage extends HighPriorityDistributionMessage
     return STARTUP_RESPONSE_MESSAGE;
   }
 
-  private void fromDataProblem(String s) {
-    if (this.fromDataProblems == null) {
-      this.fromDataProblems = new StringBuffer();
-    }
-
-    this.fromDataProblems.append(s);
-    this.fromDataProblems.append(System.getProperty("line.separator", "\n"));
-  }
-
   @Override
   public Version[] getSerializationVersions() {
     return null;

--- a/geode-core/src/main/java/org/apache/geode/internal/InternalInstantiator.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/InternalInstantiator.java
@@ -889,7 +889,7 @@ public class InternalInstantiator {
       DataSerializer.writeObject(this.eventId, out);
     }
 
-    private void fromDataProblem(String s) {
+    private void recordFromDataProblem(String s) {
       if (this.fromDataProblems == null) {
         this.fromDataProblems = new StringBuffer();
       }
@@ -913,8 +913,9 @@ public class InternalInstantiator {
               InternalDataSerializer.getCachedClass(this.instantiatorClassName); // fix for bug
                                                                                  // 41206
         } catch (ClassNotFoundException ex) {
-          fromDataProblem(LocalizedStrings.InternalInstantiator_COULD_NOT_LOAD_INSTANTIATOR_CLASS_0
-              .toLocalizedString(ex));
+          recordFromDataProblem(
+              LocalizedStrings.InternalInstantiator_COULD_NOT_LOAD_INSTANTIATOR_CLASS_0
+                  .toLocalizedString(ex));
           this.instantiatorClass = null;
         }
         try {
@@ -922,8 +923,9 @@ public class InternalInstantiator {
               InternalDataSerializer.getCachedClass(this.instantiatedClassName); // fix for bug
                                                                                  // 41206
         } catch (ClassNotFoundException ex) {
-          fromDataProblem(LocalizedStrings.InternalInstantiator_COULD_NOT_LOAD_INSTANTIATED_CLASS_0
-              .toLocalizedString(ex));
+          recordFromDataProblem(
+              LocalizedStrings.InternalInstantiator_COULD_NOT_LOAD_INSTANTIATED_CLASS_0
+                  .toLocalizedString(ex));
           this.instantiatedClass = null;
         }
       }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/DiskInitFileParser.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/DiskInitFileParser.java
@@ -584,7 +584,7 @@ public class DiskInitFileParser {
     DataInputStream dis = new DataInputStream(bais);
     PersistentMemberID result = new PersistentMemberID();
     if (Version.GFE_70.compareTo(gfversion) > 0) {
-      result.fromData662(dis);
+      result._fromData662(dis);
     } else {
       InternalDataSerializer.invokeFromData(result, dis);
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/PersistentMemberID.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/PersistentMemberID.java
@@ -79,7 +79,7 @@ public class PersistentMemberID implements DataSerializable {
     this.name = DataSerializer.readString(in);
   }
 
-  public void fromData662(DataInput in) throws IOException, ClassNotFoundException {
+  public void _fromData662(DataInput in) throws IOException, ClassNotFoundException {
     long diskStoreIdHigh = in.readLong();
     long diskStoreIdLow = in.readLong();
     this.diskStoreId = new DiskStoreID(diskStoreIdHigh, diskStoreIdLow);

--- a/geode-core/src/test/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
+++ b/geode-core/src/test/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
@@ -186,13 +186,11 @@ org/apache/geode/distributed/internal/ShutdownMessage,2
 fromData,27
 toData,24
 
-org/apache/geode/distributed/internal/StartupMessage,3
-fromDataProblem,38
+org/apache/geode/distributed/internal/StartupMessage,2
 fromData,293
 toData,318
 
-org/apache/geode/distributed/internal/StartupResponseMessage,3
-fromDataProblem,43
+org/apache/geode/distributed/internal/StartupResponseMessage,2
 fromData,220
 toData,170
 
@@ -392,8 +390,7 @@ org/apache/geode/internal/InternalInstantiator$RegistrationContextMessage,2
 fromData,14
 toData,14
 
-org/apache/geode/internal/InternalInstantiator$RegistrationMessage,3
-fromDataProblem,38
+org/apache/geode/internal/InternalInstantiator$RegistrationMessage,2
 fromData,125
 toData,46
 
@@ -1823,9 +1820,8 @@ org/apache/geode/internal/cache/persistence/MembershipViewRequest$MembershipView
 fromData,36
 toData,38
 
-org/apache/geode/internal/cache/persistence/PersistentMemberID,3
+org/apache/geode/internal/cache/persistence/PersistentMemberID,2
 fromData,74
-fromData662,66
 toData,71
 
 org/apache/geode/internal/cache/persistence/PersistentMemberPattern,2


### PR DESCRIPTION
Methods beginning with toData or fromData in DataSerializable classes
must now correspond to a valid Version or AnalyzeSerializablesJUnitTest
will reject them.  I've renamed a few methods and adjusted
sanctionedDataSerializables.txt to remove them (fromDataProblem,
fromData662)

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
