### PR TITLE
GEODE-5208 remove test hooks from TypeRegistration

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/pdx/internal/ClientTypeRegistration.java
+++ b/geode-core/src/main/java/org/apache/geode/pdx/internal/ClientTypeRegistration.java
@@ -266,9 +266,6 @@ public class ClientTypeRegistration implements TypeRegistration {
   }
 
   @Override
-  public void testClearRegistry() {}
-
-  @Override
   public boolean isClient() {
     return true;
   }

--- a/geode-core/src/main/java/org/apache/geode/pdx/internal/LonerTypeRegistration.java
+++ b/geode-core/src/main/java/org/apache/geode/pdx/internal/LonerTypeRegistration.java
@@ -34,35 +34,36 @@ public class LonerTypeRegistration implements TypeRegistration {
     this.cache = cache;
   }
 
+  @Override
   public int defineType(PdxType newType) {
     initializeRegistry();
     return delegate.defineType(newType);
   }
 
+  @Override
   public PdxType getType(int typeId) {
     initializeRegistry();
     return delegate.getType(typeId);
   }
 
+  @Override
   public void addRemoteType(int typeId, PdxType type) {
     initializeRegistry();
     delegate.addRemoteType(typeId, type);
   }
 
-  public int getLastAllocatedTypeId() {
-    initializeRegistry();
-    return delegate.getLastAllocatedTypeId();
-  }
-
+  @Override
   public void initialize() {
     // do nothing. This type registry is initialized lazily.
   }
 
+  @Override
   public void gatewaySenderStarted(GatewaySender gatewaySender) {
     initializeRegistry(false);
     delegate.gatewaySenderStarted(gatewaySender);
   }
 
