### PR TITLE
GEODE-5055: Handle index in progress for old clients

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/PartitionedRegionFunctionResultSender.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/PartitionedRegionFunctionResultSender.java
@@ -24,6 +24,7 @@ import org.apache.geode.cache.execute.FunctionException;
 import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.internal.DistributionManager;
+import org.apache.geode.internal.Version;
 import org.apache.geode.internal.cache.ForceReattemptException;
 import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.internal.cache.partitioned.PartitionedRegionFunctionStreamingMessage;
@@ -73,6 +74,14 @@ public class PartitionedRegionFunctionResultSender implements InternalResultSend
   private Set<Integer> bucketSet;
 
   private BucketMovedException bme;
+
+
+  public Version getClientVersion() {
+    if (serverSender != null && serverSender.sc != null) { // is a client-server connection
+      return serverSender.sc.getClientVersion();
+    }
+    return null;
+  }
 
   /**
    * Have to combine next two constructor in one and make a new class which will send Results back.

--- a/geode-core/src/main/java/org/apache/geode/internal/i18n/LocalizedStrings.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/i18n/LocalizedStrings.java
@@ -7736,6 +7736,12 @@ public class LocalizedStrings {
 
   public static final StringId LuceneIndexCreation_INDEX_WAS_DESTROYED_WHILE_BEING_CREATED =
       new StringId(6675, "Lucene index {0} on region {1} was destroyed while being created");
+
+  public static final StringId LuceneIndexingInProgress_CANNOT_BE_DETERMINED_BECAUSE_OF_VERSION_MISMATCH =
+      new StringId(6676,
+          "Lucene indexing in progress status cannot be determined if all members hosting the user data region : {0}, are not above Apache Geode 1.6.0 version ");
+  public static final StringId LuceneQueryException_INDEX_NOT_AVAILABLE_CURRENTLY_INDEXING =
+      new StringId(6677, "Lucene Index is not available, currently indexing");
   /** Testing strings, messageId 90000-99999 **/
 
   /**

--- a/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneQueriesDUnitTest.java
+++ b/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneQueriesDUnitTest.java
@@ -23,11 +23,13 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.TermQuery;
+import org.awaitility.Awaitility;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -96,6 +98,20 @@ public class LuceneQueriesDUnitTest extends LuceneQueriesAccessorBase {
         cache.getCacheTransactionManager().rollback();
       }
     });
+  }
+
+  @Test
+  @Parameters(method = "getListOfRegionTestTypes")
+  public void afterLuceneIndexAndRegionIsCreatedShouldBeAbleToGetIndexingStatus(
+      RegionTestableType regionTestType) throws Exception {
+    createRegionAndIndexForAllDataStores(regionTestType, createIndex);
+    putDataInRegion(accessor);
+    assertTrue(waitForFlushBeforeExecuteTextSearch(accessor, 60000));
+    assertTrue(waitForFlushBeforeExecuteTextSearch(dataStore1, 60000));
+    accessor.invoke(() -> Awaitility.await().atMost(30, TimeUnit.SECONDS).until(() -> assertFalse(
+        LuceneServiceProvider.get(getCache()).isIndexingInProgress(INDEX_NAME, REGION_NAME))));
+    executeTextSearch(accessor);
+
   }
 
   @Test

--- a/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneQueriesReindexDUnitTest.java
+++ b/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneQueriesReindexDUnitTest.java
@@ -14,13 +14,18 @@
  */
 package org.apache.geode.cache.lucene;
 
+import static org.apache.geode.cache.lucene.LuceneDUnitTest.RegionTestableType.PARTITION_WITH_CLIENT;
 import static org.apache.geode.cache.lucene.test.LuceneTestUtilities.INDEX_NAME;
 import static org.apache.geode.cache.lucene.test.LuceneTestUtilities.REGION_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.TimeUnit;
 
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
+import org.awaitility.Awaitility;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -94,6 +99,54 @@ public class LuceneQueriesReindexDUnitTest extends LuceneQueriesAccessorBase {
     waitForFlushBeforeExecuteTextSearch(accessor, 60000);
     executeTextSearch(accessor);
   }
