### PR TITLE
GEODE-5408 Update docs for gfsh remove --all

### DIFF
--- a/geode-docs/tools_modules/gfsh/command-pages/remove.html.md.erb
+++ b/geode-docs/tools_modules/gfsh/command-pages/remove.html.md.erb
@@ -36,28 +36,32 @@ remove --region=value [--key=value] [--all(=value)?] [--key-class=value]
 | <span class="keyword parmname">\\-\\-key</span>        | String or JSON text that will be used to create a key to retrieve a value . |                                                 |
 | <span class="keyword parmname">&#8209;&#8209;key&#8209;class </span> | Fully qualified class name of the key's type.                               | key constraint for the current region or String |
 | <span class="keyword parmname">\\-\\-region</span>     | *Required.* Region from which to remove the entry.                          |                                                 |
-| <span class="keyword parmname">\\-\\-all</span>        | Clears the region by removing all entries.                                  | false                                           |
-
-<span class="tablecap">Table 1. Remove Parameters</span>
+| <span class="keyword parmname">\\-\\-all</span>        | A boolean value that, when true, clears the region by removing all entries. This option is not available for partitioned regions.  | false                                           |
 
 **Example Commands:**
 
 ``` pre
-gfsh>remove --region=/region1/region12 --key=('id': '133abg134')
-gfsh>remove --region=/region1/region12 --key=('id': '133abg134') --key-class=data.ProfileKey 
-gfsh>remove --region=/region1/region12 --all
+gfsh>remove --region=/region1 --key=('id': '133abg134')
+gfsh>remove --region=/region1 --key=('id': '133abg134') --key-class=data.ProfileKey 
+gfsh>remove --region=/region1 --all=true
 ```
 
 **Error Messages:**
 
 ``` pre
-"Region name is either empty or Null";
-"Key is either empty or Null";
-"Value is either empty or Null";
-"Region <{0}> not found in any of the members";
-"Region <{0}> Not Found";
-"Key is not present in the region";
-"Cleared all keys in the region";
+"Region name is either empty or Null"
+
+"Key is either empty or Null"
+
+"Value is either empty or Null"
+
+"Region <{0}> not found in any of the members"
+
+"Region <{0}> Not Found"
+
+"Key is not present in the region"
+
+"Option --all is not supported on partitioned region"
 ```
 
 


### PR DESCRIPTION
In addition to documenting that the --all option is not available for use with partitioned regions:

- removed an unneeded table caption
- removed an incorrect "error" message
- revised region names so they did not specify subregions in the example commands