### PR TITLE
GEODE-3563 SSL socket handling problems in TCPConduit run

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/TcpServer.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/TcpServer.java
@@ -359,7 +359,8 @@ public class TcpServer {
       long startTime = DistributionStats.getStatTime();
       DataInputStream input = null;
       try {
-        getSocketCreator().startHandshakeIfSocketIsSSL(socket, READ_TIMEOUT);
+        socket.setSoTimeout(READ_TIMEOUT);
+        getSocketCreator().handshakeIfSocketIsSSL(socket, READ_TIMEOUT);
 
         try {
           input = new DataInputStream(socket.getInputStream());

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/AcceptorImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/AcceptorImpl.java
@@ -1549,12 +1549,12 @@ public class AcceptorImpl implements Acceptor, Runnable, CommBufferPool {
   }
 
   private CommunicationMode getCommunicationModeForNonSelector(Socket socket) throws IOException {
-    this.socketCreator.startHandshakeIfSocketIsSSL(socket, this.acceptTimeout);
+    socket.setSoTimeout(0);
+    this.socketCreator.handshakeIfSocketIsSSL(socket, this.acceptTimeout);
     byte communicationModeByte = (byte) socket.getInputStream().read();
     if (communicationModeByte == -1) {
       throw new EOFException();
     }
-    socket.setSoTimeout(0);
     return CommunicationMode.fromModeNumber(communicationModeByte);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/net/SocketCreator.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/SocketCreator.java
@@ -957,14 +957,15 @@ public class SocketCreator {
   }
 
   /**
-   * Will be a server socket... this one simply registers the listeners.
+   * Use this method to perform the SSL handshake on a newly accepted socket. Non-SSL
+   * sockets are ignored by this method.
    *
-   * @param timeout the socket's timeout will be set to this (in milliseconds).
+   * @param timeout the number of milliseconds allowed for the handshake to complete
    */
-  public void startHandshakeIfSocketIsSSL(Socket socket, int timeout) throws IOException {
-    socket.setSoTimeout(timeout);
-
+  public void handshakeIfSocketIsSSL(Socket socket, int timeout) throws IOException {
     if (socket instanceof SSLSocket) {
+      int oldTimeout = socket.getSoTimeout();
+      socket.setSoTimeout(timeout);
       SSLSocket sslSocket = (SSLSocket) socket;
       try {
         sslSocket.startHandshake();
@@ -985,6 +986,8 @@ public class SocketCreator {
           throw ex;
         }
         // else ignore
+      } finally {
+        socket.setSoTimeout(oldTimeout);
       }
     }
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/tcp/TCPConduit.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/tcp/TCPConduit.java
@@ -688,7 +688,8 @@ public class TCPConduit implements Runnable {
                 ex);
             break;
           }
-          socketCreator.startHandshakeIfSocketIsSSL(othersock, idleConnectionTimeout);
+          othersock.setSoTimeout(0);
+          socketCreator.handshakeIfSocketIsSSL(othersock, idleConnectionTimeout);
         }
         if (stopped) {
           try {

--- a/geode-core/src/test/java/org/apache/geode/internal/net/DummySocketCreator.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/net/DummySocketCreator.java
@@ -35,7 +35,7 @@ public class DummySocketCreator extends SocketCreator {
   }
 
   @Override
-  public void startHandshakeIfSocketIsSSL(Socket socket, int timeout) throws IOException {
+  public void handshakeIfSocketIsSSL(Socket socket, int timeout) throws IOException {
     this.socketSoTimeouts.add(timeout);
     throw new SSLException("This is a test SSLException");
   }

--- a/geode-core/src/test/java/org/apache/geode/internal/net/SocketCreatorJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/net/SocketCreatorJUnitTest.java
@@ -16,8 +16,13 @@ package org.apache.geode.internal.net;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-import java.net.Socket;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSocket;
 
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -46,11 +51,17 @@ public class SocketCreatorJUnitTest {
   @Test
   public void testConfigureServerSSLSocketSetsSoTimeout() throws Exception {
     final SocketCreator socketCreator = new SocketCreator(mock(SSLConfig.class));
-    final Socket socket = mock(Socket.class);
+    final SSLSocket socket = mock(SSLSocket.class);
+    Certificate[] certs = new Certificate[] {mock(X509Certificate.class)};
+    SSLSession session = mock(SSLSession.class);
+    when(session.getPeerCertificates()).thenReturn(certs);
+    when(socket.getSession()).thenReturn(session);
 
     final int timeout = 1938236;
-    socketCreator.startHandshakeIfSocketIsSSL(socket, timeout);
+    socketCreator.handshakeIfSocketIsSSL(socket, timeout);
 
+    verify(socket).getSession();
+    verify(session).getPeerCertificates();
     verify(socket).setSoTimeout(timeout);
   }
 


### PR DESCRIPTION
Modified the handshake method to establish a timeout and revert it when done.
Added testing to ensure the timeout is being established and honored.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
