### PR TITLE
GEODE-5246: QueryService.getIndexes should not return null when there are no indexes

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/QueryIndexDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/QueryIndexDUnitTest.java
@@ -1291,12 +1291,10 @@ public class QueryIndexDUnitTest extends JUnit4CacheTestCase {
       if (qs != null) {
         try {
           Collection indexes = qs.getIndexes(region);
-          if (indexes == null) {
+          if (indexes.isEmpty()) {
             return; // no IndexManager defined
           }
-          if (indexes.size() == 0) {
-            return; // no indexes defined
-          }
+
           Iterator iter = indexes.iterator();
           if (iter.hasNext()) {
             Index idx = (Index) (iter.next());

--- a/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/CreateDefinedIndexesCommandDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/CreateDefinedIndexesCommandDUnitTest.java
@@ -278,8 +278,8 @@ public class CreateDefinedIndexesCommandDUnitTest {
       QueryService queryService = cache.getQueryService();
       Region region1 = cache.getRegion(region1Name);
 
-      // Returns null instead of an empty collection if there are no indexes...
-      assertThat(queryService.getIndexes(region1)).isNull();
+      assertThat(queryService.getIndexes(region1)).isNotNull();
+      assertThat(queryService.getIndexes(region1).isEmpty()).isTrue();
     }, server1, server2);
 
     VMProvider.invokeInEveryMember(() -> {
@@ -287,7 +287,8 @@ public class CreateDefinedIndexesCommandDUnitTest {
       QueryService queryService = cache.getQueryService();
       Region region2 = cache.getRegion(region2Name);
 
-      assertThat(queryService.getIndexes(region2)).isNull();
+      assertThat(queryService.getIndexes(region2)).isNotNull();
+      assertThat(queryService.getIndexes(region2).isEmpty()).isTrue();
     }, server3);
 
     locator.invoke(() -> {

--- a/geode-core/src/main/java/org/apache/geode/cache/query/QueryService.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/QueryService.java
@@ -469,7 +469,8 @@ public interface QueryService {
   /**
    * Get a collection of all the indexes in the Cache.
    *
-   * @return the collection of all indexes in this Cache
+   * @return the collection of all indexes in this Cache, or an empty (unmodifiable) collection if
+   *         no indexes are found.
    */
   Collection<Index> getIndexes();
 
@@ -477,7 +478,8 @@ public interface QueryService {
    * Get a collection of all the indexes on the specified Region
    *
    * @param region the region for the requested indexes
-   * @return the collection of indexes on the specified region
+   * @return the collection of indexes on the specified region, or an empty (unmodifiable)
+   *         collection if no indexes are found.
    */
   Collection<Index> getIndexes(Region<?, ?> region);
 
@@ -490,7 +492,8 @@ public interface QueryService {
    *
    * @param region the region for the requested indexes
    * @param indexType the type of indexes to get. Currently must be Indexable.FUNCTIONAL
-   * @return the collection of indexes for the specified region and type
+   * @return the collection of indexes for the specified region and type, or an empty (unmodifiable)
+   *         collection if no indexes are found.
    */
   @Deprecated
   Collection<Index> getIndexes(Region<?, ?> region, IndexType indexType);

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/DefaultQueryService.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/DefaultQueryService.java
@@ -380,16 +380,14 @@ public class DefaultQueryService implements InternalQueryService {
     Iterator rootRegions = cache.rootRegions().iterator();
     while (rootRegions.hasNext()) {
       Region region = (Region) rootRegions.next();
-      Collection indexes = getIndexes(region);
-      if (indexes != null)
-        allIndexes.addAll(indexes);
+      allIndexes.addAll(getIndexes(region));
+
       Iterator subRegions = region.subregions(true).iterator();
       while (subRegions.hasNext()) {
-        indexes = getIndexes((Region) subRegions.next());
-        if (indexes != null)
-          allIndexes.addAll(indexes);
+        allIndexes.addAll(getIndexes((Region) subRegions.next()));
       }
     }
+
     return allIndexes;
   }
 
@@ -420,8 +418,10 @@ public class DefaultQueryService implements InternalQueryService {
     }
 
     IndexManager indexManager = IndexUtils.getIndexManager(cache, region, false);
-    if (indexManager == null)
-      return null;
+    if (indexManager == null) {
+      return Collections.emptyList();
+    }
+
     return indexManager.getIndexes(indexType);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/DefaultQueryService.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/DefaultQueryService.java
@@ -403,9 +403,12 @@ public class DefaultQueryService implements InternalQueryService {
     if (region instanceof PartitionedRegion) {
       return ((PartitionedRegion) region).getIndexes();
     }
+
     IndexManager indexManager = IndexUtils.getIndexManager(cache, region, false);
-    if (indexManager == null)
-      return null;
+    if (indexManager == null) {
+      return Collections.emptyList();
+    }
+
     return indexManager.getIndexes();
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheCreation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheCreation.java
@@ -1933,7 +1933,8 @@ public class CacheCreation implements InternalCache {
 
     @Override
     public Collection<Index> getIndexes(Region<?, ?> region) {
-      return this.indexes.get(region.getFullPath());
+      Collection<Index> indexes = this.indexes.get(region.getFullPath());
+      return (indexes != null) ? indexes : Collections.emptyList();
     }
 
     @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheXmlGenerator.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheXmlGenerator.java
@@ -1664,11 +1664,9 @@ public class CacheXmlGenerator extends CacheXml implements XMLReader {
     }
 
     // generate index data here
-    Collection indexesForRegion = this.cache.getQueryService().getIndexes(region);
-    if (indexesForRegion != null) {
-      for (Object index : indexesForRegion) {
-        generate((Index) index);
-      }
+    Collection<Index> indexesForRegion = this.cache.getQueryService().getIndexes(region);
+    for (Index index : indexesForRegion) {
+      generate(index);
     }
 
     if (region instanceof PartitionedRegion) {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/DestroyIndexFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/DestroyIndexFunction.java
@@ -14,7 +14,7 @@
  */
 package org.apache.geode.management.internal.cli.functions;
 
-import java.util.List;
+import java.util.Collection;
 
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.CacheClosedException;
@@ -96,17 +96,16 @@ public class DestroyIndexFunction extends CliFunction {
    * @return true if the index was found and removed/false if the index was not found.
    */
   private boolean removeIndexByName(String name, QueryService queryService) {
-    List<Index> indexes = (List<Index>) queryService.getIndexes();
     boolean removed = false;
+    Collection<Index> indexes = queryService.getIndexes();
 
-    if (indexes != null) {
-      for (Index index : indexes) {
-        if (index.getName().equals(name)) {
-          queryService.removeIndex(index);
-          removed = true;
-        }
+    for (Index index : indexes) {
+      if (index.getName().equals(name)) {
+        queryService.removeIndex(index);
+        removed = true;
       }
     }
+
     return removed;
   }
 


### PR DESCRIPTION
GEODE-5246: Avoid NULL in QueryService.getIndexes

- Added Unit tests.
- Changed `DefaultQueryService` to return an empty list instead of
  `null` when no indexes are defined.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
