### PR TITLE
GEODE-5380: create PR pipeline that integrates with GitHub pull requests

### DIFF
--- a/ci/pipelines/deploy_meta.sh
+++ b/ci/pipelines/deploy_meta.sh
@@ -19,8 +19,21 @@ GEODE_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 SANITIZED_GEODE_BRANCH=$(echo ${GEODE_BRANCH} | tr "/" "-")
 TARGET=geode
 GEODE_FORK=${1:-apache}
+TEAM=$(fly targets | grep ^${TARGET} | awk '{print $3}')
+
+PUBLIC=true
 
 echo "Deploying pipline for ${GEODE_FORK}/${GEODE_BRANCH}"
 
+if [ "${TEAM}" = "staging" ]; then
+  PUBLIC=false
+fi
+
 set -x
-fly -t ${TARGET} set-pipeline -p meta-${SANITIZED_GEODE_BRANCH} -c meta.yml --var geode-build-branch=${GEODE_BRANCH} --var geode-fork=${GEODE_FORK}
+fly -t ${TARGET} set-pipeline \
+  -p meta-${SANITIZED_GEODE_BRANCH} \
+  -c meta.yml \
+  --var geode-build-branch=${GEODE_BRANCH} \
+  --var geode-fork=${GEODE_FORK} \
+  --var concourse-team=${TEAM} \
+  --yaml-var public-pipelines=${PUBLIC}

--- a/ci/pipelines/meta.yml
+++ b/ci/pipelines/meta.yml
@@ -29,7 +29,7 @@ resources:
     target: https://concourse.apachegeode-ci.info
     insecure: "true"
     teams:
-    - name: main
+    - name: ((!concourse-team))
       username: ((!concourse-username))
       password: ((!concourse-password))
 - name: geode-pipeline
@@ -63,7 +63,7 @@ resources:
 jobs:
 - name: set-pipeline
   serial: true
-  public: true
+  public: ((!public-pipelines))
   plan:
   - get: geode-pipeline
     trigger: true
@@ -82,12 +82,38 @@ jobs:
         GEODE_FORK: ((!geode-fork))
         CONCOURSE_USERNAME: ((!concourse-username))
         CONCOURSE_PASSWORD: ((!concourse-password))
+        CONCOURSE_TEAM: ((!concourse-team))
       run:
         path: geode-pipeline/ci/pipelines/geode-build/deploy_pipeline.sh
 
+- name: set-pr-pipeline
+  serial: true
+  public: ((!public-pipelines))
+  plan:
+  - get: geode-pipeline
+    trigger: true
+  - get: apachegeode-build-concourse-docker-image
+  - task: deploy-pr
+    image: apachegeode-build-concourse-docker-image
+    config:
+      inputs:
+      - name: geode-pipeline
+      outputs:
+      - name: results
+      platform: linux
+      params:
+        OUTPUT_DIRECTORY: results
+        GEODE_BRANCH: ((!geode-build-branch))
+        GEODE_FORK: ((!geode-fork))
+        CONCOURSE_USERNAME: ((!concourse-username))
+        CONCOURSE_PASSWORD: ((!concourse-password))
+        CONCOURSE_TEAM: ((!concourse-team))
+      run:
+        path: geode-pipeline/ci/pipelines/pull-request/deploy_pr_pipeline.sh
+
 - name: set-docker-images-pipeline
   serial: true
-  public: true
+  public: ((!public-pipelines))
   plan:
   - get: geode-docker-images-pipeline
     trigger: true
@@ -95,11 +121,11 @@ jobs:
     params:
       pipelines:
       - name: docker-images
-        team: main
+        team: ((!concourse-team))
         config_file: geode-docker-images-pipeline/ci/pipelines/docker-images.yml
 - name: set-metrics-pipeline
   serial: true
-  public: true
+  public: ((!public-pipelines))
   plan:
   - get: geode-metrics-pipeline
     trigger: true
@@ -107,5 +133,5 @@ jobs:
     params:
       pipelines:
       - name: develop-metrics
-        team: main
+        team: ((!concourse-team))
         config_file: geode-metrics-pipeline/ci/pipelines/metrics.yml