+
+  @Test
+  @Parameters(method = "getListOfRegionTestTypes")
+  public void afterReindexingWeShouldBeAbleToGetTheStatusOfIndexingProgress(
+      RegionTestableType regionTestType) throws Exception {
+    dataStore1.invoke(() -> {
+      regionTestType.createDataStore(getCache(), REGION_NAME);
+    });
+    dataStore2.invoke(() -> {
+      regionTestType.createDataStore(getCache(), REGION_NAME);
+    });
+    accessor.invoke(() -> {
+      regionTestType.createAccessor(getCache(), REGION_NAME);
+    });
+
+    putDataInRegion(accessor);
+
+    // re-index stored data
+    AsyncInvocation ai1 = dataStore1.invokeAsync(() -> {
+      createIndex("text");
+    });
+
+    AsyncInvocation ai2 = dataStore2.invokeAsync(() -> {
+      createIndex("text");
+    });
+
+    AsyncInvocation ai3 = accessor.invokeAsync(() -> {
+      if (regionTestType != PARTITION_WITH_CLIENT) {
+        createIndex("text");
+      }
+    });
+
+    ai1.join();
+    ai2.join();
+    ai3.join();
+
+    ai1.checkException();
+    ai2.checkException();
+    ai3.checkException();
+
+    waitForFlushBeforeExecuteTextSearch(accessor, 60000);
+
+    accessor.invoke(() -> Awaitility.await().atMost(30, TimeUnit.SECONDS).until(() -> assertFalse(
+        LuceneServiceProvider.get(getCache()).isIndexingInProgress(INDEX_NAME, REGION_NAME))));
+    executeTextSearch(accessor);
+  }
+
+
 
   @Test
   @Parameters(method = "getListOfRegionTestTypes")

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/LuceneService.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/LuceneService.java
@@ -23,6 +23,7 @@ import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.DataPolicy;
 import org.apache.geode.cache.GemFireCache;
+import org.apache.geode.cache.lucene.internal.LuceneIndexCreationInProgressException;
 
 /**
  *
@@ -172,4 +173,19 @@ public interface LuceneService {
    */
   boolean waitUntilFlushed(String indexName, String regionPath, long timeout, TimeUnit unit)
       throws InterruptedException;
