### PR TITLE
GEODE-5280: Fixes NPE when logging event

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/BucketRegionQueue.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/BucketRegionQueue.java
@@ -432,8 +432,10 @@ public class BucketRegionQueue extends AbstractBucketRegionQueue {
         updateLargestQueuedKey((Long) key);
       }
       if (logger.isDebugEnabled()) {
-        logger.debug("Put successfully in the queue : {} was initialized: {}",
-            event.getRawNewValue(), this.initialized);
+        if (event != null) {
+          logger.debug("Put successfully in the queue : {} was initialized: {}",
+              event.getRawNewValue(), this.initialized);
+        }
       }
     }
     if (this.getBucketAdvisor().isPrimary()) {


### PR DESCRIPTION
Fixes NullPointerException when logging event in a debug mode