### PR TITLE
GEODE-5206: Add an 'ignoreFailure' flag to CliFunctionResult

### DIFF
--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/AlterConnectionCommand.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/AlterConnectionCommand.java
@@ -103,7 +103,7 @@ public class AlterConnectionCommand extends SingleGfshCommand {
     ConnectorService.Connection mergedConnection =
         (ConnectorService.Connection) successResult.getResultObject();
 
-    ResultModel result = ResultModel.createMemberStatusResult(results, EXPERIMENTAL, null);
+    ResultModel result = ResultModel.createMemberStatusResult(results, EXPERIMENTAL, null, false);
     result.setConfigObject(mergedConnection);
     return result;
   }

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/AlterMappingCommand.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/AlterMappingCommand.java
@@ -105,7 +105,7 @@ public class AlterMappingCommand extends SingleGfshCommand {
     // action
     List<CliFunctionResult> results =
         executeAndGetFunctionResult(new AlterMappingFunction(), newMapping, targetMembers);
-    ResultModel result = ResultModel.createMemberStatusResult(results, EXPERIMENTAL, null);
+    ResultModel result = ResultModel.createMemberStatusResult(results, EXPERIMENTAL, null, false);
 
     // find the merged regionMapping from the function result
     CliFunctionResult successResult =

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/CreateConnectionCommand.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/CreateConnectionCommand.java
@@ -86,7 +86,7 @@ public class CreateConnectionCommand extends SingleGfshCommand {
     List<CliFunctionResult> results =
         executeAndGetFunctionResult(new CreateConnectionFunction(), connection, targetMembers);
 
-    ResultModel result = ResultModel.createMemberStatusResult(results, EXPERIMENTAL, null);
+    ResultModel result = ResultModel.createMemberStatusResult(results, EXPERIMENTAL, null, false);
     result.setConfigObject(connection);
     return result;
   }

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/CreateMappingCommand.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/CreateMappingCommand.java
@@ -83,7 +83,7 @@ public class CreateMappingCommand extends SingleGfshCommand {
     List<CliFunctionResult> results =
         executeAndGetFunctionResult(new CreateMappingFunction(), mapping, targetMembers);
 
-    ResultModel result = ResultModel.createMemberStatusResult(results, EXPERIMENTAL, null);
+    ResultModel result = ResultModel.createMemberStatusResult(results, EXPERIMENTAL, null, false);
     result.setConfigObject(mapping);
     return result;
   }

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyConnectionCommand.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyConnectionCommand.java
@@ -54,7 +54,7 @@ public class DestroyConnectionCommand extends SingleGfshCommand {
     // action
     List<CliFunctionResult> results =
         executeAndGetFunctionResult(new DestroyConnectionFunction(), name, targetMembers);
-    ResultModel result = ResultModel.createMemberStatusResult(results, EXPERIMENTAL, null);
+    ResultModel result = ResultModel.createMemberStatusResult(results, EXPERIMENTAL, null, false);
     result.setConfigObject(name);
     return result;
   }

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyMappingCommand.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyMappingCommand.java
@@ -55,7 +55,7 @@ public class DestroyMappingCommand extends SingleGfshCommand {
     List<CliFunctionResult> results =
         executeAndGetFunctionResult(new DestroyMappingFunction(), regionName, targetMembers);
 
-    ResultModel result = ResultModel.createMemberStatusResult(results, EXPERIMENTAL, null);
+    ResultModel result = ResultModel.createMemberStatusResult(results, EXPERIMENTAL, null, false);
     result.setConfigObject(regionName);
     return result;
   }

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/AlterConnectionCommandTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/AlterConnectionCommandTest.java
@@ -65,7 +65,7 @@ public class AlterConnectionCommandTest {
     result = mock(CliFunctionResult.class);
     when(result.isSuccessful()).thenReturn(true);
     when(result.getMemberIdOrName()).thenReturn("memberName");
-    when(result.getStatus()).thenReturn("message");
+    when(result.getStatusMessage()).thenReturn("message");
     ccService = mock(InternalConfigurationPersistenceService.class);
     cacheConfig = mock(CacheConfig.class);
     when(ccService.getCacheConfig("cluster")).thenReturn(cacheConfig);

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/AlterConnectionFunctionTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/AlterConnectionFunctionTest.java
@@ -132,7 +132,7 @@ public class AlterConnectionFunctionTest {
 
     ArgumentCaptor<CliFunctionResult> argument = ArgumentCaptor.forClass(CliFunctionResult.class);
     verify(resultSender, times(1)).lastResult(argument.capture());
-    assertThat(argument.getValue().getStatus()).contains(CONNECTION_NAME);
+    assertThat(argument.getValue().getStatusMessage()).contains(CONNECTION_NAME);
   }
 
   @Test

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/AlterMappingCommandTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/AlterMappingCommandTest.java
@@ -65,7 +65,7 @@ public class AlterMappingCommandTest {
     result = mock(CliFunctionResult.class);
     when(result.isSuccessful()).thenReturn(true);
     when(result.getMemberIdOrName()).thenReturn("memberName");
-    when(result.getStatus()).thenReturn("message");
+    when(result.getStatusMessage()).thenReturn("message");
     ccService = mock(InternalConfigurationPersistenceService.class);
     doReturn(ccService).when(command).getConfigurationPersistenceService();
     cacheConfig = mock(CacheConfig.class);

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/AlterMappingFunctionTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/AlterMappingFunctionTest.java
@@ -132,7 +132,7 @@ public class AlterMappingFunctionTest {
 
     ArgumentCaptor<CliFunctionResult> argument = ArgumentCaptor.forClass(CliFunctionResult.class);
     verify(resultSender, times(1)).lastResult(argument.capture());
-    assertThat(argument.getValue().getStatus()).contains(REGION_NAME);
+    assertThat(argument.getValue().getStatusMessage()).contains(REGION_NAME);
   }
 
   @Test

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/CreateConnectionFunctionTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/CreateConnectionFunctionTest.java
@@ -129,7 +129,7 @@ public class CreateConnectionFunctionTest {
 
     ArgumentCaptor<CliFunctionResult> argument = ArgumentCaptor.forClass(CliFunctionResult.class);
     verify(resultSender, times(1)).lastResult(argument.capture());
-    assertThat(argument.getValue().getStatus())
+    assertThat(argument.getValue().getStatusMessage())
         .contains(ConnectionConfigExistsException.class.getName());
   }
 

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/CreateMappingFunctionTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/CreateMappingFunctionTest.java
@@ -130,7 +130,7 @@ public class CreateMappingFunctionTest {
 
     ArgumentCaptor<CliFunctionResult> argument = ArgumentCaptor.forClass(CliFunctionResult.class);
     verify(resultSender, times(1)).lastResult(argument.capture());
-    assertThat(argument.getValue().getStatus())
+    assertThat(argument.getValue().getStatusMessage())
         .contains(RegionMappingExistsException.class.getName());
   }
 }

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/DescribeConnectionFunctionTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/DescribeConnectionFunctionTest.java
@@ -119,7 +119,8 @@ public class DescribeConnectionFunctionTest {
 
     ArgumentCaptor<CliFunctionResult> argument = ArgumentCaptor.forClass(CliFunctionResult.class);
     verify(resultSender, times(1)).lastResult(argument.capture());
-    assertThat(argument.getValue().getStatus()).contains(NullPointerException.class.getName());
+    assertThat(argument.getValue().getStatusMessage())
+        .contains(NullPointerException.class.getName());
   }
 
   @Test
@@ -131,6 +132,6 @@ public class DescribeConnectionFunctionTest {
 
     ArgumentCaptor<CliFunctionResult> argument = ArgumentCaptor.forClass(CliFunctionResult.class);
     verify(resultSender, times(1)).lastResult(argument.capture());
-    assertThat(argument.getValue().getStatus()).contains("some message");
+    assertThat(argument.getValue().getStatusMessage()).contains("some message");
   }
 }

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/DescribeMappingFunctionTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/DescribeMappingFunctionTest.java
@@ -120,7 +120,8 @@ public class DescribeMappingFunctionTest {
 
     ArgumentCaptor<CliFunctionResult> argument = ArgumentCaptor.forClass(CliFunctionResult.class);
     verify(resultSender, times(1)).lastResult(argument.capture());
-    assertThat(argument.getValue().getStatus()).contains(NullPointerException.class.getName());
+    assertThat(argument.getValue().getStatusMessage())
+        .contains(NullPointerException.class.getName());
   }
 
   @Test
@@ -132,6 +133,6 @@ public class DescribeMappingFunctionTest {
 
     ArgumentCaptor<CliFunctionResult> argument = ArgumentCaptor.forClass(CliFunctionResult.class);
     verify(resultSender, times(1)).lastResult(argument.capture());
-    assertThat(argument.getValue().getStatus()).contains("some message");
+    assertThat(argument.getValue().getStatusMessage()).contains("some message");
   }
 }

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyConnectionFunctionTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyConnectionFunctionTest.java
@@ -119,7 +119,7 @@ public class DestroyConnectionFunctionTest {
 
     ArgumentCaptor<CliFunctionResult> argument = ArgumentCaptor.forClass(CliFunctionResult.class);
     verify(resultSender, times(1)).lastResult(argument.capture());
-    assertThat(argument.getValue().getStatus())
+    assertThat(argument.getValue().getStatusMessage())
         .contains("Connection named \"" + connectionName + "\" not found");
   }
 }

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyMappingCommandFunctionTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyMappingCommandFunctionTest.java
@@ -118,7 +118,7 @@ public class DestroyMappingCommandFunctionTest {
 
     ArgumentCaptor<CliFunctionResult> argument = ArgumentCaptor.forClass(CliFunctionResult.class);
     verify(resultSender, times(1)).lastResult(argument.capture());
-    assertThat(argument.getValue().getStatus())
+    assertThat(argument.getValue().getStatusMessage())
         .contains("Region mapping for region \"" + regionName + "\" not found");
   }
 }

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/ListConnectionFunctionTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/ListConnectionFunctionTest.java
@@ -152,7 +152,8 @@ public class ListConnectionFunctionTest {
 
     ArgumentCaptor<CliFunctionResult> argument = ArgumentCaptor.forClass(CliFunctionResult.class);
     verify(resultSender, times(1)).lastResult(argument.capture());
-    assertThat(argument.getValue().getStatus()).contains(NullPointerException.class.getName());
+    assertThat(argument.getValue().getStatusMessage())
+        .contains(NullPointerException.class.getName());
   }
 
   @Test
