### PR TITLE
GEODE-5220: Validate Region Attributes Earlier

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/wan/GatewaySender.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/wan/GatewaySender.java
@@ -413,6 +413,4 @@ public interface GatewaySender {
    *
    */
   void destroy();
-
-
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
@@ -3082,6 +3082,7 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
       boolean success = false;
       try {
         setRegionByPath(region.getFullPath(), region);
+        region.preInitialize();
         region.initialize(snapshotInputStream, imageTarget, internalRegionArgs);
         success = true;
       } catch (CancelException | RedundancyAlreadyMetException e) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalRegion.java
@@ -217,6 +217,14 @@ public interface InternalRegion extends Region, HasCachePerfStats, RegionEntryCo
 
   void handleCacheClose(Operation op);
 
+  /**
+   * Execute any validation required prior to initializing the region.
+   * This method should throw an exception whenever an invalid configuration is detected.
+   */
+  default void preInitialize() {
+    // Do nothing by default.
+  }
+
   void initialize(InputStream snapshotInputStream, InternalDistributedMember imageTarget,
       InternalRegionArguments internalRegionArgs)
       throws TimeoutException, IOException, ClassNotFoundException;

--- a/geode-test/src/main/java/org/apache/geode/test/dunit/rules/MemberVM.java
+++ b/geode-test/src/main/java/org/apache/geode/test/dunit/rules/MemberVM.java
@@ -12,7 +12,6 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package org.apache.geode.test.dunit.rules;
 
 import java.io.File;
@@ -110,7 +109,7 @@ public class MemberVM extends VMProvider implements Member {
         .waitTillAsyncEventQueuesAreReadyOnServers(queueId, serverCount));
   }
 
