### PR TITLE
GEODE-5373: Adjust timing for GMSHealthMonitorJUnitTest.testRemoveMem…

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitorJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitorJUnitTest.java
@@ -365,7 +365,7 @@ public class GMSHealthMonitorJUnitTest {
 
     gmsHealthMonitor.installView(v);
 
-    Thread.sleep(memberTimeout / GMSHealthMonitor.LOGICAL_INTERVAL);
+    Thread.sleep(memberTimeout);
 
     ArrayList<InternalDistributedMember> recipient = new ArrayList<InternalDistributedMember>();
     recipient.add(mockMembers.get(0));
@@ -379,7 +379,7 @@ public class GMSHealthMonitorJUnitTest {
     gmsHealthMonitor.processMessage(sm);
 
     Awaitility.await("waiting for remove(member) to be invoked")
-        .atMost(3 * memberTimeout, TimeUnit.SECONDS).until(() -> {
+        .atMost(3 * memberTimeout, TimeUnit.MILLISECONDS).until(() -> {
           verify(joinLeave, atLeastOnce()).remove(any(InternalDistributedMember.class),
               any(String.class));
         });


### PR DESCRIPTION
…berCalled

- This test fails on Windows when run in conjunction with other tests - on its
  own it always passes. There appears to be a thread scheduling difference in
  Windows that is resulting in the Failure Detection Scheduler thread running
  after the sleep interval.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
