### PR TITLE
GEODE-5237 DiskAccessException can sometimes state that actual usage is less than critical

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DiskStoreMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DiskStoreMonitor.java
@@ -15,6 +15,7 @@
 package org.apache.geode.internal.cache;
 
 import java.io.File;
+import java.text.DecimalFormat;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -266,7 +267,8 @@ public class DiskStoreMonitor {
       double use = 100.0 * (total - remaining) / total;
       recordStats(total, remaining, elapsed);
 
-      String pct = Math.round(use) + "%";
+      final DecimalFormat decimalFormat = new DecimalFormat("#.#");
+      String pct = decimalFormat.format(use) + "%";
       if (logger.isTraceEnabled(LogMarker.DISK_STORE_MONITOR_VERBOSE)) {
         logger.trace(LogMarker.DISK_STORE_MONITOR_VERBOSE,
             "Directory {} has {} bytes free out of {} ({} usage)", dir().getAbsolutePath(),
@@ -289,8 +291,9 @@ public class DiskStoreMonitor {
           criticalMessage = "the file system only has " + remaining
               + " bytes free which is below the minimum of " + minBytes + ".";
         } else {
-          criticalMessage = "the file system is " + pct
-              + " full, which exceeds the critical threshold of " + critical + "%.";
+          criticalMessage =
+              "the file system is " + pct + " full, which reached the critical threshold of "
+                  + decimalFormat.format(critical) + "%.";
         }
       }
       handleStateChange(next, pct, criticalMessage);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/DiskUsageTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/DiskUsageTest.java
@@ -132,7 +132,7 @@ public class DiskUsageTest {
     assertThat(diskUsage.getNext()).isEqualTo(DiskState.CRITICAL);
     assertThat(diskUsage.getPct()).isEqualTo("2%");
     assertThat(diskUsage.getCriticalMessage())
-        .isEqualTo("the file system is 2% full, which exceeds the critical threshold of 1.9%.");
+        .isEqualTo("the file system is 2% full, which reached the critical threshold of 1.9%.");
   }
 
   @Test
@@ -164,6 +164,38 @@ public class DiskUsageTest {
     assertThat(diskUsage.getPct()).isEqualTo("2%");
     assertThat(diskUsage.getCriticalMessage())
         .isEqualTo("the file system only has 98 bytes free which is below the minimum of 1048576.");
+  }
+
+  @Test
+  public void criticalMessageStatesUsageExceedsCritical() {
+    File dir = mock(File.class);
+    when(dir.exists()).thenReturn(true);
+    when(dir.getTotalSpace()).thenReturn(1024L * 1024L * 3L);
+    when(dir.getUsableSpace()).thenReturn(1024L * 1024L * 2L);
+
+    TestableDiskUsage diskUsage = new TestableDiskUsage(dir, 1/* one megabyte */);
+
+    assertThat(diskUsage.update(0.0f, 33.2f)).isEqualTo(DiskState.CRITICAL);
+    assertThat(diskUsage.getNext()).isEqualTo(DiskState.CRITICAL);
+    // assertThat(diskUsage.getPct()).isEqualTo("33.3%");
+    assertThat(diskUsage.getCriticalMessage())
+        .isEqualTo("the file system is 33.3% full, which reached the critical threshold of 33.2%.");
+  }
+
+  @Test
+  public void criticalMessageStatesUsageExceedsCriticalWithManyDigits() {
+    File dir = mock(File.class);
+    when(dir.exists()).thenReturn(true);
+    when(dir.getTotalSpace()).thenReturn(1024L * 1024L * 3L);
+    when(dir.getUsableSpace()).thenReturn(1024L * 1024L * 2L);
+
+    TestableDiskUsage diskUsage = new TestableDiskUsage(dir, 1/* one megabyte */);
+
+    assertThat(diskUsage.update(0.0f, 33.25783495783648593746336f)).isEqualTo(DiskState.CRITICAL);
+    assertThat(diskUsage.getNext()).isEqualTo(DiskState.CRITICAL);
+    assertThat(diskUsage.getPct()).isEqualTo("33.3%");
+    assertThat(diskUsage.getCriticalMessage())
+        .isEqualTo("the file system is 33.3% full, which reached the critical threshold of 33.3%.");
   }
 
   @Test


### PR DESCRIPTION

This problem was caused by rounding the current disk usage, which has now been removed; both the current usage and critical threshold are not formatted the same way.

