### PR TITLE
GEODE-5393: StateFlushOperation hangs waiting for non-existant operat…

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/ShutdownAllRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/ShutdownAllRequest.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -293,7 +294,7 @@ public class ShutdownAllRequest extends AdminRequest {
     public Set getResults() {
       logger.debug("{} shutdownAll returning {}", this,
           results/* , new Exception("stack trace") */);
-      return results;
+      return new HashSet(results);
     }
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/ShutdownAllRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/ShutdownAllRequest.java
@@ -261,13 +261,11 @@ public class ShutdownAllRequest extends AdminRequest {
       }
       if (msg instanceof ShutdownAllResponse) {
         if (((ShutdownAllResponse) msg).isToShutDown()) {
-          if (logger.isDebugEnabled()) {
-            synchronized (results) {
-              logger.debug("{} adding {} to result set {}", this, msg.getSender(),
-                  results);
-            }
+          synchronized (results) {
+            logger.debug("{} adding {} to result set {}", this, msg.getSender(),
+                results);
+            this.results.add(msg.getSender());
           }
-          this.results.add(msg.getSender());
         } else {
           // for member without cache, we will not wait for its result
           // so no need to wait its DS to close either
@@ -292,9 +290,11 @@ public class ShutdownAllRequest extends AdminRequest {
     }
 
     public Set getResults() {
-      logger.debug("{} shutdownAll returning {}", this,
-          results/* , new Exception("stack trace") */);
-      return new HashSet(results);
+      synchronized (results) {
+        logger.debug("{} shutdownAll returning {}", this,
+            results);
+        return new HashSet(results);
+      }
     }
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegionDataView.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegionDataView.java
@@ -326,7 +326,7 @@ public class LocalRegionDataView implements InternalDataView {
       token = reg.postPutAllSend(putallOp, successfulPuts);
       reg.postPutAllFireEvents(putallOp, successfulPuts);
     } finally {
-      if (reg instanceof DistributedRegion) {
+      if (token != -1 && reg instanceof DistributedRegion) {
         putallOp.endOperation(token);
       }
     }
@@ -348,7 +348,7 @@ public class LocalRegionDataView implements InternalDataView {
       token = reg.postRemoveAllSend(op, successfulOps);
       reg.postRemoveAllFireEvents(op, successfulOps);
     } finally {
-      if (reg instanceof DistributedRegion) {
+      if (token != -1 && reg instanceof DistributedRegion) {
         op.endOperation(token);
       }
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXCommitMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXCommitMessage.java
@@ -300,7 +300,7 @@ public class TXCommitMessage extends PooledDistributionMessage
       // need to continue the iteration if one of the regions is destroyed
       // since others may still be okay
       try {
-        long newv = dr.getDistributionAdvisor().endOperation(viewVersion);
+        dr.getDistributionAdvisor().endOperation(viewVersion);
       } catch (RuntimeException ex) {
         rte = ex;
       }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/DistributedCacheOperationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/DistributedCacheOperationTest.java
@@ -15,6 +15,8 @@
 package org.apache.geode.internal.cache;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -26,6 +28,7 @@ import java.util.Map;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import org.apache.geode.cache.CacheEvent;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.DistributedCacheOperation.CacheOperationMessage;
 import org.apache.geode.internal.cache.persistence.PersistentMemberID;
@@ -47,5 +50,63 @@ public class DistributedCacheOperationTest {
         persistentIds);
 
     assertThat(mockDistributedCacheOperation.supportsDirectAck()).isFalse();
+  }
+
+  /**
+   * The startOperation and endOperation methods of DistributedCacheOperation record the
+   * beginning and end of distribution of an operation. If startOperation is invoked it
+   * is essential that endOperation be invoked or the state-flush operation will hang.<br>
+   * This test ensures that if distribution of the operation throws an exception then
+   * endOperation is correctly invoked before allowing the exception to escape the startOperation
+   * method.
+   */
+  @Test
+  public void endOperationIsInvokedOnDistributionError() {
+    DistributedRegion region = mock(DistributedRegion.class);
+    CacheDistributionAdvisor advisor = mock(CacheDistributionAdvisor.class);
+    when(region.getDistributionAdvisor()).thenReturn(advisor);
+    TestOperation operation = new TestOperation(null);
+    operation.region = region;
+    try {
+      operation.startOperation();
+    } catch (RuntimeException e) {
+      assertEquals("boom", e.getMessage());
+    }
+    assertTrue(operation.endOperationInvoked);
+  }
+
+  static class TestOperation extends DistributedCacheOperation {
+    boolean endOperationInvoked;
+    DistributedRegion region;
+
+    public TestOperation(CacheEvent event) {
+      super(event);
+    }
+
+    @Override
+    public DistributedRegion getRegion() {
+      return region;
+    }
+
+    @Override
+    public boolean containsRegionContentChange() {
+      return true;
+    }
+
+    @Override
+    public void endOperation(long viewVersion) {
+      endOperationInvoked = true;
+      super.endOperation(viewVersion);
+    }
+
+    @Override
+    protected CacheOperationMessage createMessage() {
+      return null;
+    }
+
+    @Override
+    protected void _distribute() {
+      throw new RuntimeException("boom");
+    }
   }
 }


### PR DESCRIPTION
…ion to complete

I've added additional debugging to DistributionAdvisor so that it knows
which threads are performing operations and can log them at debug level.
This let me determine that a putAll operation was the source of the hang
due to an exception being thrown during message distribution in
DistributedCacheOperation.startOperation().  The exception resulted in
DistributionAdvisor.endOperation() not being invoked correctly.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
