### PR TITLE
GEODE-5318: Extract the valid region name

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateDefinedIndexesCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateDefinedIndexesCommand.java
@@ -80,12 +80,26 @@ public class CreateDefinedIndexesCommand extends SingleGfshCommand {
     }
 
     for (RegionConfig.Index index : updatedIndexes) {
-      RegionConfig region = config.findRegionConfiguration(index.getFromClause());
-      if (region == null) {
+      RegionConfig regionConfig = getValidRegionConfig(index.getFromClause(), config);
+      if (regionConfig == null) {
         throw new IllegalStateException("RegionConfig is null");
       }
 
-      region.getIndexes().add(index);
+      regionConfig.getIndexes().add(index);
     }
+  }
+
+  RegionConfig getValidRegionConfig(String regionPath, CacheConfig cacheConfig) {
+    // Check to see if the region path contains an alias e.g "/region1 r1"
+    // Then the first string will be the regionPath
+    String[] regionPathTokens = regionPath.trim().split(" ");
+    regionPath = regionPathTokens[0];
+    // check to see if the region path is in the form of "--region=region.entrySet() z"
+    RegionConfig regionConfig = cacheConfig.findRegionConfiguration(regionPath);
+    while (regionPath.contains(".") && (regionConfig) == null) {
+      regionPath = regionPath.substring(0, regionPath.lastIndexOf("."));
+      regionConfig = cacheConfig.findRegionConfiguration(regionPath);
+    }
+    return regionConfig;
   }
 }

--- a/geode-wan/src/test/java/org/apache/geode/management/internal/configuration/ClusterConfigurationIndexWithFromClauseDUnitTest.java
+++ b/geode-wan/src/test/java/org/apache/geode/management/internal/configuration/ClusterConfigurationIndexWithFromClauseDUnitTest.java
@@ -28,6 +28,7 @@ import org.junit.runner.RunWith;
 import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.util.CommandStringBuilder;
+import org.apache.geode.test.dunit.IgnoredException;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.junit.categories.DistributedTest;
@@ -77,6 +78,44 @@ public class ClusterConfigurationIndexWithFromClauseDUnitTest {
     verifyIndexRecreated(INDEX_NAME);
   }
 
+  @Test
+  @Parameters(method = "getRegionTypes")
+  public void indexCreatedWithDefinedIndexWithEntrySetInFromClauseMustPersistInClusterConfig(
+      RegionShortcut regionShortcut)
+      throws Exception {
+    IgnoredException.addIgnoredException("java.lang.IllegalStateException");
+    MemberVM vm1 = lsRule.startServerVM(1, locator.getPort());
+    gfshCommandRule.connectAndVerify(locator);
+    createRegionUsingGfsh(REGION_NAME, regionShortcut, null);
+    createIndexUsingGfsh("\"" + REGION_NAME + ".entrySet() z\"", "z.key", INDEX_NAME);
+    String serverName = vm1.getName();
+    CommandStringBuilder csb = new CommandStringBuilder(CliStrings.CREATE_DEFINED_INDEXES);
+    gfshCommandRule.executeAndAssertThat(csb.toString()).statusIsSuccess();
+    lsRule.stopVM(1);
+    lsRule.startServerVM(1, locator.getPort());
+    verifyIndexRecreated(INDEX_NAME);
+
+  }
+
+  @Test
+  @Parameters(method = "getRegionTypes")
+  public void indexCreatedWithDefinedIndexWithAliasInFromClauseMustPersistInClusterConfig(
+      RegionShortcut regionShortcut)
+      throws Exception {
+    IgnoredException.addIgnoredException("java.lang.IllegalStateException");
+    MemberVM vm1 = lsRule.startServerVM(1, locator.getPort());
+    gfshCommandRule.connectAndVerify(locator);
+    createRegionUsingGfsh(REGION_NAME, regionShortcut, null);
+    createIndexUsingGfsh("\"" + REGION_NAME + " z\"", "z.ID", INDEX_NAME);
+    String serverName = vm1.getName();
+    CommandStringBuilder csb = new CommandStringBuilder(CliStrings.CREATE_DEFINED_INDEXES);
+    gfshCommandRule.executeAndAssertThat(csb.toString()).statusIsSuccess();
+    lsRule.stopVM(1);
+    lsRule.startServerVM(1, locator.getPort());
+    verifyIndexRecreated(INDEX_NAME);
+
+  }
+
   private void verifyIndexRecreated(String indexName) throws Exception {
     CommandStringBuilder csb = new CommandStringBuilder(CliStrings.LIST_INDEX);
     gfshCommandRule.executeAndAssertThat(csb.toString()).statusIsSuccess();
@@ -90,6 +129,15 @@ public class ClusterConfigurationIndexWithFromClauseDUnitTest {
     csb.addOption(CliStrings.CREATE_INDEX__EXPRESSION, expression);
     csb.addOption(CliStrings.CREATE_INDEX__REGION, regionName);
     csb.addOption(CliStrings.CREATE_INDEX__NAME, indexName);
+    gfshCommandRule.executeAndAssertThat(csb.toString()).statusIsSuccess();
+  }
+
+  private void defineIndexUsingGfsh(String regionName, String expression, String indexName)
+      throws Exception {
+    CommandStringBuilder csb = new CommandStringBuilder(CliStrings.DEFINE_INDEX);
+    csb.addOption(CliStrings.DEFINE_INDEX__EXPRESSION, expression);
+    csb.addOption(CliStrings.DEFINE_INDEX__REGION, regionName);
+    csb.addOption(CliStrings.DEFINE_INDEX_NAME, indexName);
     gfshCommandRule.executeAndAssertThat(csb.toString()).statusIsSuccess();
   }
 


### PR DESCRIPTION
	* Incase of entrySet being used in the from clause while defining an index
	* the region name extracted should not include entrySet part.
	* Including the entrySet causes updates to cluster config to fail.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
