### PR TITLE
GEODE-5430: Allow disk store commands to use custom log4j2 config

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DiskStoreCommandsUtils.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DiskStoreCommandsUtils.java
@@ -12,13 +12,16 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package org.apache.geode.management.internal.cli.commands;
+
+import static org.apache.logging.log4j.core.config.ConfigurationFactory.CONFIGURATION_FILE_PROPERTY;
 
 import java.io.File;
 import java.net.URL;
 import java.util.List;
 import java.util.Set;
+
+import org.apache.commons.lang.StringUtils;
 
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.internal.cache.InternalCache;
@@ -26,10 +29,14 @@ import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.management.internal.cli.CliUtil;
 
 class DiskStoreCommandsUtils {
+
   static void configureLogging(final List<String> commandList) {
-    URL configUrl = LogService.class.getResource(LogService.CLI_CONFIG);
-    String configFilePropertyValue = configUrl.toString();
-    commandList.add("-Dlog4j.configurationFile=" + configFilePropertyValue);
+    String configFilePropertyValue = System.getProperty(CONFIGURATION_FILE_PROPERTY);
+    if (StringUtils.isBlank(configFilePropertyValue)) {
+      URL configUrl = LogService.class.getResource(LogService.CLI_CONFIG);
+      configFilePropertyValue = configUrl.toString();
+    }
+    commandList.add("-D" + CONFIGURATION_FILE_PROPERTY + "=" + configFilePropertyValue);
   }
 
   static String validatedDirectories(String[] diskDirs) {
@@ -54,7 +61,6 @@ class DiskStoreCommandsUtils {
   }
 
   static Set<DistributedMember> getNormalMembers(final InternalCache cache) {
-    // TODO determine what this does (as it is untested and unmockable!)
     return CliUtil.getAllNormalMembers(cache);
   }
 }


### PR DESCRIPTION
If you edit the gfsh script to specify a custom log4j2 xml
configuration file, this change will propagate that custom
config file to any forked disk store commands.
