### PR TITLE
GEODE-5292: Fix memory leak for off heap regions with overflow

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DiskRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DiskRegion.java
@@ -769,8 +769,6 @@ public class DiskRegion extends AbstractDiskRegion {
         DiskId id = de.getDiskId();
         if (id != null) {
           synchronized (id) {
-            regionEntry.setValueToNull(); // TODO why call _setValue twice in a row?
-            regionEntry.removePhase2();
             id.unmarkForWriting();
             if (EntryBits.isNeedsValue(id.getUserBits())) {
               long oplogId = id.getOplogId();

--- a/geode-core/src/test/java/org/apache/geode/cache/ConcurrentRegionOperationIntegrationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/ConcurrentRegionOperationIntegrationTest.java
@@ -33,7 +33,6 @@ import org.apache.geode.distributed.ConfigurationProperties;
 import org.apache.geode.internal.cache.LocalRegion;
 import org.apache.geode.internal.cache.RegionClearedException;
 import org.apache.geode.internal.cache.RegionEntry;
-import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.offheap.MemoryAllocator;
 import org.apache.geode.internal.offheap.MemoryAllocatorImpl;
 import org.apache.geode.internal.util.concurrent.ConcurrentMapWithReusableEntries;
@@ -47,7 +46,6 @@ public class ConcurrentRegionOperationIntegrationTest {
 
   @Before
   public void createCache() {
-    LogService.getLogger().error("*** In Test.createCache()");
     cache = new CacheFactory().set(ConfigurationProperties.OFF_HEAP_MEMORY_SIZE, "100m").create();
     offHeapStore = MemoryAllocatorImpl.getAllocator();
 
@@ -56,7 +54,6 @@ public class ConcurrentRegionOperationIntegrationTest {
 
   @After
   public void closeCache() {
-    LogService.getLogger().error("*** In Test.closeCache()");
     cache.close();
   }
 

--- a/geode-core/src/test/java/org/apache/geode/cache/ConcurrentRegionOperationIntegrationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/ConcurrentRegionOperationIntegrationTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.awaitility.Awaitility;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.distributed.ConfigurationProperties;
+import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.RegionClearedException;
+import org.apache.geode.internal.cache.RegionEntry;
+import org.apache.geode.internal.logging.LogService;
+import org.apache.geode.internal.offheap.MemoryAllocator;
+import org.apache.geode.internal.offheap.MemoryAllocatorImpl;
+import org.apache.geode.internal.util.concurrent.ConcurrentMapWithReusableEntries;
+import org.apache.geode.test.junit.categories.IntegrationTest;
+
+@Category(IntegrationTest.class)
+public class ConcurrentRegionOperationIntegrationTest {
+
+  private Cache cache;
+  private MemoryAllocator offHeapStore;
+
+  @Before
+  public void createCache() {
+    LogService.getLogger().error("*** In Test.createCache()");
+    cache = new CacheFactory().set(ConfigurationProperties.OFF_HEAP_MEMORY_SIZE, "100m").create();
+    offHeapStore = MemoryAllocatorImpl.getAllocator();
+
+    assertEquals(0, offHeapStore.getStats().getObjects());
+  }
+
+  @After
+  public void closeCache() {
+    LogService.getLogger().error("*** In Test.closeCache()");
+    cache.close();
+  }
+
+  @Test
+  public void replaceWithClearAndDestroy() throws RegionClearedException {
+    Region<Integer, String> region = createRegion();
+
+    region.put(1, "value");
+    region.put(2, "value");
+
+    ConcurrentMapWithReusableEntries<Object, Object> underlyingMap =
+        ((LocalRegion) region).getRegionMap().getCustomEntryConcurrentHashMap();
+    RegionEntry spyEntry = spy((RegionEntry) underlyingMap.get(1));
+    underlyingMap.remove(1);
+    underlyingMap.put(1, spyEntry);
+
+    // we want to have spies that cause a clear and destroy in the middle of `region.replace()`
+    doAnswer(invocation -> {
+      // Execute the clear in a separate thread and wait for it to finish.
+      // We are trying to test the case where clear happens concurrently with replace.
+      // If we invoke clear in the replace thread, it can get locks which it will not
+      // be able to get in a separate thread.
+      CompletableFuture.runAsync(region::clear).get();
+      throw new RegionDestroyedException("Fake Exception", "/region");
+    }).when(spyEntry).setValueWithTombstoneCheck(any(), any());
+
+    assertThatExceptionOfType(RegionDestroyedException.class)
+        .isThrownBy(() -> region.replace(1, "value", "newvalue"))
+        .withMessageContaining("Fake Exception");
+
+    Awaitility.await().pollDelay(0, TimeUnit.MICROSECONDS)
+        .pollInterval(1, TimeUnit.MILLISECONDS)
+        .atMost(10, TimeUnit.SECONDS).until(() -> {
+          assertEquals(0, offHeapStore.getStats().getObjects());
+        });
+  }
+
+  private Region<Integer, String> createRegion() {
+    return cache.<Integer, String>createRegionFactory()
+        .setDataPolicy(DataPolicy.PRELOADED)
+        .setEvictionAttributes(
+            EvictionAttributes.createLRUEntryAttributes(1, EvictionAction.OVERFLOW_TO_DISK))
+        .setOffHeap(true)
+        .setDiskSynchronous(false)
+        .create("region");
+  }
+}


### PR DESCRIPTION
For a region that has been configured with off-heap storage and overflow
to disk, memory can be leaked if

- region clear
- region destroy
- region replace

all happen concurrently. The root cause appears to be region clear
modifying entries for values stored on disk without synchronizing the
entries. This prevents replace from freeing the off-heap memory for the
new value when the replace fails because the region is being destroyed.

This commit adds an integration test that uses spies on a region entry
to trigger the concurrent events during a replace operation and checks
for orphaned off-heap memory.

The proposed fix is to not modify the region entries on disk while
performing a clear operation.

Signed-off-by: Dan Smith <dsmith@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
