### PR TITLE
GEODE-5256: Parameters Precedence in Start Server

### DIFF
--- a/geode-assembly/src/test/java/org/apache/geode/management/internal/cli/commands/StartServerCommandAcceptanceTest.java
+++ b/geode-assembly/src/test/java/org/apache/geode/management/internal/cli/commands/StartServerCommandAcceptanceTest.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.management.internal.cli.commands;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestName;
+
+import org.apache.geode.cache.server.CacheServer;
+import org.apache.geode.internal.AvailablePortHelper;
+import org.apache.geode.internal.cache.xmlcache.CacheCreation;
+import org.apache.geode.internal.cache.xmlcache.CacheXmlGenerator;
+import org.apache.geode.test.junit.categories.AcceptanceTest;
+import org.apache.geode.test.junit.rules.gfsh.GfshExecution;
+import org.apache.geode.test.junit.rules.gfsh.GfshRule;
+import org.apache.geode.test.junit.rules.gfsh.GfshScript;
+import org.apache.geode.test.junit.rules.serializable.SerializableTestName;
+
+/**
+ * Start server parameters should take precedence over cache.xml file and cluster configuration
+ * service. See GEODE-5256.
+ */
+@Category(AcceptanceTest.class)
+public class StartServerCommandAcceptanceTest {
+
+  @Rule
+  public GfshRule gfshRule = new GfshRule();
+
+  @Rule
+  public TestName testName = new SerializableTestName();
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Test
+  public void startStandaloneServerWithParametersShouldOverrideCacheXmlConfiguration()
+      throws IOException {
+    File logFile = temporaryFolder.newFile(testName.getMethodName() + ".log");
+    File cacheXmlFile = temporaryFolder.newFile(testName.getMethodName() + "Cache.xml");
+
+    CacheCreation creation = new CacheCreation();
+    CacheServer server = creation.addCacheServer();
+    server.setPort(40404);
+    server.setBindAddress(null);
+    server.setHostnameForClients(null);
+    server.setMaxConnections(800);
+    server.setMaxThreads(0);
+    server.setMaximumMessageCount(230000);
+    server.setMessageTimeToLive(180);
+    server.setSocketBufferSize(32768);
+    PrintWriter pw = new PrintWriter(new FileWriter(cacheXmlFile), true);
+    CacheXmlGenerator.generate(creation, pw);
+    pw.close();
+
+    Integer serverPort = AvailablePortHelper.getRandomAvailableTCPPort();
+    StringBuilder startServerCommandBuilder = new StringBuilder("start server");
+    startServerCommandBuilder.append(" --max-threads=100");
+    startServerCommandBuilder.append(" --max-connections=1200");
+    startServerCommandBuilder.append(" --max-message-count=5000");
+    startServerCommandBuilder.append(" --message-time-to-live=360");
+    startServerCommandBuilder.append(" --socket-buffer-size=16384");
+    startServerCommandBuilder.append(" --server-port=" + serverPort);
+    startServerCommandBuilder.append(" --name=" + testName.getMethodName());
+    startServerCommandBuilder.append(" --cache-xml-file=" + cacheXmlFile.getAbsolutePath());
+    startServerCommandBuilder.append(" --J=-Dgemfire.log-file=" + logFile.getAbsolutePath());
+
+    GfshExecution execution = GfshScript.of(startServerCommandBuilder.toString()).execute(gfshRule);
+    assertThat(execution.getOutputText())
+        .containsPattern("Server .* " + testName.getMethodName() + " is currently online.");
+
+    // Assert Server Properties.
+    try (BufferedReader br = new BufferedReader(new FileReader(logFile))) {
+      String line;
+      while ((line = br.readLine()) != null) {
+        if (line.contains("CacheServer Configuration:")) {
+          assertThat(line.contains("max-threads=100")).isTrue();
+          assertThat(line.contains("port=" + serverPort)).isTrue();
+          assertThat(line.contains("max-connections=1200")).isTrue();
+          assertThat(line.contains("message-time-to-live=360")).isTrue();
+          assertThat(line.contains("socket-buffer-size=16384")).isTrue();
+          assertThat(line.contains("maximum-message-count=5000")).isTrue();
+        }
+      }
+    }
+  }
+
+
+  @Test
+  public void startServerWithParametersWhenClusterConfigurationServiceIsEnabledShouldOverrideDefaults()
+      throws IOException {
+    Integer serverPort = AvailablePortHelper.getRandomAvailableTCPPort();
+    File logFile = temporaryFolder.newFile(testName.getMethodName() + ".log");
+
+    StringBuilder startServerCommandBuilder = new StringBuilder("start server");
+    startServerCommandBuilder.append(" --max-threads=50");
+    startServerCommandBuilder.append(" --max-connections=200");
+    startServerCommandBuilder.append(" --max-message-count=500");
+    startServerCommandBuilder.append(" --message-time-to-live=120");
+    startServerCommandBuilder.append(" --socket-buffer-size=8192");
+    startServerCommandBuilder.append(" --server-port=" + serverPort);
+    startServerCommandBuilder.append(" --use-cluster-configuration=true");
+    startServerCommandBuilder.append(" --name=" + testName.getMethodName());
+    startServerCommandBuilder.append(" --J=-Dgemfire.log-file=" + logFile.getAbsolutePath());
+
+    // Start Locator, configure PDX (just to have a non-empty cluster-configuration) and start
+    // server.
+    GfshExecution startClusterExecution = GfshScript
+        .of("start locator --name=locator1 --connect=true --enable-cluster-configuration=true",
+            "configure pdx --read-serialized=true", startServerCommandBuilder.toString())
+        .execute(gfshRule);
+
+    assertThat(startClusterExecution.getOutputText())
+        .contains("Successfully connected to: JMX Manager")
+        .contains("Changes to configuration for group 'cluster' are persisted.")
+        .containsPattern("Server .* " + testName.getMethodName() + " is currently online.");
+
+    // Assert Server Properties.
+    try (BufferedReader br = new BufferedReader(new FileReader(logFile))) {
+      String line;
+      while ((line = br.readLine()) != null) {
+        if (line.contains("CacheServer Configuration:")) {
+          assertThat(line.contains("max-threads=50")).isTrue();
+          assertThat(line.contains("port=" + serverPort)).isTrue();
+          assertThat(line.contains("max-connections=200")).isTrue();
+          assertThat(line.contains("message-time-to-live=120")).isTrue();
+          assertThat(line.contains("socket-buffer-size=8192")).isTrue();
+          assertThat(line.contains("maximum-message-count=500")).isTrue();
+        }
+      }
+    }
+  }
+}

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache30/ReconnectWithCacheXMLDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache30/ReconnectWithCacheXMLDUnitTest.java
@@ -85,9 +85,9 @@ public class ReconnectWithCacheXMLDUnitTest extends JUnit4CacheTestCase {
   }
 
   @Test
