### PR TITLE
GEODE-5423 gradle configuration is much faster

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,9 @@ buildscript {
   }
 }
 
+apply plugin: 'wrapper'
+apply plugin: 'com.gradle.build-scan'
+
 wrapper {
   gradleVersion = minimumGradleVersion
 }

--- a/geode-old-versions/build.gradle
+++ b/geode-old-versions/build.gradle
@@ -15,51 +15,27 @@
  * limitations under the License.
  */
 
-
 disableMavenPublishing()
-
-project.ext.installs = new Properties();
-
-def addOldVersion(def source, def geodeVersion, def downloadInstall) {
-  sourceSets.create(source, {})
-
-  dependencies.add "${source}Compile", "org.apache.geode:geode-common:$geodeVersion"
-  dependencies.add "${source}Compile", "org.apache.geode:geode-core:$geodeVersion"
-  dependencies.add "${source}Compile", "org.apache.geode:geode-lucene:$geodeVersion"
-  dependencies.add "${source}Compile", "org.apache.geode:geode-old-client-support:$geodeVersion"
-  dependencies.add "${source}Compile", "org.apache.geode:geode-wan:$geodeVersion"
-  dependencies.add "${source}Compile", "org.apache.geode:geode-cq:$geodeVersion"
-  dependencies.add "${source}Compile", "org.apache.geode:geode-rebalancer:$geodeVersion"
-
-  if (downloadInstall) {
-    configurations.create("${source}OldInstall")
-
-    dependencies.add "${source}OldInstall", "org.apache.geode:apache-geode:$geodeVersion"
-
-    project.ext.installs.setProperty(source, "$buildDir/apache-geode-${geodeVersion}")
-    task "downloadAndUnzipFile${geodeVersion}"(type: Copy) {
-      from zipTree(configurations["${source}OldInstall"].singleFile)
-      into buildDir
-    }
-
-    createGeodeClasspathsFile.dependsOn tasks["downloadAndUnzipFile${geodeVersion}"]
-  }
-}
-
-
 def generatedResources = "$buildDir/generated-resources/main"
+project.ext.installs = new Properties()
 
-sourceSets {
-  main {
-    output.dir(generatedResources, builtBy: 'createGeodeClasspathsFile')
-  }
-}
-
-task createGeodeClasspathsFile  {
+task createGeodeClasspathsFile {
   File classpathsFile = file("$generatedResources/geodeOldVersionClasspaths.txt")
   File installsFile = file("$generatedResources/geodeOldVersionInstalls.txt")
   outputs.file(classpathsFile)
   outputs.file(installsFile)
+
+
+  // Add sourceSets for backwards compatibility, rolling upgrade, and
+  // pdx testing.
+  addOldVersion('test100', '1.0.0-incubating', false)
+  addOldVersion('test110', '1.1.0', false)
+  addOldVersion('test111', '1.1.1', false)
+  addOldVersion('test120', '1.2.0', true)
+  addOldVersion('test130', '1.3.0', true)
+  addOldVersion('test140', '1.4.0', true)
+  addOldVersion('test150', '1.5.0', true)
+  addOldVersion('test160', '1.6.0', true)
 
   doLast {
     Properties versions = new Properties();
@@ -79,15 +55,51 @@ task createGeodeClasspathsFile  {
       project.ext.installs.store(fos, '')
     }
   }
+}
 
-  // Add sourceSets for backwards compatibility, rolling upgrade, and
-  // pdx testing.
-  addOldVersion('test100', '1.0.0-incubating', false)
-  addOldVersion('test110', '1.1.0', false)
-  addOldVersion('test111', '1.1.1', false)
-  addOldVersion('test120', '1.2.0', true)
-  addOldVersion('test130', '1.3.0', true)
-  addOldVersion('test140', '1.4.0', true)
-  addOldVersion('test150', '1.5.0', true)
-  addOldVersion('test160', '1.6.0', true)
+def addOldVersion(def source, def geodeVersion, def downloadInstall) {
+  sourceSets.create("${source}", {})
+
+  configurations {
+    "${source}Compile"
+  }
+
+  dependencies.add "${source}Compile", "org.apache.geode:geode-common:${geodeVersion}"
+  dependencies.add "${source}Compile", "org.apache.geode:geode-core:${geodeVersion}"
+  dependencies.add "${source}Compile", "org.apache.geode:geode-lucene:${geodeVersion}"
+  dependencies.add "${source}Compile", "org.apache.geode:geode-old-client-support:${geodeVersion}"
+  dependencies.add "${source}Compile", "org.apache.geode:geode-wan:${geodeVersion}"
+  dependencies.add "${source}Compile", "org.apache.geode:geode-cq:${geodeVersion}"
+  dependencies.add "${source}Compile", "org.apache.geode:geode-rebalancer:${geodeVersion}"
+
+  if (downloadInstall) {
+    configurations.create("${source}OldInstall")
+
+    dependencies {
+      "${source}OldInstall"  "org.apache.geode:apache-geode:${geodeVersion}"
+    }
+
+    project.ext.installs.setProperty(source, "${buildDir}/apache-geode-${geodeVersion}")
+
+    task("downloadAndUnzipFile${geodeVersion}") {
+      inputs.file {
+        configurations."${source}OldInstall"
+      }
+
+      outputs.file("${buildDir}/apache-geode-${geodeVersion}")
+      doLast {
+        copy {
+          from zipTree(configurations."${source}OldInstall".singleFile)
+          into project.buildDir
+        }
+      }
+    }
+    createGeodeClasspathsFile.dependsOn tasks["downloadAndUnzipFile${geodeVersion}"]
+  }
+}
+
+sourceSets {
+  main {
+    output.dir(generatedResources, builtBy: 'createGeodeClasspathsFile')
+  }
 }


### PR DESCRIPTION
GEODE-5423 Defer download and copy tasks to execution stage of Gradle

Custom tasks for fetching and unpacking geode-old-versions was doing
filesystem work during configure, every time a build was executed,
regardless of changes or targets requested. Reorganizing this task and
its dependencies several benefits:
- moves the blocking IO heavy operation into the execution stage
- allows parallel tasks to execute during the download and unzip
- does not do IO checks for non-build targets like `gradlew tasks`
- will not re-trigger the task on subsequent builds


In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
