### PR TITLE
GEODE-5335: Do not resolve addresses when calling netstat and lsof

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/NetstatFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/NetstatFunction.java
@@ -110,13 +110,11 @@ public class NetstatFunction implements InternalFunction {
   }
 
   private static void addNetstatDefaultOptions(final List<String> cmdOptionsList) {
+    cmdOptionsList.add("-v");
+    cmdOptionsList.add("-a");
+    cmdOptionsList.add("-n");
     if (isLinux()) {
-      cmdOptionsList.add("-v");
-      cmdOptionsList.add("-a");
       cmdOptionsList.add("-e");
-    } else {
-      cmdOptionsList.add("-v");
-      cmdOptionsList.add("-a");
     }
   }
 
@@ -158,8 +156,12 @@ public class NetstatFunction implements InternalFunction {
         .append(" output ###################").append(lineSeparator);
 
     if (isLinux() || isMacOSX() || isSolaris()) {
+      List<String> cmdOptionsList = new ArrayList<>();
+      cmdOptionsList.add(LSOF_COMMAND);
+      cmdOptionsList.add("-n");
+      cmdOptionsList.add("-P");
 
-      ProcessBuilder procBuilder = new ProcessBuilder(LSOF_COMMAND);
+      ProcessBuilder procBuilder = new ProcessBuilder(cmdOptionsList);
       try {
         Process lsof = procBuilder.start();
         InputStreamReader reader = new InputStreamReader(lsof.getInputStream());

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/NetstatDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/NetstatDUnitTest.java
@@ -15,13 +15,24 @@
 
 package org.apache.geode.management.internal.cli;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.Scanner;
+
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.TemporaryFolder;
 
+import org.apache.geode.management.cli.Result;
+import org.apache.geode.management.internal.cli.result.CommandResult;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.junit.categories.DistributedTest;
@@ -32,68 +43,148 @@ public class NetstatDUnitTest {
   @ClassRule
   public static ClusterStartupRule lsRule = new ClusterStartupRule();
 
+  @ClassRule
+  public static GfshCommandRule gfsh = new GfshCommandRule();
+
   @Rule
-  public GfshCommandRule gfshConnector = new GfshCommandRule();
+  public TemporaryFolder temp = new TemporaryFolder();
 
-  private static String netStatCommand = null;
-  private static String netStatLsofCommand = null;
+  private static MemberVM locator0, server0, server1;
 
-  private static MemberVM server0, server1;
+  private static final String GROUP_1 = "group-1";
+
+  private static final String GROUP_2 = "group-2";
+
+  private static String netStatLsofCommand;
 
   @BeforeClass
   public static void beforeClass() throws Exception {
-    server0 = lsRule.startServerVM(0, x -> x.withJMXManager().withEmbeddedLocator());
-    int locatorPort = server0.getEmbeddedLocatorPort();
+    locator0 = lsRule.startLocatorVM(0);
 
-    // start server with jmx Manager as well
-    server1 = lsRule.startServerVM(1, x -> x.withJMXManager().withConnectionToLocator(locatorPort));
+    Properties props = new Properties();
+    props.setProperty("groups", GROUP_1);
+    server0 = lsRule.startServerVM(1, props, locator0.getPort());
+    props.setProperty("groups", GROUP_2);
+    server1 = lsRule.startServerVM(2, props, locator0.getPort());
 
-    // start server with no jmx Manager
-    lsRule.startServerVM(2, locatorPort);
+    gfsh.connectAndVerify(locator0);
 
-    // start another server
-    lsRule.startServerVM(3, locatorPort);
-
-    netStatCommand = "netstat --with-lsof=false --member=" + server1.getName();
     netStatLsofCommand = "netstat --with-lsof=true --member=" + server1.getName();
+
   }
 
   @Test
-  public void testConnectToLocator() throws Exception {
-    gfshConnector.connect(server0.getEmbeddedLocatorPort(), GfshCommandRule.PortType.locator);
-    gfshConnector.executeAndAssertThat(netStatCommand).statusIsSuccess();
+  public void testOutputToConsoleForAllMembers() throws Exception {
+    CommandResult result = gfsh.executeCommand("netstat");
+    assertThat(result.getStatus()).isEqualTo(Result.Status.OK);
+
+    String rawOutput = result.getMessageFromContent();
+    String[] lines = rawOutput.split("\n");
+
+    assertThat(lines.length).isGreaterThan(5);
+    assertThat(lines[4].trim().split("[,\\s]+")).containsExactlyInAnyOrder("locator-0", "server-1",
+        "server-2");
   }
 
   @Test
-  public void testConnectToJmxManagerOne() throws Exception {
-    gfshConnector.connect(server0.getJmxPort(), GfshCommandRule.PortType.jmxManager);
-    gfshConnector.executeAndAssertThat(netStatCommand).statusIsSuccess();
+  public void testOutputToConsoleForOneMember() throws Exception {
+    CommandResult result = gfsh.executeCommand("netstat --member=server-1");
+    assertThat(result.getStatus()).isEqualTo(Result.Status.OK);
+
+    String rawOutput = result.getMessageFromContent();
+    String[] lines = rawOutput.split("\n");
+
+    assertThat(lines.length).isGreaterThan(5);
+    assertThat(lines[4].trim().split("[,\\s]+")).containsExactlyInAnyOrder("server-1");
   }
 
   @Test
-  public void testConnectToJmxManagerTwo() throws Exception {
-    gfshConnector.connect(server1.getJmxPort(), GfshCommandRule.PortType.jmxManager);
-    gfshConnector.executeAndAssertThat(netStatCommand).statusIsSuccess();
+  public void testOutputToConsoleWithLsofForOneMember() throws Exception {
+    CommandResult result = gfsh.executeCommand("netstat --member=server-1 --with-lsof");
+    assertThat(result.getStatus()).isEqualTo(Result.Status.OK);
+
+    String rawOutput = result.getMessageFromContent();
+    String[] lines = rawOutput.split("\n");
+
+    assertThat(lines.length).isGreaterThan(5);
+    assertThat(lines[4].trim().split("[,\\s]+")).containsExactlyInAnyOrder("server-1");
+    assertThat(lines).filteredOn(e -> e.contains("## lsof output ##")).hasSize(1);
+  }
+
+  @Test
+  public void testOutputToFile() throws Exception {
+    File outputFile = new File(temp.newFolder(), "command.log.txt");
+
+    CommandResult result = gfsh.executeCommand("netstat --file=" + outputFile.getAbsolutePath());
+    assertThat(result.getStatus()).isEqualTo(Result.Status.OK);
+
+    List<String> lines = new ArrayList<>();
+    Scanner scanner = new Scanner(outputFile);
+    while (scanner.hasNextLine()) {
+      lines.add(scanner.nextLine());
+    }
+
+    assertThat(lines.size()).isGreaterThan(5);
+    assertThat(lines.get(4).trim().split("[,\\s]+")).containsExactlyInAnyOrder("locator-0",
+        "server-1", "server-2");
+  }
+
+  @Test
+  public void testOutputToFileForOneGroup() throws Exception {
+    File outputFile = new File(temp.newFolder(), "command.log.txt");
+
+    CommandResult result = gfsh.executeCommand(
+        String.format("netstat --file=%s --group=%s", outputFile.getAbsolutePath(), GROUP_1));
+    assertThat(result.getStatus()).isEqualTo(Result.Status.OK);
+
+    List<String> lines = new ArrayList<>();
+    Scanner scanner = new Scanner(outputFile);
+    while (scanner.hasNextLine()) {
+      lines.add(scanner.nextLine());
+    }
+
+    assertThat(lines.size()).isGreaterThan(5);
+    assertThat(lines.get(4).trim().split("[,\\s]+")).containsExactly("server-1");
+  }
+
+  @Test
+  public void testOutputWithLsofToFile() throws Exception {
+    File outputFile = new File(temp.newFolder(), "command.log.txt");
+
+    CommandResult result =
+        gfsh.executeCommand("netstat --with-lsof=true --file=" + outputFile.getAbsolutePath());
+    assertThat(result.getStatus()).isEqualTo(Result.Status.OK);
+
+    List<String> lines = new ArrayList<>();
+    Scanner scanner = new Scanner(outputFile);
+    while (scanner.hasNextLine()) {
+      lines.add(scanner.nextLine());
+    }
+
+    assertThat(lines.size()).isGreaterThan(5);
+    assertThat(lines.get(4).trim().split("[,\\s]+")).containsExactlyInAnyOrder("locator-0",
+        "server-1", "server-2");
+    assertThat(lines).filteredOn(e -> e.contains("## lsof output ##")).hasSize(1);
   }
 
   @Ignore("GEODE-2488")
   @Test
   public void testConnectToLocatorWithLargeCommandResponse() throws Exception {
-    gfshConnector.connect(server0.getEmbeddedLocatorPort(), GfshCommandRule.PortType.locator);
-    gfshConnector.executeAndAssertThat(netStatLsofCommand).statusIsSuccess();
+    gfsh.connect(server0.getEmbeddedLocatorPort(), GfshCommandRule.PortType.locator);
+    gfsh.executeAndAssertThat(netStatLsofCommand).statusIsSuccess();
   }
 
   @Ignore("GEODE-2488")
   @Test
   public void testConnectToJmxManagerOneWithLargeCommandResponse() throws Exception {
-    gfshConnector.connect(server0.getJmxPort(), GfshCommandRule.PortType.jmxManager);
-    gfshConnector.executeAndAssertThat(netStatLsofCommand).statusIsSuccess();
+    gfsh.connect(server0.getJmxPort(), GfshCommandRule.PortType.jmxManager);
+    gfsh.executeAndAssertThat(netStatLsofCommand).statusIsSuccess();
   }
 
   @Ignore("GEODE-2488")
   @Test
   public void testConnectToJmxManagerTwoWithLargeCommandResponse() throws Exception {
-    gfshConnector.connect(server1.getJmxPort(), GfshCommandRule.PortType.jmxManager);
-    gfshConnector.executeAndAssertThat(netStatLsofCommand).statusIsSuccess();
+    gfsh.connect(server1.getJmxPort(), GfshCommandRule.PortType.jmxManager);
+    gfsh.executeAndAssertThat(netStatLsofCommand).statusIsSuccess();
   }
 }


### PR DESCRIPTION
- This avoids long command pauses (or failures) if DNS is slow or
  misconfigured.
- Add more netstat tests

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
