### PR TITLE
GEODE-5383: Check that data propagated earlier

### DIFF
--- a/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/WANTestBase.java
+++ b/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/WANTestBase.java
@@ -3296,7 +3296,7 @@ public class WANTestBase extends DistributedTestCase {
             + abstractSender.getSecondaryEventQueueSize() + ". Queue content is: "
             + displayQueueContent(queue), 0, abstractSender.getSecondaryEventQueueSize());
       });
-      assertEquals("Except events in all secondary queues after drain is 0", 0,
+      assertEquals("Expected events in all secondary queues after drain is 0", 0,
           abstractSender.getSecondaryEventQueueSize());
     } finally {
       exp.remove();

--- a/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/disttx/DistTXWANDUnitTest.java
+++ b/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/disttx/DistTXWANDUnitTest.java
@@ -156,12 +156,14 @@ public class DistTXWANDUnitTest extends WANTestBase {
 
     vm4.invoke(() -> WANTestBase.doDistTXPuts(getTestMethodName() + "_PR", 5));
 
+    // verify that the data was received
+    vm2.invoke(() -> WANTestBase.validateRegionSize(getTestMethodName() + "_PR", 5));
+
     // verify all buckets drained on all sender nodes.
     vm4.invoke(() -> WANTestBase.validateParallelSenderQueueAllBucketsDrained("ln"));
     vm5.invoke(() -> WANTestBase.validateParallelSenderQueueAllBucketsDrained("ln"));
     vm6.invoke(() -> WANTestBase.validateParallelSenderQueueAllBucketsDrained("ln"));
     vm7.invoke(() -> WANTestBase.validateParallelSenderQueueAllBucketsDrained("ln"));
 
-    vm2.invoke(() -> WANTestBase.validateRegionSize(getTestMethodName() + "_PR", 5));
   }
 }


### PR DESCRIPTION
Check that the data is propagated through WAN before checking the
status of the event queues. This test was flaky because the event queues
were being checked before the events had been added to the event queue,
so the queue was changing as it was being checked. By checking that the
data has been propaged to the other cluster first, we can know that all
events have been added.

Co-authored-by: Finn Southerland <fsoutherland@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
