### PR TITLE
GEODE-5349 State-flush operation may exit early allowing for cache inconsistency

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
@@ -2489,7 +2489,7 @@ public class DistributedRegion extends LocalRegion implements InternalDistribute
         && this.getDistributionManager().getMembershipManager().isConnected()) {
       getDistributionAdvisor().forceNewMembershipVersion();
       try {
-        getDistributionAdvisor().waitForCurrentOperations(timeout);
+        getDistributionAdvisor().waitForCurrentOperations(logger, timeout, timeout * 2l);
       } catch (Exception e) {
         // log this but try to close the region so that listeners are invoked
         logger.warn(LocalizedMessage.create(LocalizedStrings.GemFireCache_0_ERROR_CLOSING_REGION_1,

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/EventID.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/EventID.java
@@ -45,7 +45,6 @@ import org.apache.geode.internal.cache.ha.ThreadIdentifier;
 import org.apache.geode.internal.cache.tier.sockets.ClientProxyMembershipID;
 import org.apache.geode.internal.i18n.LocalizedStrings;
 import org.apache.geode.internal.logging.LogService;
-import org.apache.geode.internal.logging.log4j.LogMarker;
 import org.apache.geode.internal.util.Breadcrumbs;
 
 /**
@@ -504,7 +503,7 @@ public class EventID implements DataSerializableFixedID, Serializable, Externali
 
   @Override
   public String toString() {
-    if (logger.isTraceEnabled(LogMarker.EVENT_ID_TO_STRING_VERBOSE)) {
+    if (logger.isDebugEnabled()) {
       return expensiveToString();
     } else {
       return cheapToString();
@@ -525,7 +524,7 @@ public class EventID implements DataSerializableFixedID, Serializable, Externali
       }
       buf.append(";");
     } else {
-      buf.append("id=").append(membershipID.length).append("bytes;");
+      buf.append("[id=").append(membershipID.length).append(" bytes;");
     }
     // buf.append(this.membershipID.toString());
     buf.append("threadID=");

--- a/geode-core/src/main/java/org/apache/geode/internal/i18n/LocalizedStrings.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/i18n/LocalizedStrings.java
@@ -5816,9 +5816,6 @@ public class LocalizedStrings {
           "AutoConnectionSource UpdateLocatorListTask started with interval={0} ms.");
   public static final StringId AutoConnectionSourceImpl_COULD_NOT_CREATE_A_NEW_CONNECTION_TO_SERVER_0 =
       new StringId(4484, "Could not create a new connection to server: {0}");
-  public static final StringId DistributionAdvisor_0_SEC_HAVE_ELAPSED_WHILE_WAITING_FOR_CURRENT_OPERATIONS_TO_DISTRIBUTE =
-      new StringId(4485,
-          "{0} seconds have elapsed while waiting for current operations to distribute");
   public static final StringId DistributionManager_I_0_AM_THE_ELDER =
       new StringId(4486, "I, {0}, am the elder.");
   public static final StringId InternalLocator_STARTING_PEER_LOCATION_FOR_0 =


### PR DESCRIPTION
This ticket concerns an inconsistency introduced in a server due to a transaction taking a long time to complete at the same time a new copy of a region/bucket is being created.

I removed the ability for this method to exit without the operation count
falling to zero.  Instead it issues a fatal-level log message, which
translates into a severe-level alert for operators.  This can help tech
support know which server a customer should terminate in order to break
a distributed deadlock.

I also added an info-level message that is issued if a warning/fatal message
has been issued noting that the wait has completed.  This parallels what
we do in ReplyProcessor21 if we've issued a warning that a cache-op response
hasn't been received within the ack-wait-threshold period.


Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