@@ -163,6 +164,6 @@ public class ListConnectionFunctionTest {
 
     ArgumentCaptor<CliFunctionResult> argument = ArgumentCaptor.forClass(CliFunctionResult.class);
     verify(resultSender, times(1)).lastResult(argument.capture());
-    assertThat(argument.getValue().getStatus()).contains("some message");
+    assertThat(argument.getValue().getStatusMessage()).contains("some message");
   }
 }

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/ListMappingFunctionTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/ListMappingFunctionTest.java
@@ -152,7 +152,8 @@ public class ListMappingFunctionTest {
 
     ArgumentCaptor<CliFunctionResult> argument = ArgumentCaptor.forClass(CliFunctionResult.class);
     verify(resultSender, times(1)).lastResult(argument.capture());
-    assertThat(argument.getValue().getStatus()).contains(NullPointerException.class.getName());
+    assertThat(argument.getValue().getStatusMessage())
+        .contains(NullPointerException.class.getName());
   }
 
   @Test
@@ -163,6 +164,6 @@ public class ListMappingFunctionTest {
 
     ArgumentCaptor<CliFunctionResult> argument = ArgumentCaptor.forClass(CliFunctionResult.class);
     verify(resultSender, times(1)).lastResult(argument.capture());
-    assertThat(argument.getValue().getStatus()).contains("some message");
+    assertThat(argument.getValue().getStatusMessage()).contains("some message");
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/CliFunctionResult.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/CliFunctionResult.java
@@ -32,10 +32,13 @@ public class CliFunctionResult implements Comparable<CliFunctionResult>, DataSer
   private String memberIdOrName;
   private Serializable[] serializables = new String[0];
   private Object resultObject;
-  private boolean successful;
   private XmlEntity xmlEntity;
   private byte[] byteData = new byte[0];
-  private boolean ignorableFailure = false;
+  private StatusState state;
+
+  public enum StatusState {
+    OK, ERROR, IGNORED
+  }
 
   @Deprecated
   public CliFunctionResult() {}
@@ -43,21 +46,21 @@ public class CliFunctionResult implements Comparable<CliFunctionResult>, DataSer
   @Deprecated
   public CliFunctionResult(final String memberIdOrName) {
     this.memberIdOrName = memberIdOrName;
-    this.successful = true;
+    this.state = StatusState.OK;
   }
 
   @Deprecated
   public CliFunctionResult(final String memberIdOrName, final Serializable[] serializables) {
     this.memberIdOrName = memberIdOrName;
     this.serializables = serializables;
-    this.successful = true;
+    this.state = StatusState.OK;
   }
 
   @Deprecated
   public CliFunctionResult(final String memberIdOrName, final XmlEntity xmlEntity) {
     this.memberIdOrName = memberIdOrName;
     this.xmlEntity = xmlEntity;
-    this.successful = true;
+    this.state = StatusState.OK;
   }
 
   @Deprecated
@@ -66,7 +69,7 @@ public class CliFunctionResult implements Comparable<CliFunctionResult>, DataSer
     this.memberIdOrName = memberIdOrName;
     this.xmlEntity = xmlEntity;
     this.serializables = serializables;
-    this.successful = true;
+    this.state = StatusState.OK;
   }
 
   @Deprecated
