### PR TITLE
GEODE-5261 - Add a test for connection-pool prefill during shutdown

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/ConnectionConnector.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/ConnectionConnector.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache.client.internal;
+
+import java.io.IOException;
+
+import org.apache.geode.CancelCriterion;
+import org.apache.geode.cache.wan.GatewaySender;
+import org.apache.geode.distributed.internal.InternalDistributedSystem;
+import org.apache.geode.distributed.internal.ServerLocation;
+import org.apache.geode.internal.cache.tier.ClientSideHandshake;
+import org.apache.geode.internal.cache.tier.CommunicationMode;
+import org.apache.geode.internal.cache.tier.sockets.CacheClientUpdater;
+import org.apache.geode.internal.cache.tier.sockets.ClientProxyMembershipID;
+import org.apache.geode.internal.net.SocketCreator;
+import org.apache.geode.internal.net.SocketCreatorFactory;
+import org.apache.geode.internal.security.SecurableCommunicationChannel;
+
+public class ConnectionConnector {
+  private final ClientSideHandshakeImpl handshake;
+  private final int socketBufferSize;
+  private final int handshakeTimeout;
+  private final boolean usedByGateway;
+  private final CancelCriterion cancelCriterion;
+  private final SocketCreator socketCreator;
+  private int readTimeout;
+  private InternalDistributedSystem ds;
+  private EndpointManager endpointManager;
+  private GatewaySender gatewaySender;
+
+  public ConnectionConnector(EndpointManager endpointManager, InternalDistributedSystem sys,
+      int socketBufferSize, int handshakeTimeout, int readTimeout, ClientProxyMembershipID proxyId,
+      CancelCriterion cancelCriterion, boolean usedByGateway, GatewaySender sender,
+      boolean multiuserSecureMode) {
+
+    this.handshake =
+        new ClientSideHandshakeImpl(proxyId, sys, sys.getSecurityService(), multiuserSecureMode);
+    this.handshake.setClientReadTimeout(readTimeout);
+    this.endpointManager = endpointManager;
+    this.ds = sys;
+    this.socketBufferSize = socketBufferSize;
+    this.handshakeTimeout = handshakeTimeout;
+    this.readTimeout = readTimeout;
+    this.usedByGateway = usedByGateway;
+    this.gatewaySender = sender;
+    this.cancelCriterion = cancelCriterion;
+    if (this.usedByGateway || (this.gatewaySender != null)) {
+      this.socketCreator =
+          SocketCreatorFactory.getSocketCreatorForComponent(SecurableCommunicationChannel.GATEWAY);
+      if (sender != null && !sender.getGatewayTransportFilters().isEmpty()) {
+        this.socketCreator.initializeTransportFilterClientSocketFactory(sender);
+      }
+    } else {
+      // If configured use SSL properties for cache-server
+      this.socketCreator =
+          SocketCreatorFactory.getSocketCreatorForComponent(SecurableCommunicationChannel.SERVER);
+    }
+  }
+
+  public ConnectionImpl connectClientToServer(ServerLocation location, boolean forQueue)
+      throws IOException {
+    ConnectionImpl connection = new ConnectionImpl(this.ds, this.cancelCriterion);
+    ClientSideHandshake connHandShake = new ClientSideHandshakeImpl(handshake);
+    connection.connect(endpointManager, location, connHandShake, socketBufferSize, handshakeTimeout,
+        readTimeout, getCommMode(forQueue), this.gatewaySender, this.socketCreator);
+    connection.setHandshake(connHandShake);
+    return connection;
+  }
+
+  public CacheClientUpdater connectServerToClient(Endpoint endpoint, QueueManager qManager,
+      boolean isPrimary, ClientUpdater failedUpdater, String clientUpdateName) {
+    CacheClientUpdater updater = new CacheClientUpdater(clientUpdateName, endpoint.getLocation(),
+        isPrimary, ds, new ClientSideHandshakeImpl(this.handshake), qManager, endpointManager,
+        endpoint, handshakeTimeout, this.socketCreator);
+
+    if (!updater.isConnected()) {
+      return null;
+    }
+
+    updater.setFailedUpdater(failedUpdater);
+    updater.start();
+    return updater;
+  }
+
+  private CommunicationMode getCommMode(boolean forQueue) {
+    if (this.usedByGateway || (this.gatewaySender != null)) {
+      return CommunicationMode.GatewayToGateway;
+    } else if (forQueue) {
+      return CommunicationMode.ClientToServerForQueue;
+    } else {
+      return CommunicationMode.ClientToServer;
+    }
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/ConnectionFactoryImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/ConnectionFactoryImpl.java
@@ -29,16 +29,11 @@ import org.apache.geode.cache.client.internal.ServerBlackList.FailureTracker;
 import org.apache.geode.cache.wan.GatewaySender;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.ServerLocation;
-import org.apache.geode.internal.cache.tier.ClientSideHandshake;
-import org.apache.geode.internal.cache.tier.CommunicationMode;
 import org.apache.geode.internal.cache.tier.sockets.CacheClientUpdater;
 import org.apache.geode.internal.cache.tier.sockets.ClientProxyMembershipID;
 import org.apache.geode.internal.i18n.LocalizedStrings;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.logging.log4j.LocalizedMessage;
-import org.apache.geode.internal.net.SocketCreator;
-import org.apache.geode.internal.net.SocketCreatorFactory;
-import org.apache.geode.internal.security.SecurableCommunicationChannel;
 import org.apache.geode.security.GemFireSecurityException;
 
 /**
@@ -54,19 +49,11 @@ public class ConnectionFactoryImpl implements ConnectionFactory {
   // TODO - GEODE-1746, the handshake holds state. It seems like the code depends
   // on all of the handshake operations happening in a single thread. I don't think we
   // want that, need to refactor.
-  private final ClientSideHandshakeImpl handshake;
-  private final int socketBufferSize;
-  private final int handshakeTimeout;
-  private final boolean usedByGateway;
   private final ServerBlackList blackList;
-  private final CancelCriterion cancelCriterion;
-  private final SocketCreator socketCreator;
   private ConnectionSource source;
-  private int readTimeout;
-  private InternalDistributedSystem ds;
-  private EndpointManager endpointManager;
-  private GatewaySender gatewaySender;
   private PoolImpl pool;
+  private final CancelCriterion cancelCriterion;
+  private final ConnectionConnector connectionConnector;
 
   /**
    * Test hook for client version support
@@ -80,45 +67,23 @@ public class ConnectionFactoryImpl implements ConnectionFactory {
       InternalDistributedSystem sys, int socketBufferSize, int handshakeTimeout, int readTimeout,
       ClientProxyMembershipID proxyId, CancelCriterion cancelCriterion, boolean usedByGateway,
       GatewaySender sender, long pingInterval, boolean multiuserSecureMode, PoolImpl pool) {
-    this.handshake =
-        new ClientSideHandshakeImpl(proxyId, sys, sys.getSecurityService(), multiuserSecureMode);
-    this.handshake.setClientReadTimeout(readTimeout);
+    this(
+        new ConnectionConnector(endpointManager, sys, socketBufferSize, handshakeTimeout,
+            readTimeout, proxyId, cancelCriterion, usedByGateway, sender, multiuserSecureMode),
+        source, pingInterval, pool, cancelCriterion);
+  }
+
+  public ConnectionFactoryImpl(ConnectionConnector connectionConnector, ConnectionSource source,
+      long pingInterval, PoolImpl pool, CancelCriterion cancelCriterion) {
     this.source = source;
-    this.endpointManager = endpointManager;
-    this.ds = sys;
-    this.socketBufferSize = socketBufferSize;
-    this.handshakeTimeout = handshakeTimeout;
-    this.readTimeout = readTimeout;
-    this.usedByGateway = usedByGateway;
-    this.gatewaySender = sender;
     this.blackList = new ServerBlackList(pingInterval);
-    this.cancelCriterion = cancelCriterion;
     this.pool = pool;
-    if (this.usedByGateway || (this.gatewaySender != null)) {
-      this.socketCreator =
-          SocketCreatorFactory.getSocketCreatorForComponent(SecurableCommunicationChannel.GATEWAY);
-      if (sender != null && !sender.getGatewayTransportFilters().isEmpty()) {
-        this.socketCreator.initializeTransportFilterClientSocketFactory(sender);
-      }
-    } else {
-      // If configured use SSL properties for cache-server
-      this.socketCreator =
-          SocketCreatorFactory.getSocketCreatorForComponent(SecurableCommunicationChannel.SERVER);
-    }
+    this.cancelCriterion = cancelCriterion;
+    this.connectionConnector = connectionConnector;
   }
 
   public void start(ScheduledExecutorService background) {
     blackList.start(background);
-  }
-
-  private CommunicationMode getCommMode(boolean forQueue) {
-    if (this.usedByGateway || (this.gatewaySender != null)) {
-      return CommunicationMode.GatewayToGateway;
-    } else if (forQueue) {
-      return CommunicationMode.ClientToServerForQueue;
-    } else {
-      return CommunicationMode.ClientToServer;
-    }
   }
 
   public ServerBlackList getBlackList() {
@@ -127,20 +92,15 @@ public class ConnectionFactoryImpl implements ConnectionFactory {
 
   public Connection createClientToServerConnection(ServerLocation location, boolean forQueue)
       throws GemFireSecurityException {
-    ConnectionImpl connection = new ConnectionImpl(this.ds, this.cancelCriterion);
     FailureTracker failureTracker = blackList.getFailureTracker(location);
 
     boolean initialized = false;
-
+    Connection connection = null;
     try {
-      ClientSideHandshake connHandShake = new ClientSideHandshakeImpl(handshake);
-      connection.connect(endpointManager, location, connHandShake, socketBufferSize,
-          handshakeTimeout, readTimeout, getCommMode(forQueue), this.gatewaySender,
-          this.socketCreator);
-      failureTracker.reset();
-      connection.setHandshake(connHandShake);
-      authenticateIfRequired(connection);
+      connection = connectionConnector.connectClientToServer(location, forQueue);
       initialized = true;
+      failureTracker.reset();
+      authenticateIfRequired(connection);
     } catch (GemFireConfigException e) {
       throw e;
     } catch (CancelException e) {
@@ -291,16 +251,8 @@ public class ConnectionFactoryImpl implements ConnectionFactory {
       logger.debug("Establishing: {}", clientUpdateName);
     }
     // Launch the thread
-    CacheClientUpdater updater = new CacheClientUpdater(clientUpdateName, endpoint.getLocation(),
-        isPrimary, ds, new ClientSideHandshakeImpl(this.handshake), qManager, endpointManager,
-        endpoint, handshakeTimeout, this.socketCreator);
-
-    if (!updater.isConnected()) {
-      return null;
-    }
-
-    updater.setFailedUpdater(failedUpdater);
-    updater.start();
+    CacheClientUpdater updater = connectionConnector.connectServerToClient(endpoint, qManager,
+        isPrimary, failedUpdater, clientUpdateName);
 
     return updater;
   }

--- a/geode-core/src/test/java/org/apache/geode/cache/client/internal/ConnectionFactoryJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/client/internal/ConnectionFactoryJUnitTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache.client.internal;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.CancelCriterion;
+import org.apache.geode.CancelException;
+import org.apache.geode.distributed.PoolCancelledException;
+import org.apache.geode.distributed.internal.ServerLocation;
+import org.apache.geode.internal.net.SocketCreatorFactory;
+import org.apache.geode.test.junit.categories.UnitTest;
+
+@Category(UnitTest.class)
+public class ConnectionFactoryJUnitTest {
+
+  @Before
+  public void setUp() throws Exception {}
+
+  @After
+  public void tearDown() throws Exception {
+    SocketCreatorFactory.close();
+  }
+
+  @Test(expected = CancelException.class)
+  public void connectionFactoryThrowsCancelException() throws CancelException, IOException {
+    ServerLocation serverLocation = mock(ServerLocation.class);
+    doReturn(false).when(serverLocation).getRequiresCredentials();
+
+    ConnectionConnector connector = mock(ConnectionConnector.class);
+    doReturn(mock(ConnectionImpl.class)).when(connector).connectClientToServer(serverLocation,
+        false);
+
+    ConnectionSource connectionSource = mock(ConnectionSource.class);
+    doReturn(serverLocation).when(connectionSource).findServer(any(Set.class));
+
+    // mocks don't seem to work well with CancelCriterion so let's create a real one
+    CancelCriterion cancelCriterion = new CancelCriterion() {
+      @Override
+      public String cancelInProgress() {
+        return "shutting down for test";
+      }
+
+      @Override
+      public RuntimeException generateCancelledException(Throwable throwable) {
+        return new PoolCancelledException(cancelInProgress(), throwable);
+      }
+    };
+
+    ConnectionFactoryImpl connectionFactory = new ConnectionFactoryImpl(connector, connectionSource,
+        60000, mock(PoolImpl.class), cancelCriterion);
+
+    connectionFactory.createClientToServerConnection(Collections.emptySet());
+  }
+}


### PR DESCRIPTION
Refactored ConnectionFactoryImpl to allow it to be unit tested.
Added a unit test to prove that createClientToServerConnection(Set) throws a
CancelException if the pool is shutting down.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [na] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
