### PR TITLE
Update expected number of gateway senders

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/test/junit/rules/GfshCommandRule.java
+++ b/geode-core/src/test/java/org/apache/geode/test/junit/rules/GfshCommandRule.java
@@ -82,13 +82,7 @@ public class GfshCommandRule extends DescribedExternalResource {
   private File workingDir;
   private CommandResult commandResult;
 
-  public GfshCommandRule() {
-    try {
-      temporaryFolder.create();
-    } catch (IOException e) {
-      throw new UncheckedIOException(e);
-    }
-  }
+  public GfshCommandRule() {}
 
   public GfshCommandRule(Supplier<Integer> portSupplier, PortType portType) {
     this();
@@ -99,6 +93,11 @@ public class GfshCommandRule extends DescribedExternalResource {
   @Override
   protected void before(Description description) throws Throwable {
     LogWrapper.close();
+    try {
+      temporaryFolder.create();
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
     workingDir = temporaryFolder.newFolder("gfsh_files");
     this.gfsh = new HeadlessGfsh(getClass().getName(), gfshTimeout, workingDir.getAbsolutePath());
     ignoredException =

--- a/geode-core/src/test/java/org/apache/geode/test/junit/rules/MemberStarterRule.java
+++ b/geode-core/src/test/java/org/apache/geode/test/junit/rules/MemberStarterRule.java
@@ -26,6 +26,8 @@ import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.apache.geode.distributed.ConfigurationProperties.NAME;
 import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_MANAGER;
 import static org.awaitility.Awaitility.await;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -272,7 +274,8 @@ public abstract class MemberStarterRule<T> extends SerializableExternalResource 
   public void waitTilGatewaySendersAreReady(int expectedGatewayObjectCount) throws Exception {
     DistributedSystemMXBean dsMXBean = getManagementService().getDistributedSystemMXBean();
     await().atMost(30, TimeUnit.SECONDS)
-        .until(() -> dsMXBean.listGatewaySenderObjectNames().length == expectedGatewayObjectCount);
+        .until(() -> assertThat(dsMXBean.listGatewaySenderObjectNames().length,
+            is(expectedGatewayObjectCount)));
   }
 
   public void waitTillDiskStoreIsReady(String diskstoreName, int serverCount) {

--- a/geode-wan/src/test/java/org/apache/geode/management/internal/cli/commands/CreateRegionCommandDUnitTest.java
+++ b/geode-wan/src/test/java/org/apache/geode/management/internal/cli/commands/CreateRegionCommandDUnitTest.java
@@ -86,7 +86,7 @@ public class CreateRegionCommandDUnitTest {
         "create gateway-sender --parallel=true --remote-distributed-system-id=2 --id="
             + gatewaySenderName)
         .statusIsSuccess();
-    locator.waitTilGatewaySendersAreReady(1);
+    locator.waitTilGatewaySendersAreReady(2);
 
     gfsh.executeAndAssertThat("create region --type=REPLICATE  --name=" + regionName
         + " --gateway-sender-id=" + gatewaySenderName)


### PR DESCRIPTION
CreateRegionCommandDUnit test contained a race condition that caused a
test to fail if the GatewaySenders were created faster than the 100ms
poll rate of Awaitility. We actually expect two GatewaySenders, one for
each server in the cluster.

The wait was updated to use an assertion for better error messages when
the test fails.

[#158341308]

Co-Authored-by: Bradford D. Boyle <bboyle@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
