### PR TITLE
GEODE-5252: Race in management adapter could fail to create MXBeans.

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/ManagementAdapter.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/ManagementAdapter.java
@@ -20,7 +20,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import javax.management.InstanceNotFoundException;
 import javax.management.MBeanServer;
@@ -130,18 +129,13 @@ public class ManagementAdapter {
 
   private final Object regionOpLock = new Object();
 
-  // having a readwrite lock to synchronize between handling cache creation/removal vs handling
-  // other notifications
-  private final ReentrantReadWriteLock readWriteLock = new ReentrantReadWriteLock();
-
   /**
    * Adapter life cycle is tied with the Cache . So its better to make all cache level artifacts as
    * instance variable
    *
    * @param cache gemfire cache
    */
-  public void handleCacheCreation(InternalCache cache) throws ManagementException {
-    readWriteLock.writeLock().lock();
+  protected void handleCacheCreation(InternalCache cache) throws ManagementException {
     try {
       this.internalCache = cache;
       this.service =
@@ -191,74 +185,69 @@ public class ManagementAdapter {
         if (logger.isDebugEnabled()) {
           logger.debug("Management Service is initialised and Running");
         }
+
       }
-      readWriteLock.writeLock().unlock();
     }
   }
 
   /**
    * Handles all the distributed mbean creation part when a Manager is started
    */
-  public void handleManagerStart() throws ManagementException {
-    readWriteLock.readLock().lock();
-    try {
-      if (!isServiceInitialised("handleManagerStart")) {
-        return;
+  protected void handleManagerStart() throws ManagementException {
+    if (!isServiceInitialised("handleManagerStart")) {
+      return;
+    }
+    MBeanJMXAdapter jmxAdapter = service.getJMXAdapter();
+    Map<ObjectName, Object> registeredMBeans = jmxAdapter.getLocalGemFireMBean();
+
+    DistributedSystemBridge dsBridge = new DistributedSystemBridge(service, internalCache);
+    this.aggregator = new MBeanAggregator(dsBridge);
+    // register the aggregator for Federation framework to use
+    service.addProxyListener(aggregator);
+
+    /*
+     * get the local member mbean as it need to be provided to aggregator first
+     */
+
+    MemberMXBean localMember = service.getMemberMXBean();
+    ObjectName memberObjectName = MBeanJMXAdapter.getMemberMBeanName(
+        InternalDistributedSystem.getConnectedInstance().getDistributedMember());
+
+    FederationComponent addedComp =
+        service.getLocalManager().getFedComponents().get(memberObjectName);
+
+    service.afterCreateProxy(memberObjectName, MemberMXBean.class, localMember, addedComp);
+
+    for (ObjectName objectName : registeredMBeans.keySet()) {
+      if (objectName.equals(memberObjectName)) {
+        continue;
       }
-      MBeanJMXAdapter jmxAdapter = service.getJMXAdapter();
-      Map<ObjectName, Object> registeredMBeans = jmxAdapter.getLocalGemFireMBean();
+      Object object = registeredMBeans.get(objectName);
+      ObjectInstance instance;
+      try {
+        instance = mbeanServer.getObjectInstance(objectName);
+        String className = instance.getClassName();
+        Class cls = ClassLoadUtil.classFromName(className);
+        Type[] intfTyps = cls.getGenericInterfaces();
 
-      DistributedSystemBridge dsBridge = new DistributedSystemBridge(service, internalCache);
-      this.aggregator = new MBeanAggregator(dsBridge);
-      // register the aggregator for Federation framework to use
-      service.addProxyListener(aggregator);
+        FederationComponent newObj = service.getLocalManager().getFedComponents().get(objectName);
 
-      /*
-       * get the local member mbean as it need to be provided to aggregator first
-       */
+        for (Type intfTyp1 : intfTyps) {
+          Class intfTyp = (Class) intfTyp1;
+          service.afterCreateProxy(objectName, intfTyp, object, newObj);
 
-      MemberMXBean localMember = service.getMemberMXBean();
-      ObjectName memberObjectName = MBeanJMXAdapter.getMemberMBeanName(
-          InternalDistributedSystem.getConnectedInstance().getDistributedMember());
-
-      FederationComponent addedComp =
-          service.getLocalManager().getFedComponents().get(memberObjectName);
-
-      service.afterCreateProxy(memberObjectName, MemberMXBean.class, localMember, addedComp);
-
-      for (ObjectName objectName : registeredMBeans.keySet()) {
-        if (objectName.equals(memberObjectName)) {
-          continue;
         }
-        Object object = registeredMBeans.get(objectName);
-        ObjectInstance instance;
-        try {
-          instance = mbeanServer.getObjectInstance(objectName);
-          String className = instance.getClassName();
-          Class cls = ClassLoadUtil.classFromName(className);
-          Type[] intfTyps = cls.getGenericInterfaces();
-
-          FederationComponent newObj = service.getLocalManager().getFedComponents().get(objectName);
-
-          for (Type intfTyp1 : intfTyps) {
-            Class intfTyp = (Class) intfTyp1;
-            service.afterCreateProxy(objectName, intfTyp, object, newObj);
-
-          }
-        } catch (InstanceNotFoundException e) {
-          if (logger.isDebugEnabled()) {
-            logger.debug("Failed in Registering distributed mbean ");
-          }
-          throw new ManagementException(e);
-        } catch (ClassNotFoundException e) {
-          if (logger.isDebugEnabled()) {
-            logger.debug("Failed in Registering distributed mbean");
-          }
-          throw new ManagementException(e);
+      } catch (InstanceNotFoundException e) {
+        if (logger.isDebugEnabled()) {
+          logger.debug("Failed in Registering distributed mbean ");
         }
+        throw new ManagementException(e);
+      } catch (ClassNotFoundException e) {
+        if (logger.isDebugEnabled()) {
+          logger.debug("Failed in Registering distributed mbean");
+        }
+        throw new ManagementException(e);
       }
-    } finally {
-      readWriteLock.readLock().unlock();
     }
   }
 
@@ -266,85 +255,75 @@ public class ManagementAdapter {
    * Handles all the clean up activities when a Manager is stopped It clears the distributed mbeans
    * and underlying data structures
    */
-  public void handleManagerStop() throws ManagementException {
-    readWriteLock.readLock().lock();
-    try {
-      if (!isServiceInitialised("handleManagerStop")) {
-        return;
-      }
-      MBeanJMXAdapter jmxAdapter = service.getJMXAdapter();
-      Map<ObjectName, Object> registeredMBeans = jmxAdapter.getLocalGemFireMBean();
-
-      ObjectName aggregatemMBeanPattern;
-      try {
-        aggregatemMBeanPattern = new ObjectName(ManagementConstants.AGGREGATE_MBEAN_PATTERN);
-      } catch (MalformedObjectNameException | NullPointerException e1) {
-        throw new ManagementException(e1);
-      }
-
-      MemberMXBean localMember = service.getMemberMXBean();
-
-      ObjectName memberObjectName = MBeanJMXAdapter.getMemberMBeanName(
-          InternalDistributedSystem.getConnectedInstance().getDistributedMember());
-
-      FederationComponent removedComp =
-          service.getLocalManager().getFedComponents().get(memberObjectName);
-
-      service.afterRemoveProxy(memberObjectName, MemberMXBean.class, localMember, removedComp);
-
-      for (ObjectName objectName : registeredMBeans.keySet()) {
-        if (objectName.equals(memberObjectName)) {
-          continue;
-        }
-        if (aggregatemMBeanPattern.apply(objectName)) {
-          continue;
-        }
-        Object object = registeredMBeans.get(objectName);
-        ObjectInstance instance;
-        try {
-          instance = mbeanServer.getObjectInstance(objectName);
-          String className = instance.getClassName();
-          Class cls = ClassLoadUtil.classFromName(className);
-          Type[] intfTyps = cls.getGenericInterfaces();
-
-          FederationComponent oldObj = service.getLocalManager().getFedComponents().get(objectName);
-
-          for (Type intfTyp1 : intfTyps) {
-            Class intfTyp = (Class) intfTyp1;
-            service.afterRemoveProxy(objectName, intfTyp, object, oldObj);
-          }
-        } catch (InstanceNotFoundException | ClassNotFoundException e) {
-          logger.warn("Failed to invoke aggregator for {} with exception {}", objectName,
-              e.getMessage(), e);
-        }
-      }
-      service.removeProxyListener(this.aggregator);
-      this.aggregator = null;
-    } finally {
-      readWriteLock.readLock().unlock();
+  protected void handleManagerStop() throws ManagementException {
+    if (!isServiceInitialised("handleManagerStop")) {
+      return;
     }
+    MBeanJMXAdapter jmxAdapter = service.getJMXAdapter();
+    Map<ObjectName, Object> registeredMBeans = jmxAdapter.getLocalGemFireMBean();
+
+    ObjectName aggregatemMBeanPattern;
+    try {
+      aggregatemMBeanPattern = new ObjectName(ManagementConstants.AGGREGATE_MBEAN_PATTERN);
+    } catch (MalformedObjectNameException | NullPointerException e1) {
+      throw new ManagementException(e1);
+    }
+
+    MemberMXBean localMember = service.getMemberMXBean();
+
+    ObjectName memberObjectName = MBeanJMXAdapter.getMemberMBeanName(
+        InternalDistributedSystem.getConnectedInstance().getDistributedMember());
+
+    FederationComponent removedComp =
+        service.getLocalManager().getFedComponents().get(memberObjectName);
+
+    service.afterRemoveProxy(memberObjectName, MemberMXBean.class, localMember, removedComp);
+
+    for (ObjectName objectName : registeredMBeans.keySet()) {
+      if (objectName.equals(memberObjectName)) {
+        continue;
+      }
+      if (aggregatemMBeanPattern.apply(objectName)) {
+        continue;
+      }
+      Object object = registeredMBeans.get(objectName);
+      ObjectInstance instance;
+      try {
+        instance = mbeanServer.getObjectInstance(objectName);
+        String className = instance.getClassName();
+        Class cls = ClassLoadUtil.classFromName(className);
+        Type[] intfTyps = cls.getGenericInterfaces();
+
+        FederationComponent oldObj = service.getLocalManager().getFedComponents().get(objectName);
+
+        for (Type intfTyp1 : intfTyps) {
+          Class intfTyp = (Class) intfTyp1;
+          service.afterRemoveProxy(objectName, intfTyp, object, oldObj);
+        }
+      } catch (InstanceNotFoundException | ClassNotFoundException e) {
+        logger.warn("Failed to invoke aggregator for {} with exception {}", objectName,
+            e.getMessage(), e);
+      }
+    }
+    service.removeProxyListener(this.aggregator);
+    this.aggregator = null;
   }
 
   /**
    * Assumption is always cache and MemberMbean has been will be created first
    */
-  public void handleManagerCreation() throws ManagementException {
-    readWriteLock.readLock().lock();
-    try {
-      if (!isServiceInitialised("handleManagerCreation")) {
-        return;
-      }
-
-      ObjectName managerMBeanName = MBeanJMXAdapter.getManagerName();
-
-      ManagerMBeanBridge bridge = new ManagerMBeanBridge(service);
-
-      ManagerMXBean bean = new ManagerMBean(bridge);
-
-      service.registerInternalMBean(bean, managerMBeanName);
-    } finally {
-      readWriteLock.readLock().unlock();
+  protected void handleManagerCreation() throws ManagementException {
+    if (!isServiceInitialised("handleManagerCreation")) {
+      return;
     }
+
+    ObjectName managerMBeanName = MBeanJMXAdapter.getManagerName();
+
+    ManagerMBeanBridge bridge = new ManagerMBeanBridge(service);
+
+    ManagerMXBean bean = new ManagerMBean(bridge);
+
+    service.registerInternalMBean(bean, managerMBeanName);
   }
 
   /**
@@ -354,37 +333,32 @@ public class ManagementAdapter {
    * @param region the region for which the call back is invoked
    */
   public <K, V> void handleRegionCreation(Region<K, V> region) throws ManagementException {
-    readWriteLock.readLock().lock();
-    try {
-      if (!isServiceInitialised("handleRegionCreation")) {
+    if (!isServiceInitialised("handleRegionCreation")) {
+      return;
+    }
+    // Moving region creation operation inside a guarded block
+    // After getting access to regionOpLock it again checks for region
+    // destroy status
+
+    synchronized (regionOpLock) {
+      LocalRegion localRegion = (LocalRegion) region;
+      if (localRegion.isDestroyed()) {
         return;
       }
-      // Moving region creation operation inside a guarded block
-      // After getting access to regionOpLock it again checks for region
-      // destroy status
+      // Bridge is responsible for extracting data from GemFire Layer
+      RegionMBeanBridge<K, V> bridge = RegionMBeanBridge.getInstance(region);
 
-      synchronized (regionOpLock) {
-        LocalRegion localRegion = (LocalRegion) region;
-        if (localRegion.isDestroyed()) {
-          return;
-        }
-        // Bridge is responsible for extracting data from GemFire Layer
-        RegionMBeanBridge<K, V> bridge = RegionMBeanBridge.getInstance(region);
+      RegionMXBean regionMBean = new RegionMBean<>(bridge);
+      ObjectName regionMBeanName = MBeanJMXAdapter.getRegionMBeanName(
+          internalCache.getDistributedSystem().getDistributedMember(), region.getFullPath());
+      ObjectName changedMBeanName = service.registerInternalMBean(regionMBean, regionMBeanName);
+      service.federate(changedMBeanName, RegionMXBean.class, true);
 
-        RegionMXBean regionMBean = new RegionMBean<>(bridge);
-        ObjectName regionMBeanName = MBeanJMXAdapter.getRegionMBeanName(
-            internalCache.getDistributedSystem().getDistributedMember(), region.getFullPath());
-        ObjectName changedMBeanName = service.registerInternalMBean(regionMBean, regionMBeanName);
-        service.federate(changedMBeanName, RegionMXBean.class, true);
-
-        Notification notification = new Notification(JMXNotificationType.REGION_CREATED,
-            memberSource, SequenceNumber.next(), System.currentTimeMillis(),
-            ManagementConstants.REGION_CREATED_PREFIX + region.getFullPath());
-        memberLevelNotifEmitter.sendNotification(notification);
-        memberMBeanBridge.addRegion(region);
-      }
-    } finally {
-      readWriteLock.readLock().unlock();
+      Notification notification = new Notification(JMXNotificationType.REGION_CREATED, memberSource,
+          SequenceNumber.next(), System.currentTimeMillis(),
+          ManagementConstants.REGION_CREATED_PREFIX + region.getFullPath());
+      memberLevelNotifEmitter.sendNotification(notification);
+      memberMBeanBridge.addRegion(region);
     }
   }
 
@@ -393,65 +367,54 @@ public class ManagementAdapter {
    *
    * @param disk the disk store for which the call back is invoked
    */
-  public void handleDiskCreation(DiskStore disk) throws ManagementException {
-    readWriteLock.readLock().lock();
-    try {
-      if (!isServiceInitialised("handleDiskCreation")) {
-        return;
-      }
-      DiskStoreMBeanBridge bridge = new DiskStoreMBeanBridge(disk);
-      DiskStoreMXBean diskStoreMBean = new DiskStoreMBean(bridge);
-      ObjectName diskStoreMBeanName = MBeanJMXAdapter.getDiskStoreMBeanName(
-          internalCache.getDistributedSystem().getDistributedMember(), disk.getName());
-      ObjectName changedMBeanName =
-          service.registerInternalMBean(diskStoreMBean, diskStoreMBeanName);
-
-      service.federate(changedMBeanName, DiskStoreMXBean.class, true);
-
-      Notification notification = new Notification(JMXNotificationType.DISK_STORE_CREATED,
-          memberSource, SequenceNumber.next(), System.currentTimeMillis(),
-          ManagementConstants.DISK_STORE_CREATED_PREFIX + disk.getName());
-      memberLevelNotifEmitter.sendNotification(notification);
-      memberMBeanBridge.addDiskStore(disk);
-    } finally {
-      readWriteLock.readLock().unlock();
+  protected void handleDiskCreation(DiskStore disk) throws ManagementException {
+    if (!isServiceInitialised("handleDiskCreation")) {
+      return;
     }
+    DiskStoreMBeanBridge bridge = new DiskStoreMBeanBridge(disk);
+    DiskStoreMXBean diskStoreMBean = new DiskStoreMBean(bridge);
+    ObjectName diskStoreMBeanName = MBeanJMXAdapter.getDiskStoreMBeanName(
+        internalCache.getDistributedSystem().getDistributedMember(), disk.getName());
+    ObjectName changedMBeanName = service.registerInternalMBean(diskStoreMBean, diskStoreMBeanName);
+
+    service.federate(changedMBeanName, DiskStoreMXBean.class, true);
+
+    Notification notification = new Notification(JMXNotificationType.DISK_STORE_CREATED,
+        memberSource, SequenceNumber.next(), System.currentTimeMillis(),
+        ManagementConstants.DISK_STORE_CREATED_PREFIX + disk.getName());
+    memberLevelNotifEmitter.sendNotification(notification);
+    memberMBeanBridge.addDiskStore(disk);
   }
 
   /**
    * Handles LockService Creation
    *
    */
-  public void handleLockServiceCreation(DLockService lockService) throws ManagementException {
-    readWriteLock.readLock().lock();
-    try {
-      if (!isServiceInitialised("handleLockServiceCreation")) {
-        return;
-      }
-      // Internal Locks Should not be exposed to client for monitoring
-      if (internalLocks.contains(lockService.getName())) {
-        return;
-      }
-      LockServiceMBeanBridge bridge = new LockServiceMBeanBridge(lockService);
-      LockServiceMXBean lockServiceMBean = new LockServiceMBean(bridge);
-
-      ObjectName lockServiceMBeanName = MBeanJMXAdapter.getLockServiceMBeanName(
-          internalCache.getDistributedSystem().getDistributedMember(), lockService.getName());
-
-      ObjectName changedMBeanName =
-          service.registerInternalMBean(lockServiceMBean, lockServiceMBeanName);
-
-      service.federate(changedMBeanName, LockServiceMXBean.class, true);
-
-      Notification notification = new Notification(JMXNotificationType.LOCK_SERVICE_CREATED,
-          memberSource, SequenceNumber.next(), System.currentTimeMillis(),
-          ManagementConstants.LOCK_SERVICE_CREATED_PREFIX + lockService.getName());
-      memberLevelNotifEmitter.sendNotification(notification);
-
-      memberMBeanBridge.addLockServiceStats(lockService);
-    } finally {
-      readWriteLock.readLock().unlock();
+  protected void handleLockServiceCreation(DLockService lockService) throws ManagementException {
+    if (!isServiceInitialised("handleLockServiceCreation")) {
+      return;
     }
+    // Internal Locks Should not be exposed to client for monitoring
+    if (internalLocks.contains(lockService.getName())) {
+      return;
+    }
+    LockServiceMBeanBridge bridge = new LockServiceMBeanBridge(lockService);
+    LockServiceMXBean lockServiceMBean = new LockServiceMBean(bridge);
+
+    ObjectName lockServiceMBeanName = MBeanJMXAdapter.getLockServiceMBeanName(
+        internalCache.getDistributedSystem().getDistributedMember(), lockService.getName());
+
+    ObjectName changedMBeanName =
+        service.registerInternalMBean(lockServiceMBean, lockServiceMBeanName);
+
+    service.federate(changedMBeanName, LockServiceMXBean.class, true);
+
+    Notification notification = new Notification(JMXNotificationType.LOCK_SERVICE_CREATED,
+        memberSource, SequenceNumber.next(), System.currentTimeMillis(),
+        ManagementConstants.LOCK_SERVICE_CREATED_PREFIX + lockService.getName());
+    memberLevelNotifEmitter.sendNotification(notification);
+
+    memberMBeanBridge.addLockServiceStats(lockService);
   }
 
   /**
@@ -459,29 +422,24 @@ public class ManagementAdapter {
    *
    * @param sender the specific gateway sender
    */
-  public void handleGatewaySenderCreation(GatewaySender sender) throws ManagementException {
-    readWriteLock.readLock().lock();
-    try {
-      if (!isServiceInitialised("handleGatewaySenderCreation")) {
-        return;
-      }
-      GatewaySenderMBeanBridge bridge = new GatewaySenderMBeanBridge(sender);
-
-      GatewaySenderMXBean senderMBean = new GatewaySenderMBean(bridge);
-      ObjectName senderObjectName = MBeanJMXAdapter.getGatewaySenderMBeanName(
-          internalCache.getDistributedSystem().getDistributedMember(), sender.getId());
-
-      ObjectName changedMBeanName = service.registerInternalMBean(senderMBean, senderObjectName);
-
-      service.federate(changedMBeanName, GatewaySenderMXBean.class, true);
-
-      Notification notification = new Notification(JMXNotificationType.GATEWAY_SENDER_CREATED,
-          memberSource, SequenceNumber.next(), System.currentTimeMillis(),
-          ManagementConstants.GATEWAY_SENDER_CREATED_PREFIX);
-      memberLevelNotifEmitter.sendNotification(notification);
-    } finally {
-      readWriteLock.readLock().unlock();
+  protected void handleGatewaySenderCreation(GatewaySender sender) throws ManagementException {
+    if (!isServiceInitialised("handleGatewaySenderCreation")) {
+      return;
     }
+    GatewaySenderMBeanBridge bridge = new GatewaySenderMBeanBridge(sender);
+
+    GatewaySenderMXBean senderMBean = new GatewaySenderMBean(bridge);
+    ObjectName senderObjectName = MBeanJMXAdapter.getGatewaySenderMBeanName(
+        internalCache.getDistributedSystem().getDistributedMember(), sender.getId());
+
+    ObjectName changedMBeanName = service.registerInternalMBean(senderMBean, senderObjectName);
+
+    service.federate(changedMBeanName, GatewaySenderMXBean.class, true);
+
+    Notification notification = new Notification(JMXNotificationType.GATEWAY_SENDER_CREATED,
+        memberSource, SequenceNumber.next(), System.currentTimeMillis(),
+        ManagementConstants.GATEWAY_SENDER_CREATED_PREFIX);
+    memberLevelNotifEmitter.sendNotification(notification);
   }
 
   /**
@@ -489,25 +447,15 @@ public class ManagementAdapter {
    *
    * @param recv specific gateway receiver
    */
-  public void handleGatewayReceiverCreate(GatewayReceiver recv) throws ManagementException {
-    readWriteLock.readLock().lock();
-    try {
-      if (!isServiceInitialised("handleGatewayReceiverCreate")) {
-        return;
-      }
-      if (!recv.isManualStart()) {
-        return;
-      }
-      GatewayReceiverMBeanBridge bridge = new GatewayReceiverMBeanBridge(recv);
-
-      GatewayReceiverMXBean receiverMBean = new GatewayReceiverMBean(bridge);
-      ObjectName recvObjectName = MBeanJMXAdapter
-          .getGatewayReceiverMBeanName(internalCache.getDistributedSystem().getDistributedMember());
-
-      createGatewayReceiverMBean(recv);
-    } finally {
-      readWriteLock.readLock().unlock();
+  protected void handleGatewayReceiverCreate(GatewayReceiver recv) throws ManagementException {
+    if (!isServiceInitialised("handleGatewayReceiverCreate")) {
+      return;
     }
+    if (!recv.isManualStart()) {
+      return;
+    }
+
+    createGatewayReceiverMBean(recv);
   }
 
   private void createGatewayReceiverMBean(GatewayReceiver recv) {
@@ -532,28 +480,23 @@ public class ManagementAdapter {
    *
    * @param recv specific gateway receiver
    */
-  public void handleGatewayReceiverDestroy(GatewayReceiver recv) throws ManagementException {
-    readWriteLock.readLock().lock();
-    try {
-      if (!isServiceInitialised("handleGatewayReceiverDestroy")) {
-        return;
-      }
-
-      GatewayReceiverMBean mbean = (GatewayReceiverMBean) service.getLocalGatewayReceiverMXBean();
-      GatewayReceiverMBeanBridge bridge = mbean.getBridge();
-
-      bridge.destroyServer();
-      ObjectName objectName = (MBeanJMXAdapter.getGatewayReceiverMBeanName(
-          internalCache.getDistributedSystem().getDistributedMember()));
-
-      service.unregisterMBean(objectName);
-      Notification notification = new Notification(JMXNotificationType.GATEWAY_RECEIVER_DESTROYED,
-          memberSource, SequenceNumber.next(), System.currentTimeMillis(),
-          ManagementConstants.GATEWAY_RECEIVER_DESTROYED_PREFIX);
-      memberLevelNotifEmitter.sendNotification(notification);
-    } finally {
-      readWriteLock.readLock().unlock();
+  protected void handleGatewayReceiverDestroy(GatewayReceiver recv) throws ManagementException {
+    if (!isServiceInitialised("handleGatewayReceiverDestroy")) {
+      return;
     }
+
+    GatewayReceiverMBean mbean = (GatewayReceiverMBean) service.getLocalGatewayReceiverMXBean();
+    GatewayReceiverMBeanBridge bridge = mbean.getBridge();
+
+    bridge.destroyServer();
+    ObjectName objectName = (MBeanJMXAdapter
+        .getGatewayReceiverMBeanName(internalCache.getDistributedSystem().getDistributedMember()));
+
+    service.unregisterMBean(objectName);
+    Notification notification = new Notification(JMXNotificationType.GATEWAY_RECEIVER_DESTROYED,
+        memberSource, SequenceNumber.next(), System.currentTimeMillis(),
+        ManagementConstants.GATEWAY_RECEIVER_DESTROYED_PREFIX);
+    memberLevelNotifEmitter.sendNotification(notification);
   }
 
   /**
@@ -561,29 +504,24 @@ public class ManagementAdapter {
    *
    * @param recv specific gateway receiver
    */
-  public void handleGatewayReceiverStart(GatewayReceiver recv) throws ManagementException {
-    readWriteLock.readLock().lock();
-    try {
-      if (!isServiceInitialised("handleGatewayReceiverStart")) {
-        return;
-      }
-
-      if (!recv.isManualStart()) {
-        createGatewayReceiverMBean(recv);
-      }
-
-      GatewayReceiverMBean mbean = (GatewayReceiverMBean) service.getLocalGatewayReceiverMXBean();
-      GatewayReceiverMBeanBridge bridge = mbean.getBridge();
-
-      bridge.startServer();
-
-      Notification notification = new Notification(JMXNotificationType.GATEWAY_RECEIVER_STARTED,
-          memberSource, SequenceNumber.next(), System.currentTimeMillis(),
-          ManagementConstants.GATEWAY_RECEIVER_STARTED_PREFIX);
-      memberLevelNotifEmitter.sendNotification(notification);
-    } finally {
-      readWriteLock.readLock().unlock();
+  protected void handleGatewayReceiverStart(GatewayReceiver recv) throws ManagementException {
+    if (!isServiceInitialised("handleGatewayReceiverStart")) {
+      return;
     }
+
+    if (!recv.isManualStart()) {
+      createGatewayReceiverMBean(recv);
+    }
+
+    GatewayReceiverMBean mbean = (GatewayReceiverMBean) service.getLocalGatewayReceiverMXBean();
+    GatewayReceiverMBeanBridge bridge = mbean.getBridge();
+
+    bridge.startServer();
+
+    Notification notification = new Notification(JMXNotificationType.GATEWAY_RECEIVER_STARTED,
+        memberSource, SequenceNumber.next(), System.currentTimeMillis(),
+        ManagementConstants.GATEWAY_RECEIVER_STARTED_PREFIX);
+    memberLevelNotifEmitter.sendNotification(notification);
   }
 
   /**
@@ -591,48 +529,38 @@ public class ManagementAdapter {
    *
    * @param recv specific gateway receiver
    */
-  public void handleGatewayReceiverStop(GatewayReceiver recv) throws ManagementException {
-    readWriteLock.readLock().lock();
-    try {
-      if (!isServiceInitialised("handleGatewayReceiverStop")) {
-        return;
-      }
-      GatewayReceiverMBean mbean = (GatewayReceiverMBean) service.getLocalGatewayReceiverMXBean();
-      GatewayReceiverMBeanBridge bridge = mbean.getBridge();
-
-      bridge.stopServer();
-
-      Notification notification = new Notification(JMXNotificationType.GATEWAY_RECEIVER_STOPPED,
-          memberSource, SequenceNumber.next(), System.currentTimeMillis(),
-          ManagementConstants.GATEWAY_RECEIVER_STOPPED_PREFIX);
-      memberLevelNotifEmitter.sendNotification(notification);
-    } finally {
-      readWriteLock.readLock().unlock();
+  protected void handleGatewayReceiverStop(GatewayReceiver recv) throws ManagementException {
+    if (!isServiceInitialised("handleGatewayReceiverStop")) {
+      return;
     }
+    GatewayReceiverMBean mbean = (GatewayReceiverMBean) service.getLocalGatewayReceiverMXBean();
+    GatewayReceiverMBeanBridge bridge = mbean.getBridge();
+
+    bridge.stopServer();
+
+    Notification notification = new Notification(JMXNotificationType.GATEWAY_RECEIVER_STOPPED,
+        memberSource, SequenceNumber.next(), System.currentTimeMillis(),
+        ManagementConstants.GATEWAY_RECEIVER_STOPPED_PREFIX);
+    memberLevelNotifEmitter.sendNotification(notification);
   }
 
-  public void handleAsyncEventQueueCreation(AsyncEventQueue queue) throws ManagementException {
-    readWriteLock.readLock().lock();
-    try {
-      if (!isServiceInitialised("handleAsyncEventQueueCreation")) {
-        return;
-      }
-      AsyncEventQueueMBeanBridge bridge = new AsyncEventQueueMBeanBridge(queue);
-      AsyncEventQueueMXBean queueMBean = new AsyncEventQueueMBean(bridge);
-      ObjectName senderObjectName = MBeanJMXAdapter.getAsyncEventQueueMBeanName(
-          internalCache.getDistributedSystem().getDistributedMember(), queue.getId());
-
-      ObjectName changedMBeanName = service.registerInternalMBean(queueMBean, senderObjectName);
-
-      service.federate(changedMBeanName, AsyncEventQueueMXBean.class, true);
-
-      Notification notification = new Notification(JMXNotificationType.ASYNC_EVENT_QUEUE_CREATED,
-          memberSource, SequenceNumber.next(), System.currentTimeMillis(),
-          ManagementConstants.ASYNC_EVENT_QUEUE_CREATED_PREFIX);
-      memberLevelNotifEmitter.sendNotification(notification);
-    } finally {
-      readWriteLock.readLock().unlock();
+  protected void handleAsyncEventQueueCreation(AsyncEventQueue queue) throws ManagementException {
+    if (!isServiceInitialised("handleAsyncEventQueueCreation")) {
+      return;
     }
+    AsyncEventQueueMBeanBridge bridge = new AsyncEventQueueMBeanBridge(queue);
+    AsyncEventQueueMXBean queueMBean = new AsyncEventQueueMBean(bridge);
+    ObjectName senderObjectName = MBeanJMXAdapter.getAsyncEventQueueMBeanName(
+        internalCache.getDistributedSystem().getDistributedMember(), queue.getId());
+
+    ObjectName changedMBeanName = service.registerInternalMBean(queueMBean, senderObjectName);
+
+    service.federate(changedMBeanName, AsyncEventQueueMXBean.class, true);
+
+    Notification notification = new Notification(JMXNotificationType.ASYNC_EVENT_QUEUE_CREATED,
+        memberSource, SequenceNumber.next(), System.currentTimeMillis(),
+        ManagementConstants.ASYNC_EVENT_QUEUE_CREATED_PREFIX);
+    memberLevelNotifEmitter.sendNotification(notification);
   }
 
   /**
@@ -640,40 +568,35 @@ public class ManagementAdapter {
    *
    * @param queue The AsyncEventQueue being removed
    */
-  public void handleAsyncEventQueueRemoval(AsyncEventQueue queue) throws ManagementException {
-    readWriteLock.readLock().lock();
-    try {
-      if (!isServiceInitialised("handleAsyncEventQueueRemoval")) {
-        return;
-      }
-
-      ObjectName asycnEventQueueMBeanName = MBeanJMXAdapter.getAsyncEventQueueMBeanName(
-          internalCache.getDistributedSystem().getDistributedMember(), queue.getId());
-      AsyncEventQueueMBean bean;
-      try {
-        bean = (AsyncEventQueueMBean) service.getLocalAsyncEventQueueMXBean(queue.getId());
-        if (bean == null) {
-          return;
-        }
-      } catch (ManagementException e) {
-        // If no bean found its a NO-OP
-        if (logger.isDebugEnabled()) {
-          logger.debug(e.getMessage(), e);
-        }
-        return;
-      }
-
-      bean.stopMonitor();
-
-      service.unregisterMBean(asycnEventQueueMBeanName);
-
-      Notification notification = new Notification(JMXNotificationType.ASYNC_EVENT_QUEUE_CLOSED,
-          memberSource, SequenceNumber.next(), System.currentTimeMillis(),
-          ManagementConstants.ASYNC_EVENT_QUEUE_CLOSED_PREFIX + queue.getId());
-      memberLevelNotifEmitter.sendNotification(notification);
-    } finally {
-      readWriteLock.readLock().unlock();
+  protected void handleAsyncEventQueueRemoval(AsyncEventQueue queue) throws ManagementException {
+    if (!isServiceInitialised("handleAsyncEventQueueRemoval")) {
+      return;
     }
+
+    ObjectName asycnEventQueueMBeanName = MBeanJMXAdapter.getAsyncEventQueueMBeanName(
+        internalCache.getDistributedSystem().getDistributedMember(), queue.getId());
+    AsyncEventQueueMBean bean;
+    try {
+      bean = (AsyncEventQueueMBean) service.getLocalAsyncEventQueueMXBean(queue.getId());
+      if (bean == null) {
+        return;
+      }
+    } catch (ManagementException e) {
+      // If no bean found its a NO-OP
+      if (logger.isDebugEnabled()) {
+        logger.debug(e.getMessage(), e);
+      }
+      return;
+    }
+
+    bean.stopMonitor();
+
+    service.unregisterMBean(asycnEventQueueMBeanName);
+
+    Notification notification = new Notification(JMXNotificationType.ASYNC_EVENT_QUEUE_CLOSED,
+        memberSource, SequenceNumber.next(), System.currentTimeMillis(),
+        ManagementConstants.ASYNC_EVENT_QUEUE_CLOSED_PREFIX + queue.getId());
+    memberLevelNotifEmitter.sendNotification(notification);
   }
 
   /**
@@ -681,26 +604,21 @@ public class ManagementAdapter {
    * particular alert level
    *
    */
-  public void handleSystemNotification(AlertDetails details) {
-    readWriteLock.readLock().lock();
-    try {
-      if (!isServiceInitialised("handleSystemNotification")) {
-        return;
-      }
-      if (service.isManager()) {
-        String systemSource = "DistributedSystem("
-            + service.getDistributedSystemMXBean().getDistributedSystemId() + ")";
-        Map<String, String> userData = prepareUserData(details);
+  protected void handleSystemNotification(AlertDetails details) {
+    if (!isServiceInitialised("handleSystemNotification")) {
+      return;
+    }
+    if (service.isManager()) {
+      String systemSource = "DistributedSystem("
+          + service.getDistributedSystemMXBean().getDistributedSystemId() + ")";
+      Map<String, String> userData = prepareUserData(details);
 
 
-        Notification notification = new Notification(JMXNotificationType.SYSTEM_ALERT, systemSource,
-            SequenceNumber.next(), details.getMsgTime().getTime(), details.getMsg());
+      Notification notification = new Notification(JMXNotificationType.SYSTEM_ALERT, systemSource,
+          SequenceNumber.next(), details.getMsgTime().getTime(), details.getMsg());
 
-        notification.setUserData(userData);
-        service.handleNotification(notification);
-      }
-    } finally {
-      readWriteLock.readLock().unlock();
+      notification.setUserData(userData);
+      service.handleNotification(notification);
     }
   }
 
@@ -729,42 +647,37 @@ public class ManagementAdapter {
    *
    * @param cacheServer cache server instance
    */
-  public void handleCacheServerStart(CacheServer cacheServer) {
-    readWriteLock.readLock().lock();
-    try {
-      if (!isServiceInitialised("handleCacheServerStart")) {
-        return;
-      }
-
-      CacheServerBridge cacheServerBridge = new CacheServerBridge(internalCache, cacheServer);
-      cacheServerBridge.setMemberMBeanBridge(memberMBeanBridge);
-
-      CacheServerMBean cacheServerMBean = new CacheServerMBean(cacheServerBridge);
-
-      ObjectName cacheServerMBeanName = MBeanJMXAdapter.getClientServiceMBeanName(
-          cacheServer.getPort(), internalCache.getDistributedSystem().getDistributedMember());
-
-      ObjectName changedMBeanName =
-          service.registerInternalMBean(cacheServerMBean, cacheServerMBeanName);
-
-      ClientMembershipListener managementClientListener = new CacheServerMembershipListenerAdapter(
-          cacheServerMBean, memberLevelNotifEmitter, changedMBeanName);
-      ClientMembership.registerClientMembershipListener(managementClientListener);
-
-      cacheServerBridge.setClientMembershipListener(managementClientListener);
-
-      service.federate(changedMBeanName, CacheServerMXBean.class, true);
-
-      Notification notification = new Notification(JMXNotificationType.CACHE_SERVER_STARTED,
-          memberSource, SequenceNumber.next(), System.currentTimeMillis(),
-          ManagementConstants.CACHE_SERVER_STARTED_PREFIX);
-
-      memberLevelNotifEmitter.sendNotification(notification);
-
-      memberMBeanBridge.setCacheServer(true);
-    } finally {
-      readWriteLock.readLock().unlock();
+  protected void handleCacheServerStart(CacheServer cacheServer) {
+    if (!isServiceInitialised("handleCacheServerStart")) {
+      return;
     }
+
+    CacheServerBridge cacheServerBridge = new CacheServerBridge(internalCache, cacheServer);
+    cacheServerBridge.setMemberMBeanBridge(memberMBeanBridge);
+
+    CacheServerMBean cacheServerMBean = new CacheServerMBean(cacheServerBridge);
+
+    ObjectName cacheServerMBeanName = MBeanJMXAdapter.getClientServiceMBeanName(
+        cacheServer.getPort(), internalCache.getDistributedSystem().getDistributedMember());
+
+    ObjectName changedMBeanName =
+        service.registerInternalMBean(cacheServerMBean, cacheServerMBeanName);
+
+    ClientMembershipListener managementClientListener = new CacheServerMembershipListenerAdapter(
+        cacheServerMBean, memberLevelNotifEmitter, changedMBeanName);
+    ClientMembership.registerClientMembershipListener(managementClientListener);
+
+    cacheServerBridge.setClientMembershipListener(managementClientListener);
+
+    service.federate(changedMBeanName, CacheServerMXBean.class, true);
+
+    Notification notification = new Notification(JMXNotificationType.CACHE_SERVER_STARTED,
+        memberSource, SequenceNumber.next(), System.currentTimeMillis(),
+        ManagementConstants.CACHE_SERVER_STARTED_PREFIX);
+
+    memberLevelNotifEmitter.sendNotification(notification);
+
+    memberMBeanBridge.setCacheServer(true);
   }
 
   /**
@@ -772,38 +685,32 @@ public class ManagementAdapter {
    *
    * @param server cache server instance
    */
-  public void handleCacheServerStop(CacheServer server) {
-    readWriteLock.readLock().lock();
-    try {
-      if (!isServiceInitialised("handleCacheServerStop")) {
-        return;
-      }
-
-      CacheServerMBean mbean =
-          (CacheServerMBean) service.getLocalCacheServerMXBean(server.getPort());
-
-      ClientMembershipListener listener = mbean.getBridge().getClientMembershipListener();
-
-      if (listener != null) {
-        ClientMembership.unregisterClientMembershipListener(listener);
-      }
-
-      mbean.stopMonitor();
-
-      ObjectName cacheServerMBeanName = MBeanJMXAdapter.getClientServiceMBeanName(server.getPort(),
-          internalCache.getDistributedSystem().getDistributedMember());
-      service.unregisterMBean(cacheServerMBeanName);
-
-      Notification notification = new Notification(JMXNotificationType.CACHE_SERVER_STOPPED,
-          memberSource, SequenceNumber.next(), System.currentTimeMillis(),
-          ManagementConstants.CACHE_SERVER_STOPPED_PREFIX);
-
-      memberLevelNotifEmitter.sendNotification(notification);
-
-      memberMBeanBridge.setCacheServer(false);
-    } finally {
-      readWriteLock.readLock().unlock();
+  protected void handleCacheServerStop(CacheServer server) {
+    if (!isServiceInitialised("handleCacheServerStop")) {
+      return;
     }
+
+    CacheServerMBean mbean = (CacheServerMBean) service.getLocalCacheServerMXBean(server.getPort());
+
+    ClientMembershipListener listener = mbean.getBridge().getClientMembershipListener();
+
+    if (listener != null) {
+      ClientMembership.unregisterClientMembershipListener(listener);
+    }
+
+    mbean.stopMonitor();
+
+    ObjectName cacheServerMBeanName = MBeanJMXAdapter.getClientServiceMBeanName(server.getPort(),
+        internalCache.getDistributedSystem().getDistributedMember());
+    service.unregisterMBean(cacheServerMBeanName);
+
+    Notification notification = new Notification(JMXNotificationType.CACHE_SERVER_STOPPED,
+        memberSource, SequenceNumber.next(), System.currentTimeMillis(),
+        ManagementConstants.CACHE_SERVER_STOPPED_PREFIX);
+
+    memberLevelNotifEmitter.sendNotification(notification);
+
+    memberMBeanBridge.setCacheServer(false);
   }
 
   /**
@@ -811,8 +718,7 @@ public class ManagementAdapter {
    *
    * @param cache GemFire Cache instance. For now client cache is not supported
    */
-  public void handleCacheRemoval(Cache cache) throws ManagementException {
-    readWriteLock.writeLock().lock();
+  protected void handleCacheRemoval(Cache cache) throws ManagementException {
     if (!isServiceInitialised("handleCacheRemoval")) {
       return;
     }
@@ -837,7 +743,6 @@ public class ManagementAdapter {
       this.memberMBeanBridge = null;
       this.memberBean = null;
       this.memberLevelNotifEmitter = null;
-      readWriteLock.writeLock().unlock();
     }
   }
 
@@ -888,46 +793,41 @@ public class ManagementAdapter {
    * Handles particular region destroy or close operation it will remove the corresponding MBean
    *
    */
-  public void handleRegionRemoval(Region region) throws ManagementException {
-    readWriteLock.readLock().lock();
-    try {
-      if (!isServiceInitialised("handleRegionRemoval")) {
+  protected void handleRegionRemoval(Region region) throws ManagementException {
+    if (!isServiceInitialised("handleRegionRemoval")) {
+      return;
+    }
+    /*
+     * Moved region remove operation to a guarded block. If a region is getting created it wont
+     * allow it to destroy any region.
+     */
+
+    synchronized (regionOpLock) {
+      ObjectName regionMBeanName = MBeanJMXAdapter.getRegionMBeanName(
+          internalCache.getDistributedSystem().getDistributedMember(), region.getFullPath());
+      RegionMBean bean;
+      try {
+        bean = (RegionMBean) service.getLocalRegionMBean(region.getFullPath());
+      } catch (ManagementException e) {
+        // If no bean found its a NO-OP
+        // Mostly for situation like DiskAccessException while creating region
+        // which does a compensatory close region
+        if (logger.isDebugEnabled()) {
+          logger.debug(e.getMessage(), e);
+        }
         return;
       }
-      /*
-       * Moved region remove operation to a guarded block. If a region is getting created it wont
-       * allow it to destroy any region.
-       */
 
-      synchronized (regionOpLock) {
-        ObjectName regionMBeanName = MBeanJMXAdapter.getRegionMBeanName(
-            internalCache.getDistributedSystem().getDistributedMember(), region.getFullPath());
-        RegionMBean bean;
-        try {
-          bean = (RegionMBean) service.getLocalRegionMBean(region.getFullPath());
-        } catch (ManagementException e) {
-          // If no bean found its a NO-OP
-          // Mostly for situation like DiskAccessException while creating region
-          // which does a compensatory close region
-          if (logger.isDebugEnabled()) {
-            logger.debug(e.getMessage(), e);
-          }
-          return;
-        }
-
-        if (bean != null) {
-          bean.stopMonitor();
-        }
-        service.unregisterMBean(regionMBeanName);
-
-        Notification notification = new Notification(JMXNotificationType.REGION_CLOSED,
-            memberSource, SequenceNumber.next(), System.currentTimeMillis(),
-            ManagementConstants.REGION_CLOSED_PREFIX + region.getFullPath());
-        memberLevelNotifEmitter.sendNotification(notification);
-        memberMBeanBridge.removeRegion(region);
+      if (bean != null) {
+        bean.stopMonitor();
       }
-    } finally {
-      readWriteLock.readLock().unlock();
+      service.unregisterMBean(regionMBeanName);
+
+      Notification notification = new Notification(JMXNotificationType.REGION_CLOSED, memberSource,
+          SequenceNumber.next(), System.currentTimeMillis(),
+          ManagementConstants.REGION_CLOSED_PREFIX + region.getFullPath());
+      memberLevelNotifEmitter.sendNotification(notification);
+      memberMBeanBridge.removeRegion(region);
     }
   }
 
@@ -935,42 +835,37 @@ public class ManagementAdapter {
    * Handles DiskStore Removal
    *
    */
-  public void handleDiskRemoval(DiskStore disk) throws ManagementException {
-    readWriteLock.readLock().lock();
-    try {
-      if (!isServiceInitialised("handleDiskRemoval")) {
-        return;
-      }
-
-      ObjectName diskStoreMBeanName = MBeanJMXAdapter.getDiskStoreMBeanName(
-          internalCache.getDistributedSystem().getDistributedMember(), disk.getName());
-
-      DiskStoreMBean bean;
-      try {
-        bean = (DiskStoreMBean) service.getLocalDiskStoreMBean(disk.getName());
-        if (bean == null) {
-          return;
-        }
-      } catch (ManagementException e) {
-        // If no bean found its a NO-OP
-        if (logger.isDebugEnabled()) {
-          logger.debug(e.getMessage(), e);
-        }
-        return;
-      }
-
-      bean.stopMonitor();
-
-      service.unregisterMBean(diskStoreMBeanName);
-
-      Notification notification = new Notification(JMXNotificationType.DISK_STORE_CLOSED,
-          memberSource, SequenceNumber.next(), System.currentTimeMillis(),
-          ManagementConstants.DISK_STORE_CLOSED_PREFIX + disk.getName());
-      memberLevelNotifEmitter.sendNotification(notification);
-      memberMBeanBridge.removeDiskStore(disk);
-    } finally {
-      readWriteLock.readLock().unlock();
+  protected void handleDiskRemoval(DiskStore disk) throws ManagementException {
+    if (!isServiceInitialised("handleDiskRemoval")) {
+      return;
     }
+
+    ObjectName diskStoreMBeanName = MBeanJMXAdapter.getDiskStoreMBeanName(
+        internalCache.getDistributedSystem().getDistributedMember(), disk.getName());
+
+    DiskStoreMBean bean;
+    try {
+      bean = (DiskStoreMBean) service.getLocalDiskStoreMBean(disk.getName());
+      if (bean == null) {
+        return;
+      }
+    } catch (ManagementException e) {
+      // If no bean found its a NO-OP
+      if (logger.isDebugEnabled()) {
+        logger.debug(e.getMessage(), e);
+      }
+      return;
+    }
+
+    bean.stopMonitor();
+
+    service.unregisterMBean(diskStoreMBeanName);
+
+    Notification notification = new Notification(JMXNotificationType.DISK_STORE_CLOSED,
+        memberSource, SequenceNumber.next(), System.currentTimeMillis(),
+        ManagementConstants.DISK_STORE_CLOSED_PREFIX + disk.getName());
+    memberLevelNotifEmitter.sendNotification(notification);
+    memberMBeanBridge.removeDiskStore(disk);
   }
 
   /**
@@ -978,27 +873,22 @@ public class ManagementAdapter {
    *
    * @param lockService lock service instance
    */
-  public void handleLockServiceRemoval(DLockService lockService) throws ManagementException {
-    readWriteLock.readLock().lock();
-    try {
-      if (!isServiceInitialised("handleLockServiceRemoval")) {
-        return;
-      }
-
-      ObjectName lockServiceMBeanName = MBeanJMXAdapter.getLockServiceMBeanName(
-          internalCache.getDistributedSystem().getDistributedMember(), lockService.getName());
-
-      LockServiceMXBean bean = service.getLocalLockServiceMBean(lockService.getName());
-
-      service.unregisterMBean(lockServiceMBeanName);
-
-      Notification notification = new Notification(JMXNotificationType.LOCK_SERVICE_CLOSED,
-          memberSource, SequenceNumber.next(), System.currentTimeMillis(),
-          ManagementConstants.LOCK_SERVICE_CLOSED_PREFIX + lockService.getName());
-      memberLevelNotifEmitter.sendNotification(notification);
-    } finally {
-      readWriteLock.readLock().unlock();
+  protected void handleLockServiceRemoval(DLockService lockService) throws ManagementException {
+    if (!isServiceInitialised("handleLockServiceRemoval")) {
+      return;
     }
+
+    ObjectName lockServiceMBeanName = MBeanJMXAdapter.getLockServiceMBeanName(
+        internalCache.getDistributedSystem().getDistributedMember(), lockService.getName());
+
+    LockServiceMXBean bean = service.getLocalLockServiceMBean(lockService.getName());
+
+    service.unregisterMBean(lockServiceMBeanName);
+
+    Notification notification = new Notification(JMXNotificationType.LOCK_SERVICE_CLOSED,
+        memberSource, SequenceNumber.next(), System.currentTimeMillis(),
+        ManagementConstants.LOCK_SERVICE_CLOSED_PREFIX + lockService.getName());
+    memberLevelNotifEmitter.sendNotification(notification);
   }
 
   /**
@@ -1010,163 +900,129 @@ public class ManagementAdapter {
    *
    * @param locator instance of locator which is getting started
    */
-  public void handleLocatorStart(Locator locator) throws ManagementException {
-    readWriteLock.readLock().lock();
-    try {
-      if (!isServiceInitialised("handleLocatorCreation")) {
-        return;
-      }
-
-      ObjectName locatorMBeanName = MBeanJMXAdapter
-          .getLocatorMBeanName(internalCache.getDistributedSystem().getDistributedMember());
-
-      LocatorMBeanBridge bridge = new LocatorMBeanBridge(locator);
-      LocatorMBean locatorMBean = new LocatorMBean(bridge);
-
-      ObjectName changedMBeanName = service.registerInternalMBean(locatorMBean, locatorMBeanName);
-
-      service.federate(changedMBeanName, LocatorMXBean.class, true);
-
-      Notification notification =
-          new Notification(JMXNotificationType.LOCATOR_STARTED, memberSource, SequenceNumber.next(),
-              System.currentTimeMillis(), ManagementConstants.LOCATOR_STARTED_PREFIX);
-
-      memberLevelNotifEmitter.sendNotification(notification);
-    } finally {
-      readWriteLock.readLock().unlock();
+  protected void handleLocatorStart(Locator locator) throws ManagementException {
+    if (!isServiceInitialised("handleLocatorCreation")) {
+      return;
     }
+
+    ObjectName locatorMBeanName = MBeanJMXAdapter
+        .getLocatorMBeanName(internalCache.getDistributedSystem().getDistributedMember());
+
+    LocatorMBeanBridge bridge = new LocatorMBeanBridge(locator);
+    LocatorMBean locatorMBean = new LocatorMBean(bridge);
+
+    ObjectName changedMBeanName = service.registerInternalMBean(locatorMBean, locatorMBeanName);
+
+    service.federate(changedMBeanName, LocatorMXBean.class, true);
+
+    Notification notification =
+        new Notification(JMXNotificationType.LOCATOR_STARTED, memberSource, SequenceNumber.next(),
+            System.currentTimeMillis(), ManagementConstants.LOCATOR_STARTED_PREFIX);
+
+    memberLevelNotifEmitter.sendNotification(notification);
+
   }
 
-  public void handleGatewaySenderStart(GatewaySender sender) throws ManagementException {
-    readWriteLock.readLock().lock();
-    try {
-      if (!isServiceInitialised("handleGatewaySenderStart")) {
-        return;
-      }
-      if ((sender.getRemoteDSId() < 0)) {
-        return;
-      }
-      GatewaySenderMBean bean =
-          (GatewaySenderMBean) service.getLocalGatewaySenderMXBean(sender.getId());
+  protected void handleGatewaySenderStart(GatewaySender sender) throws ManagementException {
+    if (!isServiceInitialised("handleGatewaySenderStart")) {
+      return;
+    }
+    if ((sender.getRemoteDSId() < 0)) {
+      return;
+    }
+    GatewaySenderMBean bean =
+        (GatewaySenderMBean) service.getLocalGatewaySenderMXBean(sender.getId());
 
-      bean.getBridge().setDispatcher();
+    bean.getBridge().setDispatcher();
 
-      Notification notification = new Notification(JMXNotificationType.GATEWAY_SENDER_STARTED,
+    Notification notification = new Notification(JMXNotificationType.GATEWAY_SENDER_STARTED,
+        memberSource, SequenceNumber.next(), System.currentTimeMillis(),
+        ManagementConstants.GATEWAY_SENDER_STARTED_PREFIX + sender.getId());
+
+    memberLevelNotifEmitter.sendNotification(notification);
+  }
+
+  protected void handleGatewaySenderStop(GatewaySender sender) throws ManagementException {
+    if (!isServiceInitialised("handleGatewaySenderStop")) {
+      return;
+    }
+
+    Notification notification = new Notification(JMXNotificationType.GATEWAY_SENDER_STOPPED,
+        memberSource, SequenceNumber.next(), System.currentTimeMillis(),
+        ManagementConstants.GATEWAY_SENDER_STOPPED_PREFIX + sender.getId());
+
+    memberLevelNotifEmitter.sendNotification(notification);
+  }
+
+  protected void handleGatewaySenderPaused(GatewaySender sender) throws ManagementException {
+    if (!isServiceInitialised("handleGatewaySenderPaused")) {
+      return;
+    }
+
+    Notification notification = new Notification(JMXNotificationType.GATEWAY_SENDER_PAUSED,
+        memberSource, SequenceNumber.next(), System.currentTimeMillis(),
+        ManagementConstants.GATEWAY_SENDER_PAUSED_PREFIX + sender.getId());
+
+    memberLevelNotifEmitter.sendNotification(notification);
+  }
+
+  protected void handleGatewaySenderResumed(GatewaySender sender) throws ManagementException {
+    if (!isServiceInitialised("handleGatewaySenderResumed")) {
+      return;
+    }
+
+    Notification notification = new Notification(JMXNotificationType.GATEWAY_SENDER_RESUMED,
+        memberSource, SequenceNumber.next(), System.currentTimeMillis(),
+        ManagementConstants.GATEWAY_SENDER_RESUMED_PREFIX + sender.getId());
+
+    memberLevelNotifEmitter.sendNotification(notification);
+  }
+
+  protected void handleGatewaySenderRemoved(GatewaySender sender) throws ManagementException {
+    if (!isServiceInitialised("handleGatewaySenderRemoved")) {
+      return;
+    }
+    if ((sender.getRemoteDSId() < 0)) {
+      return;
+    }
+
+    GatewaySenderMBean bean =
+        (GatewaySenderMBean) service.getLocalGatewaySenderMXBean(sender.getId());
+    bean.stopMonitor();
+
+    ObjectName gatewaySenderName = MBeanJMXAdapter.getGatewaySenderMBeanName(
+        internalCache.getDistributedSystem().getDistributedMember(), sender.getId());
+    service.unregisterMBean(gatewaySenderName);
+
+    Notification notification = new Notification(JMXNotificationType.GATEWAY_SENDER_REMOVED,
+        memberSource, SequenceNumber.next(), System.currentTimeMillis(),
+        ManagementConstants.GATEWAY_SENDER_REMOVED_PREFIX + sender.getId());
+    memberLevelNotifEmitter.sendNotification(notification);
+  }
+
+  protected void handleCacheServiceCreation(CacheService cacheService) throws ManagementException {
+    if (!isServiceInitialised("handleCacheServiceCreation")) {
+      return;
+    }
+    // Don't register the CacheServices in the Locator
+    InternalDistributedMember member =
+        internalCache.getInternalDistributedSystem().getDistributedMember();
+    if (member.getVmKind() == ClusterDistributionManager.LOCATOR_DM_TYPE) {
+      return;
+    }
+    CacheServiceMBeanBase mbean = cacheService.getMBean();
+    if (mbean != null) {
+      String id = mbean.getId();
+      ObjectName cacheServiceObjectName = MBeanJMXAdapter.getCacheServiceMBeanName(member, id);
+
+      ObjectName changedMBeanName = service.registerInternalMBean(mbean, cacheServiceObjectName);
+
+      service.federate(changedMBeanName, mbean.getInterfaceClass(), true);
+
+      Notification notification = new Notification(JMXNotificationType.CACHE_SERVICE_CREATED,
           memberSource, SequenceNumber.next(), System.currentTimeMillis(),
-          ManagementConstants.GATEWAY_SENDER_STARTED_PREFIX + sender.getId());
-
+          ManagementConstants.CACHE_SERVICE_CREATED_PREFIX + id);
       memberLevelNotifEmitter.sendNotification(notification);
-    } finally {
-      readWriteLock.readLock().unlock();
-    }
-  }
-
-  public void handleGatewaySenderStop(GatewaySender sender) throws ManagementException {
-    readWriteLock.readLock().lock();
-    try {
-      if (!isServiceInitialised("handleGatewaySenderStop")) {
-        return;
-      }
-
-      Notification notification = new Notification(JMXNotificationType.GATEWAY_SENDER_STOPPED,
-          memberSource, SequenceNumber.next(), System.currentTimeMillis(),
-          ManagementConstants.GATEWAY_SENDER_STOPPED_PREFIX + sender.getId());
-
-      memberLevelNotifEmitter.sendNotification(notification);
-    } finally {
-      readWriteLock.readLock().unlock();
-    }
-  }
-
-  public void handleGatewaySenderPaused(GatewaySender sender) throws ManagementException {
-    readWriteLock.readLock().lock();
-    try {
-      if (!isServiceInitialised("handleGatewaySenderPaused")) {
-        return;
-      }
-
-      Notification notification = new Notification(JMXNotificationType.GATEWAY_SENDER_PAUSED,
-          memberSource, SequenceNumber.next(), System.currentTimeMillis(),
-          ManagementConstants.GATEWAY_SENDER_PAUSED_PREFIX + sender.getId());
-
-      memberLevelNotifEmitter.sendNotification(notification);
-    } finally {
-      readWriteLock.readLock().unlock();
-    }
-  }
-
-  public void handleGatewaySenderResumed(GatewaySender sender) throws ManagementException {
-    readWriteLock.readLock().lock();
-    try {
-      if (!isServiceInitialised("handleGatewaySenderResumed")) {
-        return;
-      }
-
-      Notification notification = new Notification(JMXNotificationType.GATEWAY_SENDER_RESUMED,
-          memberSource, SequenceNumber.next(), System.currentTimeMillis(),
-          ManagementConstants.GATEWAY_SENDER_RESUMED_PREFIX + sender.getId());
-
-      memberLevelNotifEmitter.sendNotification(notification);
-    } finally {
-      readWriteLock.readLock().unlock();
-    }
-  }
-
-  public void handleGatewaySenderRemoved(GatewaySender sender) throws ManagementException {
-    readWriteLock.readLock().lock();
-    try {
-      if (!isServiceInitialised("handleGatewaySenderRemoved")) {
-        return;
-      }
-      if ((sender.getRemoteDSId() < 0)) {
-        return;
-      }
-
-      GatewaySenderMBean bean =
-          (GatewaySenderMBean) service.getLocalGatewaySenderMXBean(sender.getId());
-      bean.stopMonitor();
-
-      ObjectName gatewaySenderName = MBeanJMXAdapter.getGatewaySenderMBeanName(
-          internalCache.getDistributedSystem().getDistributedMember(), sender.getId());
-      service.unregisterMBean(gatewaySenderName);
-
-      Notification notification = new Notification(JMXNotificationType.GATEWAY_SENDER_REMOVED,
-          memberSource, SequenceNumber.next(), System.currentTimeMillis(),
-          ManagementConstants.GATEWAY_SENDER_REMOVED_PREFIX + sender.getId());
-      memberLevelNotifEmitter.sendNotification(notification);
-    } finally {
-      readWriteLock.readLock().unlock();
-    }
-  }
-
-  public void handleCacheServiceCreation(CacheService cacheService) throws ManagementException {
-    readWriteLock.readLock().lock();
-    try {
-      if (!isServiceInitialised("handleCacheServiceCreation")) {
-        return;
-      }
-      // Don't register the CacheServices in the Locator
-      InternalDistributedMember member =
-          internalCache.getInternalDistributedSystem().getDistributedMember();
-      if (member.getVmKind() == ClusterDistributionManager.LOCATOR_DM_TYPE) {
-        return;
-      }
-      CacheServiceMBeanBase mbean = cacheService.getMBean();
-      if (mbean != null) {
-        String id = mbean.getId();
-        ObjectName cacheServiceObjectName = MBeanJMXAdapter.getCacheServiceMBeanName(member, id);
-
-        ObjectName changedMBeanName = service.registerInternalMBean(mbean, cacheServiceObjectName);
-
-        service.federate(changedMBeanName, mbean.getInterfaceClass(), true);
-
-        Notification notification = new Notification(JMXNotificationType.CACHE_SERVICE_CREATED,
-            memberSource, SequenceNumber.next(), System.currentTimeMillis(),
-            ManagementConstants.CACHE_SERVICE_CREATED_PREFIX + id);
-        memberLevelNotifEmitter.sendNotification(notification);
-      }
-    } finally {
-      readWriteLock.readLock().unlock();
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/ManagementListener.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/ManagementListener.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.management.internal.beans;
 
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
 import org.apache.geode.cache.DiskStore;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.asyncqueue.AsyncEventQueue;
@@ -44,6 +46,10 @@ public class ManagementListener implements ResourceEventsListener {
   private ManagementAdapter adapter;
 
   private LogWriterI18n logger;
+
+  // having a readwrite lock to synchronize between handling cache creation/removal vs handling
+  // other notifications
+  private final ReentrantReadWriteLock readWriteLock = new ReentrantReadWriteLock();
 
   /**
    * Constructor
@@ -97,121 +103,134 @@ public class ManagementListener implements ResourceEventsListener {
    * @param resource the GFE resource type
    */
   public void handleEvent(ResourceEvent event, Object resource) {
-    if (!shouldProceed(event)) {
-      return;
-    }
-    switch (event) {
-      case CACHE_CREATE:
-        InternalCache createdCache = (InternalCache) resource;
-        adapter.handleCacheCreation(createdCache);
-        break;
-      case CACHE_REMOVE:
-        InternalCache removedCache = (InternalCache) resource;
-        adapter.handleCacheRemoval(removedCache);
-        break;
-      case REGION_CREATE:
-        Region createdRegion = (Region) resource;
-        adapter.handleRegionCreation(createdRegion);
-        break;
-      case REGION_REMOVE:
-        Region removedRegion = (Region) resource;
-        adapter.handleRegionRemoval(removedRegion);
-        break;
-      case DISKSTORE_CREATE:
-        DiskStore createdDisk = (DiskStore) resource;
-        adapter.handleDiskCreation(createdDisk);
-        break;
-      case DISKSTORE_REMOVE:
-        DiskStore removedDisk = (DiskStore) resource;
-        adapter.handleDiskRemoval(removedDisk);
-        break;
-      case GATEWAYRECEIVER_CREATE:
-        GatewayReceiver createdRecv = (GatewayReceiver) resource;
-        adapter.handleGatewayReceiverCreate(createdRecv);
-        break;
-      case GATEWAYRECEIVER_DESTROY:
-        GatewayReceiver destroyedRecv = (GatewayReceiver) resource;
-        adapter.handleGatewayReceiverDestroy(destroyedRecv);
-        break;
-      case GATEWAYRECEIVER_START:
-        GatewayReceiver startedRecv = (GatewayReceiver) resource;
-        adapter.handleGatewayReceiverStart(startedRecv);
-        break;
-      case GATEWAYRECEIVER_STOP:
-        GatewayReceiver stoppededRecv = (GatewayReceiver) resource;
-        adapter.handleGatewayReceiverStop(stoppededRecv);
-        break;
-      case GATEWAYSENDER_CREATE:
-        GatewaySender sender = (GatewaySender) resource;
-        adapter.handleGatewaySenderCreation(sender);
-        break;
-      case GATEWAYSENDER_START:
-        GatewaySender startedSender = (GatewaySender) resource;
-        adapter.handleGatewaySenderStart(startedSender);
-        break;
-      case GATEWAYSENDER_STOP:
-        GatewaySender stoppedSender = (GatewaySender) resource;
-        adapter.handleGatewaySenderStop(stoppedSender);
-        break;
-      case GATEWAYSENDER_PAUSE:
-        GatewaySender pausedSender = (GatewaySender) resource;
-        adapter.handleGatewaySenderPaused(pausedSender);
-        break;
-      case GATEWAYSENDER_RESUME:
-        GatewaySender resumedSender = (GatewaySender) resource;
-        adapter.handleGatewaySenderResumed(resumedSender);
-        break;
-      case GATEWAYSENDER_REMOVE:
-        GatewaySender removedSender = (GatewaySender) resource;
-        adapter.handleGatewaySenderRemoved(removedSender);
-        break;
-      case LOCKSERVICE_CREATE:
-        DLockService createdLockService = (DLockService) resource;
-        adapter.handleLockServiceCreation(createdLockService);
-        break;
-      case LOCKSERVICE_REMOVE:
-        DLockService removedLockService = (DLockService) resource;
-        adapter.handleLockServiceRemoval(removedLockService);
-        break;
-      case MANAGER_CREATE:
-        adapter.handleManagerCreation();
-        break;
-      case MANAGER_START:
-        adapter.handleManagerStart();
-        break;
-      case MANAGER_STOP:
-        adapter.handleManagerStop();
-        break;
-      case ASYNCEVENTQUEUE_CREATE:
-        AsyncEventQueue queue = (AsyncEventQueue) resource;
-        adapter.handleAsyncEventQueueCreation(queue);
-        break;
-      case ASYNCEVENTQUEUE_REMOVE:
-        AsyncEventQueue removedQueue = (AsyncEventQueue) resource;
-        adapter.handleAsyncEventQueueRemoval(removedQueue);
-        break;
-      case SYSTEM_ALERT:
-        AlertDetails details = (AlertDetails) resource;
-        adapter.handleSystemNotification(details);
-        break;
-      case CACHE_SERVER_START:
-        CacheServer startedServer = (CacheServer) resource;
-        adapter.handleCacheServerStart(startedServer);
-        break;
-      case CACHE_SERVER_STOP:
-        CacheServer stoppedServer = (CacheServer) resource;
-        adapter.handleCacheServerStop(stoppedServer);
-        break;
-      case LOCATOR_START:
-        Locator loc = (Locator) resource;
-        adapter.handleLocatorStart(loc);
-        break;
-      case CACHE_SERVICE_CREATE:
-        CacheService service = (CacheService) resource;
-        adapter.handleCacheServiceCreation(service);
-        break;
-      default:
-        break;
+    try {
+      if (!shouldProceed(event)) {
+        return;
+      }
+      if (event == ResourceEvent.CACHE_CREATE || event == ResourceEvent.CACHE_REMOVE) {
+        readWriteLock.writeLock().lock();
+      } else {
+        readWriteLock.readLock().lock();
+      }
+      switch (event) {
+        case CACHE_CREATE:
+          InternalCache createdCache = (InternalCache) resource;
+          adapter.handleCacheCreation(createdCache);
+          break;
+        case CACHE_REMOVE:
+          InternalCache removedCache = (InternalCache) resource;
+          adapter.handleCacheRemoval(removedCache);
+          break;
+        case REGION_CREATE:
+          Region createdRegion = (Region) resource;
+          adapter.handleRegionCreation(createdRegion);
+          break;
+        case REGION_REMOVE:
+          Region removedRegion = (Region) resource;
+          adapter.handleRegionRemoval(removedRegion);
+          break;
+        case DISKSTORE_CREATE:
+          DiskStore createdDisk = (DiskStore) resource;
+          adapter.handleDiskCreation(createdDisk);
+          break;
+        case DISKSTORE_REMOVE:
+          DiskStore removedDisk = (DiskStore) resource;
+          adapter.handleDiskRemoval(removedDisk);
+          break;
+        case GATEWAYRECEIVER_CREATE:
+          GatewayReceiver createdRecv = (GatewayReceiver) resource;
+          adapter.handleGatewayReceiverCreate(createdRecv);
+          break;
+        case GATEWAYRECEIVER_DESTROY:
+          GatewayReceiver destroyedRecv = (GatewayReceiver) resource;
+          adapter.handleGatewayReceiverDestroy(destroyedRecv);
+          break;
+        case GATEWAYRECEIVER_START:
+          GatewayReceiver startedRecv = (GatewayReceiver) resource;
+          adapter.handleGatewayReceiverStart(startedRecv);
+          break;
+        case GATEWAYRECEIVER_STOP:
+          GatewayReceiver stoppededRecv = (GatewayReceiver) resource;
+          adapter.handleGatewayReceiverStop(stoppededRecv);
+          break;
+        case GATEWAYSENDER_CREATE:
+          GatewaySender sender = (GatewaySender) resource;
+          adapter.handleGatewaySenderCreation(sender);
+          break;
+        case GATEWAYSENDER_START:
+          GatewaySender startedSender = (GatewaySender) resource;
+          adapter.handleGatewaySenderStart(startedSender);
+          break;
+        case GATEWAYSENDER_STOP:
+          GatewaySender stoppedSender = (GatewaySender) resource;
+          adapter.handleGatewaySenderStop(stoppedSender);
+          break;
+        case GATEWAYSENDER_PAUSE:
+          GatewaySender pausedSender = (GatewaySender) resource;
+          adapter.handleGatewaySenderPaused(pausedSender);
+          break;
+        case GATEWAYSENDER_RESUME:
+          GatewaySender resumedSender = (GatewaySender) resource;
+          adapter.handleGatewaySenderResumed(resumedSender);
+          break;
+        case GATEWAYSENDER_REMOVE:
+          GatewaySender removedSender = (GatewaySender) resource;
+          adapter.handleGatewaySenderRemoved(removedSender);
+          break;
+        case LOCKSERVICE_CREATE:
+          DLockService createdLockService = (DLockService) resource;
+          adapter.handleLockServiceCreation(createdLockService);
+          break;
+        case LOCKSERVICE_REMOVE:
+          DLockService removedLockService = (DLockService) resource;
+          adapter.handleLockServiceRemoval(removedLockService);
+          break;
+        case MANAGER_CREATE:
+          adapter.handleManagerCreation();
+          break;
+        case MANAGER_START:
+          adapter.handleManagerStart();
+          break;
+        case MANAGER_STOP:
+          adapter.handleManagerStop();
+          break;
+        case ASYNCEVENTQUEUE_CREATE:
+          AsyncEventQueue queue = (AsyncEventQueue) resource;
+          adapter.handleAsyncEventQueueCreation(queue);
+          break;
+        case ASYNCEVENTQUEUE_REMOVE:
+          AsyncEventQueue removedQueue = (AsyncEventQueue) resource;
+          adapter.handleAsyncEventQueueRemoval(removedQueue);
+          break;
+        case SYSTEM_ALERT:
+          AlertDetails details = (AlertDetails) resource;
+          adapter.handleSystemNotification(details);
+          break;
+        case CACHE_SERVER_START:
+          CacheServer startedServer = (CacheServer) resource;
+          adapter.handleCacheServerStart(startedServer);
+          break;
+        case CACHE_SERVER_STOP:
+          CacheServer stoppedServer = (CacheServer) resource;
+          adapter.handleCacheServerStop(stoppedServer);
+          break;
+        case LOCATOR_START:
+          Locator loc = (Locator) resource;
+          adapter.handleLocatorStart(loc);
+          break;
+        case CACHE_SERVICE_CREATE:
+          CacheService service = (CacheService) resource;
+          adapter.handleCacheServiceCreation(service);
+          break;
+        default:
+          break;
+      }
+    } finally {
+      if (event == ResourceEvent.CACHE_CREATE || event == ResourceEvent.CACHE_REMOVE) {
+        readWriteLock.writeLock().unlock();
+      } else {
+        readWriteLock.readLock().unlock();
+      }
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/ManagementListener.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/ManagementListener.java
@@ -103,10 +103,10 @@ public class ManagementListener implements ResourceEventsListener {
    * @param resource the GFE resource type
    */
   public void handleEvent(ResourceEvent event, Object resource) {
+    if (!shouldProceed(event)) {
+      return;
+    }
     try {
-      if (!shouldProceed(event)) {
-        return;
-      }
       if (event == ResourceEvent.CACHE_CREATE || event == ResourceEvent.CACHE_REMOVE) {
         readWriteLock.writeLock().lock();
       } else {

--- a/geode-core/src/test/java/org/apache/geode/management/internal/beans/ManagementAdapterTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/beans/ManagementAdapterTest.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.management.internal.beans;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.powermock.api.mockito.PowerMockito.doReturn;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Scanner;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.distributed.internal.ResourceEvent;
+import org.apache.geode.internal.cache.DiskStoreImpl;
+import org.apache.geode.internal.cache.DiskStoreStats;
+import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.test.junit.categories.IntegrationTest;
+import org.apache.geode.test.junit.rules.ServerStarterRule;
+
+@Category(IntegrationTest.class)
+public class ManagementAdapterTest {
+
+  private InternalCache cache = null;
+  private DiskStoreImpl diskStore = mock(DiskStoreImpl.class);
+  private volatile boolean race = false;
+
+  @Rule
+  public ServerStarterRule serverRule =
+      new ServerStarterRule().withWorkingDir().withLogFile().withAutoStart();
+
+  @Before
+  public void before() {
+    cache = serverRule.getCache();
+    doReturn(new DiskStoreStats(cache.getInternalDistributedSystem(), "disk-stats")).when(diskStore)
+        .getStats();
+    doReturn(new File[] {}).when(diskStore).getDiskDirs();
+  }
+
+  @Test
+  public void testHandlingNotificationsConcurrently() throws InterruptedException {
+    /*
+     * Tests to see if there are any concurrency issues handling resource lifecycle events.
+     *
+     * There are three runnables with specific tasks as below:
+     * r1 - continuously send cache creation/removal notifications, thread modifying the state
+     * r2 - continuously send disk creation/removal, thread relying on state
+     * r3 - monitors log to see if there is a null pointer due race'
+     *
+     * Test runs at most 2 seconds or until a race.
+     */
+
+    Runnable r1 = () -> {
+      while (!race) {
+        try {
+          cache.getInternalDistributedSystem().handleResourceEvent(ResourceEvent.CACHE_REMOVE,
+              cache);
+          Thread.sleep(10);
+          cache.getInternalDistributedSystem().handleResourceEvent(ResourceEvent.CACHE_CREATE,
+              cache);
+          Thread.sleep(10);
+        } catch (InterruptedException e) {
+          e.printStackTrace();
+        }
+      }
+    };
+
+    Runnable r2 = () -> {
+      while (!race) {
+        try {
+          cache.getInternalDistributedSystem().handleResourceEvent(ResourceEvent.DISKSTORE_CREATE,
+              diskStore);
+          Thread.sleep(5);
+          cache.getInternalDistributedSystem().handleResourceEvent(ResourceEvent.DISKSTORE_REMOVE,
+              diskStore);
+          Thread.sleep(5);
+        } catch (InterruptedException e) {
+          e.printStackTrace();
+        }
+      }
+    };
+
+    // r3 scans server log to see if there is null pointer due to caused by cache removal.
+    Runnable r3 = () -> {
+      while (!race) {
+        try {
+          File logFile = new File(serverRule.getWorkingDir() + "/server.log");
+          Scanner scanner = new Scanner(logFile);
+          while (scanner.hasNextLine()) {
+            final String lineFromFile = scanner.nextLine();
+            if (lineFromFile.contains("java.lang.NullPointerException")) {
+              race = true;
+              break;
+            }
+          }
+        } catch (FileNotFoundException e) {
+          // ignore this exception as the temp file might have been deleted after timeout
+        }
+      }
+    };
+
+    List<Runnable> runnables = Arrays.asList(r1, r2, r3);
+
+    final int numThreads = runnables.size();
+    final List<Throwable> exceptions = Collections.synchronizedList(new ArrayList<Throwable>());
+    final ExecutorService threadPool = Executors.newFixedThreadPool(numThreads);
+    try {
+      final CountDownLatch allExecutorThreadsReady = new CountDownLatch(numThreads);
+      final CountDownLatch afterInitBlocker = new CountDownLatch(1);
+      final CountDownLatch allDone = new CountDownLatch(numThreads);
+      for (final Runnable submittedTestRunnable : runnables) {
+        threadPool.submit(() -> {
+          allExecutorThreadsReady.countDown();
+          try {
+            afterInitBlocker.await();
+            submittedTestRunnable.run();
+          } catch (final Throwable e) {
+            exceptions.add(e);
+          } finally {
+            allDone.countDown();
+          }
+        });
+      }
+      // wait until all threads are ready
+      allExecutorThreadsReady.await(runnables.size() * 10, TimeUnit.MILLISECONDS);
+      // start all test runners
+      afterInitBlocker.countDown();
+      // wait until all done or timeout
+      allDone.await(2, TimeUnit.SECONDS);
+    } finally {
+      threadPool.shutdownNow();
+    }
+    assertThat(exceptions).as("failed with exception(s)" + exceptions).isEmpty();
+    assertThat(race).as("is service to be null due to race").isEqualTo(false);
+  }
+}


### PR DESCRIPTION
  Fixed a race condition which causes creation of MBeans to fail while
  handling resource lifecycle change notifications.
  * A readwrite lock is added to synchronize between handling notifications
    of cache creation/removal and handling other notifications.
  * Added a test which to test the synchronization for a fixed amount of time.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