-  public void testCacheServerLauncherPortRetained() throws Exception {
-    CacheServerLauncher.setDisableDefaultServer(true);
-    CacheServerLauncher.setServerPort(AvailablePortHelper.getRandomAvailableTCPPort());
+  public void testCacheServerLauncherPortRetained() {
+    CacheServerLauncher.setParameters(new CacheServerLauncher.Parameters(
+        AvailablePortHelper.getRandomAvailableTCPPort(), null, true));
     Cache cache = getCache();
 
     final AtomicBoolean membershipFailed = new AtomicBoolean();
@@ -119,7 +119,7 @@ public class ReconnectWithCacheXMLDUnitTest extends JUnit4CacheTestCase {
 
     Cache newCache = cache.getReconnectedCache();
     CacheServer server = newCache.getCacheServers().iterator().next();
-    assertEquals(CacheServerLauncher.getServerPort().intValue(), server.getPort());
+    assertEquals(CacheServerLauncher.getParameters().getServerPort().intValue(), server.getPort());
     assertEquals(20, server.getMaxConnections()); // this setting is in the XML file
   }
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache30/ReconnectWithCacheXMLDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache30/ReconnectWithCacheXMLDUnitTest.java
@@ -28,13 +28,11 @@ import org.junit.experimental.categories.Category;
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.server.CacheServer;
 import org.apache.geode.distributed.ConfigurationProperties;
+import org.apache.geode.distributed.ServerLauncherParameters;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.membership.MembershipTestHook;
 import org.apache.geode.distributed.internal.membership.gms.MembershipManagerHelper;
 import org.apache.geode.internal.AvailablePortHelper;
-import org.apache.geode.internal.cache.CacheServerLauncher;
-import org.apache.geode.test.dunit.Wait;
-import org.apache.geode.test.dunit.WaitCriterion;
 import org.apache.geode.test.dunit.cache.internal.JUnit4CacheTestCase;
 import org.apache.geode.test.junit.categories.ClientServerTest;
 import org.apache.geode.test.junit.categories.MembershipTest;
@@ -47,17 +45,14 @@ import org.apache.geode.util.test.TestUtil;
  */
 @Category({MembershipTest.class, ClientServerTest.class})
 public class ReconnectWithCacheXMLDUnitTest extends JUnit4CacheTestCase {
+  private static final long serialVersionUID = 1L;
+  private String xmlProperty = DistributionConfig.GEMFIRE_PREFIX + "autoReconnect-useCacheXMLFile";
+  private String oldPropertySetting;
 
 
   public ReconnectWithCacheXMLDUnitTest() {
     super();
   }
-
-  private static final long serialVersionUID = 1L;
-
-
-  private String xmlProperty = DistributionConfig.GEMFIRE_PREFIX + "autoReconnect-useCacheXMLFile";
-  private String oldPropertySetting;
 
   @Override
   public final void postSetUp() {
@@ -65,7 +60,7 @@ public class ReconnectWithCacheXMLDUnitTest extends JUnit4CacheTestCase {
   }
 
   @Override
-  public final void preTearDownCacheTestCase() throws Exception {
+  public final void preTearDownCacheTestCase() {
     if (oldPropertySetting == null) {
       System.getProperties().remove(xmlProperty);
     } else {
@@ -86,8 +81,8 @@ public class ReconnectWithCacheXMLDUnitTest extends JUnit4CacheTestCase {
 
   @Test
   public void testCacheServerLauncherPortRetained() {
-    CacheServerLauncher.setParameters(new CacheServerLauncher.Parameters(
-        AvailablePortHelper.getRandomAvailableTCPPort(), null, true));
+    ServerLauncherParameters.INSTANCE.withPort(AvailablePortHelper.getRandomAvailableTCPPort())
+        .withDisableDefaultServer(true);
     Cache cache = getCache();
 
     final AtomicBoolean membershipFailed = new AtomicBoolean();
@@ -102,25 +97,12 @@ public class ReconnectWithCacheXMLDUnitTest extends JUnit4CacheTestCase {
     });
     MembershipManagerHelper.crashDistributedSystem(cache.getDistributedSystem());
     assertTrue(membershipFailed.get());
-
-    WaitCriterion wc = new WaitCriterion() {
-      @Override
-      public boolean done() {
-        return cache.getReconnectedCache() != null;
-      }
-
-      @Override
-      public String description() {
-        return "waiting for cache to reconnect";
-      }
-    };
-    Wait.waitForCriterion(wc, 60000, 5000, true);
-    await().atMost(60, TimeUnit.SECONDS).until(() -> cache.getReconnectedCache() != null);
+    await().atMost(60000, TimeUnit.MILLISECONDS).pollInterval(5000, TimeUnit.MILLISECONDS)
+        .until(() -> cache.getReconnectedCache() != null);
 
     Cache newCache = cache.getReconnectedCache();
     CacheServer server = newCache.getCacheServers().iterator().next();
-    assertEquals(CacheServerLauncher.getParameters().getServerPort().intValue(), server.getPort());
+    assertEquals(ServerLauncherParameters.INSTANCE.getPort().intValue(), server.getPort());
     assertEquals(20, server.getMaxConnections()); // this setting is in the XML file
   }
-
 }

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/StartServerWithXmlDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/StartServerWithXmlDUnitTest.java
@@ -54,8 +54,8 @@ public class StartServerWithXmlDUnitTest {
     server = cluster.getVM(1);
 
     server.invoke(() -> {
-      CacheServerLauncher.setServerBindAddress("localhost");
-      CacheServerLauncher.setDisableDefaultServer(false);
+      CacheServerLauncher
+          .setParameters(new CacheServerLauncher.Parameters(null, "localhost", false));
       CacheFactory cf = new CacheFactory(props);
       Cache cache = cf.create();
     });

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/StartServerWithXmlDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/StartServerWithXmlDUnitTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.CacheFactory;
+import org.apache.geode.distributed.ServerLauncherParameters;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
@@ -54,8 +55,7 @@ public class StartServerWithXmlDUnitTest {
     server = cluster.getVM(1);
 
     server.invoke(() -> {
-      CacheServerLauncher
-          .setParameters(new CacheServerLauncher.Parameters(null, "localhost", false));
+      ServerLauncherParameters.INSTANCE.withBindAddress("localhost");
       CacheFactory cf = new CacheFactory(props);
       Cache cache = cf.create();
     });

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/ServerLauncherBuilderIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/ServerLauncherBuilderIntegrationTest.java
@@ -1,0 +1,314 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.distributed;
+
+import static com.googlecode.catchexception.apis.BDDCatchException.caughtException;
+import static com.googlecode.catchexception.apis.BDDCatchException.when;
+import static org.apache.geode.distributed.ConfigurationProperties.NAME;
+import static org.apache.geode.distributed.DistributedSystem.PROPERTIES_FILE_PROPERTY;
+import static org.apache.geode.distributed.internal.DistributionConfig.GEMFIRE_PREFIX;
+import static org.apache.geode.internal.cache.AbstractCacheServer.TEST_OVERRIDE_DEFAULT_PORT_PROPERTY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Properties;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestName;
+
+import org.apache.geode.distributed.ServerLauncher.Builder;
+import org.apache.geode.distributed.ServerLauncher.Command;
+import org.apache.geode.internal.AvailablePortHelper;
+import org.apache.geode.internal.i18n.LocalizedStrings;
+
+/**
+ * Integration tests for using {@link ServerLauncher} as an in-process API within an existing JVM.
+ */
+public class ServerLauncherBuilderIntegrationTest {
+
+  private static final String CURRENT_DIRECTORY = System.getProperty("user.dir");
+
+  @Rule
+  public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
+
+  @Rule
+  public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Rule
+  public final TestName testName = new TestName();
+
+  @Test
+  public void buildWithMemberNameSetInGemFireProperties() {
+    // given: gemfire.properties containing a name
+    givenGemFirePropertiesFile(withMemberName());
+
+    // when: starting with null MemberName
+    ServerLauncher launcher = new Builder().setCommand(Command.START).build();
+
+    // then: name in gemfire.properties file should be used for MemberName
+    assertThat(launcher.getMemberName()).isNull(); // name will be read during start()
+  }
+
+  @Test
+  public void buildWithoutMemberNameThrowsIllegalStateException() {
+    // given: gemfire.properties with no name
+    givenGemFirePropertiesFile(withoutMemberName());
+
+    // when: no MemberName is specified
+    when(new Builder().setCommand(Command.START)).build();
+
+    // then: throw IllegalStateException
+    then(caughtException()).isExactlyInstanceOf(IllegalStateException.class)
+        .hasMessage(memberNameValidationErrorMessage());
+  }
+
+  @Test
+  public void buildWithWorkingDirectoryNotEqualToCurrentDirectoryThrowsIllegalStateException() {
+    // given: using LocatorLauncher in-process
+
+    // when: setting WorkingDirectory to non-current directory
+    when(new Builder().setCommand(Command.START).setMemberName("memberOne")
+        .setWorkingDirectory(getWorkingDirectoryPath())).build();
+
+    // then: throw IllegalStateException
+    then(caughtException()).isExactlyInstanceOf(IllegalStateException.class)
+        .hasMessage(workingDirectoryOptionNotValidErrorMessage());
+  }
+
+  @Test
+  public void parseArgumentsParsesValuesSeparatedByCommas() throws UnknownHostException {
+    // given: a new builder
+    Builder builder = new Builder();
+
+    // when: parsing many arguments
+    builder.parseArguments("start", "memberOne", "--server-bind-address",
+        InetAddress.getLocalHost().getHostAddress(), "--dir", getWorkingDirectoryPath(),
+        "--hostname-for-clients", "Tucows", "--pid", "1234", "--server-port", "11235",
+        "--redirect-output", "--force", "--debug", "--max-connections", "300",
+        "--max-message-count", "1000", "--message-time-to-live", "10000", "--socket-buffer-size",
+        "1024", "--max-threads", "900");
+
+    // then: the getters should return properly parsed values
+    assertThat(builder.getCommand()).isEqualTo(Command.START);
+    assertThat(builder.getDebug()).isTrue();
+    assertThat(builder.getForce()).isTrue();
+    assertThat(builder.getHostNameForClients()).isEqualTo("Tucows");
+    assertThat(builder.getPid().intValue()).isEqualTo(1234);
+    assertThat(builder.getServerBindAddress()).isEqualTo(InetAddress.getLocalHost());
+    assertThat(builder.getServerPort().intValue()).isEqualTo(11235);
+    assertThat(builder.getRedirectOutput()).isTrue();
+    assertThat(builder.getWorkingDirectory()).isEqualTo(getWorkingDirectoryPath());
+    assertThat(builder.getMaxConnections()).isEqualTo(300);
+    assertThat(builder.getMaxMessageCount()).isEqualTo(1000);
+    assertThat(builder.getMessageTimeToLive()).isEqualTo(10000);
+    assertThat(builder.getSocketBufferSize()).isEqualTo(1024);
+    assertThat(builder.getMaxThreads()).isEqualTo(900);
+  }
+
+  @Test
+  public void parseArgumentsParsesValuesSeparatedByEquals() {
+    // given: a new builder
+    Builder builder = new Builder();
+
+    // when: parsing arguments with values separated by equals
+    builder.parseArguments("start", "--dir=" + getWorkingDirectoryPath(),
+        "--server-port=" + "12345", "memberOne", "--max-connections=300",
+        "--max-message-count=1000", "--message-time-to-live=10000", "--socket-buffer-size=1024",
+        "--max-threads=900");
+
+    // then: the getters should return properly parsed values
+    assertThat(builder.getCommand()).isEqualTo(Command.START);
+    assertThat(builder.getDebug()).isFalse();
+    assertThat(builder.getForce()).isFalse();
+    assertThat(builder.getHelp()).isFalse();
+    assertThat(builder.getHostNameForClients()).isNull();
+    assertThat(builder.getMemberName()).isEqualTo("memberOne");
+    assertThat(builder.getPid()).isNull();
+    assertThat(builder.getServerBindAddress()).isNull();
+    assertThat(builder.getServerPort().intValue()).isEqualTo(12345);
+    assertThat(builder.getWorkingDirectory()).isEqualTo(getWorkingDirectoryPath());
+    assertThat(builder.getMaxConnections()).isEqualTo(300);
+    assertThat(builder.getMaxMessageCount()).isEqualTo(1000);
+    assertThat(builder.getMessageTimeToLive()).isEqualTo(10000);
+    assertThat(builder.getSocketBufferSize()).isEqualTo(1024);
+    assertThat(builder.getMaxThreads()).isEqualTo(900);
+  }
+
+  @Test
+  public void getWorkingDirectoryReturnsCurrentDirectoryByDefault() {
+    // given:
+
+    // when: not setting WorkingDirectory
+
+    // then: getDirectory returns default
+    assertThat(new Builder().getWorkingDirectory()).isEqualTo(CURRENT_DIRECTORY);
+  }
+
+  @Test
+  public void setWorkingDirectoryToNullUsesCurrentDirectory() {
+    // given: a new builder
+    Builder builder = new Builder();
+
+    // when: setting WorkingDirectory to null
+    assertThat(builder.setWorkingDirectory(null)).isSameAs(builder);
+
+    // then: getDirectory returns default
+    assertThat(builder.getWorkingDirectory()).isEqualTo(CURRENT_DIRECTORY);
+  }
+
+  @Test
+  public void setWorkingDirectoryToEmptyStringUsesCurrentDirectory() {
+    // given: a new builder
+    Builder builder = new Builder();
+
+    // when: setting WorkingDirectory to empty string
+    assertThat(builder.setWorkingDirectory("")).isSameAs(builder);
+
+    // then: getDirectory returns default
+    assertThat(builder.getWorkingDirectory()).isEqualTo(CURRENT_DIRECTORY);
+  }
+
+  @Test
+  public void setWorkingDirectoryToBlankStringUsesCurrentDirectory() {
+    // given: a new builder
+    Builder builder = new Builder();
+
+    // when: setting WorkingDirectory to white space
+    assertThat(builder.setWorkingDirectory("  ")).isSameAs(builder);
+
+    // then: getDirectory returns default
+    assertThat(builder.getWorkingDirectory()).isEqualTo(CURRENT_DIRECTORY);
+  }
+
+  @Test
+  public void setWorkingDirectoryToExistingDirectory() {
+    // given: a new builder
+    Builder builder = new Builder();
+
+    // when: setting WorkingDirectory to a directory
+    assertThat(builder.setWorkingDirectory(getWorkingDirectoryPath())).isSameAs(builder);
+
+    // then: getDirectory returns that directory
+    assertThat(builder.getWorkingDirectory()).isEqualTo(getWorkingDirectoryPath());
+  }
+
+  @Test
+  public void setWorkingDirectoryToExistingFileThrowsIllegalArgumentException() throws IOException {
+    // given: a file instead of a directory
+    File nonDirectory = temporaryFolder.newFile();
+
+    // when: setting WorkingDirectory to that file
+    when(new Builder()).setWorkingDirectory(nonDirectory.getCanonicalPath());
+
+    // then: throw IllegalArgumentException
+    then(caughtException()).isExactlyInstanceOf(IllegalArgumentException.class)
+        .hasMessage(workingDirectoryNotFoundErrorMessage())
+        .hasCause(new FileNotFoundException(nonDirectory.getCanonicalPath()));
+  }
+
+  @Test
+  public void setWorkingDirectoryToNonExistingDirectory() {
+    // given:
+
+    // when: setting WorkingDirectory to non-existing directory
+    when(new Builder()).setWorkingDirectory("/path/to/non_existing/directory");
+
+    // then: throw IllegalArgumentException
+    then(caughtException()).isExactlyInstanceOf(IllegalArgumentException.class)
+        .hasMessage(workingDirectoryNotFoundErrorMessage())
+        .hasCause(new FileNotFoundException("/path/to/non_existing/directory"));
+  }
+
+  @Test
+  public void serverPortCanBeOverriddenBySystemProperty() {
+    // given: overridden default port
+    int overriddenPort = AvailablePortHelper.getRandomAvailableTCPPort();
+    System.setProperty(TEST_OVERRIDE_DEFAULT_PORT_PROPERTY, String.valueOf(overriddenPort));
+
+    // when: creating new ServerLauncher
+    ServerLauncher launcher = new Builder().build();
+
+    // then: server port should be the overridden default port
+    assertThat(launcher.getServerPort()).isEqualTo(overriddenPort);
+  }
+
+  private String memberNameValidationErrorMessage() {
+    return LocalizedStrings.Launcher_Builder_MEMBER_NAME_VALIDATION_ERROR_MESSAGE
+        .toLocalizedString("Server");
+  }
+
+  private String workingDirectoryOptionNotValidErrorMessage() {
+    return LocalizedStrings.Launcher_Builder_WORKING_DIRECTORY_OPTION_NOT_VALID_ERROR_MESSAGE
+        .toLocalizedString("Server");
+  }
+
+  private String workingDirectoryNotFoundErrorMessage() {
+    return LocalizedStrings.Launcher_Builder_WORKING_DIRECTORY_NOT_FOUND_ERROR_MESSAGE
+        .toLocalizedString("Server");
+  }
+
+  private File getWorkingDirectory() {
+    return temporaryFolder.getRoot();
+  }
+
+  private String getWorkingDirectoryPath() {
+    try {
+      return temporaryFolder.getRoot().getCanonicalPath();
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  private Properties withoutMemberName() {
+    return new Properties();
+  }
+
+  private Properties withMemberName() {
+    Properties properties = new Properties();
+    properties.setProperty(NAME, "locator123");
+    return properties;
+  }
+
+  /**
+   * Creates a gemfire properties file in temporaryFolder:
+   * <ol>
+   * <li>creates gemfire.properties in <code>temporaryFolder</code></li>
+   * <li>writes config to the file</li>
+   * <li>sets "gemfirePropertyFile" system property</li>
+   * </ol>
+   */
+  private void givenGemFirePropertiesFile(final Properties config) {
+    try {
+      String name = GEMFIRE_PREFIX + "properties";
+      File file = new File(getWorkingDirectory(), name);
+      config.store(new FileWriter(file, false), testName.getMethodName());
+      assertThat(file).isFile().exists();
+
+      System.setProperty(PROPERTIES_FILE_PROPERTY, file.getCanonicalPath());
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+}

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/ServerLauncherIntegrationTestCase.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/ServerLauncherIntegrationTestCase.java
@@ -77,7 +77,7 @@ public abstract class ServerLauncherIntegrationTestCase extends LauncherIntegrat
   }
 
   @After
-  public void tearDownAbstractServerLauncherIntegrationTestCase() throws Exception {
+  public void tearDownAbstractServerLauncherIntegrationTestCase() {
     if (launcher != null) {
       launcher.stop();
     }
@@ -136,7 +136,7 @@ public abstract class ServerLauncherIntegrationTestCase extends LauncherIntegrat
   protected File givenCacheXmlFileWithServerProperties(final int serverPort,
       final String bindAddress, final String hostnameForClients, final int maxConnections,
       final int maxThreads, final int maximumMessageCount, final int messageTimeToLive,
-      final int socketBufferSize) throws IOException {
+      final int socketBufferSize) {
     try {
       cacheXmlFile = writeCacheXml(serverPort, bindAddress, hostnameForClients, maxConnections,
           maxThreads, maximumMessageCount, messageTimeToLive, socketBufferSize);

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/ServerLauncherIntegrationTestCase.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/ServerLauncherIntegrationTestCase.java
@@ -37,6 +37,7 @@ import org.junit.rules.ErrorCollector;
 
 import org.apache.geode.cache.DataPolicy;
 import org.apache.geode.cache.Scope;
+import org.apache.geode.cache.server.CacheServer;
 import org.apache.geode.distributed.AbstractLauncher.Status;
 import org.apache.geode.distributed.ServerLauncher.Builder;
 import org.apache.geode.distributed.ServerLauncher.ServerState;
@@ -132,6 +133,20 @@ public abstract class ServerLauncherIntegrationTestCase extends LauncherIntegrat
     return awaitStart(builder);
   }
 
+  protected File givenCacheXmlFileWithServerProperties(final int serverPort,
+      final String bindAddress, final String hostnameForClients, final int maxConnections,
+      final int maxThreads, final int maximumMessageCount, final int messageTimeToLive,
+      final int socketBufferSize) throws IOException {
+    try {
+      cacheXmlFile = writeCacheXml(serverPort, bindAddress, hostnameForClients, maxConnections,
+          maxThreads, maximumMessageCount, messageTimeToLive, socketBufferSize);
+      System.setProperty(CACHE_XML_FILE, cacheXmlFile.getCanonicalPath());
+      return cacheXmlFile;
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
   protected File givenCacheXmlFileWithServerPort(final int cacheXmlPort) {
     try {
       cacheXmlFile = writeCacheXml(cacheXmlPort);
@@ -171,6 +186,33 @@ public abstract class ServerLauncherIntegrationTestCase extends LauncherIntegrat
     attrs.setDataPolicy(DataPolicy.REPLICATE);
     creation.createRegion(getUniqueName(), attrs);
     creation.addCacheServer().setPort(serverPort);
+
+    File cacheXmlFile = new File(getWorkingDirectory(), getUniqueName() + ".xml");
+    PrintWriter pw = new PrintWriter(new FileWriter(cacheXmlFile), true);
+    CacheXmlGenerator.generate(creation, pw);
+    pw.close();
+
+    return cacheXmlFile;
+  }
+
+  private File writeCacheXml(final int serverPort, final String bindAddress,
+      final String hostnameForClients, final int maxConnections, final int maxThreads,
+      final int maximumMessageCount, final int messageTimeToLive, final int socketBufferSize)
+      throws IOException {
+    CacheCreation creation = new CacheCreation();
+    RegionAttributesCreation attrs = new RegionAttributesCreation(creation);
+    attrs.setScope(Scope.DISTRIBUTED_ACK);
+    attrs.setDataPolicy(DataPolicy.REPLICATE);
+    creation.createRegion(getUniqueName(), attrs);
+    CacheServer server = creation.addCacheServer();
+    server.setPort(serverPort);
+    server.setBindAddress(bindAddress);
+    server.setHostnameForClients(hostnameForClients);
+    server.setMaxConnections(maxConnections);
+    server.setMaxThreads(maxThreads);
+    server.setMaximumMessageCount(maximumMessageCount);
+    server.setMessageTimeToLive(messageTimeToLive);
+    server.setSocketBufferSize(socketBufferSize);
 
     File cacheXmlFile = new File(getWorkingDirectory(), getUniqueName() + ".xml");
     PrintWriter pw = new PrintWriter(new FileWriter(cacheXmlFile), true);

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/ServerLauncherLocalFileIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/ServerLauncherLocalFileIntegrationTest.java
@@ -31,7 +31,7 @@ import org.apache.geode.internal.process.ProcessControllerFactory;
 public class ServerLauncherLocalFileIntegrationTest extends ServerLauncherLocalIntegrationTest {
 
   @Before
-  public void setUpServerLauncherLocalFileTest() throws Exception {
+  public void setUpServerLauncherLocalFileTest() {
     System.setProperty(ProcessControllerFactory.PROPERTY_DISABLE_ATTACH_API, "true");
     assertThat(new ProcessControllerFactory().isAttachAPIFound()).isFalse();
   }

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/ServerLauncherLocalIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/ServerLauncherLocalIntegrationTest.java
@@ -26,7 +26,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
-import java.io.IOException;
 import java.net.BindException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -211,7 +210,7 @@ public class ServerLauncherLocalIntegrationTest extends ServerLauncherLocalInteg
   }
 
   @Test
-  public void startWithParametersOverridesCacheXmlConfiguration() throws IOException {
+  public void startWithParametersOverridesCacheXmlConfiguration() {
     int[] freePorts = getRandomAvailableTCPPorts(2);
     int xmlPort = freePorts[0];
     int serverPort = freePorts[1];

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/ServerLauncherRemoteFileIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/ServerLauncherRemoteFileIntegrationTest.java
@@ -34,7 +34,7 @@ import org.apache.geode.lang.AttachAPINotFoundException;
 public class ServerLauncherRemoteFileIntegrationTest extends ServerLauncherRemoteIntegrationTest {
 
   @Before
-  public void setUpServerLauncherRemoteFileTest() throws Exception {
+  public void setUpServerLauncherRemoteFileTest() {
     System.setProperty(ProcessControllerFactory.PROPERTY_DISABLE_ATTACH_API, "true");
     assertThat(new ProcessControllerFactory().isAttachAPIFound()).isFalse();
   }
@@ -44,7 +44,7 @@ public class ServerLauncherRemoteFileIntegrationTest extends ServerLauncherRemot
    */
   @Override
   @Test
-  public void statusWithPidReturnsOnlineWithDetails() throws Exception {
+  public void statusWithPidReturnsOnlineWithDetails() {
     givenRunningServer();
 
     assertThatThrownBy(() -> new Builder().setPid(getServerPid()).build().status())
@@ -56,7 +56,7 @@ public class ServerLauncherRemoteFileIntegrationTest extends ServerLauncherRemot
    */
   @Override
   @Test
-  public void stopWithPidDeletesPidFile() throws Exception {
+  public void stopWithPidDeletesPidFile() {
     givenRunningServer();
 
     assertThatThrownBy(() -> new Builder().setPid(getServerPid()).build().stop())
@@ -68,7 +68,7 @@ public class ServerLauncherRemoteFileIntegrationTest extends ServerLauncherRemot
    */
   @Override
   @Test
-  public void stopWithPidReturnsStopped() throws Exception {
+  public void stopWithPidReturnsStopped() {
     givenRunningServer();
 
     assertThatThrownBy(() -> new Builder().setPid(getServerPid()).build().stop())
@@ -80,7 +80,7 @@ public class ServerLauncherRemoteFileIntegrationTest extends ServerLauncherRemot
    */
   @Override
   @Test
-  public void stopWithPidStopsServerProcess() throws Exception {
+  public void stopWithPidStopsServerProcess() {
     givenRunningServer();
 
     assertThatThrownBy(() -> new Builder().setPid(getServerPid()).build().stop())

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/ServerLauncherRemoteIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/ServerLauncherRemoteIntegrationTest.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.BindException;
 import java.net.InetAddress;
 
@@ -42,33 +43,33 @@ import org.apache.geode.internal.process.ProcessControllerFactory;
 public class ServerLauncherRemoteIntegrationTest extends ServerLauncherRemoteIntegrationTestCase {
 
   @Before
-  public void setUpServerLauncherRemoteIntegrationTest() throws Exception {
+  public void setUpServerLauncherRemoteIntegrationTest() {
     assertThat(new ProcessControllerFactory().isAttachAPIFound()).isTrue();
   }
 
   @Test
-  public void startCreatesPidFile() throws Exception {
+  public void startCreatesPidFile() {
     startServer();
 
     assertThat(getPidFile()).exists();
   }
 
   @Test
-  public void pidFileContainsServerPid() throws Exception {
+  public void pidFileContainsServerPid() {
     startServer();
 
     assertThatPidIsAlive(getServerPid());
   }
 
   @Test
-  public void startCreatesLogFile() throws Exception {
+  public void startCreatesLogFile() {
     startServer();
 
     assertThat(getLogFile()).exists();
   }
 
   @Test
-  public void startDeletesStaleControlFiles() throws Exception {
+  public void startDeletesStaleControlFiles() {
     File stopRequestFile = givenControlFile(getStopRequestFileName());
     File statusRequestFile = givenControlFile(getStatusRequestFileName());
     File statusFile = givenControlFile(getStatusFileName());
@@ -84,7 +85,7 @@ public class ServerLauncherRemoteIntegrationTest extends ServerLauncherRemoteInt
    * This test takes > 1 minute to run in {@link ServerLauncherRemoteFileIntegrationTest}.
    */
   @Test
-  public void startOverwritesStalePidFile() throws Exception {
+  public void startOverwritesStalePidFile() {
     givenPidFile(fakePid);
 
     startServer();
@@ -93,7 +94,7 @@ public class ServerLauncherRemoteIntegrationTest extends ServerLauncherRemoteInt
   }
 
   @Test
-  public void startWithDisableDefaultServerDoesNotUseDefaultPort() throws Exception {
+  public void startWithDisableDefaultServerDoesNotUseDefaultPort() {
     givenServerPortIsFree(defaultServerPort);
 
     startServer(withDisableDefaultServer());
@@ -102,7 +103,7 @@ public class ServerLauncherRemoteIntegrationTest extends ServerLauncherRemoteInt
   }
 
   @Test
-  public void startWithDisableDefaultServerSucceedsWhenDefaultPortInUse() throws Exception {
+  public void startWithDisableDefaultServerSucceedsWhenDefaultPortInUse() {
     givenServerPortInUse(defaultServerPort);
 
     startServer(withDisableDefaultServer());
@@ -114,7 +115,7 @@ public class ServerLauncherRemoteIntegrationTest extends ServerLauncherRemoteInt
    * This test takes > 1 minute to run in {@link ServerLauncherRemoteFileIntegrationTest}.
    */
   @Test
-  public void startWithForceOverwritesExistingPidFile() throws Exception {
+  public void startWithForceOverwritesExistingPidFile() {
     givenPidFile(localPid);
 
     startServer(withForce());
@@ -124,7 +125,8 @@ public class ServerLauncherRemoteIntegrationTest extends ServerLauncherRemoteInt
   }
 
   @Test
-  public void startWithServerPortInUseFailsWithBindException() throws Exception {
+  public void startWithServerPortInUseFailsWithBindException()
+      throws IOException, InterruptedException {
     givenServerPortInUse(nonDefaultServerPort);
 
     startServerShouldFail(withServerPort(nonDefaultServerPort));
@@ -133,7 +135,7 @@ public class ServerLauncherRemoteIntegrationTest extends ServerLauncherRemoteInt
   }
 
   @Test
-  public void startWithServerPortOverridesPortInCacheXml() throws Exception {
+  public void startWithServerPortOverridesPortInCacheXml() {
     givenCacheXmlFileWithServerPort(unusedServerPort);
 
     ServerLauncher launcher = startServer(
@@ -147,7 +149,7 @@ public class ServerLauncherRemoteIntegrationTest extends ServerLauncherRemoteInt
   }
 
   @Test
-  public void startWithServerPortOverridesDefaultWithCacheXml() throws Exception {
+  public void startWithServerPortOverridesDefaultWithCacheXml() {
     givenCacheXmlFile();
 
     ServerLauncher launcher = startServer(
@@ -161,7 +163,8 @@ public class ServerLauncherRemoteIntegrationTest extends ServerLauncherRemoteInt
   }
 
   @Test
-  public void startWithDefaultPortInUseFailsWithBindException() throws Exception {
+  public void startWithDefaultPortInUseFailsWithBindException()
+      throws IOException, InterruptedException {
     givenServerPortInUse(defaultServerPort);
 
     startServerShouldFail();
@@ -170,7 +173,7 @@ public class ServerLauncherRemoteIntegrationTest extends ServerLauncherRemoteInt
   }
 
   @Test
-  public void statusForDisableDefaultServerHasEmptyPort() throws Exception {
+  public void statusForDisableDefaultServerHasEmptyPort() {
     givenRunningServer(withDisableDefaultServer());
 
     ServerState serverState =
@@ -180,7 +183,7 @@ public class ServerLauncherRemoteIntegrationTest extends ServerLauncherRemoteInt
   }
 
   @Test
-  public void statusWithPidReturnsOnlineWithDetails() throws Exception {
+  public void statusWithPidReturnsOnlineWithDetails() throws IOException {
     givenRunningServer();
 
     ServerState serverState = new Builder().setPid(getServerPid()).build().status();
@@ -199,7 +202,7 @@ public class ServerLauncherRemoteIntegrationTest extends ServerLauncherRemoteInt
   }
 
   @Test
-  public void statusWithWorkingDirectoryReturnsOnlineWithDetails() throws Exception {
+  public void statusWithWorkingDirectoryReturnsOnlineWithDetails() throws IOException {
     givenRunningServer();
 
     ServerState serverState =
@@ -219,7 +222,7 @@ public class ServerLauncherRemoteIntegrationTest extends ServerLauncherRemoteInt
   }
 
   @Test
-  public void statusWithEmptyPidFileThrowsIllegalArgumentException() throws Exception {
+  public void statusWithEmptyPidFileThrowsIllegalArgumentException() {
     givenEmptyPidFile();
 
     ServerLauncher launcher = new Builder().setWorkingDirectory(getWorkingDirectoryPath()).build();
@@ -229,7 +232,7 @@ public class ServerLauncherRemoteIntegrationTest extends ServerLauncherRemoteInt
   }
 
   @Test
-  public void statusWithEmptyWorkingDirectoryReturnsNotRespondingWithDetails() throws Exception {
+  public void statusWithEmptyWorkingDirectoryReturnsNotRespondingWithDetails() throws IOException {
     givenEmptyWorkingDirectory();
 
     ServerState serverState =
@@ -248,7 +251,7 @@ public class ServerLauncherRemoteIntegrationTest extends ServerLauncherRemoteInt
   }
 
   @Test
-  public void statusWithStalePidFileReturnsNotResponding() throws Exception {
+  public void statusWithStalePidFileReturnsNotResponding() {
     givenPidFile(fakePid);
 
     ServerState serverState =
@@ -258,7 +261,7 @@ public class ServerLauncherRemoteIntegrationTest extends ServerLauncherRemoteInt
   }
 
   @Test
-  public void stopWithPidReturnsStopped() throws Exception {
+  public void stopWithPidReturnsStopped() {
     givenRunningServer();
 
     ServerState serverState = new Builder().setPid(getServerPid()).build().stop();
@@ -267,7 +270,7 @@ public class ServerLauncherRemoteIntegrationTest extends ServerLauncherRemoteInt
   }
 
   @Test
-  public void stopWithPidStopsServerProcess() throws Exception {
+  public void stopWithPidStopsServerProcess() {
     givenRunningServer();
 
     new Builder().setPid(getServerPid()).build().stop();
@@ -276,7 +279,7 @@ public class ServerLauncherRemoteIntegrationTest extends ServerLauncherRemoteInt
   }
 
   @Test
-  public void stopWithPidDeletesPidFile() throws Exception {
+  public void stopWithPidDeletesPidFile() {
     givenRunningServer();
 
     new Builder().setPid(getServerPid()).build().stop();
@@ -285,7 +288,7 @@ public class ServerLauncherRemoteIntegrationTest extends ServerLauncherRemoteInt
   }
 
   @Test
-  public void stopWithWorkingDirectoryReturnsStopped() throws Exception {
+  public void stopWithWorkingDirectoryReturnsStopped() {
     givenRunningServer();
 
     ServerState serverState =
@@ -295,7 +298,7 @@ public class ServerLauncherRemoteIntegrationTest extends ServerLauncherRemoteInt
   }
 
   @Test
-  public void stopWithWorkingDirectoryStopsServerProcess() throws Exception {
+  public void stopWithWorkingDirectoryStopsServerProcess() {
     givenRunningServer();
 
     new Builder().setWorkingDirectory(getWorkingDirectoryPath()).build().stop();
@@ -304,7 +307,7 @@ public class ServerLauncherRemoteIntegrationTest extends ServerLauncherRemoteInt
   }
 
   @Test
-  public void stopWithWorkingDirectoryDeletesPidFile() throws Exception {
+  public void stopWithWorkingDirectoryDeletesPidFile() {
     givenRunningServer();
 
     new Builder().setWorkingDirectory(getWorkingDirectoryPath()).build().stop();

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/ServerLauncherRemoteIntegrationTestCase.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/ServerLauncherRemoteIntegrationTestCase.java
@@ -55,12 +55,12 @@ public abstract class ServerLauncherRemoteIntegrationTestCase
   private ServerCommand serverCommand;
 
   @Before
-  public void setUpServerLauncherRemoteIntegrationTestCase() throws Exception {
+  public void setUpServerLauncherRemoteIntegrationTestCase() {
     serverCommand = new ServerCommand(this);
   }
 
   @After
-  public void tearDownServerLauncherRemoteIntegrationTestCase() throws Exception {
+  public void tearDownServerLauncherRemoteIntegrationTestCase() {
     if (process != null) {
       process.destroy();
       process = null;
@@ -129,7 +129,7 @@ public abstract class ServerLauncherRemoteIntegrationTestCase
 
   protected ServerLauncher startServer(final ServerCommand command,
       final ProcessStreamReader.InputListener outListener,
-      final ProcessStreamReader.InputListener errListener) throws Exception {
+      final ProcessStreamReader.InputListener errListener) throws IOException {
     executeCommandWithReaders(command.create(), outListener, errListener);
     ServerLauncher launcher = awaitStart(getWorkingDirectory());
     assertThat(process.isAlive()).isTrue();

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/ServerLauncherWithProviderRegressionTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/ServerLauncherWithProviderRegressionTest.java
@@ -51,7 +51,7 @@ public class ServerLauncherWithProviderRegressionTest extends ServerLauncherInte
   }
 
   @Test
-  public void startGetsCacheFromServerLauncherCacheProvider() throws Exception {
+  public void startGetsCacheFromServerLauncherCacheProvider() {
     startServer(newBuilder().setDisableDefaultServer(true).setSpringXmlLocation(springXml()));
 
     Cache cache = launcher.getCache();

--- a/geode-core/src/integrationTest/java/org/apache/geode/test/dunit/rules/DistributedTestRule.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/test/dunit/rules/DistributedTestRule.java
@@ -32,7 +32,6 @@ import org.apache.geode.distributed.internal.DistributionMessageObserver;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.tcpserver.TcpClient;
 import org.apache.geode.internal.admin.ClientStatsManager;
-import org.apache.geode.internal.cache.CacheServerLauncher;
 import org.apache.geode.internal.cache.DiskStoreObserver;
 import org.apache.geode.internal.cache.InitialImageOperation;
 import org.apache.geode.internal.cache.tier.InternalClientMembership;
@@ -203,7 +202,6 @@ public class DistributedTestRule extends AbstractDistributedTestRule {
 
       // keep alphabetized to detect duplicate lines
       CacheCreation.clearThreadLocals();
-      CacheServerLauncher.clearStatics();
       CacheServerTestUtil.clearCacheReference();
       ClientProxyMembershipID.system = null;
       ClientServerTestCase.AUTO_LOAD_BALANCE = false;

--- a/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/excludedClasses.txt
+++ b/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/excludedClasses.txt
@@ -4,6 +4,7 @@ org/apache/geode/cache/operations/internal/UpdateOnlyMap
 org/apache/geode/cache/query/internal/index/CompactRangeIndex$1
 org/apache/geode/distributed/LocatorLauncher$Command
 org/apache/geode/distributed/ServerLauncher$Command
+org/apache/geode/distributed/ServerLauncherParameters
 org/apache/geode/distributed/internal/DistributionConfigImpl
 org/apache/geode/distributed/internal/OverflowQueueWithDMStats
 org/apache/geode/distributed/internal/ThrottlingMemLinkedQueueWithDMStats

--- a/geode-core/src/main/java/org/apache/geode/distributed/ServerLauncher.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/ServerLauncher.java
@@ -272,7 +272,6 @@ public class ServerLauncher extends AbstractLauncher<String> {
     setDebug(Boolean.TRUE.equals(builder.getDebug()));
     this.deletePidFileOnStop = Boolean.TRUE.equals(builder.getDeletePidFileOnStop());
     this.disableDefaultServer = Boolean.TRUE.equals(builder.getDisableDefaultServer());
-    CacheServerLauncher.setDisableDefaultServer(this.disableDefaultServer);
     this.distributedSystemProperties = builder.getDistributedSystemProperties();
     this.force = Boolean.TRUE.equals(builder.getForce());
     this.help = Boolean.TRUE.equals(builder.getHelp());
@@ -282,13 +281,7 @@ public class ServerLauncher extends AbstractLauncher<String> {
     this.rebalance = Boolean.TRUE.equals(builder.getRebalance());
     this.redirectOutput = Boolean.TRUE.equals(builder.getRedirectOutput());
     this.serverBindAddress = builder.getServerBindAddress();
-    if (builder.isServerBindAddressSetByUser() && this.serverBindAddress != null) {
-      CacheServerLauncher.setServerBindAddress(this.serverBindAddress.getHostAddress());
-    }
     this.serverPort = builder.getServerPort();
-    if (builder.isServerPortSetByUser() && this.serverPort != null) {
-      CacheServerLauncher.setServerPort(this.serverPort);
-    }
     this.springXmlLocation = builder.getSpringXmlLocation();
     this.workingDirectory = builder.getWorkingDirectory();
     this.criticalHeapPercentage = builder.getCriticalHeapPercentage();
@@ -314,6 +307,20 @@ public class ServerLauncher extends AbstractLauncher<String> {
         return statusInProcess();
       }
     };
+
+    // GEODE-5256: set startup properties on CacheServerLauncher statics, used later to start the
+    // server through CacheCreation if a cache.xml or if the cluster-configuration-service is
+    // enabled.
+    Integer serverPort =
+        (builder.isServerPortSetByUser() && this.serverPort != null) ? this.serverPort : null;
+    String serverBindAddress =
+        (builder.isServerBindAddressSetByUser() && this.serverBindAddress != null)
+            ? this.serverBindAddress.getHostAddress() : null;
+    CacheServerLauncher.Parameters parameters =
+        new CacheServerLauncher.Parameters(serverPort, this.maxThreads, this.maxConnections,
+            this.maxMessageCount, this.socketBufferSize, serverBindAddress, this.messageTimeToLive,
+            this.hostNameForClients, this.disableDefaultServer);
+    CacheServerLauncher.setParameters(parameters);
   }
 
   /**
@@ -942,8 +949,6 @@ public class ServerLauncher extends AbstractLauncher<String> {
       final String serverBindAddress =
           getServerBindAddress() == null ? null : getServerBindAddress().getHostAddress();
       final Integer serverPort = getServerPort();
-      CacheServerLauncher.setServerBindAddress(serverBindAddress);
-      CacheServerLauncher.setServerPort(serverPort);
       final CacheServer cacheServer = cache.addCacheServer();
       cacheServer.setBindAddress(serverBindAddress);
       cacheServer.setPort(serverPort);
@@ -1506,17 +1511,17 @@ public class ServerLauncher extends AbstractLauncher<String> {
         }
 
         if (options.hasArgument(CliStrings.START_SERVER__MAX__MESSAGE__COUNT)) {
-          setMaxConnections(Integer.parseInt(
+          setMaxMessageCount(Integer.parseInt(
               ObjectUtils.toString(options.valueOf(CliStrings.START_SERVER__MAX__MESSAGE__COUNT))));
         }
 
         if (options.hasArgument(CliStrings.START_SERVER__MESSAGE__TIME__TO__LIVE)) {
-          setMaxConnections(Integer.parseInt(ObjectUtils
+          setMessageTimeToLive(Integer.parseInt(ObjectUtils
               .toString(options.valueOf(CliStrings.START_SERVER__MESSAGE__TIME__TO__LIVE))));
         }
 
         if (options.hasArgument(CliStrings.START_SERVER__SOCKET__BUFFER__SIZE)) {
-          setMaxConnections(Integer.parseInt(ObjectUtils
+          setSocketBufferSize(Integer.parseInt(ObjectUtils
               .toString(options.valueOf(CliStrings.START_SERVER__SOCKET__BUFFER__SIZE))));
         }
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/ServerLauncher.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/ServerLauncher.java
@@ -62,7 +62,6 @@ import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.internal.GemFireVersion;
 import org.apache.geode.internal.cache.AbstractCacheServer;
 import org.apache.geode.internal.cache.CacheConfig;
-import org.apache.geode.internal.cache.CacheServerLauncher;
 import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.PartitionedRegion;
@@ -316,11 +315,17 @@ public class ServerLauncher extends AbstractLauncher<String> {
     String serverBindAddress =
         (builder.isServerBindAddressSetByUser() && this.serverBindAddress != null)
             ? this.serverBindAddress.getHostAddress() : null;
-    CacheServerLauncher.Parameters parameters =
-        new CacheServerLauncher.Parameters(serverPort, this.maxThreads, this.maxConnections,
-            this.maxMessageCount, this.socketBufferSize, serverBindAddress, this.messageTimeToLive,
-            this.hostNameForClients, this.disableDefaultServer);
-    CacheServerLauncher.setParameters(parameters);
+
+    ServerLauncherParameters.INSTANCE
+        .withPort(serverPort)
+        .withMaxThreads(this.maxThreads)
+        .withBindAddress(serverBindAddress)
+        .withMaxConnections(this.maxConnections)
+        .withMaxMessageCount(this.maxMessageCount)
+        .withSocketBufferSize(this.socketBufferSize)
+        .withMessageTimeToLive(this.messageTimeToLive)
+        .withHostnameForClients(this.hostNameForClients)
+        .withDisableDefaultServer(this.disableDefaultServer);
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/distributed/ServerLauncherParameters.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/ServerLauncherParameters.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.distributed;
+
+/**
+ * GEODE-5256: Parameters containing startup options specified by the user.
+ * Shared from ServerLauncher during startup, and available to other internal classes through static
+ * accessors.
+ */
+public enum ServerLauncherParameters {
+  INSTANCE;
+
+  private Integer port = null;
+  private Integer maxThreads = null;
+  private String bindAddress = null;
+  private Integer maxConnections = null;
+  private Integer maxMessageCount = null;
+  private Integer socketBufferSize = null;
+  private Integer messageTimeToLive = null;
+  private String hostnameForClients = null;
+  private Boolean disableDefaultServer = null;
+
+  public Integer getPort() {
+    return port;
+  }
+
+  public Integer getMaxThreads() {
+    return maxThreads;
+  }
+
+  public String getBindAddress() {
+    return bindAddress;
+  }
+
+  public Integer getMaxConnections() {
+    return maxConnections;
+  }
+
+  public Integer getMaxMessageCount() {
+    return maxMessageCount;
+  }
+
+  public Integer getSocketBufferSize() {
+    return socketBufferSize;
+  }
+
+  public Integer getMessageTimeToLive() {
+    return messageTimeToLive;
+  }
+
+  public String getHostnameForClients() {
+    return hostnameForClients;
+  }
+
+  public Boolean isDisableDefaultServer() {
+    return disableDefaultServer;
+  }
+
+  public ServerLauncherParameters withPort(Integer port) {
+    this.port = port;
+    return this;
+  }
+
+  public ServerLauncherParameters withMaxThreads(Integer maxThreads) {
+    this.maxThreads = maxThreads;
+    return this;
+  }
+
+  public ServerLauncherParameters withBindAddress(String bindAddress) {
+    this.bindAddress = bindAddress;
+    return this;
+  }
+
+  public ServerLauncherParameters withMaxConnections(Integer maxConnections) {
+    this.maxConnections = maxConnections;
+    return this;
+  }
+
+  public ServerLauncherParameters withMaxMessageCount(Integer maxMessageCount) {
+    this.maxMessageCount = maxMessageCount;
+    return this;
+  }
+
+  public ServerLauncherParameters withSocketBufferSize(Integer socketBufferSize) {
+    this.socketBufferSize = socketBufferSize;
+    return this;
+  }
+
+  public ServerLauncherParameters withMessageTimeToLive(Integer messageTimeToLive) {
+    this.messageTimeToLive = messageTimeToLive;
+    return this;
+  }
+
+  public ServerLauncherParameters withHostnameForClients(String hostnameForClients) {
+    this.hostnameForClients = hostnameForClients;
+    return this;
+  }
+
+  public ServerLauncherParameters withDisableDefaultServer(Boolean disableDefaultServer) {
+    this.disableDefaultServer = disableDefaultServer;
+    return this;
+  }
+
+  public void clear() {
+    port = null;
+    maxThreads = null;
+    bindAddress = null;
+    maxConnections = null;
+    maxMessageCount = null;
+    socketBufferSize = null;
+    messageTimeToLive = null;
+    hostnameForClients = null;
+    disableDefaultServer = null;
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheCreation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheCreation.java
@@ -574,11 +574,7 @@ public class CacheCreation implements InternalCache {
     // before region initialization to after it to fix bug 33587.
     // Create and start the CacheServers after the gateways have been initialized
     // to fix bug 39736.
-
-    Integer serverPort = CacheServerLauncher.getServerPort();
-    String serverBindAdd = CacheServerLauncher.getServerBindAddress();
-    Boolean disableDefaultServer = CacheServerLauncher.getDisableDefaultServer();
-    startCacheServers(getCacheServers(), cache, serverPort, serverBindAdd, disableDefaultServer);
+    startCacheServers(getCacheServers(), cache, CacheServerLauncher.getParameters());
 
     for (GatewayReceiver receiverCreation : this.getGatewayReceivers()) {
       GatewayReceiverFactory factory = cache.createGatewayReceiverFactory();
@@ -633,11 +629,56 @@ public class CacheCreation implements InternalCache {
   }
 
   /**
+   * Reconfigures the server using the specified parameters.
+   *
+   * @param serverImpl CacheServer implementation.
+   * @param parameters Parameters to reconfigure the server.
+   */
+  void reconfigureServer(CacheServerImpl serverImpl, CacheServerLauncher.Parameters parameters) {
+    if (parameters == null)
+      return;
+
+    if (parameters.getServerPort() != null
+        && parameters.getServerPort() != CacheServer.DEFAULT_PORT)
+      serverImpl.setPort(parameters.getServerPort());
+    if (parameters.getMaxThreads() != null
+        && parameters.getMaxThreads() != CacheServer.DEFAULT_MAX_THREADS)
+      serverImpl.setMaxThreads(parameters.getMaxThreads());
+    if (parameters.getMaxConnections() != null
+        && parameters.getMaxConnections() != CacheServer.DEFAULT_MAX_CONNECTIONS)
+      serverImpl.setMaxConnections(parameters.getMaxConnections());
+    if (parameters.getMaxMessageCount() != null
+        && parameters.getMaxMessageCount() != CacheServer.DEFAULT_MAXIMUM_MESSAGE_COUNT)
+      serverImpl.setMaximumMessageCount(parameters.getMaxMessageCount());
+    if (parameters.getSocketBufferSize() != null
+        && parameters.getSocketBufferSize() != CacheServer.DEFAULT_SOCKET_BUFFER_SIZE)
+      serverImpl.setSocketBufferSize(parameters.getSocketBufferSize());
+    if (parameters.getServerBindAddress() != null
+        && parameters.getServerBindAddress() != CacheServer.DEFAULT_BIND_ADDRESS)
+      serverImpl.setBindAddress(parameters.getServerBindAddress().trim());
+    if (parameters.getMessageTimeToLive() != null
+        && parameters.getMessageTimeToLive() != CacheServer.DEFAULT_MESSAGE_TIME_TO_LIVE)
+      serverImpl.setMessageTimeToLive(parameters.getMessageTimeToLive());
+    if (parameters.getHostnameForClients() != null
+        && parameters.getHostnameForClients() != CacheServer.DEFAULT_HOSTNAME_FOR_CLIENTS)
+      serverImpl.setHostnameForClients(parameters.getHostnameForClients());
+  }
+
+  /**
    * starts declarative cache servers if a server is not running on the port already. Also adds a
    * default server to the param declarativeCacheServers if a serverPort is specified.
    */
-  void startCacheServers(List<CacheServer> declarativeCacheServers, Cache cache, Integer serverPort,
-      String serverBindAdd, Boolean disableDefaultServer) {
+  void startCacheServers(List<CacheServer> declarativeCacheServers, Cache cache,
+      CacheServerLauncher.Parameters parameters) {
+    Integer serverPort = null;
+    String serverBindAdd = null;
+    Boolean disableDefaultServer = null;
+
+    if (parameters != null) {
+      serverPort = parameters.getServerPort();
+      serverBindAdd = parameters.getServerBindAddress();
+      disableDefaultServer = parameters.isDisableDefaultServer();
+    }
 
     if (declarativeCacheServers.size() > 1 && (serverPort != null || serverBindAdd != null)) {
       throw new RuntimeException(
@@ -648,6 +689,7 @@ public class CacheCreation implements InternalCache {
     CacheServerCreation defaultServer = null;
     boolean hasServerPortOrBindAddress = serverPort != null || serverBindAdd != null;
     boolean isDefaultServerDisabled = disableDefaultServer == null || !disableDefaultServer;
+
     if (declarativeCacheServers.isEmpty() && hasServerPortOrBindAddress
         && isDefaultServerDisabled) {
       boolean existingCacheServer = false;
@@ -686,16 +728,12 @@ public class CacheCreation implements InternalCache {
 
       CacheServerImpl impl = (CacheServerImpl) cache.addCacheServer();
       impl.configureFrom(declaredCacheServer);
+
       if (declaredCacheServer == defaultServer) {
         impl.setIsDefaultServer();
       }
 
-      if (serverPort != null && serverPort != CacheServer.DEFAULT_PORT) {
-        impl.setPort(serverPort);
-      }
-      if (serverBindAdd != null) {
-        impl.setBindAddress(serverBindAdd.trim());
-      }
+      reconfigureServer(impl, parameters);
 
       try {
         if (!impl.isRunning()) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheCreation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheCreation.java
@@ -97,6 +97,7 @@ import org.apache.geode.cache.wan.GatewayTransportFilter;
 import org.apache.geode.distributed.DistributedLockService;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.DistributedSystem;
+import org.apache.geode.distributed.ServerLauncherParameters;
 import org.apache.geode.distributed.internal.DistributionAdvisor;
 import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
@@ -107,7 +108,6 @@ import org.apache.geode.internal.SystemTimer;
 import org.apache.geode.internal.cache.CacheConfig;
 import org.apache.geode.internal.cache.CachePerfStats;
 import org.apache.geode.internal.cache.CacheServerImpl;
-import org.apache.geode.internal.cache.CacheServerLauncher;
 import org.apache.geode.internal.cache.CacheService;
 import org.apache.geode.internal.cache.DiskStoreAttributes;
 import org.apache.geode.internal.cache.DiskStoreFactoryImpl;
@@ -574,7 +574,7 @@ public class CacheCreation implements InternalCache {
     // before region initialization to after it to fix bug 33587.
     // Create and start the CacheServers after the gateways have been initialized
     // to fix bug 39736.
-    startCacheServers(getCacheServers(), cache, CacheServerLauncher.getParameters());
+    startCacheServers(getCacheServers(), cache, ServerLauncherParameters.INSTANCE);
 
     for (GatewayReceiver receiverCreation : this.getGatewayReceivers()) {
       GatewayReceiverFactory factory = cache.createGatewayReceiverFactory();
@@ -634,13 +634,13 @@ public class CacheCreation implements InternalCache {
    * @param serverImpl CacheServer implementation.
    * @param parameters Parameters to reconfigure the server.
    */
-  void reconfigureServer(CacheServerImpl serverImpl, CacheServerLauncher.Parameters parameters) {
+  void reconfigureServer(CacheServerImpl serverImpl, ServerLauncherParameters parameters) {
     if (parameters == null)
       return;
 
-    if (parameters.getServerPort() != null
-        && parameters.getServerPort() != CacheServer.DEFAULT_PORT)
-      serverImpl.setPort(parameters.getServerPort());
+    if (parameters.getPort() != null
+        && parameters.getPort() != CacheServer.DEFAULT_PORT)
+      serverImpl.setPort(parameters.getPort());
     if (parameters.getMaxThreads() != null
         && parameters.getMaxThreads() != CacheServer.DEFAULT_MAX_THREADS)
       serverImpl.setMaxThreads(parameters.getMaxThreads());
@@ -653,9 +653,9 @@ public class CacheCreation implements InternalCache {
     if (parameters.getSocketBufferSize() != null
         && parameters.getSocketBufferSize() != CacheServer.DEFAULT_SOCKET_BUFFER_SIZE)
       serverImpl.setSocketBufferSize(parameters.getSocketBufferSize());
-    if (parameters.getServerBindAddress() != null
-        && parameters.getServerBindAddress() != CacheServer.DEFAULT_BIND_ADDRESS)
-      serverImpl.setBindAddress(parameters.getServerBindAddress().trim());
+    if (parameters.getBindAddress() != null
+        && parameters.getBindAddress() != CacheServer.DEFAULT_BIND_ADDRESS)
+      serverImpl.setBindAddress(parameters.getBindAddress().trim());
     if (parameters.getMessageTimeToLive() != null
         && parameters.getMessageTimeToLive() != CacheServer.DEFAULT_MESSAGE_TIME_TO_LIVE)
       serverImpl.setMessageTimeToLive(parameters.getMessageTimeToLive());
@@ -669,14 +669,14 @@ public class CacheCreation implements InternalCache {
    * default server to the param declarativeCacheServers if a serverPort is specified.
    */
   void startCacheServers(List<CacheServer> declarativeCacheServers, Cache cache,
-      CacheServerLauncher.Parameters parameters) {
+      ServerLauncherParameters parameters) {
     Integer serverPort = null;
     String serverBindAdd = null;
     Boolean disableDefaultServer = null;
 
     if (parameters != null) {
-      serverPort = parameters.getServerPort();
-      serverBindAdd = parameters.getServerBindAddress();
+      serverPort = parameters.getPort();
+      serverBindAdd = parameters.getBindAddress();
       disableDefaultServer = parameters.isDisableDefaultServer();
     }
 

--- a/geode-core/src/test/java/org/apache/geode/distributed/ServerLauncherBuilderTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/ServerLauncherBuilderTest.java
@@ -44,28 +44,28 @@ public class ServerLauncherBuilderTest {
   public RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
 
   @Before
-  public void before() throws Exception {
+  public void before() throws UnknownHostException {
     localHost = InetAddress.getLocalHost();
     localHostName = localHost.getCanonicalHostName();
   }
 
   @Test
-  public void defaultCommandIsUnspecified() throws Exception {
+  public void defaultCommandIsUnspecified() {
     assertThat(Builder.DEFAULT_COMMAND).isEqualTo(Command.UNSPECIFIED);
   }
 
   @Test
-  public void getCommandReturnsUnspecifiedByDefault() throws Exception {
+  public void getCommandReturnsUnspecifiedByDefault() {
     assertThat(new Builder().getCommand()).isEqualTo(Builder.DEFAULT_COMMAND);
   }
 
   @Test
-  public void getCriticalHeapPercentageReturnsNullByDefault() throws Exception {
+  public void getCriticalHeapPercentageReturnsNullByDefault() {
     assertThat(new Builder().getCriticalHeapPercentage()).isNull();
   }
 
   @Test
-  public void getEvictionHeapPercentageReturnsNullByDefault() throws Exception {
+  public void getEvictionHeapPercentageReturnsNullByDefault() {
     assertThat(new Builder().getEvictionHeapPercentage()).isNull();
   }
 
@@ -75,169 +75,169 @@ public class ServerLauncherBuilderTest {
   }
 
   @Test
-  public void getHostNameForClientsReturnsNullByDefault() throws Exception {
+  public void getHostNameForClientsReturnsNullByDefault() {
     Builder builder = new Builder();
 
     assertThat(builder.getHostNameForClients()).isNull();
   }
 
   @Test
-  public void getMaxConnectionsReturnsNullByDefault() throws Exception {
+  public void getMaxConnectionsReturnsNullByDefault() {
     assertThat(new Builder().getMaxConnections()).isNull();
   }
 
   @Test
-  public void getMaxMessageCountReturnsNullByDefault() throws Exception {
+  public void getMaxMessageCountReturnsNullByDefault() {
     assertThat(new Builder().getMaxMessageCount()).isNull();
   }
 
   @Test
-  public void getMaxThreadsReturnsNullByDefault() throws Exception {
+  public void getMaxThreadsReturnsNullByDefault() {
     assertThat(new Builder().getMaxThreads()).isNull();
   }
 
   @Test
-  public void getMessageTimeToLiveReturnsNullByDefault() throws Exception {
+  public void getMessageTimeToLiveReturnsNullByDefault() {
     assertThat(new Builder().getMessageTimeToLive()).isNull();
   }
 
   @Test
-  public void getMemberNameReturnsNullByDefault() throws Exception {
+  public void getMemberNameReturnsNullByDefault() {
     assertThat(new Builder().getMemberName()).isNull();
   }
 
   @Test
-  public void getPidReturnsNullByDefault() throws Exception {
+  public void getPidReturnsNullByDefault() {
     assertThat(new Builder().getPid()).isNull();
   }
 
   @Test
-  public void getRedirectOutputReturnsNullByDefault() throws Exception {
+  public void getRedirectOutputReturnsNullByDefault() {
     assertThat(new Builder().getRedirectOutput()).isNull();
   }
 
   @Test
-  public void getServerBindAddressReturnsNullByDefault() throws Exception {
+  public void getServerBindAddressReturnsNullByDefault() {
     assertThat(new Builder().getServerBindAddress()).isNull();
   }
 
   @Test
-  public void getServerPortReturnsDefaultPortByDefault() throws Exception {
+  public void getServerPortReturnsDefaultPortByDefault() {
     assertThat(new Builder().getServerPort()).isEqualTo(Integer.valueOf(CacheServer.DEFAULT_PORT));
   }
 
   @Test
-  public void getSocketBufferSizeReturnsNullByDefault() throws Exception {
+  public void getSocketBufferSizeReturnsNullByDefault() {
     assertThat(new Builder().getSocketBufferSize()).isNull();
   }
 
   @Test
-  public void setCommandReturnsBuilderInstance() throws Exception {
+  public void setCommandReturnsBuilderInstance() {
     Builder builder = new Builder();
 
     assertThat(builder.setCommand(Command.STATUS)).isSameAs(builder);
   }
 
   @Test
-  public void setCriticalHeapPercentageReturnsBuilderInstance() throws Exception {
+  public void setCriticalHeapPercentageReturnsBuilderInstance() {
     Builder builder = new Builder();
 
     assertThat(builder.setCriticalHeapPercentage(55.5f)).isSameAs(builder);
   }
 
   @Test
-  public void setEvictionHeapPercentageReturnsBuilderInstance() throws Exception {
+  public void setEvictionHeapPercentageReturnsBuilderInstance() {
     Builder builder = new Builder();
 
     assertThat(builder.setEvictionHeapPercentage(55.55f)).isSameAs(builder);
   }
 
   @Test
-  public void setForceReturnsBuilderInstance() throws Exception {
+  public void setForceReturnsBuilderInstance() {
     Builder builder = new Builder();
 
     assertThat(builder.setForce(true)).isSameAs(builder);
   }
 
   @Test
-  public void setHostNameForClientsReturnsBuilderInstance() throws Exception {
+  public void setHostNameForClientsReturnsBuilderInstance() {
     Builder builder = new Builder();
 
     assertThat(builder.setHostNameForClients("Pegasus")).isSameAs(builder);
   }
 
   @Test
-  public void setMaxConnectionsReturnsBuilderInstance() throws Exception {
+  public void setMaxConnectionsReturnsBuilderInstance() {
     Builder builder = new Builder();
 
     assertThat(builder.setMaxConnections(1000)).isSameAs(builder);
   }
 
   @Test
-  public void setMaxMessageCountReturnsBuilderInstance() throws Exception {
+  public void setMaxMessageCountReturnsBuilderInstance() {
     Builder builder = new Builder();
 
     assertThat(builder.setMaxMessageCount(50)).isSameAs(builder);
   }
 
   @Test
-  public void setMaxThreadsReturnsBuilderInstance() throws Exception {
+  public void setMaxThreadsReturnsBuilderInstance() {
     Builder builder = new Builder();
 
     assertThat(builder.setMaxThreads(16)).isSameAs(builder);
   }
 
   @Test
-  public void setMemberNameReturnsBuilderInstance() throws Exception {
+  public void setMemberNameReturnsBuilderInstance() {
     Builder builder = new Builder();
 
     assertThat(builder.setMemberName("serverOne")).isSameAs(builder);
   }
 
   @Test
-  public void setPidReturnsBuilderInstance() throws Exception {
+  public void setPidReturnsBuilderInstance() {
     Builder builder = new Builder();
 
     assertThat(builder.setPid(0)).isSameAs(builder);
   }
 
   @Test
-  public void setServerBindAddressReturnsBuilderInstance() throws Exception {
+  public void setServerBindAddressReturnsBuilderInstance() {
     Builder builder = new Builder();
 
     assertThat(builder.setServerBindAddress(null)).isSameAs(builder);
   }
 
   @Test
-  public void setRedirectOutputReturnsBuilderInstance() throws Exception {
+  public void setRedirectOutputReturnsBuilderInstance() {
     Builder builder = new Builder();
 
     assertThat(builder.setRedirectOutput(Boolean.TRUE)).isSameAs(builder);
   }
 
   @Test
-  public void setServerPortReturnsBuilderInstance() throws Exception {
+  public void setServerPortReturnsBuilderInstance() {
     Builder builder = new Builder();
 
     assertThat(builder.setServerPort(null)).isSameAs(builder);
   }
 
   @Test
-  public void setMessageTimeToLiveReturnsBuilderInstance() throws Exception {
+  public void setMessageTimeToLiveReturnsBuilderInstance() {
     Builder builder = new Builder();
 
     assertThat(builder.setMessageTimeToLive(30000)).isSameAs(builder);
   }
 
   @Test
-  public void setSocketBufferSizeReturnsBuilderInstance() throws Exception {
+  public void setSocketBufferSizeReturnsBuilderInstance() {
     Builder builder = new Builder();
 
     assertThat(builder.setSocketBufferSize(32768)).isSameAs(builder);
   }
 
   @Test
-  public void setCommandWithNullResultsInDefaultCommand() throws Exception {
+  public void setCommandWithNullResultsInDefaultCommand() {
     Builder builder = new Builder();
 
     new Builder().setCommand(null);
@@ -246,7 +246,7 @@ public class ServerLauncherBuilderTest {
   }
 
   @Test
-  public void setCommandToStatusResultsInStatus() throws Exception {
+  public void setCommandToStatusResultsInStatus() {
     Builder builder = new Builder();
 
     builder.setCommand(Command.STATUS);
@@ -255,7 +255,7 @@ public class ServerLauncherBuilderTest {
   }
 
   @Test
-  public void setCriticalHeapPercentageToPercentileUsesValue() throws Exception {
+  public void setCriticalHeapPercentageToPercentileUsesValue() {
     Builder builder = new Builder();
 
     builder.setCriticalHeapPercentage(55.5f);
@@ -264,7 +264,7 @@ public class ServerLauncherBuilderTest {
   }
 
   @Test
-  public void setCriticalHeapPercentageToNullResultsInNull() throws Exception {
+  public void setCriticalHeapPercentageToNullResultsInNull() {
     Builder builder = new Builder();
 
     builder.setCriticalHeapPercentage(null);
@@ -273,19 +273,19 @@ public class ServerLauncherBuilderTest {
   }
 
   @Test
-  public void setCriticalHeapPercentageAbove100ThrowsIllegalArgumentException() throws Exception {
+  public void setCriticalHeapPercentageAbove100ThrowsIllegalArgumentException() {
     assertThatThrownBy(() -> new Builder().setCriticalHeapPercentage(100.01f))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
-  public void setCriticalHeapPercentageBelowZeroThrowsIllegalArgumentException() throws Exception {
+  public void setCriticalHeapPercentageBelowZeroThrowsIllegalArgumentException() {
     assertThatThrownBy(() -> new Builder().setCriticalHeapPercentage(-0.01f))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
-  public void setEvictionHeapPercentageToPercentileUsesValue() throws Exception {
+  public void setEvictionHeapPercentageToPercentileUsesValue() {
     Builder builder = new Builder();
 
     builder.setEvictionHeapPercentage(55.55f);
@@ -294,7 +294,7 @@ public class ServerLauncherBuilderTest {
   }
 
   @Test
-  public void setEvictionHeapPercentageToNullResultsInNull() throws Exception {
+  public void setEvictionHeapPercentageToNullResultsInNull() {
     Builder builder = new Builder();
 
     builder.setEvictionHeapPercentage(null);
@@ -303,19 +303,19 @@ public class ServerLauncherBuilderTest {
   }
 
   @Test
-  public void setEvictionHeapPercentageAboveO100ThrowsIllegalArgumentException() throws Exception {
+  public void setEvictionHeapPercentageAboveO100ThrowsIllegalArgumentException() {
     assertThatThrownBy(() -> new Builder().setEvictionHeapPercentage(101.0f))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
-  public void setEvictionHeapPercentageBelowZeroThrowsIllegalArgumentException() throws Exception {
+  public void setEvictionHeapPercentageBelowZeroThrowsIllegalArgumentException() {
     assertThatThrownBy(() -> new Builder().setEvictionHeapPercentage(-10.0f))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
-  public void setForceToTrueUsesValue() throws Exception {
+  public void setForceToTrueUsesValue() {
     Builder builder = new Builder();
 
     builder.setForce(true);
@@ -324,7 +324,7 @@ public class ServerLauncherBuilderTest {
   }
 
   @Test
-  public void setHostNameForClientsToStringUsesValue() throws Exception {
+  public void setHostNameForClientsToStringUsesValue() {
     Builder builder = new Builder();
 
     builder.setHostNameForClients("Pegasus");
@@ -351,7 +351,7 @@ public class ServerLauncherBuilderTest {
   }
 
   @Test
-  public void setMaxConnectionsToPositiveIntegerUsesValue() throws Exception {
+  public void setMaxConnectionsToPositiveIntegerUsesValue() {
     Builder builder = new Builder();
 
     builder.setMaxConnections(1000);
@@ -360,7 +360,7 @@ public class ServerLauncherBuilderTest {
   }
 
   @Test
-  public void setMaxConnectionsToNullResultsInNull() throws Exception {
+  public void setMaxConnectionsToNullResultsInNull() {
     Builder builder = new Builder();
 
     builder.setMaxConnections(null);
@@ -369,13 +369,13 @@ public class ServerLauncherBuilderTest {
   }
 
   @Test
-  public void setMaxConnectionsToNegativeValueThrowsIllegalArgumentException() throws Exception {
+  public void setMaxConnectionsToNegativeValueThrowsIllegalArgumentException() {
     assertThatThrownBy(() -> new Builder().setMaxConnections(-10))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
-  public void setMaxMessageCountToPositiveIntegerUsesValue() throws Exception {
+  public void setMaxMessageCountToPositiveIntegerUsesValue() {
     Builder builder = new Builder();
 
     builder.setMaxMessageCount(50);
@@ -384,7 +384,7 @@ public class ServerLauncherBuilderTest {
   }
 
   @Test
-  public void setMaxMessageCountToNullResultsInNull() throws Exception {
+  public void setMaxMessageCountToNullResultsInNull() {
     Builder builder = new Builder();
 
     builder.setMaxMessageCount(null);
@@ -393,13 +393,13 @@ public class ServerLauncherBuilderTest {
   }
 
   @Test
-  public void setMaxMessageCountToZeroResultsInIllegalArgumentException() throws Exception {
+  public void setMaxMessageCountToZeroResultsInIllegalArgumentException() {
     assertThatThrownBy(() -> new Builder().setMaxMessageCount(0))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
-  public void setMaxThreadsToPositiveIntegerUsesValue() throws Exception {
+  public void setMaxThreadsToPositiveIntegerUsesValue() {
     Builder builder = new Builder();
 
     builder.setMaxThreads(16);
@@ -408,7 +408,7 @@ public class ServerLauncherBuilderTest {
   }
 
   @Test
-  public void setMaxThreadsToNullResultsInNull() throws Exception {
+  public void setMaxThreadsToNullResultsInNull() {
     Builder builder = new Builder();
 
     builder.setMaxThreads(null);
@@ -417,13 +417,13 @@ public class ServerLauncherBuilderTest {
   }
 
   @Test
-  public void setMaxThreadsToNegativeValueThrowsIllegalArgumentException() throws Exception {
+  public void setMaxThreadsToNegativeValueThrowsIllegalArgumentException() {
     assertThatThrownBy(() -> new Builder().setMaxThreads(-4))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
-  public void setMemberNameToStringUsesValue() throws Exception {
+  public void setMemberNameToStringUsesValue() {
     Builder builder = new Builder();
 
     builder.setMemberName("serverOne");
@@ -432,25 +432,25 @@ public class ServerLauncherBuilderTest {
   }
 
   @Test
-  public void setMemberNameToBlankStringThrowsIllegalArgumentException() throws Exception {
+  public void setMemberNameToBlankStringThrowsIllegalArgumentException() {
     assertThatThrownBy(() -> new Builder().setMemberName("  "))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
-  public void setMemberNameToEmptyStringThrowsIllegalArgumentException() throws Exception {
+  public void setMemberNameToEmptyStringThrowsIllegalArgumentException() {
     assertThatThrownBy(() -> new Builder().setMemberName(""))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
-  public void setMemberNameToNullStringThrowsIllegalArgumentException() throws Exception {
+  public void setMemberNameToNullStringThrowsIllegalArgumentException() {
     assertThatThrownBy(() -> new Builder().setMemberName(null))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
-  public void setMessageTimeToLiveToPositiveIntegerUsesValue() throws Exception {
+  public void setMessageTimeToLiveToPositiveIntegerUsesValue() {
     Builder builder = new Builder();
 
     builder.setMessageTimeToLive(30000);
@@ -459,7 +459,7 @@ public class ServerLauncherBuilderTest {
   }
 
   @Test
-  public void setMessageTimeToNullResultsInNull() throws Exception {
+  public void setMessageTimeToNullResultsInNull() {
     Builder builder = new Builder();
 
     builder.setMessageTimeToLive(null);
@@ -468,13 +468,13 @@ public class ServerLauncherBuilderTest {
   }
 
   @Test
-  public void setMessageTimeToLiveToZeroThrowsIllegalArgumentException() throws Exception {
+  public void setMessageTimeToLiveToZeroThrowsIllegalArgumentException() {
     assertThatThrownBy(() -> new Builder().setMessageTimeToLive(0))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
-  public void setPidToZeroOrGreaterUsesValue() throws Exception {
+  public void setPidToZeroOrGreaterUsesValue() {
     Builder builder = new Builder();
 
     builder.setPid(0);
@@ -491,7 +491,7 @@ public class ServerLauncherBuilderTest {
   }
 
   @Test
-  public void setPidToNullResultsInNull() throws Exception {
+  public void setPidToNullResultsInNull() {
     Builder builder = new Builder();
 
     builder.setPid(null);
@@ -500,12 +500,12 @@ public class ServerLauncherBuilderTest {
   }
 
   @Test
-  public void setPidToNegativeValueThrowsIllegalArgumentException() throws Exception {
+  public void setPidToNegativeValueThrowsIllegalArgumentException() {
     assertThatThrownBy(() -> new Builder().setPid(-1)).isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
-  public void setServerBindAddressToNullResultsInNull() throws Exception {
+  public void setServerBindAddressToNullResultsInNull() {
     Builder builder = new Builder();
 
     builder.setServerBindAddress(null);
@@ -514,7 +514,7 @@ public class ServerLauncherBuilderTest {
   }
 
   @Test
-  public void setServerBindAddressToEmptyStringResultsInNull() throws Exception {
+  public void setServerBindAddressToEmptyStringResultsInNull() {
     Builder builder = new Builder();
 
     builder.setServerBindAddress("");
@@ -523,7 +523,7 @@ public class ServerLauncherBuilderTest {
   }
 
   @Test
-  public void setServerBindAddressToBlankStringResultsInNull() throws Exception {
+  public void setServerBindAddressToBlankStringResultsInNull() {
     Builder builder = new Builder();
 
     builder.setServerBindAddress("  ");
@@ -532,7 +532,7 @@ public class ServerLauncherBuilderTest {
   }
 
   @Test
-  public void setServerBindAddressToCanonicalLocalHostUsesValue() throws Exception {
+  public void setServerBindAddressToCanonicalLocalHostUsesValue() {
     Builder builder = new Builder();
 
     builder.setServerBindAddress(localHostName);
@@ -541,7 +541,7 @@ public class ServerLauncherBuilderTest {
   }
 
   @Test
-  public void setServerBindAddressToLocalHostNameUsesValue() throws Exception {
+  public void setServerBindAddressToLocalHostNameUsesValue() throws UnknownHostException {
     String host = InetAddress.getLocalHost().getHostName();
 
     Builder builder = new Builder().setServerBindAddress(host);
@@ -550,20 +550,20 @@ public class ServerLauncherBuilderTest {
   }
 
   @Test
-  public void setServerBindAddressToUnknownHostThrowsIllegalArgumentException() throws Exception {
+  public void setServerBindAddressToUnknownHostThrowsIllegalArgumentException() {
     assertThatThrownBy(() -> new Builder().setServerBindAddress("badHostName.example.com"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasCauseInstanceOf(UnknownHostException.class);
   }
 
   @Test
-  public void setServerBindAddressToNonLocalHostThrowsIllegalArgumentException() throws Exception {
+  public void setServerBindAddressToNonLocalHostThrowsIllegalArgumentException() {
     assertThatThrownBy(() -> new Builder().setServerBindAddress("yahoo.com"))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
-  public void setServerPortToNullResultsInDefaultPort() throws Exception {
+  public void setServerPortToNullResultsInDefaultPort() {
     Builder builder = new Builder();
 
     builder.setServerPort(null);
@@ -573,7 +573,7 @@ public class ServerLauncherBuilderTest {
 
 
   @Test
-  public void setServerPortToZeroOrGreaterUsesValue() throws Exception {
+  public void setServerPortToZeroOrGreaterUsesValue() {
     Builder builder = new Builder();
 
     builder.setServerPort(0);
@@ -602,19 +602,19 @@ public class ServerLauncherBuilderTest {
   }
 
   @Test
-  public void setServerPortAboveMaxValueThrowsIllegalArgumentException() throws Exception {
+  public void setServerPortAboveMaxValueThrowsIllegalArgumentException() {
     assertThatThrownBy(() -> new Builder().setServerPort(65536))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
-  public void setServerPortToNegativeValueThrowsIllegalArgumentException() throws Exception {
+  public void setServerPortToNegativeValueThrowsIllegalArgumentException() {
     assertThatThrownBy(() -> new Builder().setServerPort(-1))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
-  public void setSocketBufferSizeToPositiveIntegerUsesValue() throws Exception {
+  public void setSocketBufferSizeToPositiveIntegerUsesValue() {
     Builder builder = new Builder();
 
     builder.setSocketBufferSize(32768);
@@ -623,7 +623,7 @@ public class ServerLauncherBuilderTest {
   }
 
   @Test
-  public void setSocketBufferSizeToNullResultsInNull() throws Exception {
+  public void setSocketBufferSizeToNullResultsInNull() {
     Builder builder = new Builder();
 
     builder.setSocketBufferSize(null);
@@ -632,13 +632,13 @@ public class ServerLauncherBuilderTest {
   }
 
   @Test
-  public void setSocketBufferSizeToNegativeValueThrowsIllegalArgumentException() throws Exception {
+  public void setSocketBufferSizeToNegativeValueThrowsIllegalArgumentException() {
     assertThatThrownBy(() -> new Builder().setSocketBufferSize(-8192))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
-  public void parseArgumentsWithForceSetsForceToTrue() throws Exception {
+  public void parseArgumentsWithForceSetsForceToTrue() {
     Builder builder = new Builder();
 
     builder.parseArguments("start", "--force");
@@ -654,7 +654,7 @@ public class ServerLauncherBuilderTest {
   }
 
   @Test
-  public void parseArgumentsParsesValuesSeparatedWithCommas() throws Exception {
+  public void parseArgumentsParsesValuesSeparatedWithCommas() throws UnknownHostException {
     // given: fresh builder
     Builder builder = new Builder();
 
@@ -662,7 +662,9 @@ public class ServerLauncherBuilderTest {
     builder.parseArguments("start", "serverOne", "--assign-buckets", "--disable-default-server",
         "--debug", "--force", "--rebalance", "--redirect-output", "--pid", "1234",
         "--server-bind-address", InetAddress.getLocalHost().getHostAddress(), "--server-port",
-        "11235", "--hostname-for-clients", "192.168.99.100");
+        "11235", "--hostname-for-clients", "192.168.99.100", "--max-connections", "300",
+        "--max-message-count", "1000", "--message-time-to-live", "10000", "--socket-buffer-size",
+        "1024", "--max-threads", "900");
 
     // then: getters should return parsed values
     assertThat(builder.getCommand()).isEqualTo(Command.START);
@@ -678,10 +680,15 @@ public class ServerLauncherBuilderTest {
     assertThat(builder.getPid().intValue()).isEqualTo(1234);
     assertThat(builder.getServerBindAddress()).isEqualTo(InetAddress.getLocalHost());
     assertThat(builder.getServerPort().intValue()).isEqualTo(11235);
+    assertThat(builder.getMaxConnections()).isEqualTo(300);
+    assertThat(builder.getMaxMessageCount()).isEqualTo(1000);
+    assertThat(builder.getMessageTimeToLive()).isEqualTo(10000);
+    assertThat(builder.getSocketBufferSize()).isEqualTo(1024);
+    assertThat(builder.getMaxThreads()).isEqualTo(900);
   }
 
   @Test
-  public void parseArgumentsParsesValuesSeparatedWithEquals() throws Exception {
+  public void parseArgumentsParsesValuesSeparatedWithEquals() throws UnknownHostException {
     // given: fresh builder
     Builder builder = new Builder();
 
@@ -689,7 +696,9 @@ public class ServerLauncherBuilderTest {
     builder.parseArguments("start", "serverOne", "--assign-buckets", "--disable-default-server",
         "--debug", "--force", "--rebalance", "--redirect-output", "--pid=1234",
         "--server-bind-address=" + InetAddress.getLocalHost().getHostAddress(),
-        "--server-port=11235", "--hostname-for-clients=192.168.99.100");
+        "--server-port=11235", "--hostname-for-clients=192.168.99.100", "--max-connections=300",
+        "--max-message-count=1000", "--message-time-to-live=10000", "--socket-buffer-size=1024",
+        "--max-threads=900");
 
     // then: getters should return parsed values
     assertThat(builder.getCommand()).isEqualTo(Command.START);
@@ -705,10 +714,15 @@ public class ServerLauncherBuilderTest {
     assertThat(builder.getPid().intValue()).isEqualTo(1234);
     assertThat(builder.getServerBindAddress()).isEqualTo(InetAddress.getLocalHost());
     assertThat(builder.getServerPort().intValue()).isEqualTo(11235);
+    assertThat(builder.getMaxConnections()).isEqualTo(300);
+    assertThat(builder.getMaxMessageCount()).isEqualTo(1000);
+    assertThat(builder.getMessageTimeToLive()).isEqualTo(10000);
+    assertThat(builder.getSocketBufferSize()).isEqualTo(1024);
+    assertThat(builder.getMaxThreads()).isEqualTo(900);
   }
 
   @Test
-  public void parseCommandWithNullStringArrayResultsInDefaultCommand() throws Exception {
+  public void parseCommandWithNullStringArrayResultsInDefaultCommand() {
     Builder builder = new Builder();
 
     builder.parseCommand((String[]) null);
@@ -717,7 +731,7 @@ public class ServerLauncherBuilderTest {
   }
 
   @Test
-  public void parseCommandWithEmptyStringArrayResultsInDefaultCommand() throws Exception {
+  public void parseCommandWithEmptyStringArrayResultsInDefaultCommand() {
     Builder builder = new Builder();
 
     builder.parseCommand(); // empty String array
@@ -726,7 +740,7 @@ public class ServerLauncherBuilderTest {
   }
 
   @Test
-  public void parseCommandWithStartResultsInStartCommand() throws Exception {
+  public void parseCommandWithStartResultsInStartCommand() {
     Builder builder = new Builder();
 
     builder.parseCommand(Command.START.getName());
@@ -735,7 +749,7 @@ public class ServerLauncherBuilderTest {
   }
 
   @Test
-  public void parseCommandWithStatusResultsInStatusCommand() throws Exception {
+  public void parseCommandWithStatusResultsInStatusCommand() {
     Builder builder = new Builder();
 
     builder.parseCommand("Status");
@@ -744,7 +758,7 @@ public class ServerLauncherBuilderTest {
   }
 
   @Test
-  public void parseCommandWithMixedCaseResultsInCorrectCase() throws Exception {
+  public void parseCommandWithMixedCaseResultsInCorrectCase() {
     Builder builder = new Builder();
 
     builder.parseCommand("sToP");
@@ -753,7 +767,7 @@ public class ServerLauncherBuilderTest {
   }
 
   @Test
-  public void parseCommandWithTwoCommandsWithSwitchesUsesFirstCommand() throws Exception {
+  public void parseCommandWithTwoCommandsWithSwitchesUsesFirstCommand() {
     Builder builder = new Builder();
 
     builder.parseCommand("--opt", "START", "-o", Command.STATUS.getName());
@@ -762,7 +776,7 @@ public class ServerLauncherBuilderTest {
   }
 
   @Test
-  public void parseCommandWithTwoCommandsWithoutSwitchesUsesFirstCommand() throws Exception {
+  public void parseCommandWithTwoCommandsWithoutSwitchesUsesFirstCommand() {
     Builder builder = new Builder();
 
     builder.parseCommand("START", Command.STATUS.getName());
@@ -771,7 +785,7 @@ public class ServerLauncherBuilderTest {
   }
 
   @Test
-  public void parseCommandWithBadInputResultsInDefaultCommand() throws Exception {
+  public void parseCommandWithBadInputResultsInDefaultCommand() {
     Builder builder = new Builder();
 
     builder.parseCommand("badCommandName", "--start", "stat");
@@ -780,7 +794,7 @@ public class ServerLauncherBuilderTest {
   }
 
   @Test
-  public void parseMemberNameWithNullStringArrayResultsInNull() throws Exception {
+  public void parseMemberNameWithNullStringArrayResultsInNull() {
     Builder builder = new Builder();
 
     builder.parseMemberName((String[]) null);
@@ -789,7 +803,7 @@ public class ServerLauncherBuilderTest {
   }
 
   @Test
-  public void parseMemberNameWithEmptyStringArrayResultsInNull() throws Exception {
+  public void parseMemberNameWithEmptyStringArrayResultsInNull() {
     Builder builder = new Builder();
 
     builder.parseMemberName(); // empty String array
@@ -798,7 +812,7 @@ public class ServerLauncherBuilderTest {
   }
 
   @Test
-  public void parseMemberNameWithCommandAndOptionsResultsInNull() throws Exception {
+  public void parseMemberNameWithCommandAndOptionsResultsInNull() {
     Builder builder = new Builder();
 
     builder.parseMemberName(Command.START.getName(), "--opt", "-o");
@@ -807,7 +821,7 @@ public class ServerLauncherBuilderTest {
   }
 
   @Test
-  public void parseMemberNameWithStringUsesValue() throws Exception {
+  public void parseMemberNameWithStringUsesValue() {
     Builder builder = new Builder();
 
     builder.parseMemberName("memberOne");
@@ -816,7 +830,7 @@ public class ServerLauncherBuilderTest {
   }
 
   @Test
-  public void buildCreatesServerLauncherWithBuilderValues() throws Exception {
+  public void buildCreatesServerLauncherWithBuilderValues() throws UnknownHostException {
     ServerLauncher launcher = new Builder().setCommand(Command.STOP).setAssignBuckets(true)
         .setForce(true).setMemberName("serverOne").setRebalance(true)
         .setServerBindAddress(InetAddress.getLocalHost().getHostAddress()).setServerPort(11235)
@@ -846,7 +860,7 @@ public class ServerLauncherBuilderTest {
   }
 
   @Test
-  public void buildUsesMemberNameSetInApiProperties() throws Exception {
+  public void buildUsesMemberNameSetInApiProperties() {
     ServerLauncher launcher =
         new Builder().setCommand(ServerLauncher.Command.START).set(NAME, "serverABC").build();
 
@@ -855,7 +869,7 @@ public class ServerLauncherBuilderTest {
   }
 
   @Test
-  public void buildUsesMemberNameSetInSystemProperties() throws Exception {
+  public void buildUsesMemberNameSetInSystemProperties() {
     System.setProperty(DistributionConfig.GEMFIRE_PREFIX + NAME, "serverXYZ");
 
     ServerLauncher launcher = new Builder().setCommand(ServerLauncher.Command.START).build();

--- a/geode-core/src/test/java/org/apache/geode/distributed/ServerLauncherTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/ServerLauncherTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.IOException;
 import java.util.Collections;
 
 import org.junit.Before;
@@ -35,6 +36,7 @@ import org.apache.geode.cache.server.CacheServer;
 import org.apache.geode.distributed.ServerLauncher.Builder;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.internal.cache.CacheConfig;
+import org.apache.geode.internal.cache.CacheServerLauncher;
 
 /**
  * Unit tests for {@link ServerLauncher}.
@@ -44,12 +46,33 @@ import org.apache.geode.internal.cache.CacheConfig;
 public class ServerLauncherTest {
 
   @Before
-  public void before() throws Exception {
+  public void before() {
     DistributedSystem.removeSystem(InternalDistributedSystem.getConnectedInstance());
   }
 
   @Test
-  public void canBeMocked() throws Exception {
+  public void constructorCorrectlySetsCacheServerLauncherParameters() {
+    ServerLauncher launcher = new Builder().setServerBindAddress(null).setServerPort(11235)
+        .setMaxThreads(10).setMaxConnections(100).setMaxMessageCount(5).setMessageTimeToLive(10000)
+        .setSocketBufferSize(2048).setHostNameForClients("hostName4Clients")
+        .setDisableDefaultServer(Boolean.FALSE).build();
+
+    assertThat(launcher).isNotNull();
+    assertThat(CacheServerLauncher.getParameters()).isNotNull();
+    assertThat(CacheServerLauncher.getParameters().getServerPort()).isEqualTo(11235);
+    assertThat(CacheServerLauncher.getParameters().getMaxThreads()).isEqualTo(10);
+    assertThat(CacheServerLauncher.getParameters().getMaxConnections()).isEqualTo(100);
+    assertThat(CacheServerLauncher.getParameters().getMaxMessageCount()).isEqualTo(5);
+    assertThat(CacheServerLauncher.getParameters().getSocketBufferSize()).isEqualTo(2048);
+    assertThat(CacheServerLauncher.getParameters().getServerBindAddress()).isEqualTo(null);
+    assertThat(CacheServerLauncher.getParameters().getMessageTimeToLive()).isEqualTo(10000);
+    assertThat(CacheServerLauncher.getParameters().getHostnameForClients())
+        .isEqualTo("hostName4Clients");
+    assertThat(CacheServerLauncher.getParameters().isDisableDefaultServer()).isFalse();
+  }
+
+  @Test
+  public void canBeMocked() throws IOException {
     ServerLauncher launcher = mock(ServerLauncher.class);
     Cache cache = mock(Cache.class);
     CacheConfig cacheConfig = mock(CacheConfig.class);
@@ -72,7 +95,7 @@ public class ServerLauncherTest {
   }
 
   @Test
-  public void isServingReturnsTrueWhenCacheHasOneCacheServer() throws Exception {
+  public void isServingReturnsTrueWhenCacheHasOneCacheServer() {
     Cache cache = mock(Cache.class);
     CacheServer cacheServer = mock(CacheServer.class);
     when(cache.getCacheServers()).thenReturn(Collections.singletonList(cacheServer));
@@ -83,7 +106,7 @@ public class ServerLauncherTest {
   }
 
   @Test
-  public void isServingReturnsFalseWhenCacheHasZeroCacheServers() throws Exception {
+  public void isServingReturnsFalseWhenCacheHasZeroCacheServers() {
     Cache cache = mock(Cache.class);
     when(cache.getCacheServers()).thenReturn(Collections.emptyList());
 
@@ -93,7 +116,7 @@ public class ServerLauncherTest {
   }
 
   @Test
-  public void reconnectedCacheIsClosed() throws Exception {
+  public void reconnectedCacheIsClosed() {
     Cache cache = mock(Cache.class, "Cache");
     Cache reconnectedCache = mock(Cache.class, "ReconnectedCache");
     when(cache.isReconnecting()).thenReturn(false).thenReturn(false).thenReturn(true);
@@ -108,7 +131,7 @@ public class ServerLauncherTest {
   }
 
   @Test
-  public void isRunningReturnsTrueWhenRunningIsSetTrue() throws Exception {
+  public void isRunningReturnsTrueWhenRunningIsSetTrue() {
     ServerLauncher launcher = new Builder().build();
 
     launcher.running.set(true);
@@ -117,7 +140,7 @@ public class ServerLauncherTest {
   }
 
   @Test
-  public void isRunningReturnsFalseWhenRunningIsSetFalse() throws Exception {
+  public void isRunningReturnsFalseWhenRunningIsSetFalse() {
     ServerLauncher launcher = new Builder().build();
 
     launcher.running.set(false);
@@ -126,7 +149,7 @@ public class ServerLauncherTest {
   }
 
   @Test
-  public void reconnectingDistributedSystemIsDisconnectedOnStop() throws Exception {
+  public void reconnectingDistributedSystemIsDisconnectedOnStop() {
     Cache cache = mock(Cache.class, "Cache");
     DistributedSystem system = mock(DistributedSystem.class, "DistributedSystem");
     Cache reconnectedCache = mock(Cache.class, "ReconnectedCache");
@@ -150,7 +173,7 @@ public class ServerLauncherTest {
   }
 
   @Test
-  public void isWaitingReturnsTrueWhenSystemIsConnected() throws Exception {
+  public void isWaitingReturnsTrueWhenSystemIsConnected() {
     Cache cache = mock(Cache.class, "Cache");
     DistributedSystem system = mock(DistributedSystem.class, "DistributedSystem");
     when(cache.getDistributedSystem()).thenReturn(system);
@@ -163,7 +186,7 @@ public class ServerLauncherTest {
   }
 
   @Test
-  public void isWaitingReturnsFalseWhenSystemIsNotConnected() throws Exception {
+  public void isWaitingReturnsFalseWhenSystemIsNotConnected() {
     Cache cache = mock(Cache.class, "Cache");
     DistributedSystem system = mock(DistributedSystem.class, "DistributedSystem");
     when(cache.getDistributedSystem()).thenReturn(system);
@@ -177,14 +200,14 @@ public class ServerLauncherTest {
   }
 
   @Test
-  public void isWaitingReturnsFalseByDefault() throws Exception {
+  public void isWaitingReturnsFalseByDefault() {
     ServerLauncher launcher = new Builder().build();
 
     assertThat(launcher.isWaiting(null)).isFalse();
   }
 
   @Test
-  public void isWaitingReturnsFalseWhenNotRunning() throws Exception {
+  public void isWaitingReturnsFalseWhenNotRunning() {
     ServerLauncher launcher = new Builder().build();
 
     launcher.running.set(false);
@@ -193,14 +216,14 @@ public class ServerLauncherTest {
   }
 
   @Test
-  public void isDisableDefaultServerReturnsFalseByDefault() throws Exception {
+  public void isDisableDefaultServerReturnsFalseByDefault() {
     ServerLauncher launcher = new Builder().build();
 
     assertThat(launcher.isDisableDefaultServer()).isFalse();
   }
 
   @Test
-  public void isDefaultServerEnabledForCacheReturnsTrueByDefault() throws Exception {
+  public void isDefaultServerEnabledForCacheReturnsTrueByDefault() {
     Cache cache = mock(Cache.class, "Cache");
 
     ServerLauncher launcher = new Builder().build();
@@ -209,7 +232,7 @@ public class ServerLauncherTest {
   }
 
   @Test
-  public void isDefaultServerEnabledForNullThrowsNullPointerException() throws Exception {
+  public void isDefaultServerEnabledForNullThrowsNullPointerException() {
     ServerLauncher launcher = new Builder().build();
 
     assertThatThrownBy(() -> launcher.isDefaultServerEnabled(null))
@@ -217,7 +240,7 @@ public class ServerLauncherTest {
   }
 
   @Test
-  public void isDefaultServerEnabledReturnsFalseWhenCacheServersExist() throws Exception {
+  public void isDefaultServerEnabledReturnsFalseWhenCacheServersExist() {
     Cache cache = mock(Cache.class, "Cache");
     CacheServer cacheServer = mock(CacheServer.class, "CacheServer");
     when(cache.getCacheServers()).thenReturn(Collections.singletonList(cacheServer));
@@ -228,15 +251,14 @@ public class ServerLauncherTest {
   }
 
   @Test
-  public void isDisableDefaultServerReturnsTrueWhenDisabled() throws Exception {
+  public void isDisableDefaultServerReturnsTrueWhenDisabled() {
     ServerLauncher launcher = new Builder().setDisableDefaultServer(true).build();
 
     assertThat(launcher.isDisableDefaultServer()).isTrue();
   }
 
   @Test
-  public void isDefaultServerEnabledReturnsFalseWhenDefaultServerDisabledIsTrueAndNoCacheServersExist()
-      throws Exception {
+  public void isDefaultServerEnabledReturnsFalseWhenDefaultServerDisabledIsTrueAndNoCacheServersExist() {
     Cache cache = mock(Cache.class, "Cache");
     when(cache.getCacheServers()).thenReturn(Collections.emptyList());
 
@@ -246,8 +268,7 @@ public class ServerLauncherTest {
   }
 
   @Test
-  public void isDefaultServerEnabledReturnsFalseWhenDefaultServerDisabledIsTrueAndCacheServersExist()
-      throws Exception {
+  public void isDefaultServerEnabledReturnsFalseWhenDefaultServerDisabledIsTrueAndCacheServersExist() {
     Cache cache = mock(Cache.class, "Cache");
     CacheServer cacheServer = mock(CacheServer.class, "CacheServer");
     when(cache.getCacheServers()).thenReturn(Collections.singletonList(cacheServer));
@@ -258,22 +279,30 @@ public class ServerLauncherTest {
   }
 
   @Test
-  public void startCacheServerStartsCacheServerWithBuilderValues() throws Exception {
+  public void startCacheServerStartsCacheServerWithBuilderValues() throws IOException {
     Cache cache = mock(Cache.class, "Cache");
     CacheServer cacheServer = mock(CacheServer.class, "CacheServer");
     when(cache.getCacheServers()).thenReturn(Collections.emptyList());
     when(cache.addCacheServer()).thenReturn(cacheServer);
-    ServerLauncher launcher = new Builder().setServerBindAddress(null).setServerPort(11235).build();
+    ServerLauncher launcher = new Builder().setServerBindAddress(null).setServerPort(11235)
+        .setMaxThreads(10).setMaxConnections(100).setMaxMessageCount(5).setMessageTimeToLive(10000)
+        .setSocketBufferSize(2048).setHostNameForClients("hostName4Clients").build();
 
     launcher.startCacheServer(cache);
 
     verify(cacheServer, times(1)).setBindAddress(null);
     verify(cacheServer, times(1)).setPort(eq(11235));
+    verify(cacheServer, times(1)).setMaxThreads(10);
+    verify(cacheServer, times(1)).setMaxConnections(100);
+    verify(cacheServer, times(1)).setMaximumMessageCount(5);
+    verify(cacheServer, times(1)).setMessageTimeToLive(10000);
+    verify(cacheServer, times(1)).setSocketBufferSize(2048);
+    verify(cacheServer, times(1)).setHostnameForClients("hostName4Clients");
     verify(cacheServer, times(1)).start();
   }
 
   @Test
-  public void startCacheServerDoesNothingWhenDefaultServerDisabled() throws Exception {
+  public void startCacheServerDoesNothingWhenDefaultServerDisabled() throws IOException {
     Cache cache = mock(Cache.class, "Cache");
     CacheServer cacheServer = mock(CacheServer.class, "CacheServer");
     when(cache.getCacheServers()).thenReturn(Collections.emptyList());
@@ -284,11 +313,17 @@ public class ServerLauncherTest {
 
     verify(cacheServer, times(0)).setBindAddress(anyString());
     verify(cacheServer, times(0)).setPort(anyInt());
+    verify(cacheServer, times(0)).setMaxThreads(anyInt());
+    verify(cacheServer, times(0)).setMaxConnections(anyInt());
+    verify(cacheServer, times(0)).setMaximumMessageCount(anyInt());
+    verify(cacheServer, times(0)).setMessageTimeToLive(anyInt());
+    verify(cacheServer, times(0)).setSocketBufferSize(anyInt());
+    verify(cacheServer, times(0)).setHostnameForClients(anyString());
     verify(cacheServer, times(0)).start();
   }
 
   @Test
-  public void startCacheServerDoesNothingWhenCacheServerAlreadyExists() throws Exception {
+  public void startCacheServerDoesNothingWhenCacheServerAlreadyExists() throws IOException {
     Cache cache = mock(Cache.class, "Cache");
     CacheServer cacheServer1 = mock(CacheServer.class, "CacheServer1");
     CacheServer cacheServer2 = mock(CacheServer.class, "CacheServer2");
@@ -300,6 +335,12 @@ public class ServerLauncherTest {
 
     verify(cacheServer2, times(0)).setBindAddress(anyString());
     verify(cacheServer2, times(0)).setPort(anyInt());
+    verify(cacheServer2, times(0)).setMaxThreads(anyInt());
+    verify(cacheServer2, times(0)).setMaxConnections(anyInt());
+    verify(cacheServer2, times(0)).setMaximumMessageCount(anyInt());
+    verify(cacheServer2, times(0)).setMessageTimeToLive(anyInt());
+    verify(cacheServer2, times(0)).setSocketBufferSize(anyInt());
+    verify(cacheServer2, times(0)).setHostnameForClients(anyString());
     verify(cacheServer2, times(0)).start();
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/distributed/ServerLauncherTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/ServerLauncherTest.java
@@ -36,7 +36,6 @@ import org.apache.geode.cache.server.CacheServer;
 import org.apache.geode.distributed.ServerLauncher.Builder;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.internal.cache.CacheConfig;
-import org.apache.geode.internal.cache.CacheServerLauncher;
 
 /**
  * Unit tests for {@link ServerLauncher}.
@@ -58,17 +57,17 @@ public class ServerLauncherTest {
         .setDisableDefaultServer(Boolean.FALSE).build();
 
     assertThat(launcher).isNotNull();
-    assertThat(CacheServerLauncher.getParameters()).isNotNull();
-    assertThat(CacheServerLauncher.getParameters().getServerPort()).isEqualTo(11235);
-    assertThat(CacheServerLauncher.getParameters().getMaxThreads()).isEqualTo(10);
-    assertThat(CacheServerLauncher.getParameters().getMaxConnections()).isEqualTo(100);
-    assertThat(CacheServerLauncher.getParameters().getMaxMessageCount()).isEqualTo(5);
-    assertThat(CacheServerLauncher.getParameters().getSocketBufferSize()).isEqualTo(2048);
-    assertThat(CacheServerLauncher.getParameters().getServerBindAddress()).isEqualTo(null);
-    assertThat(CacheServerLauncher.getParameters().getMessageTimeToLive()).isEqualTo(10000);
-    assertThat(CacheServerLauncher.getParameters().getHostnameForClients())
+    assertThat(ServerLauncherParameters.INSTANCE).isNotNull();
+    assertThat(ServerLauncherParameters.INSTANCE.getPort()).isEqualTo(11235);
+    assertThat(ServerLauncherParameters.INSTANCE.getMaxThreads()).isEqualTo(10);
+    assertThat(ServerLauncherParameters.INSTANCE.getBindAddress()).isEqualTo(null);
+    assertThat(ServerLauncherParameters.INSTANCE.getMaxConnections()).isEqualTo(100);
+    assertThat(ServerLauncherParameters.INSTANCE.getMaxMessageCount()).isEqualTo(5);
+    assertThat(ServerLauncherParameters.INSTANCE.getSocketBufferSize()).isEqualTo(2048);
+    assertThat(ServerLauncherParameters.INSTANCE.getMessageTimeToLive()).isEqualTo(10000);
+    assertThat(ServerLauncherParameters.INSTANCE.getHostnameForClients())
         .isEqualTo("hostName4Clients");
-    assertThat(CacheServerLauncher.getParameters().isDisableDefaultServer()).isFalse();
+    assertThat(ServerLauncherParameters.INSTANCE.isDisableDefaultServer()).isFalse();
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/distributed/ServerLauncherWaitOnServerMultiThreadedTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/ServerLauncherWaitOnServerMultiThreadedTest.java
@@ -50,7 +50,7 @@ public class ServerLauncherWaitOnServerMultiThreadedTest {
   }
 
   @Test
-  public void waitOnServer() throws Exception {
+  public void waitOnServer() {
     runTest(new ServerWaitMultiThreadedTestCase());
   }
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/xmlcache/CacheCreationJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/xmlcache/CacheCreationJUnitTest.java
@@ -184,7 +184,8 @@ public class CacheCreationJUnitTest {
     String configuredServerBindAddress = null;
 
     cacheCreation.startCacheServers(cacheCreation.getCacheServers(), this.cache,
-        configuredServerPort, configuredServerBindAddress, disableDefaultCacheServer);
+        new CacheServerLauncher.Parameters(configuredServerPort, configuredServerBindAddress,
+            disableDefaultCacheServer));
 
     verify(this.cache, never()).addCacheServer();
   }
@@ -204,7 +205,8 @@ public class CacheCreationJUnitTest {
     String configuredServerBindAddress = null;
 
     cacheCreation.startCacheServers(cacheCreation.getCacheServers(), this.cache,
-        configuredServerPort, configuredServerBindAddress, disableDefaultCacheServer);
+        new CacheServerLauncher.Parameters(configuredServerPort, configuredServerBindAddress,
+            disableDefaultCacheServer));
 
     verify(this.cache, never()).addCacheServer();
   }
@@ -224,7 +226,8 @@ public class CacheCreationJUnitTest {
     String configuredServerBindAddress = null;
 
     cacheCreation.startCacheServers(cacheCreation.getCacheServers(), this.cache,
-        configuredServerPort, configuredServerBindAddress, disableDefaultCacheServer);
+        new CacheServerLauncher.Parameters(configuredServerPort, configuredServerBindAddress,
+            disableDefaultCacheServer));
 
     verify(this.cache, times(1)).addCacheServer();
     verify(mockServer).setPort(9999);
@@ -245,7 +248,8 @@ public class CacheCreationJUnitTest {
     Boolean disableDefaultCacheServer = false;
 
     cacheCreation.startCacheServers(cacheCreation.getCacheServers(), this.cache,
-        configuredServerPort, configuredServerBindAddress, disableDefaultCacheServer);
+        new CacheServerLauncher.Parameters(configuredServerPort, configuredServerBindAddress,
+            disableDefaultCacheServer));
 
     verify(this.cache, times(1)).addCacheServer();
     verify(mockServer).setPort(configuredServerPort);
@@ -272,7 +276,8 @@ public class CacheCreationJUnitTest {
     Boolean disableDefaultCacheServer = false;
 
     cacheCreation.startCacheServers(cacheCreation.getCacheServers(), this.cache,
-        configuredServerPort, configuredServerBindAddress, disableDefaultCacheServer);
+        new CacheServerLauncher.Parameters(configuredServerPort, configuredServerBindAddress,
+            disableDefaultCacheServer));
 
     verify(this.cache, never()).addCacheServer();
   }
@@ -295,7 +300,8 @@ public class CacheCreationJUnitTest {
     Boolean disableDefaultCacheServer = false;
 
     cacheCreation.startCacheServers(cacheCreation.getCacheServers(), this.cache,
-        configuredServerPort, configuredServerBindAddress, disableDefaultCacheServer);
+        new CacheServerLauncher.Parameters(configuredServerPort, configuredServerBindAddress,
+            disableDefaultCacheServer));
 
     verify(this.cache, times(2)).addCacheServer();
     verify(mockServer).configureFrom(br1);
@@ -313,7 +319,8 @@ public class CacheCreationJUnitTest {
     Boolean disableDefaultCacheServer = false;
 
     cacheCreation.startCacheServers(cacheCreation.getCacheServers(), this.cache,
-        configuredServerPort, configuredServerBindAddress, disableDefaultCacheServer);
+        new CacheServerLauncher.Parameters(configuredServerPort, configuredServerBindAddress,
+            disableDefaultCacheServer));
   }
 
   @Test
@@ -333,5 +340,38 @@ public class CacheCreationJUnitTest {
     // inOrder.verify(cache).basicCreateRegion(eq("region"), any());
     inOrder.verify(internalCache).createGatewayReceiverFactory();
     inOrder.verify(receiverFactory).create();
+  }
+
+  @Test
+  public void cacheServerLauncherParametersShouldOverrideDefaultSettings() {
+    CacheCreation cacheCreation = new CacheCreation();
+    CacheServerCreation br1 = new CacheServerCreation(cacheCreation, false);
+    cacheCreation.getCacheServers().add(br1);
+    CacheServerImpl mockServer = mock(CacheServerImpl.class);
+    when(this.cache.addCacheServer()).thenReturn(mockServer);
+    Integer serverPort = 4444;
+    Integer maxThreads = 5000;
+    Integer maxConnections = 300;
+    Integer maxMessageCount = 100;
+    Integer socketBufferSize = 1024;
+    String serverBindAddress = null;
+    Integer messageTimeToLive = 500;
+    String hostnameForClients = "hostnameForClients";
+    Boolean disableDefaultServer = false;
+
+    CacheServerLauncher.Parameters parameters = new CacheServerLauncher.Parameters(serverPort,
+        maxThreads, maxConnections, maxMessageCount, socketBufferSize, serverBindAddress,
+        messageTimeToLive, hostnameForClients, disableDefaultServer);
+    cacheCreation.startCacheServers(cacheCreation.getCacheServers(), this.cache, parameters);
+
+    verify(this.cache, times(1)).addCacheServer();
+    verify(mockServer, times(1)).setPort(serverPort);
+    verify(mockServer, times(1)).setMaxThreads(maxThreads);
+    verify(mockServer, times(1)).setMaxConnections(maxConnections);
+    verify(mockServer, times(1)).setMaximumMessageCount(maxMessageCount);
+    verify(mockServer, times(1)).setSocketBufferSize(socketBufferSize);
+    verify(mockServer, times(0)).setBindAddress(serverBindAddress);
+    verify(mockServer, times(1)).setMessageTimeToLive(messageTimeToLive);
+    verify(mockServer, times(1)).setHostnameForClients(hostnameForClients);
   }
 }


### PR DESCRIPTION
Configuration options set as part of the `start server` command now
take precedence over those configured in the `cache.xml` file, the
`cluster-configuration-service` and defaults.

- Removed unused `throws` clauses from tests.
- Renamed `ServerLauncherIntegrationTest` to
  `ServerLauncherBuilderIntegrationTest`.
- Added tests for `ServerLauncher` and `CacheCreation`.
- Added acceptance tests for `gfsh start server` command.
- Fixed `ServerLauncher.parseArguments` method, it was wrongly calling
  `setMaxConnections` for other unrelated parameters (maxMessageCount,
  messageTimeToLive and sockerBufferSize).
- The `ServerLauncher` class now sets all the relevent startup
  parameters during initialization within the static `parameters` field
  on `CacheServerLauncher` class. The `CacheCreation` class, in turn,
  reconfigures the `Server` attributes using
  `CacheServerLauncher.parameters` before starting the `AcceptorImpl`.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