+
+  /**
+   * Returns if the indexing process is in progress
+   *
+   * Before executing a lucene query, it can be checked if the indexing operation is in progress.
+   * Queries executed during the indexing process will get a
+   * {@link LuceneIndexCreationInProgressException}
+   *
+   * @param indexName index name
+   *
+   * @param regionPath region name
+   *
+   * @return true if the indexing operation is in progress otherwise false.
+   */
+  boolean isIndexingInProgress(String indexName, String regionPath);
 }

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneQueryImpl.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneQueryImpl.java
@@ -122,7 +122,7 @@ public class LuceneQueryImpl<K, V> implements LuceneQuery<K, V> {
       entries = rc.getResult();
     } catch (FunctionException e) {
       if (e.getCause() instanceof LuceneQueryException) {
-        throw new LuceneQueryException(e);
+        throw (LuceneQueryException) e.getCause();
       } else if (e.getCause() instanceof TransactionException) {
         // When run from client with single hop disabled
         throw new LuceneQueryException(LUCENE_QUERY_CANNOT_BE_EXECUTED_WITHIN_A_TRANSACTION);
@@ -133,8 +133,6 @@ public class LuceneQueryImpl<K, V> implements LuceneQuery<K, V> {
     } catch (TransactionException e) {
       // When function execution is run from server
       throw new LuceneQueryException(LUCENE_QUERY_CANNOT_BE_EXECUTED_WITHIN_A_TRANSACTION);
-    } catch (LuceneIndexCreationInProgressException e) {
-      throw new LuceneQueryException("Lucene Index is not available, currently indexing");
     }
 
     return entries;

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/distributed/IndexingInProgressFunction.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/distributed/IndexingInProgressFunction.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache.lucene.internal.distributed;
+
+
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.execute.FunctionContext;
+import org.apache.geode.cache.execute.RegionFunctionContext;
+import org.apache.geode.cache.execute.ResultSender;
+import org.apache.geode.cache.lucene.LuceneIndex;
+import org.apache.geode.cache.lucene.LuceneService;
+import org.apache.geode.cache.lucene.LuceneServiceProvider;
+import org.apache.geode.internal.cache.execute.InternalFunction;
+
+public class IndexingInProgressFunction implements InternalFunction<Object> {
+
+  private static final long serialVersionUID = 1L;
+  public static final String ID = IndexingInProgressFunction.class.getName();
+
+  @Override
+  public void execute(FunctionContext<Object> context) {
+    RegionFunctionContext ctx = (RegionFunctionContext) context;
+    ResultSender<Boolean> resultSender = ctx.getResultSender();
+
+    Region region = ctx.getDataSet();
+    Cache cache = region.getCache();
+    String indexName = (String) ctx.getArguments();
+    if (indexName == null) {
+      throw new IllegalArgumentException("Missing index name");
+    }
+    LuceneService luceneService = LuceneServiceProvider.get(cache);
+    LuceneIndex luceneIndex = luceneService.getIndex(indexName, region.getFullPath());
+    if (luceneIndex == null) {
+      resultSender.lastResult(false);
+    } else {
+      resultSender.lastResult(luceneIndex.isIndexingInProgress());
+    }
+
+  }
+
+  @Override
+  public String getId() {
+    return ID;
+  }
+
+  @Override
+  public boolean optimizeForWrite() {
+    return true;
+  }
+}

--- a/geode-lucene/src/main/resources/org/apache/geode/internal/sanctioned-geode-lucene-serializables.txt
+++ b/geode-lucene/src/main/resources/org/apache/geode/internal/sanctioned-geode-lucene-serializables.txt
@@ -2,11 +2,12 @@ org/apache/geode/cache/lucene/LuceneIndexDestroyedException,false,indexName:java
 org/apache/geode/cache/lucene/LuceneIndexExistsException,false,indexName:java/lang/String,regionPath:java/lang/String
 org/apache/geode/cache/lucene/LuceneIndexNotFoundException,false,indexName:java/lang/String,regionPath:java/lang/String
 org/apache/geode/cache/lucene/LuceneQueryException,false
-org/apache/geode/cache/lucene/internal/cli/LuceneIndexStatus,false
+org/apache/geode/cache/lucene/internal/LuceneIndexCreationInProgressException,false
 org/apache/geode/cache/lucene/internal/cli/LuceneDestroyIndexInfo,false,definedDestroyOnly:boolean
 org/apache/geode/cache/lucene/internal/cli/LuceneFunctionSerializable,false,indexName:java/lang/String,regionPath:java/lang/String
 org/apache/geode/cache/lucene/internal/cli/LuceneIndexDetails,true,1,fieldAnalyzers:java/util/Map,indexStats:java/util/Map,searchableFieldNames:java/lang/String[],serializer:java/lang/String,serverName:java/lang/String,status:org/apache/geode/cache/lucene/internal/cli/LuceneIndexStatus
 org/apache/geode/cache/lucene/internal/cli/LuceneIndexInfo,true,1,fieldAnalyzers:java/lang/String[],searchableFieldNames:java/lang/String[],serializer:java/lang/String
+org/apache/geode/cache/lucene/internal/cli/LuceneIndexStatus,false
 org/apache/geode/cache/lucene/internal/cli/LuceneQueryInfo,true,1,defaultField:java/lang/String,keysOnly:boolean,limit:int,queryString:java/lang/String
 org/apache/geode/cache/lucene/internal/cli/LuceneSearchResults,false,exceptionFlag:boolean,exceptionMessage:java/lang/String,key:java/lang/String,score:float,value:java/lang/String
 org/apache/geode/cache/lucene/internal/cli/functions/LuceneCreateIndexFunction,true,3061443846664615818
@@ -15,7 +16,7 @@ org/apache/geode/cache/lucene/internal/cli/functions/LuceneDestroyIndexFunction,
 org/apache/geode/cache/lucene/internal/cli/functions/LuceneListIndexFunction,true,-2320432506763893879
 org/apache/geode/cache/lucene/internal/cli/functions/LuceneSearchIndexFunction,true,163818919780803222
 org/apache/geode/cache/lucene/internal/directory/DumpDirectoryFiles,true,1
+org/apache/geode/cache/lucene/internal/distributed/IndexingInProgressFunction,true,1
 org/apache/geode/cache/lucene/internal/distributed/LuceneQueryFunction,true,1
 org/apache/geode/cache/lucene/internal/distributed/WaitUntilFlushedFunction,true,1
 org/apache/geode/cache/lucene/internal/results/LuceneGetPageFunction,true,1
-org/apache/geode/cache/lucene/internal/LuceneIndexCreationInProgressException,false


### PR DESCRIPTION
            * If the Lucene query function is executed by an old client (<=1.6.0) on a new server, it will wait for the index to be created.
            * Server wont return a LuceneIndexCreationInProgressException back to the old client resulting in a ClassNotFoundException.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
