### PR TITLE
GEODE-3733: Removed flaky flag

### DIFF
--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/acceptance/CacheMaxConnectionJUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/acceptance/CacheMaxConnectionJUnitTest.java
@@ -58,12 +58,11 @@ import org.apache.geode.internal.protocol.protobuf.v1.ProtobufSerializationServi
 import org.apache.geode.internal.protocol.protobuf.v1.serializer.ProtobufProtocolSerializer;
 import org.apache.geode.internal.protocol.protobuf.v1.serializer.exception.InvalidProtocolMessageException;
 import org.apache.geode.test.junit.categories.AcceptanceTest;
-import org.apache.geode.test.junit.categories.FlakyTest;
 
 /**
  * Test that using the magic byte to indicate intend to use ProtoBuf messages works
  */
-@Category({AcceptanceTest.class, FlakyTest.class}) // Flaky - GEODE-3733
+@Category({AcceptanceTest.class})
 public class CacheMaxConnectionJUnitTest {
   private static final String TEST_KEY = "testKey";
   private static final String TEST_VALUE = "testValue";


### PR DESCRIPTION
- ran 210 passes which revealed nothing
- talked to other developers and learned that there have been a number of changes since original bug
- Removing flaky flag in order to get it back into test.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [n/a] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
@upthewaterspout @WireBaron @galen-pivotal @bschuchardt @PivotalSarge