### PR TITLE
GEODE-5348: Ignore duplicate detroy events on tombstone entries.

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/internal/cache/map/RegionMapDestroyTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/map/RegionMapDestroyTest.java
@@ -226,6 +226,10 @@ public class RegionMapDestroyTest {
     event.setOriginRemote(true);
   }
 
+  private void givenRetryEvent() {
+    event.setPossibleDuplicate(true);
+  }
+
   @Test
   public void destroyWithEmptyRegionThrowsException() {
     givenConcurrencyChecks(false);
@@ -522,6 +526,17 @@ public class RegionMapDestroyTest {
 
     assertThatThrownBy(() -> arm.destroy(event, inTokenMode, duringRI, cacheWrite, isEviction,
         expectedOldValue, removeRecoveredEntry)).isInstanceOf(EntryNotFoundException.class);
+  }
+
+  @Test
+  public void destroyRetryDuplicateOfExistingTombstoneWithConcurrencyChecksDoesRemove() {
+    givenConcurrencyChecks(true);
+    givenEmptyRegionMap();
+    givenExistingEntryWithTokenAndVersionTag(Token.TOMBSTONE);
+    givenRetryEvent();
+
+    assertThat(arm.destroy(event, inTokenMode, duringRI, cacheWrite, isEviction,
+        expectedOldValue, removeRecoveredEntry)).isTrue();
   }
 
   @Test


### PR DESCRIPTION
Adds unit test for retried destroy events on tombstones.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
