### PR TITLE
GEODE-5265: fix dataStoreEntryCount statistic

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegionMap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegionMap.java
@@ -1071,7 +1071,7 @@ public abstract class AbstractRegionMap
             if (!re.isRemoved() || re.isTombstone()) {
               Object oldValue = re.getValueInVM(owner);
               final int oldSize = owner.calculateRegionEntryValueSize(re);
-              final boolean wasTombstone = re.isTombstone();
+              final boolean wasDestroyedOrRemoved = re.isDestroyedOrRemoved();
               // Create an entry event only if the calling context is
               // a receipt of a TXCommitMessage AND there are callbacks installed
               // for this region
@@ -1120,7 +1120,7 @@ public abstract class AbstractRegionMap
                     }
                   }
                   EntryLogger.logTXDestroy(_getOwnerObject(), key);
-                  if (!wasTombstone) {
+                  if (!wasDestroyedOrRemoved) {
                     owner.updateSizeOnRemove(key, oldSize);
                   }
                 } catch (RegionClearedException rce) {
@@ -1196,6 +1196,7 @@ public abstract class AbstractRegionMap
                       }
                       int oldSize = 0;
                       boolean wasTombstone = oldRe.isTombstone();
+                      boolean wasDestroyedOrRemoved = oldRe.isDestroyedOrRemoved();
                       {
                         if (!wasTombstone) {
                           oldSize = owner.calculateRegionEntryValueSize(oldRe);
@@ -1205,7 +1206,8 @@ public abstract class AbstractRegionMap
                       EntryLogger.logTXDestroy(_getOwnerObject(), key);
                       if (wasTombstone) {
                         owner.unscheduleTombstone(oldRe);
-                      } else {
+                      }
+                      if (!wasDestroyedOrRemoved) {
                         owner.updateSizeOnRemove(oldRe.getKey(), oldSize);
                       }
                       owner.txApplyDestroyPart2(oldRe, oldRe.getKey(), inTokenMode,

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegionMap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegionMap.java
@@ -886,7 +886,9 @@ public abstract class AbstractRegionMap
                         }
                       }
                       if (newValue == Token.TOMBSTONE) {
-                        owner.updateSizeOnRemove(key, oldSize);
+                        if (!oldIsTombstone) {
+                          owner.updateSizeOnRemove(key, oldSize);
+                        }
                         if (owner.getServerProxy() == null
                             && owner.getVersionVector().isTombstoneTooOld(
                                 entryVersion.getMemberID(), entryVersion.getRegionVersion())) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegionMap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegionMap.java
@@ -783,7 +783,9 @@ public abstract class AbstractRegionMap
                                            // value for the cache
           if (re.isTombstone()) {
             _getOwner().scheduleTombstone(re, re.getVersionStamp().asVersionTag());
-            _getOwner().updateSizeOnRemove(key, oldSize);
+            if (!oldValueWasTombstone) {
+              _getOwner().updateSizeOnRemove(key, oldSize);
+            }
           } else if (oldValueWasTombstone) {
             _getOwner().updateSizeOnCreate(key, _getOwner().calculateRegionEntryValueSize(re));
           } else {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegionMap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegionMap.java
@@ -767,6 +767,7 @@ public abstract class AbstractRegionMap
       try {
         if (_isOwnerALocalRegion()) {
           boolean oldValueWasTombstone = re.isTombstone();
+          boolean oldIsDestroyedOrRemoved = re.isDestroyedOrRemoved();
           if (oldValueWasTombstone) {
             // when a tombstone is to be overwritten, unschedule it first
             _getOwner().unscheduleTombstone(re);
@@ -783,10 +784,10 @@ public abstract class AbstractRegionMap
                                            // value for the cache
           if (re.isTombstone()) {
             _getOwner().scheduleTombstone(re, re.getVersionStamp().asVersionTag());
-            if (!oldValueWasTombstone) {
+            if (!oldIsDestroyedOrRemoved) {
               _getOwner().updateSizeOnRemove(key, oldSize);
             }
-          } else if (oldValueWasTombstone) {
+          } else if (oldIsDestroyedOrRemoved) {
             _getOwner().updateSizeOnCreate(key, _getOwner().calculateRegionEntryValueSize(re));
           } else {
             _getOwner().updateSizeOnPut(key, oldSize,

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegionMap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegionMap.java
@@ -872,6 +872,7 @@ public abstract class AbstractRegionMap
                     }
                   }
                   final boolean oldIsTombstone = oldRe.isTombstone();
+                  final boolean oldIsDestroyedOrRemoved = oldRe.isDestroyedOrRemoved();
                   final int oldSize = owner.calculateRegionEntryValueSize(oldRe);
                   try {
                     result = oldRe.initialImagePut(owner, lastModified, newValue, wasRecovered,
@@ -886,7 +887,7 @@ public abstract class AbstractRegionMap
                         }
                       }
                       if (newValue == Token.TOMBSTONE) {
-                        if (!oldIsTombstone) {
+                        if (!oldIsDestroyedOrRemoved) {
                           owner.updateSizeOnRemove(key, oldSize);
                         }
                         if (owner.getServerProxy() == null

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/map/RegionMapDestroy.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/map/RegionMapDestroy.java
@@ -720,11 +720,14 @@ public class RegionMapDestroy {
       EntryNotFoundException, RegionClearedException {
     focusedRegionMap.processVersionTag(re, event);
     final int oldSize = internalRegion.calculateRegionEntryValueSize(re);
+    final boolean wasRemoved = re.isDestroyedOrRemoved();
     boolean retVal = re.destroy(event.getRegion(), event, inTokenMode, cacheWrite, expectedOldValue,
         forceDestroy, removeRecoveredEntry);
     if (retVal) {
       EntryLogger.logDestroy(event);
-      internalRegion.updateSizeOnRemove(event.getKey(), oldSize);
+      if (!wasRemoved) {
+        internalRegion.updateSizeOnRemove(event.getKey(), oldSize);
+      }
     }
     return retVal;
   }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/AbstractRegionMapTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/AbstractRegionMapTest.java
@@ -717,10 +717,11 @@ public class AbstractRegionMapTest {
   }
 
   @Test
-  public void updateRecoveredEntry_givenExistingTombstoneAndSettingToTombstone_neverCallsUpdateSizeOnRemove() {
+  public void updateRecoveredEntry_givenExistingDestroyedOrRemovedAndSettingToTombstone_neverCallsUpdateSizeOnRemove() {
     RecoveredEntry recoveredEntry = mock(RecoveredEntry.class);
     RegionEntry regionEntry = mock(RegionEntry.class);
-    when(regionEntry.isTombstone()).thenReturn(true);
+    when(regionEntry.isTombstone()).thenReturn(false).thenReturn(true);
+    when(regionEntry.isDestroyedOrRemoved()).thenReturn(true);
     when(regionEntry.getVersionStamp()).thenReturn(mock(VersionStamp.class));
     TestableAbstractRegionMap arm = new TestableAbstractRegionMap(false, null, null, regionEntry);
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/AbstractRegionMapTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/AbstractRegionMapTest.java
@@ -814,9 +814,10 @@ public class AbstractRegionMapTest {
   }
 
   @Test
-  public void txApplyDestroy_givenExistingTombstone_neverCallsUpdateSizeOnRemove() {
+  public void txApplyDestroy_givenExistingDestroyedOrRemovedEntry_neverCallsUpdateSizeOnRemove() {
     RegionEntry regionEntry = mock(RegionEntry.class);
-    when(regionEntry.isTombstone()).thenReturn(true);
+    when(regionEntry.isTombstone()).thenReturn(false);
+    when(regionEntry.isDestroyedOrRemoved()).thenReturn(true);
     when(regionEntry.getVersionStamp()).thenReturn(mock(VersionStamp.class));
     TXId txId = mock(TXId.class);
     when(txId.getMemberId()).thenReturn(mock(InternalDistributedMember.class));
@@ -844,11 +845,12 @@ public class AbstractRegionMapTest {
   }
 
   @Test
-  public void txApplyDestroy_givenPutIfAbsentReturningTombstone_neverCallsUpdateSizeOnRemove()
+  public void txApplyDestroy_givenPutIfAbsentReturningDestroyedOrRemovedEntry_neverCallsUpdateSizeOnRemove()
       throws RegionClearedException {
     ConcurrentMapWithReusableEntries map = mock(ConcurrentMapWithReusableEntries.class);
     RegionEntry entry = mock(RegionEntry.class);
-    when(entry.isTombstone()).thenReturn(true);
+    when(entry.isTombstone()).thenReturn(false);
+    when(entry.isDestroyedOrRemoved()).thenReturn(true);
     VersionStamp versionStamp = mock(VersionStamp.class);
     when(entry.getVersionStamp()).thenReturn(versionStamp);
     when(versionStamp.asVersionTag()).thenReturn(mock(VersionTag.class));

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/AbstractRegionMapTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/AbstractRegionMapTest.java
@@ -766,11 +766,11 @@ public class AbstractRegionMapTest {
   }
 
   @Test
-  public void initialImagePut_givenPutIfAbsentReturningTombstone_neverCallsUpdateSizeOnRemove()
+  public void initialImagePut_givenPutIfAbsentReturningDestroyedOrRemovedEntry_neverCallsUpdateSizeOnRemove()
       throws RegionClearedException {
     ConcurrentMapWithReusableEntries map = mock(ConcurrentMapWithReusableEntries.class);
     RegionEntry entry = mock(RegionEntry.class);
-    when(entry.isTombstone()).thenReturn(true);
+    when(entry.isDestroyedOrRemoved()).thenReturn(true);
     when(entry.initialImagePut(any(), anyLong(), any(), anyBoolean(), anyBoolean()))
         .thenReturn(true);
     VersionStamp versionStamp = mock(VersionStamp.class);
@@ -794,6 +794,7 @@ public class AbstractRegionMapTest {
     ConcurrentMapWithReusableEntries map = mock(ConcurrentMapWithReusableEntries.class);
     RegionEntry entry = mock(RegionEntry.class);
     when(entry.isTombstone()).thenReturn(false);
+    when(entry.isDestroyedOrRemoved()).thenReturn(false);
     when(entry.initialImagePut(any(), anyLong(), any(), anyBoolean(), anyBoolean()))
         .thenReturn(true);
     VersionStamp versionStamp = mock(VersionStamp.class);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/AbstractRegionMapTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/AbstractRegionMapTest.java
@@ -716,30 +716,51 @@ public class AbstractRegionMapTest {
 
   @Test
   public void updateRecoveredEntry_givenExistingTombstoneAndSettingToTombstone_neverCallsUpdateSizeOnRemove() {
-    Object key = "key";
     RecoveredEntry recoveredEntry = mock(RecoveredEntry.class);
     RegionEntry regionEntry = mock(RegionEntry.class);
     when(regionEntry.isTombstone()).thenReturn(true);
     when(regionEntry.getVersionStamp()).thenReturn(mock(VersionStamp.class));
     TestableAbstractRegionMap arm = new TestableAbstractRegionMap(false, null, null, regionEntry);
 
-    arm.updateRecoveredEntry(key, recoveredEntry);
+    arm.updateRecoveredEntry(KEY, recoveredEntry);
+
+    verify(arm._getOwner(), never()).updateSizeOnRemove(any(), anyInt());
+  }
+
+  @Test
+  public void updateRecoveredEntry_givenExistingRemovedNonTombstone_neverCallsUpdateSizeOnRemove() {
+    RecoveredEntry recoveredEntry = mock(RecoveredEntry.class);
+    RegionEntry regionEntry = mock(RegionEntry.class);
+    when(regionEntry.isRemoved()).thenReturn(true);
+    when(regionEntry.isTombstone()).thenReturn(false);
+    TestableAbstractRegionMap arm = new TestableAbstractRegionMap(false, null, null, regionEntry);
+
+    arm.updateRecoveredEntry(KEY, recoveredEntry);
+
+    verify(arm._getOwner(), never()).updateSizeOnRemove(any(), anyInt());
+  }
+
+  @Test
+  public void updateRecoveredEntry_givenNoExistingEntry_neverCallsUpdateSizeOnRemove() {
+    RecoveredEntry recoveredEntry = mock(RecoveredEntry.class);
+    TestableAbstractRegionMap arm = new TestableAbstractRegionMap(false, null, null, null);
+
+    arm.updateRecoveredEntry(KEY, recoveredEntry);
 
     verify(arm._getOwner(), never()).updateSizeOnRemove(any(), anyInt());
   }
 
   @Test
   public void updateRecoveredEntry_givenExistingNonTombstoneAndSettingToTombstone_callsUpdateSizeOnRemove() {
-    Object key = "key";
     RecoveredEntry recoveredEntry = mock(RecoveredEntry.class);
     RegionEntry regionEntry = mock(RegionEntry.class);
     when(regionEntry.isTombstone()).thenReturn(false).thenReturn(true);
     when(regionEntry.getVersionStamp()).thenReturn(mock(VersionStamp.class));
     TestableAbstractRegionMap arm = new TestableAbstractRegionMap(false, null, null, regionEntry);
 
-    arm.updateRecoveredEntry(key, recoveredEntry);
+    arm.updateRecoveredEntry(KEY, recoveredEntry);
 
-    verify(arm._getOwner(), times(1)).updateSizeOnRemove(eq(key), anyInt());
+    verify(arm._getOwner(), times(1)).updateSizeOnRemove(eq(KEY), anyInt());
   }
 
   private EntryEventImpl createEventForInvalidate(LocalRegion lr) {


### PR DESCRIPTION
A number of places existed in which even though the entry had already been destroyed; it could be destroyed again. In those cases the statistic would decremented an extra time.
In one place the stat was incremented when doing txApplyDestroy even though an entry was not being added to the region.
Unit tests were added for all these places that failed before the code was fixed.

@dhemery 