### PR TITLE
GEODE-5250: Repaired a threadpool leak

### DIFF
--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/acceptance/CacheMaxConnectionJUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/acceptance/CacheMaxConnectionJUnitTest.java
@@ -173,48 +173,52 @@ public class CacheMaxConnectionJUnitTest {
     final Socket[] sockets = new Socket[connections];
 
     ExecutorService executor = Executors.newFixedThreadPool(connections);
+    try {
 
-    // Used to assert the exception is non-null.
-    ArrayList<Callable<Exception>> callables = new ArrayList<>();
+      // Used to assert the exception is non-null.
+      ArrayList<Callable<Exception>> callables = new ArrayList<>();
 
-    for (int i = 0; i < connections; i++) {
-      final int j = i;
-      callables.add(() -> {
-        try {
-          Socket socket = new Socket("localhost", cacheServerPort);
-          sockets[j] = socket;
+      for (int i = 0; i < connections; i++) {
+        final int j = i;
+        callables.add(() -> {
+          try {
+            Socket socket = new Socket("localhost", cacheServerPort);
+            sockets[j] = socket;
 
-          Awaitility.await().atMost(5, TimeUnit.SECONDS).until(socket::isConnected);
-          OutputStream outputStream = socket.getOutputStream();
+            Awaitility.await().atMost(5, TimeUnit.SECONDS).until(socket::isConnected);
+            OutputStream outputStream = socket.getOutputStream();
 
-          performAndVerifyHandshake(socket);
+            performAndVerifyHandshake(socket);
 
-          ClientProtocol.Message putMessage = MessageUtil
-              .makePutRequestMessage(serializationService, TEST_KEY, TEST_VALUE, TEST_REGION);
-          protobufProtocolSerializer.serialize(putMessage, outputStream);
-          validatePutResponse(socket, protobufProtocolSerializer);
-        } catch (Exception e) {
-          return e;
-        }
-        return null;
-      });
-    }
-    List<Future<Exception>> futures = executor.invokeAll(callables);
+            ClientProtocol.Message putMessage = MessageUtil
+                .makePutRequestMessage(serializationService, TEST_KEY, TEST_VALUE, TEST_REGION);
+            protobufProtocolSerializer.serialize(putMessage, outputStream);
+            validatePutResponse(socket, protobufProtocolSerializer);
+          } catch (Exception e) {
+            return e;
+          }
+          return null;
+        });
+      }
+      List<Future<Exception>> futures = executor.invokeAll(callables);
 
-    for (Future<Exception> f : futures) {
-      assertNull(f.get());
-    }
+      for (Future<Exception> f : futures) {
+        assertNull(f.get());
+      }
 
-    // try to start a new socket, expecting it to be disconnected.
-    try (Socket socket = new Socket("localhost", cacheServerPort)) {
-      Awaitility.await().atMost(5, TimeUnit.SECONDS).until(socket::isConnected);
-      socket.getOutputStream()
-          .write(CommunicationMode.ProtobufClientServerProtocol.getModeNumber());
-      assertEquals(-1, socket.getInputStream().read()); // EOF implies disconnected.
-    }
+      // try to start a new socket, expecting it to be disconnected.
+      try (Socket socket = new Socket("localhost", cacheServerPort)) {
+        Awaitility.await().atMost(5, TimeUnit.SECONDS).until(socket::isConnected);
+        socket.getOutputStream()
+            .write(CommunicationMode.ProtobufClientServerProtocol.getModeNumber());
+        assertEquals(-1, socket.getInputStream().read()); // EOF implies disconnected.
+      }
 
-    for (Socket currentSocket : sockets) {
-      currentSocket.close();
+      for (Socket currentSocket : sockets) {
+        currentSocket.close();
+      }
+    } finally {
+      executor.shutdownNow();
     }
   }
 


### PR DESCRIPTION
- a new fixed thread pool was being allocated but not shutdown. This fixes that omission.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [n/a] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.

@upthewaterspout @WireBaron @galen-pivotal @bschuchardt @PivotalSarge