### PR TITLE
Create temp folder in two places

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/test/junit/rules/GfshCommandRule.java
+++ b/geode-core/src/test/java/org/apache/geode/test/junit/rules/GfshCommandRule.java
@@ -82,7 +82,9 @@ public class GfshCommandRule extends DescribedExternalResource {
   private File workingDir;
   private CommandResult commandResult;
 
-  public GfshCommandRule() {}
+  public GfshCommandRule() {
+    createTempFolder();
+  }
 
   public GfshCommandRule(Supplier<Integer> portSupplier, PortType portType) {
     this();
@@ -93,11 +95,7 @@ public class GfshCommandRule extends DescribedExternalResource {
   @Override
   protected void before(Description description) throws Throwable {
     LogWrapper.close();
-    try {
-      temporaryFolder.create();
-    } catch (IOException e) {
-      throw new UncheckedIOException(e);
-    }
+    createTempFolder();
     workingDir = temporaryFolder.newFolder("gfsh_files");
     this.gfsh = new HeadlessGfsh(getClass().getName(), gfshTimeout, workingDir.getAbsolutePath());
     ignoredException =
@@ -115,6 +113,14 @@ public class GfshCommandRule extends DescribedExternalResource {
       // when config is not null, developer may deliberately pass in a wrong
       // password so that the test will verify the connection itself. So do not verify here.
       secureConnect(portSupplier.get(), portType, config.user(), config.password());
+    }
+  }
+
+  private void createTempFolder() {
+    try {
+      temporaryFolder.create();
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
     }
   }
 


### PR DESCRIPTION
Move creation of temp folder to a helper method and call from no-arg
constructor and before. The creation of the folder is idempotent so it
can be called multiple times. Calling this method in before() allows
tests to be run multiple times in IntelliJ.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