+  @Override
   public void creatingPersistentRegion() {
     if (delegate != null) {
       delegate.creatingPersistentRegion();
@@ -70,6 +71,7 @@ public class LonerTypeRegistration implements TypeRegistration {
 
   }
 
+  @Override
   public void creatingPool() {
     initializeRegistry(true);
     delegate.creatingPool();
@@ -104,7 +106,7 @@ public class LonerTypeRegistration implements TypeRegistration {
    *
    * @return true if this member is a loner and we can't determine what type of registry they want.
    */
-  public static boolean isIndeterminateLoner(InternalCache cache) {
+  static boolean isIndeterminateLoner(InternalCache cache) {
     boolean isLoner = cache.getInternalDistributedSystem().isLoner();
     boolean pdxConfigured = cache.getPdxPersistent();
     return isLoner && !pdxConfigured/* && !hasGateways */;
@@ -151,9 +153,6 @@ public class LonerTypeRegistration implements TypeRegistration {
   public Set<PdxType> getPdxTypesForClassName(String className) {
     return delegate.getPdxTypesForClassName(className);
   }
-
-  @Override
-  public void testClearRegistry() {}
 
   @Override
   public boolean isClient() {

--- a/geode-core/src/main/java/org/apache/geode/pdx/internal/NullTypeRegistration.java
+++ b/geode-core/src/main/java/org/apache/geode/pdx/internal/NullTypeRegistration.java
@@ -27,50 +27,57 @@ import org.apache.geode.pdx.PdxInitializationException;
  */
 public class NullTypeRegistration implements TypeRegistration {
 
+  @Override
   public int defineType(PdxType newType) {
     throw new PdxInitializationException("Trying to use PDX type, but type registry is disabled");
   }
 
+  @Override
   public PdxType getType(int typeId) {
     throw new PdxInitializationException("Trying to use PDX type, but type registry is disabled");
   }
 
+  @Override
   public void addRemoteType(int typeId, PdxType type) {
     throw new PdxInitializationException("Trying to use PDX type, but type registry is disabled");
   }
 
-  public int getLastAllocatedTypeId() {
-    throw new PdxInitializationException("Trying to use PDX type, but type registry is disabled");
-  }
-
+  @Override
   public void initialize() {
     // do nothing
   }
 
+  @Override
   public void gatewaySenderStarted(GatewaySender gatewaySender) {
     // do nothing
   }
 
+  @Override
   public void creatingPersistentRegion() {
     // do nothing
   }
 
+  @Override
   public void creatingPool() {
     // do nothing
   }
 
+  @Override
   public int getEnumId(Enum<?> v) {
     throw new PdxInitializationException("Trying to use PDX type, but type registry is disabled");
   }
 
+  @Override
   public void addRemoteEnum(int enumId, EnumInfo newInfo) {
     throw new PdxInitializationException("Trying to use PDX type, but type registry is disabled");
   }
 
+  @Override
   public int defineEnum(EnumInfo newInfo) {
     throw new PdxInitializationException("Trying to use PDX type, but type registry is disabled");
   }
 
+  @Override
   public EnumInfo getEnumById(int enumId) {
     throw new PdxInitializationException("Trying to use PDX type, but type registry is disabled");
   }
@@ -93,11 +100,6 @@ public class NullTypeRegistration implements TypeRegistration {
   @Override
   public Set<PdxType> getPdxTypesForClassName(String className) {
     return Collections.emptySet();
-  }
-
-  @Override
-  public void testClearRegistry() {
-
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/pdx/internal/PeerTypeRegistration.java
+++ b/geode-core/src/main/java/org/apache/geode/pdx/internal/PeerTypeRegistration.java
@@ -26,7 +26,6 @@ import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.InternalGemFireError;
 import org.apache.geode.InternalGemFireException;
-import org.apache.geode.annotations.TestingOnly;
 import org.apache.geode.cache.AttributesFactory;
 import org.apache.geode.cache.CacheWriterException;
 import org.apache.geode.cache.DataPolicy;
@@ -755,14 +754,6 @@ public class PeerTypeRegistration implements TypeRegistration {
     } else {
       return pdxTypeSet.getSnapshot();
     }
-  }
-
-  /**
-   * For testing only.
-   */
-  @TestingOnly
-  public Map<String, CopyOnWriteHashSet<PdxType>> getClassToType() {
-    return classToType;
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/pdx/internal/PeerTypeRegistration.java
+++ b/geode-core/src/main/java/org/apache/geode/pdx/internal/PeerTypeRegistration.java
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.InternalGemFireError;
 import org.apache.geode.InternalGemFireException;
+import org.apache.geode.annotations.TestingOnly;
 import org.apache.geode.cache.AttributesFactory;
 import org.apache.geode.cache.CacheWriterException;
 import org.apache.geode.cache.DataPolicy;
@@ -66,11 +67,7 @@ public class PeerTypeRegistration implements TypeRegistration {
 
   public static final String LOCK_SERVICE_NAME = "__PDX";
 
-  /**
-   * The region name. Public for tests only.
-   */
   public static final String REGION_NAME = "PdxTypes";
-
   public static final String REGION_FULL_PATH = "/" + REGION_NAME;
   public static final int PLACE_HOLDER_FOR_TYPE_ID = 0xFFFFFF;
   public static final int PLACE_HOLDER_FOR_DS_ID = 0xFF000000;
@@ -697,7 +694,7 @@ public class PeerTypeRegistration implements TypeRegistration {
   @Override
   public Map<Integer, PdxType> types() {
     // ugh, I don't think we can rely on the local map to contain all types
-    Map<Integer, PdxType> types = new HashMap<Integer, PdxType>();
+    Map<Integer, PdxType> types = new HashMap<>();
     for (Entry<Object, Object> type : getIdToType().entrySet()) {
       Object id = type.getKey();
       if (type.getValue() instanceof PdxType) {
@@ -761,9 +758,9 @@ public class PeerTypeRegistration implements TypeRegistration {
   }
 
   /**
-   * For testing purpose
+   * For testing only.
    */
-  @Deprecated
+  @TestingOnly
   public Map<String, CopyOnWriteHashSet<PdxType>> getClassToType() {
     return classToType;
   }

--- a/geode-core/src/main/java/org/apache/geode/pdx/internal/PeerTypeRegistration.java
+++ b/geode-core/src/main/java/org/apache/geode/pdx/internal/PeerTypeRegistration.java
@@ -342,29 +342,6 @@ public class PeerTypeRegistration implements TypeRegistration {
     }
   }
 
-  private int lastAllocatedTypeId; // for unit tests
-  private int lastAllocatedEnumId; // for unit tests
-
-  /**
-   * Test hook that returns the most recently allocated type id
-   *
-   * @return the most recently allocated type id
-   */
-  public int getLastAllocatedTypeId() {
-    verifyConfiguration();
-    return this.lastAllocatedTypeId;
-  }
-
-  /**
-   * Test hook that returns the most recently allocated enum id
-   *
-   * @return the most recently allocated enum id
-   */
-  public int getLastAllocatedEnumId() {
-    verifyConfiguration();
-    return this.lastAllocatedEnumId;
-  }
-
   public int defineType(PdxType newType) {
     verifyConfiguration();
     Integer existingId = typeToId.get(newType);
@@ -786,18 +763,9 @@ public class PeerTypeRegistration implements TypeRegistration {
   /**
    * For testing purpose
    */
+  @Deprecated
   public Map<String, CopyOnWriteHashSet<PdxType>> getClassToType() {
     return classToType;
-  }
-
-  /**
-   * test hook
-   */
-  @Override
-  public void testClearRegistry() {
-    idToType.clear();
-    enumToId.clear();
-    typeToId.clear();
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/pdx/internal/TypeRegistration.java
+++ b/geode-core/src/main/java/org/apache/geode/pdx/internal/TypeRegistration.java
@@ -42,11 +42,6 @@ public interface TypeRegistration {
 
   void addImportedType(int typeId, PdxType importedType);
 
-  /**
-   * Test hook to get the last allocated type id
-   */
-  int getLastAllocatedTypeId();
-
   void initialize();
 
   void gatewaySenderStarted(GatewaySender gatewaySender);
@@ -91,11 +86,6 @@ public interface TypeRegistration {
    * An empty set will be returned if no types exist.
    */
   Set<PdxType> getPdxTypesForClassName(String className);
-
-  /*
-   * test hook
-   */
-  void testClearRegistry();
 
   boolean isClient();
 

--- a/geode-core/src/main/java/org/apache/geode/pdx/internal/TypeRegistry.java
+++ b/geode-core/src/main/java/org/apache/geode/pdx/internal/TypeRegistry.java
@@ -83,17 +83,6 @@ public class TypeRegistry {
     }
   }
 
-  /*
-   * Test Hook to clear the type registry
-   */
-  public void testClearTypeRegistry() {
-    this.typeToId.clear();
-    this.idToType.clear();
-    this.idToEnum.clear();
-    this.enumInfoToId.clear();
-    this.distributedTypeRegistry.testClearRegistry();
-  }
-
   public void testClearLocalTypeRegistry() {
     this.localTypeIds.clear();
     this.localTypeIdMaps.clear();
@@ -250,17 +239,6 @@ public class TypeRegistry {
     }
 
     return newType;
-  }
-
-  /**
-   * Test hook that returns the most recently allocated type id
-   *
-   * Note that this method will not work on clients.
-   *
-   * @return the most recently allocated type id
-   */
-  public int getLastAllocatedTypeId() {
-    return this.distributedTypeRegistry.getLastAllocatedTypeId();
   }
 
   public TypeRegistration getTypeRegistration() {
@@ -536,7 +514,7 @@ public class TypeRegistry {
   /**
    * Get the size of the the type registry in this local member
    */
-  public int getLocalSize() {
+  int getLocalSize() {
     int result = this.distributedTypeRegistry.getLocalSize();
     if (result == 0) {
       // If this is the client, go ahead and return the number of cached types we have

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/gms/MembershipManagerHelper.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/gms/MembershipManagerHelper.java
@@ -19,7 +19,6 @@ import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.distributed.internal.ClusterDistributionManager;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
-import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.distributed.internal.membership.MembershipManager;
 import org.apache.geode.distributed.internal.membership.gms.interfaces.Manager;
 import org.apache.geode.distributed.internal.membership.gms.mgr.GMSMembershipManager;
@@ -37,8 +36,7 @@ public class MembershipManagerHelper {
   public static MembershipManager getMembershipManager(DistributedSystem sys) {
     InternalDistributedSystem isys = (InternalDistributedSystem) sys;
     ClusterDistributionManager dm = (ClusterDistributionManager) isys.getDM();
-    MembershipManager mgr = dm.getMembershipManager();
-    return mgr;
+    return dm.getMembershipManager();
   }
 
   /**
@@ -64,10 +62,6 @@ public class MembershipManagerHelper {
     }
   }
 
-  public static void beHealthyMember(DistributedSystem sys) {
-    ((Manager) getMembershipManager(sys)).beHealthy();
-  }
-
   /** returns the current coordinator address */
   public static DistributedMember getCoordinator(DistributedSystem sys) {
     return ((Manager) getMembershipManager(sys)).getCoordinator();
@@ -88,25 +82,6 @@ public class MembershipManagerHelper {
   public static void removeTestHook(DistributedSystem sys,
       org.apache.geode.distributed.internal.membership.MembershipTestHook hook) {
     getMembershipManager(sys).unregisterTestHook(hook);
-  }
-
-  // /**
-  // * returns the view lock. Holding this lock will prevent the processing
-  // * of new views, and will prevent other threads from being able to access
-  // * the view
-  // */
-  // public static Object getViewLock(DistributedSystem sys) {
-  // return getMembershipManager(sys).latestViewLock;
-  // }
-
-  /** returns true if the given member is shunned */
-  public static boolean isShunned(DistributedSystem sys, DistributedMember mbr) {
-    return ((Manager) getMembershipManager(sys)).isShunned(mbr);
-  }
-
-  /** returns true if the given member is a surprise member */
-  public static boolean isSurpriseMember(DistributedSystem sys, DistributedMember mbr) {
-    return getMembershipManager(sys).isSurpriseMember(mbr);
   }
 
   /**
@@ -133,13 +108,11 @@ public class MembershipManagerHelper {
       final DistributedMember member, final long timeout) {
     WaitCriterion ev = new WaitCriterion() {
       public boolean done() {
-        return !getMembershipManager(sys).getView().contains((InternalDistributedMember) member);
+        return !getMembershipManager(sys).getView().contains(member);
       }
 
       public String description() {
-        String assMsg =
-            "Waited over " + timeout + " ms for " + member + " to depart, but it didn't";
-        return assMsg;
+        return "Waited over " + timeout + " ms for " + member + " to depart, but it didn't";
       }
     };
     Wait.waitForCriterion(ev, timeout, 200, true);

--- a/geode-core/src/test/java/org/apache/geode/pdx/PdxSerializableJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/pdx/PdxSerializableJUnitTest.java
@@ -87,10 +87,6 @@ public class PdxSerializableJUnitTest {
     this.cache.close();
   }
 
-  private int getLastPdxTypeId() {
-    return this.cache.getPdxRegistry().getLastAllocatedTypeId();
-  }
-
   private int getPdxTypeIdForClass(Class c) {
     // here we are assuming Dsid == 0
     return this.cache.getPdxRegistry().getExistingTypeForClass(c).hashCode()


### PR DESCRIPTION
* Add @Deprecated to a test hook in the hope that others won't accidentally use it.
* delete some comments and make some methods less public

It would nice to get a second pair of eyes to approve the last commit, which changes a test in a way that should be safe.