### PR TITLE
GEODE-3692: Intermittent test failure: ClientAuthDUnitTest

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/security/IntegratedSecurityService.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/security/IntegratedSecurityService.java
@@ -71,6 +71,7 @@ public class IntegratedSecurityService implements SecurityService {
     // service at all.
     this.shiroSecurityManager = provider.getShiroSecurityManager();
     assert this.shiroSecurityManager != null;
+    ThreadContext.bind(this.shiroSecurityManager);
     this.securityManager = provider.getSecurityManager();
     this.postProcessor = postProcessor;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/security/IntegratedSecurityService.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/security/IntegratedSecurityService.java
@@ -112,6 +112,7 @@ public class IntegratedSecurityService implements SecurityService {
     }
 
     // in other cases like rest call, client operations, we get it from the current thread
+    ThreadContext.bind(this.shiroSecurityManager);
     currentUser = SecurityUtils.getSubject();
 
     if (currentUser == null || currentUser.getPrincipal() == null) {
@@ -130,7 +131,7 @@ public class IntegratedSecurityService implements SecurityService {
       throw new AuthenticationRequiredException("credentials are null");
     }
 
-    // this makes sure it starts with a clean user object
+    // clear current subject and bind the security manager to this thread
     ThreadContext.remove();
     ThreadContext.bind(this.shiroSecurityManager);
 

--- a/geode-core/src/main/java/org/apache/geode/internal/security/IntegratedSecurityService.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/security/IntegratedSecurityService.java
@@ -58,6 +58,7 @@ public class IntegratedSecurityService implements SecurityService {
 
   private final PostProcessor postProcessor;
   private final SecurityManager securityManager;
+  private final org.apache.shiro.mgt.SecurityManager shiroSecurityManager;
 
   /**
    * this creates a security service using a SecurityManager
@@ -68,9 +69,8 @@ public class IntegratedSecurityService implements SecurityService {
   IntegratedSecurityService(SecurityManagerProvider provider, PostProcessor postProcessor) {
     // provider must provide a shiro security manager, otherwise, this is not integrated security
     // service at all.
-    assert provider.getShiroSecurityManager() != null;
-    SecurityUtils.setSecurityManager(provider.getShiroSecurityManager());
-
+    this.shiroSecurityManager = provider.getShiroSecurityManager();
+    assert this.shiroSecurityManager != null;
     this.securityManager = provider.getSecurityManager();
     this.postProcessor = postProcessor;
   }
@@ -131,6 +131,7 @@ public class IntegratedSecurityService implements SecurityService {
 
     // this makes sure it starts with a clean user object
     ThreadContext.remove();
+    ThreadContext.bind(this.shiroSecurityManager);
 
     Subject currentUser = SecurityUtils.getSubject();
     GeodeAuthenticationToken token = new GeodeAuthenticationToken(credentials);
@@ -266,7 +267,6 @@ public class IntegratedSecurityService implements SecurityService {
     }
 
     ThreadContext.remove();
-    SecurityUtils.setSecurityManager(null);
   }
 
   /**

--- a/geode-core/src/test/java/org/apache/geode/internal/security/SecurityServiceTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/security/SecurityServiceTest.java
@@ -22,8 +22,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Properties;
 
-import org.apache.shiro.SecurityUtils;
 import org.apache.shiro.mgt.DefaultSecurityManager;
+import org.apache.shiro.util.ThreadContext;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -121,7 +121,7 @@ public class SecurityServiceTest {
 
   @Test
   public void testInitWithOutsideShiroSecurityManager() {
-    SecurityUtils.setSecurityManager(new DefaultSecurityManager());
+    ThreadContext.bind(new DefaultSecurityManager());
     this.securityService = SecurityServiceFactory.create(properties);
 
     assertThat(this.securityService.isIntegratedSecurity()).isTrue();


### PR DESCRIPTION
Replace use of SecurityUtils.setSecurityManager() with ThreadContext.bind().  The former is a fallback mechanism in Shiro and is not thread-safe.  The latter uses a thread-local and is thread-safe.



Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [no] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