@@ -76,13 +79,22 @@ public class CliFunctionResult implements Comparable<CliFunctionResult>, DataSer
     if (message != null) {
       this.serializables = new String[] {message};
     }
-    this.successful = true;
+    this.state = StatusState.OK;
   }
 
+  /**
+   * @deprecated Use {@code CliFunctionResult(String, StatusState, String)} instead
+   */
+  @Deprecated
   public CliFunctionResult(final String memberIdOrName, final boolean successful,
       final String message) {
+    this(memberIdOrName, successful ? StatusState.OK : StatusState.ERROR, message);
+  }
+
+  public CliFunctionResult(final String memberIdOrName, final StatusState state,
+      final String message) {
     this.memberIdOrName = memberIdOrName;
-    this.successful = successful;
+    this.state = state;
     if (message != null) {
       this.serializables = new String[] {message};
     }
@@ -96,9 +108,9 @@ public class CliFunctionResult implements Comparable<CliFunctionResult>, DataSer
       this.serializables = new String[] {message};
     }
     if (resultObject instanceof Throwable) {
-      this.successful = false;
+      this.state = StatusState.ERROR;
     } else {
-      this.successful = true;
+      this.state = StatusState.OK;
     }
   }
 
@@ -120,17 +132,17 @@ public class CliFunctionResult implements Comparable<CliFunctionResult>, DataSer
   }
 
   public String getStatus() {
-    if (ignorableFailure) {
+    if (isIgnorableFailure()) {
       return "IGNORED";
     }
 
-    return successful ? "OK" : "ERROR";
+    return isSuccessful() ? "OK" : "ERROR";
   }
 
   public String getStatusMessage() {
     String message = getMessage();
 
-    if (successful) {
+    if (isSuccessful()) {
       return message;
     }
 
@@ -155,7 +167,7 @@ public class CliFunctionResult implements Comparable<CliFunctionResult>, DataSer
   public String getLegacyStatus() {
     String message = getMessage();
 
-    if (successful) {
+    if (isSuccessful()) {
       return message;
     }
 
@@ -180,7 +192,7 @@ public class CliFunctionResult implements Comparable<CliFunctionResult>, DataSer
 
   @Deprecated
   public Throwable getThrowable() {
-    if (successful) {
+    if (isSuccessful()) {
       return null;
     }
     return ((Throwable) resultObject);
@@ -198,12 +210,12 @@ public class CliFunctionResult implements Comparable<CliFunctionResult>, DataSer
   @Override
   public void toData(DataOutput out) throws IOException {
     toDataPre_GEODE_1_6_0_0(out);
-    DataSerializer.writePrimitiveBoolean(this.ignorableFailure, out);
+    DataSerializer.writeEnum(this.state, out);
   }
 
   public void toDataPre_GEODE_1_6_0_0(DataOutput out) throws IOException {
     DataSerializer.writeString(this.memberIdOrName, out);
-    DataSerializer.writePrimitiveBoolean(this.successful, out);
+    DataSerializer.writePrimitiveBoolean(this.isSuccessful(), out);
     DataSerializer.writeObject(this.xmlEntity, out);
     DataSerializer.writeObjectArray(this.serializables, out);
     DataSerializer.writeObject(this.resultObject, out);
@@ -219,12 +231,12 @@ public class CliFunctionResult implements Comparable<CliFunctionResult>, DataSer
   @Override
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
     fromDataPre_GEODE_1_6_0_0(in);
-    this.ignorableFailure = DataSerializer.readPrimitiveBoolean(in);
+    this.state = DataSerializer.readEnum(StatusState.class, in);
   }
 
   public void fromDataPre_GEODE_1_6_0_0(DataInput in) throws IOException, ClassNotFoundException {
     this.memberIdOrName = DataSerializer.readString(in);
-    this.successful = DataSerializer.readPrimitiveBoolean(in);
+    this.state = DataSerializer.readPrimitiveBoolean(in) ? StatusState.OK : StatusState.ERROR;
     this.xmlEntity = DataSerializer.readObject(in);
     this.serializables = (Serializable[]) DataSerializer.readObjectArray(in);
     this.resultObject = DataSerializer.readObject(in);
@@ -238,11 +250,11 @@ public class CliFunctionResult implements Comparable<CliFunctionResult>, DataSer
   }
 
   public boolean isSuccessful() {
-    return this.successful;
+    return this.state == StatusState.OK;
   }
 
   public boolean isIgnorableFailure() {
-    return ignorableFailure;
+    return this.state == StatusState.IGNORED;
   }
 
   /**
@@ -254,10 +266,10 @@ public class CliFunctionResult implements Comparable<CliFunctionResult>, DataSer
    * is not already error.
    */
   public void setIgnorableFailure() {
-    if (successful) {
-      throw new IllegalStateException("Cannot call setIgnorableFailure when isSuccessful == true");
+    if (isSuccessful()) {
+      throw new IllegalStateException("Cannot call setIgnorableFailure when state == OK");
     }
-    this.ignorableFailure = true;
+    this.state = StatusState.IGNORED;
   }
 
   @Deprecated
@@ -311,9 +323,10 @@ public class CliFunctionResult implements Comparable<CliFunctionResult>, DataSer
 
   @Override
   public String toString() {
-    return "CliFunctionResult [memberId=" + this.memberIdOrName + ", successful=" + this.successful
-        + ", xmlEntity=" + this.xmlEntity + ", serializables=" + Arrays.toString(this.serializables)
-        + ", throwable=" + this.resultObject + ", byteData=" + Arrays.toString(this.byteData) + "]";
+    return "CliFunctionResult [memberId=" + this.memberIdOrName + ", successful="
+        + this.isSuccessful() + ", xmlEntity=" + this.xmlEntity + ", serializables="
+        + Arrays.toString(this.serializables) + ", throwable=" + this.resultObject + ", byteData="
+        + Arrays.toString(this.byteData) + "]";
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/CreateIndexFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/CreateIndexFunction.java
@@ -54,7 +54,7 @@ public class CreateIndexFunction implements InternalFunction {
       }
 
       context.getResultSender()
-          .lastResult(new CliFunctionResult(memberId, null, "Index successfully created"));
+          .lastResult(new CliFunctionResult(memberId, true, "Index successfully created"));
 
     } catch (IndexExistsException e) {
       String message =

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/result/ResultBuilder.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/result/ResultBuilder.java
@@ -197,7 +197,7 @@ public class ResultBuilder {
     boolean success = false;
     for (CliFunctionResult result : functionResults) {
       tabularData.accumulate("Member", result.getMemberIdOrName());
-      tabularData.accumulate("Status", result.getStatus());
+      tabularData.accumulate("Status", result.getLegacyStatus());
       // if one member returns back successful results, the command results in success
       if (result.isSuccessful()) {
         success = true;

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/result/model/ResultModel.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/result/model/ResultModel.java
@@ -285,8 +285,13 @@ public class ResultModel {
     return result;
   }
 
+  public static ResultModel createMemberStatusResult(List<CliFunctionResult> functionResults,
+      boolean ignoreIfFailed) {
+    return createMemberStatusResult(functionResults, null, null, ignoreIfFailed);
+  }
+
   public static ResultModel createMemberStatusResult(List<CliFunctionResult> functionResults) {
-    return createMemberStatusResult(functionResults, null, null);
+    return createMemberStatusResult(functionResults, null, null, false);
   }
 
   /**
@@ -294,15 +299,16 @@ public class ResultModel {
    * to tabulate the status from calls to a number of members.
    */
   public static ResultModel createMemberStatusResult(List<CliFunctionResult> functionResults,
-      String header, String footer) {
+      String header, String footer, boolean ignoreIfFailed) {
     ResultModel result = new ResultModel();
-    boolean atLeastOneSuccess = false;
+    boolean atLeastOneSuccess = ignoreIfFailed;
     TabularResultModel tabularResultModel = result.addTable(MEMBER_STATUS_SECTION);
     tabularResultModel.setHeader(header);
     tabularResultModel.setFooter(footer);
-    tabularResultModel.setColumnHeader("Member", "Status");
+    tabularResultModel.setColumnHeader("Member", "Status", "Message");
     for (CliFunctionResult functionResult : functionResults) {
-      tabularResultModel.addRow(functionResult.getMemberIdOrName(), functionResult.getStatus());
+      tabularResultModel.addRow(functionResult.getMemberIdOrName(), functionResult.getStatus(),
+          functionResult.getStatusMessage());
       if (functionResult.isSuccessful()) {
         atLeastOneSuccess = true;
       }

--- a/geode-core/src/main/resources/org/apache/geode/internal/sanctioned-geode-core-serializables.txt
+++ b/geode-core/src/main/resources/org/apache/geode/internal/sanctioned-geode-core-serializables.txt
@@ -520,6 +520,7 @@ org/apache/geode/management/internal/cli/exceptions/EntityNotFoundException,fals
 org/apache/geode/management/internal/cli/functions/AlterRuntimeConfigFunction,true,1
 org/apache/geode/management/internal/cli/functions/AsyncEventQueueFunctionArgs,true,-6524494645663740872,asyncEventQueueId:java/lang/String,batchSize:int,batchTimeInterval:int,diskStoreName:java/lang/String,diskSynchronous:boolean,dispatcherThreads:int,enableBatchConflation:boolean,forwardExpirationDestroy:boolean,gatewayEventFilters:java/lang/String[],gatewaySubstitutionFilter:java/lang/String,isParallel:boolean,listenerClassName:java/lang/String,listenerProperties:java/util/Properties,maxQueueMemory:int,orderPolicy:java/lang/String,persistent:boolean
 org/apache/geode/management/internal/cli/functions/ChangeLogLevelFunction,true,1
+org/apache/geode/management/internal/cli/functions/CliFunctionResult$StatusState,false
 org/apache/geode/management/internal/cli/functions/CloseDurableClientFunction,true,1
 org/apache/geode/management/internal/cli/functions/CloseDurableCqFunction,true,1
 org/apache/geode/management/internal/cli/functions/ContinuousQueryFunction,true,1

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateIndexCommandDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateIndexCommandDUnitTest.java
@@ -64,7 +64,7 @@ public class CreateIndexCommandDUnitTest {
   @Test
   public void regionNotExist() {
     gfsh.executeAndAssertThat("create index --name=myIndex --expression=id --region=/noExist")
-        .statusIsError().containsOutput("ERROR: Region not found : \"/noExist\"");
+        .statusIsError().containsOutput("ERROR", "Region not found : \"/noExist\"");
 
     locator.invoke(() -> {
       InternalConfigurationPersistenceService configurationService =

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateJndiBindingCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateJndiBindingCommandTest.java
@@ -228,7 +228,7 @@ public class CreateJndiBindingCommandTest {
         COMMAND
             + " --type=SIMPLE --name=name --jdbc-driver-class=driver --connection-url=url --datasource-config-properties={'name':'name1','type':'type1','value':'value1'}")
         .statusIsSuccess().tableHasColumnOnlyWithValues("Member", "server1")
-        .tableHasColumnOnlyWithValues("Status",
+        .tableHasColumnOnlyWithValues("Status", "OK").tableHasColumnOnlyWithValues("Message",
             "Tried creating jndi binding \"name\" on \"server1\"");
 
     ArgumentCaptor<CreateJndiBindingFunction> function =
@@ -273,7 +273,7 @@ public class CreateJndiBindingCommandTest {
         COMMAND
             + " --type=SIMPLE --name=name --jdbc-driver-class=driver --connection-url=url --datasource-config-properties={'name':'name1','type':'type1','value':'value1'}")
         .statusIsSuccess().tableHasColumnOnlyWithValues("Member", "server1")
-        .tableHasColumnOnlyWithValues("Status",
+        .tableHasColumnOnlyWithValues("Status", "OK").tableHasColumnOnlyWithValues("Message",
             "Tried creating jndi binding \"name\" on \"server1\"");
 
     verify(clusterConfigService).updateCacheConfig(any(), any());

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DestroyJndiBindingCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DestroyJndiBindingCommandTest.java
@@ -156,7 +156,8 @@ public class DestroyJndiBindingCommandTest {
 
     gfsh.executeAndAssertThat(command, COMMAND + " --name=name").statusIsSuccess()
         .tableHasColumnOnlyWithValues("Member", "server1")
-        .tableHasColumnOnlyWithValues("Status", "Jndi binding \"name\" destroyed on \"server1\"");
+        .tableHasColumnOnlyWithValues("Status", "OK")
+        .tableHasColumnOnlyWithValues("Message", "Jndi binding \"name\" destroyed on \"server1\"");
 
     verify(ccService, times(0)).updateCacheConfig(any(), any());
 
@@ -194,7 +195,8 @@ public class DestroyJndiBindingCommandTest {
 
     gfsh.executeAndAssertThat(command, COMMAND + " --name=name").statusIsSuccess()
         .tableHasColumnOnlyWithValues("Member", "server1")
-        .tableHasColumnOnlyWithValues("Status", "Jndi binding \"name\" destroyed on \"server1\"");
+        .tableHasColumnOnlyWithValues("Status", "OK")
+        .tableHasColumnOnlyWithValues("Message", "Jndi binding \"name\" destroyed on \"server1\"");
 
     assertThat(cacheConfig.getJndiBindings().isEmpty()).isTrue();
     verify(command).updateClusterConfig(eq("cluster"), eq(cacheConfig), any());

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DestroyRegionCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DestroyRegionCommandTest.java
@@ -109,11 +109,11 @@ public class DestroyRegionCommandTest {
     doReturn(Collections.singleton(DistributedMember.class)).when(command)
         .findMembersForRegion(any());
     when(result1.isSuccessful()).thenReturn(true);
-    when(result1.getStatus()).thenReturn("result1 message");
+    when(result1.getLegacyStatus()).thenReturn("result1 message");
     when(result1.getXmlEntity()).thenReturn(xmlEntity);
 
     when(result2.isSuccessful()).thenReturn(false);
-    when(result2.getStatus()).thenReturn("result2 message");
+    when(result2.getLegacyStatus()).thenReturn("result2 message");
 
     parser.executeAndAssertThat(command, "destroy region --name=test").statusIsSuccess()
         .containsOutput("result1 message").containsOutput("result2 message");
@@ -128,11 +128,11 @@ public class DestroyRegionCommandTest {
     doReturn(Collections.singleton(DistributedMember.class)).when(command)
         .findMembersForRegion(any());
     when(result1.isSuccessful()).thenReturn(true);
-    when(result1.getStatus()).thenReturn("result1 message");
+    when(result1.getLegacyStatus()).thenReturn("result1 message");
     when(result1.getXmlEntity()).thenReturn(xmlEntity);
 
     when(result2.isSuccessful()).thenReturn(false);
-    when(result2.getStatus()).thenReturn("something happened");
+    when(result2.getLegacyStatus()).thenReturn("something happened");
 
     parser.executeAndAssertThat(command, "destroy region --name=test").statusIsSuccess()
         .containsOutput("result1 message").containsOutput("something happened");
@@ -148,10 +148,10 @@ public class DestroyRegionCommandTest {
     doReturn(Collections.singleton(DistributedMember.class)).when(command)
         .findMembersForRegion(any());
     when(result1.isSuccessful()).thenReturn(false);
-    when(result1.getStatus()).thenReturn("result1 message");
+    when(result1.getLegacyStatus()).thenReturn("result1 message");
 
     when(result2.isSuccessful()).thenReturn(false);
-    when(result2.getStatus()).thenReturn("something happened");
+    when(result2.getLegacyStatus()).thenReturn("something happened");
 
     parser.executeAndAssertThat(command, "destroy region --name=test").statusIsError()
         .containsOutput("result1 message").containsOutput("something happened");

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/functions/CliFunctionResultTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/functions/CliFunctionResultTest.java
@@ -31,26 +31,26 @@ public class CliFunctionResultTest {
   @Test
   public void getStatusWithSuccessMessage() throws Exception {
     result = new CliFunctionResult("memberName", true, "message");
-    assertThat(result.getStatus()).isEqualTo("message");
+    assertThat(result.getLegacyStatus()).isEqualTo("message");
   }
 
   @Test
   public void getStatusWithErrorMessage() throws Exception {
     result = new CliFunctionResult("memberName", false, "message");
-    assertThat(result.getStatus()).isEqualTo("ERROR: message");
+    assertThat(result.getLegacyStatus()).isEqualTo("ERROR: message");
   }
 
   @Test
   public void getStatusWithExceptionOnly() throws Exception {
     result = new CliFunctionResult("memberName", new Exception("exception message"), null);
-    assertThat(result.getStatus()).isEqualTo("ERROR: java.lang.Exception: exception message");
+    assertThat(result.getLegacyStatus()).isEqualTo("ERROR: java.lang.Exception: exception message");
   }
 
   @Test
   public void getStatusWithExceptionAndSameErrorMessage() throws Exception {
     result = new CliFunctionResult("memberName", new Exception("exception message"),
         "exception message");
-    assertThat(result.getStatus()).isEqualTo("ERROR: java.lang.Exception: exception message");
+    assertThat(result.getLegacyStatus()).isEqualTo("ERROR: java.lang.Exception: exception message");
 
   }
 
@@ -58,7 +58,7 @@ public class CliFunctionResultTest {
   public void getStatusWithExceptionAndDifferentErrorMessage() throws Exception {
     result = new CliFunctionResult("memberName", new Exception("exception message"),
         "some other message");
-    assertThat(result.getStatus())
+    assertThat(result.getLegacyStatus())
         .isEqualTo("ERROR: some other message java.lang.Exception: exception message");
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/functions/GatewayReceiverCreateFunctionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/functions/GatewayReceiverCreateFunctionTest.java
@@ -67,6 +67,6 @@ public class GatewayReceiverCreateFunctionTest {
 
     CliFunctionResult result = (CliFunctionResult) resultObject.getValue();
 
-    assertThat(result.getStatus()).contains("5555");
+    assertThat(result.getStatusMessage()).contains("5555");
   }
 }

--- a/geode-core/src/test/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
+++ b/geode-core/src/test/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
@@ -2064,10 +2064,12 @@ org/apache/geode/management/internal/cli/domain/DataCommandResult$KeyInfo,2
 fromData,41
 toData,41
 
-org/apache/geode/management/internal/cli/functions/CliFunctionResult,4
-fromData,58
+org/apache/geode/management/internal/cli/functions/CliFunctionResult,6
+fromData,14
+fromDataPre_GEODE_1_6_0_0,58
 fromDataPre_GFE_8_0_0_0,31
-toData,49
+toData,14
+toDataPre_GEODE_1_6_0_0,49
 toDataPre_GFE_8_0_0_0,25
 
 org/apache/geode/management/internal/configuration/domain/Configuration,2

--- a/geode-core/src/test/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
+++ b/geode-core/src/test/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
@@ -2065,8 +2065,8 @@ fromData,41
 toData,41
 
 org/apache/geode/management/internal/cli/functions/CliFunctionResult,6
-fromData,14
-fromDataPre_GEODE_1_6_0_0,58
+fromData,19
+fromDataPre_GEODE_1_6_0_0,70
 fromDataPre_GFE_8_0_0_0,31
 toData,14
 toDataPre_GEODE_1_6_0_0,49


### PR DESCRIPTION
- The intention of this is to avoid needing to pass 'skip-if-exists' or
  'if-not-exists' flags to any command function. The function should set this
  flag if it determines that the construct it is dealing with either already
  exists or does not exist depending on the action. The calling command will
  then be able to use this information to display and set status appropriately.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
