### PR TITLE
GEODE-5332: Introduces Serializable version of Consumer - for ClusterStartupRule

### DIFF
--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/JdbcDistributedTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/JdbcDistributedTest.java
@@ -29,7 +29,6 @@ import java.sql.Statement;
 import java.util.Date;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 
 import org.awaitility.Awaitility;
 import org.junit.After;
@@ -45,6 +44,7 @@ import org.apache.geode.pdx.PdxInstance;
 import org.apache.geode.pdx.ReflectionBasedAutoSerializer;
 import org.apache.geode.pdx.internal.AutoSerializableManager;
 import org.apache.geode.test.dunit.IgnoredException;
+import org.apache.geode.test.dunit.SerializableConsumerIF;
 import org.apache.geode.test.dunit.rules.ClientVM;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.DistributedRestoreSystemProperties;
@@ -593,7 +593,7 @@ public abstract class JdbcDistributedTest implements Serializable {
   }
 
   private ClientVM getClientVM() throws Exception {
-    Consumer<ClientCacheFactory> cacheSetup = (Serializable & Consumer<ClientCacheFactory>) cf -> {
+    SerializableConsumerIF<ClientCacheFactory> cacheSetup = cf -> {
       System.setProperty(AutoSerializableManager.NO_HARDCODED_EXCLUDES_PARAM, "true");
       cf.addPoolLocator("localhost", locator.getPort());
       cf.setPdxSerializer(

--- a/geode-core/src/test/java/org/apache/geode/security/ClientAuthDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/security/ClientAuthDUnitTest.java
@@ -52,7 +52,8 @@ public class ClientAuthDUnitTest {
 
   @Test
   public void authWithCorrectPasswordShouldPass() throws Exception {
-    lsRule.startClientVM(0, "test", "test", true, server.getPort(), new ClientCacheHook(lsRule));
+    lsRule.startClientVM(0, "test", "test", true, server.getPort(),
+        () -> new ClientCacheHook(lsRule));
   }
 
   @Test
@@ -60,7 +61,7 @@ public class ClientAuthDUnitTest {
     IgnoredException.addIgnoredException(AuthenticationFailedException.class.getName());
 
     assertThatThrownBy(() -> lsRule.startClientVM(0, "test", "invalidPassword", true,
-        server.getPort(), new ClientCacheHook(lsRule)))
+        server.getPort(), () -> new ClientCacheHook(lsRule)))
             .isInstanceOf(AuthenticationFailedException.class);
   }
 

--- a/geode-core/src/test/java/org/apache/geode/security/ClientAuthorizationLegacyConfigurationDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/security/ClientAuthorizationLegacyConfigurationDUnitTest.java
@@ -20,12 +20,10 @@ import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_CLIE
 import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_CLIENT_AUTH_INIT;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.io.Serializable;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
-import java.util.function.Consumer;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -44,6 +42,7 @@ import org.apache.geode.cache.client.ClientRegionShortcut;
 import org.apache.geode.security.templates.SimpleAccessController;
 import org.apache.geode.security.templates.SimpleAuthenticator;
 import org.apache.geode.security.templates.UserPasswordAuthInit;
+import org.apache.geode.test.dunit.SerializableConsumerIF;
 import org.apache.geode.test.dunit.rules.ClientVM;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
@@ -120,7 +119,7 @@ public class ClientAuthorizationLegacyConfigurationDUnitTest {
         UserPasswordAuthInit.class.getCanonicalName() + ".create");
 
     int locatorPort = locator.getPort();
-    Consumer<ClientCacheFactory> cacheSetup = (Serializable & Consumer<ClientCacheFactory>) cf -> cf
+    SerializableConsumerIF<ClientCacheFactory> cacheSetup = cf -> cf
         .addPoolLocator("localhost", locatorPort);
 
     ClientVM client = csRule.startClientVM(2, clientProps, cacheSetup, clientVersion);
@@ -182,7 +181,7 @@ public class ClientAuthorizationLegacyConfigurationDUnitTest {
         UserPasswordAuthInit.class.getCanonicalName() + ".create");
 
     int locatorPort = locator.getPort();
-    Consumer<ClientCacheFactory> cacheSetup = (Serializable & Consumer<ClientCacheFactory>) cf -> cf
+    SerializableConsumerIF<ClientCacheFactory> cacheSetup = cf -> cf
         .addPoolLocator("localhost", locatorPort);
 
     ClientVM client = csRule.startClientVM(2, clientProps, cacheSetup, clientVersion);

--- a/geode-core/src/test/java/org/apache/geode/security/ClientDataAuthorizationUsingLegacySecurityDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/security/ClientDataAuthorizationUsingLegacySecurityDUnitTest.java
@@ -21,12 +21,10 @@ import static org.apache.geode.distributed.ConfigurationProperties.SERIALIZABLE_
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.io.Serializable;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
-import java.util.function.Consumer;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -48,6 +46,7 @@ import org.apache.geode.security.templates.SimpleAccessController;
 import org.apache.geode.security.templates.SimpleAuthenticator;
 import org.apache.geode.security.templates.UserPasswordAuthInit;
 import org.apache.geode.security.templates.UsernamePrincipal;
+import org.apache.geode.test.dunit.SerializableConsumerIF;
 import org.apache.geode.test.dunit.rules.ClientVM;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
@@ -123,7 +122,7 @@ public class ClientDataAuthorizationUsingLegacySecurityDUnitTest {
     Properties props = getVMPropertiesWithPermission("dataWrite");
     int locatorPort = locator.getPort();
 
-    Consumer<ClientCacheFactory> cacheSetup = (Serializable & Consumer<ClientCacheFactory>) cf -> cf
+    SerializableConsumerIF<ClientCacheFactory> cacheSetup = cf -> cf
         .addPoolLocator("localhost", locatorPort);
     ClientVM clientVM = csRule.startClientVM(2, props, cacheSetup, clientVersion);
 
@@ -157,7 +156,7 @@ public class ClientDataAuthorizationUsingLegacySecurityDUnitTest {
     }
     int locatorPort = locator.getPort();
 
-    Consumer<ClientCacheFactory> cacheSetup = (Serializable & Consumer<ClientCacheFactory>) cf -> cf
+    SerializableConsumerIF<ClientCacheFactory> cacheSetup = cf -> cf
         .addPoolLocator("localhost", locatorPort);
     ClientVM client = csRule.startClientVM(2, props, cacheSetup, clientVersion);
 
@@ -184,7 +183,7 @@ public class ClientDataAuthorizationUsingLegacySecurityDUnitTest {
     Properties props = getVMPropertiesWithPermission("dataRead");
     int locatorPort = locator.getPort();
 
-    Consumer<ClientCacheFactory> cacheSetup = (Serializable & Consumer<ClientCacheFactory>) cf -> cf
+    SerializableConsumerIF<ClientCacheFactory> cacheSetup = cf -> cf
         .addPoolLocator("localhost", locatorPort);
     ClientVM client = csRule.startClientVM(2, props, cacheSetup, clientVersion);
 
@@ -220,7 +219,7 @@ public class ClientDataAuthorizationUsingLegacySecurityDUnitTest {
     }
 
     int locatorPort = locator.getPort();
-    Consumer<ClientCacheFactory> cacheSetup = (Serializable & Consumer<ClientCacheFactory>) cf -> cf
+    SerializableConsumerIF<ClientCacheFactory> cacheSetup = cf -> cf
         .addPoolLocator("localhost", locatorPort);
 
     ClientVM clientVM = csRule.startClientVM(2, props, cacheSetup, clientVersion);

--- a/geode-core/src/test/java/org/apache/geode/security/ClientDataAuthorizationUsingLegacySecurityWithFailoverDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/security/ClientDataAuthorizationUsingLegacySecurityWithFailoverDUnitTest.java
@@ -23,12 +23,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 
-import java.io.Serializable;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
-import java.util.function.Consumer;
 
 import org.apache.logging.log4j.Logger;
 import org.junit.Before;
@@ -55,6 +53,7 @@ import org.apache.geode.security.templates.SimpleAccessController;
 import org.apache.geode.security.templates.SimpleAuthenticator;
 import org.apache.geode.security.templates.UserPasswordAuthInit;
 import org.apache.geode.security.templates.UsernamePrincipal;
+import org.apache.geode.test.dunit.SerializableConsumerIF;
 import org.apache.geode.test.dunit.rules.ClientVM;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
@@ -330,7 +329,7 @@ public class ClientDataAuthorizationUsingLegacySecurityWithFailoverDUnitTest {
     int server1Port = this.server1.getPort();
     int server2Port = this.server2.getPort();
 
-    Consumer<ClientCacheFactory> cacheSetup = (Serializable & Consumer<ClientCacheFactory>) cf -> cf
+    SerializableConsumerIF<ClientCacheFactory> cacheSetup = cf -> cf
         .addPoolServer("localhost", server1Port).addPoolServer("localhost", server2Port)
         .setPoolSubscriptionEnabled(true).setPoolSubscriptionRedundancy(2);
     ClientVM client1 = csRule.startClientVM(3, props, cacheSetup, clientVersion);
@@ -389,7 +388,7 @@ public class ClientDataAuthorizationUsingLegacySecurityWithFailoverDUnitTest {
           "org.apache.geode.security.templates.UsernamePrincipal");
     }
 
-    Consumer<ClientCacheFactory> cacheSetup = (Serializable & Consumer<ClientCacheFactory>) cf -> cf
+    SerializableConsumerIF<ClientCacheFactory> cacheSetup = cf -> cf
         .addPoolServer("localhost", server1Port).addPoolServer("localhost", server2Port)
         .setPoolSubscriptionEnabled(true).setPoolSubscriptionRedundancy(2);
     ClientVM client = csRule.startClientVM(3, props, cacheSetup, clientVersion);

--- a/geode-core/src/test/java/org/apache/geode/test/dunit/SerializableConsumerIF.java
+++ b/geode-core/src/test/java/org/apache/geode/test/dunit/SerializableConsumerIF.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+
+package org.apache.geode.test.dunit;
+
+import java.io.Serializable;
+import java.util.function.Consumer;
+
+/**
+ * Interface for {@link Consumer} to be used with lambda expressions invoked in other VM's.
+ */
+
+public interface SerializableConsumerIF<T> extends Serializable, Consumer<T> {
+}

--- a/geode-core/src/test/java/org/apache/geode/test/dunit/rules/ClusterStartupRule.java
+++ b/geode-core/src/test/java/org/apache/geode/test/dunit/rules/ClusterStartupRule.java
@@ -28,7 +28,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
@@ -45,6 +44,8 @@ import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.security.templates.UserPasswordAuthInit;
 import org.apache.geode.test.dunit.Host;
 import org.apache.geode.test.dunit.RMIException;
+import org.apache.geode.test.dunit.SerializableConsumerIF;
+import org.apache.geode.test.dunit.SerializableRunnableIF;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.standalone.DUnitLauncher;
 import org.apache.geode.test.dunit.standalone.VersionManager;
@@ -242,15 +243,16 @@ public class ClusterStartupRule extends ExternalResource implements Serializable
    * Consumer
    */
   public ClientVM startClientVM(int index, Properties properties,
-      Consumer<ClientCacheFactory> cacheFactorySetup, String clientVersion) throws Exception {
+      SerializableConsumerIF<ClientCacheFactory> cacheFactorySetup, String clientVersion)
+      throws Exception {
     return startClientVM(index, properties, cacheFactorySetup, clientVersion,
-        (Runnable & Serializable) () -> {
+        () -> {
         });
   }
 
   public ClientVM startClientVM(int index, Properties properties,
-      Consumer<ClientCacheFactory> cacheFactorySetup, String clientVersion,
-      Runnable clientCacheHook) throws Exception {
+      SerializableConsumerIF<ClientCacheFactory> cacheFactorySetup, String clientVersion,
+      SerializableRunnableIF clientCacheHook) throws Exception {
     VM client = getVM(index, clientVersion);
     Exception error = client.invoke(() -> {
       clientCacheRule =
@@ -272,7 +274,7 @@ public class ClusterStartupRule extends ExternalResource implements Serializable
   }
 
   public ClientVM startClientVM(int index, Properties properties,
-      Consumer<ClientCacheFactory> cacheFactorySetup) throws Exception {
+      SerializableConsumerIF<ClientCacheFactory> cacheFactorySetup) throws Exception {
     return startClientVM(index, properties, cacheFactorySetup, VersionManager.CURRENT_VERSION);
   }
 
@@ -283,8 +285,8 @@ public class ClusterStartupRule extends ExternalResource implements Serializable
     props.setProperty(UserPasswordAuthInit.PASSWORD, password);
     props.setProperty(SECURITY_CLIENT_AUTH_INIT, UserPasswordAuthInit.class.getName());
 
-    Consumer<ClientCacheFactory> consumer =
-        (Serializable & Consumer<ClientCacheFactory>) ((cacheFactory) -> {
+    SerializableConsumerIF<ClientCacheFactory> consumer =
+        ((cacheFactory) -> {
           cacheFactory.setPoolSubscriptionEnabled(subscriptionEnabled);
           for (int serverPort : serverPorts) {
             cacheFactory.addPoolServer("localhost", serverPort);
@@ -294,14 +296,15 @@ public class ClusterStartupRule extends ExternalResource implements Serializable
   }
 
   public ClientVM startClientVM(int index, String username, String password,
-      boolean subscriptionEnabled, int serverPort, Runnable clientCacheHook) throws Exception {
+      boolean subscriptionEnabled, int serverPort, SerializableRunnableIF clientCacheHook)
+      throws Exception {
     Properties props = new Properties();
     props.setProperty(UserPasswordAuthInit.USER_NAME, username);
     props.setProperty(UserPasswordAuthInit.PASSWORD, password);
     props.setProperty(SECURITY_CLIENT_AUTH_INIT, UserPasswordAuthInit.class.getName());
 
-    Consumer<ClientCacheFactory> consumer =
-        (Serializable & Consumer<ClientCacheFactory>) ((cacheFactory) -> {
+    SerializableConsumerIF<ClientCacheFactory> consumer =
+        ((cacheFactory) -> {
           cacheFactory.setPoolSubscriptionEnabled(subscriptionEnabled);
           cacheFactory.addPoolServer("localhost", serverPort);
         });

--- a/geode-core/src/test/java/org/apache/geode/test/dunit/rules/tests/ClusterStartupRuleCanSpecifyOlderVersionsDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/test/dunit/rules/tests/ClusterStartupRuleCanSpecifyOlderVersionsDUnitTest.java
@@ -17,10 +17,8 @@ package org.apache.geode.test.dunit.rules.tests;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.Serializable;
 import java.util.List;
 import java.util.Properties;
-import java.util.function.Consumer;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -30,6 +28,7 @@ import org.junit.runners.Parameterized;
 
 import org.apache.geode.cache.client.ClientCacheFactory;
 import org.apache.geode.internal.GemFireVersion;
+import org.apache.geode.test.dunit.SerializableConsumerIF;
 import org.apache.geode.test.dunit.rules.ClientVM;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
@@ -82,7 +81,7 @@ public class ClusterStartupRuleCanSpecifyOlderVersionsDUnitTest {
 
   @Test
   public void clientVersioningTest() throws Exception {
-    Consumer<ClientCacheFactory> consumer = (Serializable & Consumer<ClientCacheFactory>) cf -> {
+    SerializableConsumerIF<ClientCacheFactory> consumer = cf -> {
     };
     ClientVM locator = csRule.startClientVM(0, new Properties(), consumer, version);
     String locatorVMVersion = locator.getVM().getVersion();

--- a/geode-cq/src/test/java/org/apache/geode/management/internal/cli/commands/DescribeClientCommandDUnitTest.java
+++ b/geode-cq/src/test/java/org/apache/geode/management/internal/cli/commands/DescribeClientCommandDUnitTest.java
@@ -17,12 +17,10 @@ package org.apache.geode.management.internal.cli.commands;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.awaitility.Awaitility;
@@ -46,6 +44,7 @@ import org.apache.geode.internal.net.SocketCreator;
 import org.apache.geode.management.cli.Result;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.CommandResult;
+import org.apache.geode.test.dunit.SerializableConsumerIF;
 import org.apache.geode.test.dunit.rules.ClientVM;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
@@ -188,7 +187,7 @@ public class DescribeClientCommandDUnitTest {
 
   private ClientVM createClient(int vmId, boolean subscriptionEnabled) throws Exception {
     int server1Port = server1Vm1.getPort();
-    Consumer<ClientCacheFactory> cacheSetup = (Serializable & Consumer<ClientCacheFactory>) cf -> {
+    SerializableConsumerIF<ClientCacheFactory> cacheSetup = cf -> {
       cf.addPoolServer("localhost", server1Port);
       cf.setPoolSubscriptionEnabled(subscriptionEnabled);
       cf.setPoolPingInterval(100);


### PR DESCRIPTION
Adds a `SerializableConsumerIF` which helps with creating Serializable version of Lamdba expressions. For eg, a client calling the rule this way:

```
startupRule.startClientVM(2, new Properties(), (Serializable & Consumer<ClientCacheFactory>) cf -> {
      ...
})
```

can do this instead now:

```
startupRule.startClientVM(2, new Properties(), cf -> {
      ...
})
```


Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