--- a/ci/pipelines/pull-request/base.yml
+++ b/ci/pipelines/pull-request/base.yml
@@ -1,0 +1,277 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+
+resource_types:
+  - name: gcs-resource
+    type: docker-image
+    source:
+      repository: frodenas/gcs-resource
+  - name: email
+    type: docker-image
+    source:
+      repository: pcfseceng/email-resource
+  - name: pull-request
+    type: docker-image
+    source:
+      repository: jtarchie/pr
+
+resources:
+- name: docker-geode-build-image
+  type: docker-image
+  source:
+    username: ((!docker-username))
+    password: ((!docker-password))
+    repository: gcr.io/apachegeode-ci/((!docker-image-name))
+    tag: latest
+
+- name: geode
+  type: pull-request
+  source:
+    access_token: ((!github-pr-access-token))
+    repo: (( concat metadata.geode-fork "/geode" ))
+    base: develop
+    ignore_paths:
+    - geode-docs/*
+    - geode-book/*
+
+- name: send-notification-email
+  type: email
+  source:
+    smtp:
+      host: ((!source-email-server))
+      port: "587"
+      username: ((!source-email-username))
+      password: ((!source-email-password))
+    from: ((!source-email-address))
+    to: [ ((!notification-email-address)) ]
+
+groups:
+- name: main
+  jobs:
+  - Build
+  - DistributedTest
+  - AcceptanceTest
+  - IntegrationTest
+  - FlakyTest
+  - UITests
+
+jobs:
+- name: Build
+  serial: false
+  public: true
+  plan:
+  - aggregate:
+    - get: geode
+      trigger: true
+      version: every
+      params:
+        fetch_merge: true
+        git:
+          depth: 100
+    - get: docker-geode-build-image
+      params:
+        rootfs: true
+  # Unmerged pull request SHA, for writing status into GitHub
+  - get: geode-unmerged-request
+    resource: geode
+    version: every
+    params:
+      fetch_merge: false
+  - aggregate:
+    - put: geode
+      params:
+        path: geode-unmerged-request
+        context: $BUILD_JOB_NAME
+        status: pending
+
+    - task: build
+      image: docker-geode-build-image
+      config:
+        platform: linux
+        inputs:
+        - name: geode
+        outputs:
+        - name: built-geode
+        - name: results
+        params:
+          MAINTENANCE_VERSION: (( grab metadata.geode-build-branch ))
+          SERVICE_ACCOUNT: ((!concourse-gcp-account))
+          PUBLIC_BUCKET: ((!public-bucket))
+        run:
+          path: geode/ci/scripts/build.sh
+      on_failure:
+        aggregate:
+          - put: geode
+            params:
+              path: geode-unmerged-request
+              status: failure
+              context: $BUILD_JOB_NAME
+          - put: send-notification-email
+            params:
+              subject: results/subject
+              body: results/body
+      on_success:
+        aggregate:
+        - put: geode
+          params:
+            path: geode-unmerged-request
+            status: success
+            context: $BUILD_JOB_NAME
+
+- name: DistributedTest
+  serial: false
+  public: true
+  plan:
+  - aggregate:
+    - get: geode
+      trigger: true
+      version: every
+      params:
+        fetch_merge: true
+        git:
+          depth: 100
+    - get: docker-geode-build-image
+      params:
+        rootfs: true
+  # Unmerged pull request SHA, for writing status into GitHub
+  - get: geode-unmerged-request
+    resource: geode
+    version: every
+    params:
+      fetch_merge: false
+
+  - aggregate:
+    - put: geode
+      params:
+        path: geode-unmerged-request
+        context: $BUILD_JOB_NAME
+        status: pending
+
+    - task: run-distributed-core
+      image: docker-geode-build-image
+      tags: [large]
+      privileged: true
+      timeout: 8h
+      config:
+        inputs:
+          - name: geode
+          - name: docker-geode-build-image
+        platform: linux
+        outputs:
+          - name: built-geode
+        params:
+          MAINTENANCE_VERSION: (( grab metadata.geode-build-branch ))
+          SERVICE_ACCOUNT: ((!concourse-gcp-account))
+          PUBLIC_BUCKET: ((!public-bucket))
+          PARALLEL_DUNIT: true
+          DUNIT_PARALLEL_FORKS: 7
+          CALL_STACK_TIMEOUT: 25200
+        run:
+          args:
+          - geode-core:distributedTest
+          - distributedtestcore
+          path: geode/ci/scripts/test-run.sh
+      on_failure:
+        aggregate:
+        - put: send-notification-email
+          params:
+            subject: built-geode/subject
+            body: built-geode/body
+
+      ensure:
+        aggregate:
+        - task: archive-results-core
+          image: docker-geode-build-image
+          config:
+            inputs:
+              - name: geode
+              - name: built-geode
+            platform: linux
+            params:
+              MAINTENANCE_VERSION: (( grab metadata.geode-build-branch ))
+              SERVICE_ACCOUNT: ((!concourse-gcp-account))
+              PUBLIC_BUCKET: ((!public-bucket))
+            run:
+              args:
+              - geode-core:distributedTest
+              - distributedtestcore
+              path: geode/ci/scripts/test-archive.sh
+    - task: run-distributed-everything-else
+      image: docker-geode-build-image
+      tags: [large]
+      privileged: true
+      timeout: 8h
+      config:
+        inputs:
+          - name: geode
+          - name: docker-geode-build-image
+        platform: linux
+        outputs:
+          - name: built-geode
+        params:
+          MAINTENANCE_VERSION: (( grab metadata.geode-build-branch ))
+          SERVICE_ACCOUNT: ((!concourse-gcp-account))
+          PUBLIC_BUCKET: ((!public-bucket))
+          PARALLEL_DUNIT: true
+          DUNIT_PARALLEL_FORKS: 7
+          CALL_STACK_TIMEOUT: 25200
+          GRADLE_TASK_OPTIONS: -x geode-core:distributedTest
+        run:
+          args:
+          - distributedTest
+          - distributedtesteverythingelse
+          path: geode/ci/scripts/test-run.sh
+      on_failure:
+        aggregate:
+          - put: send-notification-email
+            params:
+              subject: built-geode/subject
+              body: built-geode/body
+      ensure:
+        aggregate:
+        - task: archive-results-everythingelse
+          image: docker-geode-build-image
+          config:
+            inputs:
+              - name: geode
+              - name: built-geode
+            platform: linux
+            params:
+              MAINTENANCE_VERSION: (( grab metadata.geode-build-branch ))
+              SERVICE_ACCOUNT: ((!concourse-gcp-account))
+              PUBLIC_BUCKET: ((!public-bucket))
+            run:
+              args:
+              - disitributedTest
+              - distributedtesteverythingelse
+              path: geode/ci/scripts/test-archive.sh
+    on_failure:
+      aggregate:
+      - put: geode
+        params:
+          path: geode-unmerged-request
+          status: failure
+          context: $BUILD_JOB_NAME
+    on_success:
+      aggregate:
+      - put: geode
+        params:
+          path: geode-unmerged-request
+          context: $BUILD_JOB_NAME
+          status: success

--- a/ci/pipelines/pull-request/deploy_pr_pipeline.sh
+++ b/ci/pipelines/pull-request/deploy_pr_pipeline.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  SCRIPTDIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+SCRIPTDIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+GEODEBUILDDIR="${SCRIPTDIR}/../geode-build"
+
+if ! [ -x "$(command -v spruce)" ]; then
+    echo "Spruce must be installed for pipeline deployment to work."
+    echo "For macos: 'brew tap starkandwayne/cf; brew install spruce'"
+    echo "For Ubuntu: follow the instructions at https://github.com/geofffranks/spruce"
+    echo ""
+    exit 1
+else
+    SPRUCE=$(which spruce || true)
+fi
+
+set -e
+
+if [ -z "${GEODE_BRANCH}" ]; then
+  GEODE_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+fi
+
+if [ "${GEODE_BRANCH}" = "HEAD" ]; then
+  echo "Unable to determine branch for deployment. Quitting..."
+  exit 1
+fi
+
+SANITIZED_GEODE_BRANCH=$(echo ${GEODE_BRANCH} | tr "/" "-")
+
+BIN_DIR=${OUTPUT_DIRECTORY}/bin
+TMP_DIR=${OUTPUT_DIRECTORY}/tmp
+mkdir -p ${BIN_DIR} ${TMP_DIR}
+curl -o ${BIN_DIR}/fly "https://concourse.apachegeode-ci.info/api/v1/cli?arch=amd64&platform=linux"
+chmod +x ${BIN_DIR}/fly
+
+PATH=${PATH}:${BIN_DIR}
+
+for i in ${GEODEBUILDDIR}/test-stubs/*.yml; do
+  X=$(basename $i)
+  echo "Merging ${i} into ${TMP_DIR}/${X}"
+  ${SPRUCE} merge --prune metadata \
+    <(echo "metadata:"; \
+      echo "  geode-build-branch: ${GEODE_BRANCH}"; \
+      echo "  geode-fork: ${GEODE_FORK}") \
+    ${SCRIPTDIR}/pr-template.yml \
+    ${i} > ${TMP_DIR}/${X}
+done
+
+echo "Spruce branch-name into resources"
+${SPRUCE} merge --prune metadata \
+  ${SCRIPTDIR}/base.yml \
+  <(echo "metadata:"; \
+    echo "  geode-build-branch: ${GEODE_BRANCH}"; \
+    echo "  geode-fork: ${GEODE_FORK}"; \
+    echo "  ") \
+  ${TMP_DIR}/*.yml > ${TMP_DIR}/final.yml
+
+
+TARGET="geode"
+
+TEAM=${CONCOURSE_TEAM}
+
+#if [[ "${GEODE_BRANCH}" == "develop" ]] || [[ ${GEODE_BRANCH} =~ ^release/* ]]; then
+#  TEAM="main"
+#fi
+
+fly login -t ${TARGET} -n ${TEAM} -c https://concourse.apachegeode-ci.info -u ${CONCOURSE_USERNAME} -p ${CONCOURSE_PASSWORD}
+fly -t ${TARGET} set-pipeline \
+  --non-interactive \
+  --pipeline ${SANITIZED_GEODE_BRANCH} \
+  --config ${TMP_DIR}/final.yml \
+  --var concourse-team=${TEAM}
+

--- a/ci/pipelines/pull-request/pr-template.yml
+++ b/ci/pipelines/pull-request/pr-template.yml
@@ -1,0 +1,108 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+jobs:
+- name: (( grab metadata.job.name ))
+  serial: false
+  public: true
+  plan:
+    - aggregate:
+      - get: geode
+        trigger: true
+        version: every
+        params:
+          fetch_merge: true
+          git:
+            depth: 100
+      - get: docker-geode-build-image
+        params:
+          rootfs: true
+    # Unmerged pull request SHA, for writing status into GitHub
+    - get: geode-unmerged-request
+      resource: geode
+      version: every
+      params:
+        fetch_merge: false
+    - aggregate:
+      - put: geode
+        params:
+          path: geode-unmerged-request
+          context: $BUILD_JOB_NAME
+          status: pending
+
+      - task: runtests
+        image: docker-geode-build-image
+        tags: (( grab metadata.job.size ))
+        privileged: true
+        timeout: (( grab metadata.job.timeout ))
+        config:
+          inputs:
+            - name: geode
+            - name: docker-geode-build-image
+          platform: linux
+          outputs:
+            - name: built-geode
+          params:
+            MAINTENANCE_VERSION: (( grab metadata.geode-build-branch ))
+            SERVICE_ACCOUNT: ((!concourse-gcp-account))
+            PUBLIC_BUCKET: ((!public-bucket))
+            PARALLEL_DUNIT: (( grab metadata.job.dunit.parallel ))
+            DUNIT_PARALLEL_FORKS: (( grab metadata.job.dunit.forks ))
+            CALL_STACK_TIMEOUT: (( grab metadata.job.call_stack_timeout ))
+          run:
+            args:
+            - (( grab metadata.job.gradle_task ))
+            - (( grab metadata.job.artifact_slug ))
+            path: geode/ci/scripts/test-run.sh
+        on_failure:
+          aggregate:
+          - put: geode
+            params:
+              path: geode-unmerged-request
+              status: failure
+              context: $BUILD_JOB_NAME
+          - put: send-notification-email
+            params:
+              subject: built-geode/subject
+              body: built-geode/body
+        on_success:
+          aggregate:
+          - put: geode
+            params:
+              path: geode-unmerged-request
+              context: $BUILD_JOB_NAME
+              status: success
+
+        ensure:
+          aggregate:
+          - task: archive-results
+            image: docker-geode-build-image
+            config:
+              inputs:
+                - name: geode
+                - name: built-geode
+              platform: linux
+              params:
+                MAINTENANCE_VERSION: (( grab metadata.geode-build-branch ))
+                SERVICE_ACCOUNT: ((!concourse-gcp-account))
+                PUBLIC_BUCKET: ((!public-bucket))
+              run:
+                args:
+                - (( grab metadata.job.gradle_task ))
+                - (( grab metadata.job.artifact_slug ))
+                path: geode/ci/scripts/test-archive.sh

--- a/ci/scripts/build.sh
+++ b/ci/scripts/build.sh
@@ -28,8 +28,12 @@ GEODE_BUILD_VERSION_FILE=${ROOT_DIR}/geode-build-version/number
 GEODE_RESULTS_VERSION_FILE=${ROOT_DIR}/results/number
 GEODE_BUILD_VERSION_NUMBER=$(grep "versionNumber *=" geode/gradle.properties | awk -F "=" '{print $2}' | tr -d ' ')
 GEODE_BUILD_DIR=/tmp/geode-build
+GEODE_PULL_REQUEST_ID_FILE=${ROOT_DIR}/geode/.git/id
+if [ -e "${GEODE_PULL_REQUEST_ID_FILE}" ]; then
+  GEODE_PULL_REQUEST_ID=$(cat ${GEODE_PULL_REQUEST_ID_FILE})
+fi
 
-if [ ! -e "${GEODE_BUILD_VERSION_FILE}" ]; then
+if [ ! -e "${GEODE_BUILD_VERSION_FILE}" ] && [ -z "${GEODE_PULL_REQUEST_ID}" ]; then
   echo "${GEODE_BUILD_VERSION_FILE} file does not exist. Concourse is probably not configured correctly."
   exit 1
 fi
@@ -52,17 +56,22 @@ if [ -z ${GEODE_BUILD_VERSION_NUMBER+x} ]; then
   exit 1
 fi
 
-CONCOURSE_VERSION=$(cat ${GEODE_BUILD_VERSION_FILE})
-CONCOURSE_PRODUCT_VERSION=${CONCOURSE_VERSION%%-*}
-GEODE_PRODUCT_VERSION=${GEODE_BUILD_VERSION_NUMBER}
-CONCOURSE_BUILD_SLUG=${CONCOURSE_VERSION##*-}
-BUILD_ID=${CONCOURSE_VERSION##*.}
-FULL_PRODUCT_VERSION=${GEODE_PRODUCT_VERSION}-${CONCOURSE_BUILD_SLUG}
+if [ -z "${GEODE_PULL_REQUEST_ID}" ]; then
+  CONCOURSE_VERSION=$(cat ${GEODE_BUILD_VERSION_FILE})
+  CONCOURSE_PRODUCT_VERSION=${CONCOURSE_VERSION%%-*}
+  GEODE_PRODUCT_VERSION=${GEODE_BUILD_VERSION_NUMBER}
+  CONCOURSE_BUILD_SLUG=${CONCOURSE_VERSION##*-}
+  BUILD_ID=${CONCOURSE_VERSION##*.}
+  FULL_PRODUCT_VERSION=${GEODE_PRODUCT_VERSION}-${CONCOURSE_BUILD_SLUG}
+  echo "Concourse VERSION is ${CONCOURSE_VERSION}"
+  echo "Geode product VERSION is ${GEODE_PRODUCT_VERSION}"
+  echo "Build ID is ${BUILD_ID}"
+else
+  FULL_PRODUCT_VERSION="geode-pr-${GEODE_PULL_REQUEST_ID}"
+fi
+
 echo -n "${FULL_PRODUCT_VERSION}" > ${GEODE_RESULTS_VERSION_FILE}
 
-echo "Concourse VERSION is ${CONCOURSE_VERSION}"
-echo "Geode product VERSION is ${GEODE_PRODUCT_VERSION}"
-echo "Build ID is ${BUILD_ID}"
 
 printf "\nUsing the following JDK:"
 java -version
@@ -81,7 +90,7 @@ ln -s ${ROOT_DIR}/geode ${GEODE_BUILD_DIR}
 
 pushd ${GEODE_BUILD_DIR}
 set +e
-./gradlew --no-daemon -PbuildId=${BUILD_ID} --system-prop "java.io.tmpdir=${TMPDIR}" build
+./gradlew --no-daemon --parallel -PbuildId=${BUILD_ID} --system-prop "java.io.tmpdir=${TMPDIR}" build
 GRADLE_EXIT_STATUS=$?
 set -e
 

--- a/ci/scripts/test-run.sh
+++ b/ci/scripts/test-run.sh
@@ -28,7 +28,12 @@ export GEODE_BUILD=${DEST_DIR}/test
 export GEODE_BUILD_VERSION_NUMBER=$(grep "versionNumber *=" geode/gradle.properties | awk -F "=" '{print $2}' | tr -d ' ')
 
 GEODE_BUILD_VERSION_FILE=${BUILDROOT}/geode-build-version/number
-if [ ! -e "${GEODE_BUILD_VERSION_FILE}" ]; then
+GEODE_PULL_REQUEST_ID_FILE=${BUILDROOT}/geode/.git/id
+if [ -e "${GEODE_PULL_REQUEST_ID_FILE}" ]; then
+  GEODE_PULL_REQUEST_ID=$(cat ${GEODE_PULL_REQUEST_ID_FILE})
+fi
+
+if [ ! -e "${GEODE_BUILD_VERSION_FILE}" ] && [ -z "${GEODE_PULL_REQUEST_ID}" ]; then
   echo "${GEODE_BUILD_VERSION_FILE} file does not exist. Concourse is probably not configured correctly."
   exit 1
 fi
@@ -56,17 +61,19 @@ function error_exit() {
 }
 
 trap error_exit ERR
-
-CONCOURSE_VERSION=$(cat ${GEODE_BUILD_VERSION_FILE})
-CONCOURSE_PRODUCT_VERSION=${CONCOURSE_VERSION%%-*}
-GEODE_PRODUCT_VERSION=${GEODE_BUILD_VERSION_NUMBER}
-CONCOURSE_BUILD_SLUG=${CONCOURSE_VERSION##*-}
-BUILD_ID=${CONCOURSE_VERSION##*.}
-FULL_PRODUCT_VERSION=${GEODE_PRODUCT_VERSION}-${CONCOURSE_BUILD_SLUG}
-
-echo "Concourse VERSION is ${CONCOURSE_VERSION}"
-echo "Product VERSION is ${FULL_PRODUCT_VERSION}"
-echo "Build ID is ${BUILD_ID}"
+if [ -z "${GEODE_PULL_REQUEST_ID}" ]; then
+  CONCOURSE_VERSION=$(cat ${GEODE_BUILD_VERSION_FILE})
+  CONCOURSE_PRODUCT_VERSION=${CONCOURSE_VERSION%%-*}
+  GEODE_PRODUCT_VERSION=${GEODE_BUILD_VERSION_NUMBER}
+  CONCOURSE_BUILD_SLUG=${CONCOURSE_VERSION##*-}
+  BUILD_ID=${CONCOURSE_VERSION##*.}
+  FULL_PRODUCT_VERSION=${GEODE_PRODUCT_VERSION}-${CONCOURSE_BUILD_SLUG}
+  echo "Concourse VERSION is ${CONCOURSE_VERSION}"
+  echo "Product VERSION is ${FULL_PRODUCT_VERSION}"
+  echo "Build ID is ${BUILD_ID}"
+else
+  FULL_PRODUCT_VERSION="geode-pr-${GEODE_PULL_REQUEST_ID}"
+fi
 
 printf "\nUsing the following JDK:"
 java -version


### PR DESCRIPTION
Single pipeline that runs all GitHub PRs. Status of each job is posted
back as a 'status' to the commit of the PR as they complete, like
Travis.

Runs in parallel.
PRs have links directly to their job in Concourse.

Signed-off-by: Sean Goller <sgoller@pivotal.io>

I hate yaml.

So close no matter how far
Couldn't be much more from the heart
forever trusting who we are
and whitespace just matters.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
