### PR TITLE
GEODE-5301: Check readiness and closed before assertion

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/ProxyBucketRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/ProxyBucketRegion.java
@@ -230,15 +230,15 @@ public class ProxyBucketRegion implements Bucket {
    * @param br the real bucket which will be the target for this proxy
    */
   public void setBucketRegion(BucketRegion br) {
-    Assert.assertTrue(this.realBucket == null);
-    Assert.assertTrue(!this.advisor.isHosting());
-    this.realBucket = br;
     // fix several bugs including 36881... creation of BR may be occurring
     // at same time another thread is destroying the PR and now that this
     // BR is visible to the destroy thread we want to prevent sending bogus
     // CreateRegion or profile update messages
     this.partitionedRegion.checkReadiness();
     this.partitionedRegion.checkClosed();
+    Assert.assertTrue(this.realBucket == null);
+    Assert.assertTrue(!this.advisor.isHosting());
+    this.realBucket = br;
   }
 
   public void clearBucketRegion(BucketRegion br) {


### PR DESCRIPTION
[GEODE-5301]

If Geode member is disconnected, it will throw DistributedSystemDisconnectedException, instead of an assertion error at ProxyBucketRegion.setBucketRegion().

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
