### PR TITLE
GEODE-5385: hang trying to create a bucket

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/PRSanityCheckMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/PRSanityCheckMessage.java
@@ -95,7 +95,7 @@ public class PRSanityCheckMessage extends PartitionMessage {
    * gemfire.PRSanityCheckEnabled=true.
    */
   public static void schedule(final PartitionedRegion pr) {
-    if (Boolean.getBoolean(DistributionConfig.GEMFIRE_PREFIX + "PRSanityCheckEnabled")) {
+    if (!Boolean.getBoolean(DistributionConfig.GEMFIRE_PREFIX + "PRSanityCheckDisabled")) {
       final DistributionManager dm = pr.getDistributionManager();
       // RegionAdvisor ra = pr.getRegionAdvisor();
       // final Set recipients = ra.adviseAllPRNodes();

--- a/geode-core/src/main/java/org/apache/geode/internal/i18n/LocalizedStrings.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/i18n/LocalizedStrings.java
@@ -1330,7 +1330,7 @@ public class LocalizedStrings {
   public static final StringId AbstractDistributionConfig_CLIENT_CONFLATION_PROP_NAME =
       new StringId(1839, "Client override for server queue conflation setting");
   public static final StringId PRHARRedundancyProvider_ALLOCATE_ENOUGH_MEMBERS_TO_HOST_BUCKET =
-      new StringId(1840, "allocate enough members to host bucket.");
+      new StringId(1840, "allocate enough members to host a new bucket");
   public static final StringId PRHARedundancyProvider_TIME_OUT_WAITING_0_MS_FOR_CREATION_OF_BUCKET_FOR_PARTITIONED_REGION_1_MEMBERS_REQUESTED_TO_CREATE_THE_BUCKET_ARE_2 =
       new StringId(1841,
           "Time out waiting {0} ms for creation of bucket for partitioned region {1}. Members requested to create the bucket are: {2}");
@@ -1358,7 +1358,7 @@ public class LocalizedStrings {
       new StringId(1852, "Excpetion  in bucket index creation : {0}");
   public static final StringId PRHARRedundancyProvider_CONFIGURED_REDUNDANCY_LEVEL_COULD_NOT_BE_SATISFIED_0 =
       new StringId(1853,
-          "Configured Redundancy Level Could Not be Satisfied. {0} to satisfy redundancy for the region.{1}");
+          "Configured redundancy level could not be satisfied. {0} to satisfy redundancy for the region.{1}");
   public static final StringId PartitionedRegionDataStore_PARTITIONEDREGION_0_CAUGHT_UNEXPECTED_EXCEPTION_DURING_CLEANUP =
       new StringId(1854, "PartitionedRegion {0}: caught unexpected exception during data cleanup");
   public static final StringId MemberFunctionExecutor_NO_MEMBER_FOUND_FOR_EXECUTING_FUNCTION_0 =
@@ -3355,7 +3355,7 @@ public class LocalizedStrings {
   public static final StringId MemberMessage_MEMBERRESPONSE_GOT_MEMBERDEPARTED_EVENT_FOR_0_CRASHED_1 =
       new StringId(3033, "MemberResponse got memberDeparted event for < {0} > crashed =  {1}");
   public static final StringId PartitionMessage_0_COULD_NOT_FIND_PARTITIONED_REGION_WITH_ID_1 =
-      new StringId(3034, "{0} : could not find partitioned region with Id  {1}");
+      new StringId(3034, "{0} : could not find partitioned region with Id {1}");
   public static final StringId PartitionMessage_ATTEMPT_FAILED =
       new StringId(3035, "Attempt failed");
   public static final StringId PartitionMessage_DISTRIBUTED_SYSTEM_IS_DISCONNECTING =

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionedRegionDestroyJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionedRegionDestroyJUnitTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache;
+
+import static org.apache.geode.internal.Assert.assertTrue;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.distributed.internal.DistributionAdvisor;
+import org.apache.geode.distributed.internal.DistributionManager;
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
+import org.apache.geode.test.junit.categories.UnitTest;
+
+@Category(UnitTest.class)
+public class PartitionedRegionDestroyJUnitTest {
+
+  private PartitionedRegion partitionedRegion;
+  private DistributionAdvisor advisor;
+  private DistributionManager manager;
+
+  @Before
+  public void setup() {
+    manager = mock(DistributionManager.class);
+    when(manager.getDistributionManagerId())
+        .thenReturn(new InternalDistributedMember("localhost", 1));
+
+    partitionedRegion = mock(PartitionedRegion.class);
+    advisor = mock(DistributionAdvisor.class);
+    when(partitionedRegion.getDistributionAdvisor()).thenReturn(advisor);
+    when(partitionedRegion.getRegionIdentifier()).thenReturn("testRegion");
+  }
+
+  @Test
+  public void destroyMessageRequiresReattemptIfRegionInitializing() {
+    when(advisor.isInitialized()).thenReturn(Boolean.FALSE);
+    DestroyPartitionedRegionMessage message = new DestroyPartitionedRegionMessage();
+    Throwable exception = message.processCheckForPR(partitionedRegion, manager);
+    assertTrue(exception instanceof ForceReattemptException);
+  }
+
+  @Test
+  public void destroyMessageRequiresNoReattemptIfRegionInitialized() {
+    when(advisor.isInitialized()).thenReturn(Boolean.TRUE);
+    DestroyPartitionedRegionMessage message = new DestroyPartitionedRegionMessage();
+    Throwable exception = message.processCheckForPR(partitionedRegion, manager);
+    assertNull(exception);
+  }
+}


### PR DESCRIPTION
We now look for a ForceReattemptException when destroying a partitioned
region.  This prevents a region ID skew that can occur if another node
is still initializing its region and is not yet ready to destroy it.

I've reenabled the PRSanityCheckMessage that watches for skews like this
and reports them.  This used to be enabled by default but somehow was
disabled a long time ago.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