-  public void waitTilGatewaySendersAreReady(int expectedGatewayObjectCount) throws Exception {
+  public void waitTilGatewaySendersAreReady(int expectedGatewayObjectCount) {
     vm.invoke(() -> ClusterStartupRule.memberStarter
         .waitTilGatewaySendersAreReady(expectedGatewayObjectCount));
   }

--- a/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/misc/WANConfigurationJUnitTest.java
+++ b/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/misc/WANConfigurationJUnitTest.java
@@ -15,6 +15,7 @@
 package org.apache.geode.internal.cache.wan.misc;
 
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -24,7 +25,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.junit.After;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -49,6 +49,7 @@ import org.apache.geode.cache30.MyGatewayTransportFilter2;
 import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.internal.cache.LocalRegion;
 import org.apache.geode.internal.cache.wan.GatewayReceiverException;
+import org.apache.geode.internal.cache.wan.GatewaySenderConfigurationException;
 import org.apache.geode.internal.cache.wan.GatewaySenderException;
 import org.apache.geode.internal.cache.wan.InternalGatewaySenderFactory;
 import org.apache.geode.internal.cache.wan.MyGatewaySenderEventListener;
@@ -155,7 +156,6 @@ public class WANConfigurationJUnitTest {
    * distribution policy
    *
    */
-  @Ignore("Bug51491")
   @Test
   public void test_GatewaySender_Parallel_DistributedRegion() {
     cache = new CacheFactory().set(MCAST_PORT, "0").create();
@@ -167,12 +167,11 @@ public class WANConfigurationJUnitTest {
     factory.addGatewaySenderId(sender1.getId());
     factory.setScope(Scope.DISTRIBUTED_ACK);
     factory.setDataPolicy(DataPolicy.REPLICATE);
-    try {
-      RegionFactory regionFactory = cache.createRegionFactory(factory.create());
-      Region region = regionFactory.create("test_GatewaySender_Parallel_DistributedRegion");
-    } catch (Exception e) {
-      fail("Unexpected Exception :" + e);
-    }
+    RegionFactory regionFactory = cache.createRegionFactory(factory.create());
+
+    assertThatThrownBy(() -> regionFactory.create("test_GatewaySender_Parallel_DistributedRegion"))
+        .isInstanceOf(GatewaySenderConfigurationException.class).hasMessage(
+            "Parallel gateway sender NYSender can not be used with replicated region /test_GatewaySender_Parallel_DistributedRegion");
   }
 
   @Test

--- a/geode-wan/src/test/java/org/apache/geode/management/internal/cli/commands/CreateRegionCommandDUnitTest.java
+++ b/geode-wan/src/test/java/org/apache/geode/management/internal/cli/commands/CreateRegionCommandDUnitTest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.management.internal.cli.commands;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TestName;
+
+import org.apache.geode.test.dunit.IgnoredException;
+import org.apache.geode.test.dunit.rules.ClusterStartupRule;
+import org.apache.geode.test.dunit.rules.MemberVM;
+import org.apache.geode.test.junit.categories.DistributedTest;
+import org.apache.geode.test.junit.categories.WanTest;
+import org.apache.geode.test.junit.rules.GfshCommandRule;
+import org.apache.geode.test.junit.rules.serializable.SerializableTestName;
+
+@Category({DistributedTest.class, WanTest.class})
+public class CreateRegionCommandDUnitTest {
+  private static MemberVM locator, server1, server2;
+
+  @ClassRule
+  public static ClusterStartupRule lsRule = new ClusterStartupRule();
+
+  @ClassRule
+  public static GfshCommandRule gfsh = new GfshCommandRule();
+
+  @Rule
+  public TestName testName = new SerializableTestName();
+
+  @BeforeClass
+  public static void before() throws Exception {
+    locator = lsRule.startLocatorVM(0);
+    server1 = lsRule.startServerVM(1, locator.getPort());
+    server2 = lsRule.startServerVM(2, locator.getPort());
+
+    gfsh.connectAndVerify(locator);
+  }
+
+  @Test
+  public void createReplicatedRegionWithParallelAsynchronousEventQueueShouldThrowExceptionAndPreventTheRegionFromBeingCreated() {
+    String regionName = testName.getMethodName();
+    String asyncQueueName = "asyncEventQueue";
+
+    gfsh.executeAndAssertThat(
+        "create async-event-queue --parallel=true --listener=org.apache.geode.internal.cache.wan.MyAsyncEventListener --id="
+            + asyncQueueName)
+        .statusIsSuccess();
+    locator.waitTillAsyncEventQueuesAreReadyOnServers(asyncQueueName, 2);
+
+    gfsh.executeAndAssertThat("create region --type=REPLICATE  --name=" + regionName
+        + " --async-event-queue-id=" + asyncQueueName)
+        .statusIsError()
+        .containsOutput("server-1",
+            "ERROR: Parallel Async Event Queue " + asyncQueueName
+                + " can not be used with replicated region /" + regionName)
+        .containsOutput("server-2", "ERROR: Parallel Async Event Queue " + asyncQueueName
+            + " can not be used with replicated region /" + regionName);
+
+    // The exception must be thrown early in the initialization, so the region itself shouldn't be
+    // added to the root regions.
+    gfsh.executeAndAssertThat("list regions").statusIsSuccess().doesNotContainOutput(regionName);
+  }
+
+  @Test
+  public void createReplicatedRegionWithParallelGatewaySenderShouldThrowExceptionAndPreventTheRegionFromBeingCreated() {
+    String regionName = testName.getMethodName();
+    String gatewaySenderName = "gatewaySender";
+    IgnoredException.addIgnoredException("could not get remote locator information");
+
+    gfsh.executeAndAssertThat(
+        "create gateway-sender --parallel=true --remote-distributed-system-id=2 --id="
+            + gatewaySenderName)
+        .statusIsSuccess();
+    locator.waitTilGatewaySendersAreReady(1);
+
+    gfsh.executeAndAssertThat("create region --type=REPLICATE  --name=" + regionName
+        + " --gateway-sender-id=" + gatewaySenderName)
+        .statusIsError()
+        .containsOutput("server-1",
+            "ERROR: Parallel gateway sender " + gatewaySenderName
+                + " can not be used with replicated region /" + regionName)
+        .containsOutput("server-2", "ERROR: Parallel gateway sender " + gatewaySenderName
+            + " can not be used with replicated region /" + regionName);
+
+    // The exception must be thrown early in the initialization, so the region itself shouldn't be
+    // added to the root regions.
+    gfsh.executeAndAssertThat("list regions").statusIsSuccess().doesNotContainOutput(regionName);
+  }
+}


### PR DESCRIPTION
- Added unit and distribution tests.
- Squashed all changes derived from reviews.
- Removed references to old bug tracking system.
- Removed unused `throws Exception` clause from `MemberVM.waitTilGatewaySendersAreReady()`.
- `DistributedRegion` creation fails ealier whenever the associated `async-event-queue` / `gateway-sender` is configured as `parallel`.
- Added `InternalRegion.preInitialize` method to execute validation before initializing the region, empty implementation by default.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
