### PR TITLE
GEODE-5278 Unexpected CommitConflictException caused by faulty region synchronization

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/versions/RegionVersionVector.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/versions/RegionVersionVector.java
@@ -806,6 +806,10 @@ public abstract class RegionVersionVector<T extends VersionSource<?>>
    */
   public boolean contains(T id, long version) {
     if (id.equals(this.myId)) {
+      if (isForSynchronization()) {
+        // a sync vector only has one holder & no valid version for the vector's owner
+        return true;
+      }
       if (getCurrentVersion() < version) {
         return false;
       } else {


### PR DESCRIPTION
Modified RegionVersionVector.contains(id,version) to answer true
if the vector is for sychronization and the ID is that of the owner
of the vector.  This causes the get-initial-image code to ignore entries
last changed by the server requesting the synch operation.


Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [na] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
