### PR TITLE
GEODE-5283: Client transaction fails with TransactionException: GemFireInternalException

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tx/AbstractPeerTXRegionStub.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tx/AbstractPeerTXRegionStub.java
@@ -41,7 +41,7 @@ public abstract class AbstractPeerTXRegionStub implements TXRegionStub {
     try {
       RemoteFetchKeysMessage.FetchKeysResponse response =
           RemoteFetchKeysMessage.send((LocalRegion) getRegion(), state.getTarget());
-      return response.waitForKeys();
+      return response.waitForKeys(response);
     } catch (RegionDestroyedException e) {
       throw new TransactionDataNotColocatedException(
           LocalizedStrings.RemoteMessage_REGION_0_NOT_COLOCATED_WITH_TRANSACTION

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tx/RemoteOperationMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tx/RemoteOperationMessage.java
@@ -239,7 +239,7 @@ public abstract class RemoteOperationMessage extends DistributionMessage
         } else {
           // don't pass arbitrary runtime exceptions and errors back if this
           // cache/vm is closing
-          thr = new RemoteOperationException("cache is closing");
+          thr = new RemoteOperationException("cache is closing", new CacheClosedException());
         }
       }
       if (logger.isTraceEnabled(LogMarker.DM_VERBOSE) && (t instanceof RuntimeException)) {


### PR DESCRIPTION
@mhansonp

Modified the exception returned to include a CacheClosedException as the cause
and added error handling for this in the reply-processor code

Added a test for this error handling


----------------------------------------------------------------------------

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [na] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
