### PR TITLE
[GEODE-5427] Isolate PR pipeline jobs from other pipelines.

### DIFF
--- a/ci/pipelines/pull-request/base.yml
+++ b/ci/pipelines/pull-request/base.yml
@@ -59,6 +59,7 @@ groups:
 jobs:
 - name: Build
   serial: false
+  max_in_flight: (( grab metadata.max_in_flight ))
   public: true
   plan:
   - aggregate:
@@ -86,6 +87,7 @@ jobs:
         status: pending
 
     - task: build
+      tags: [pr]
       image: docker-geode-build-image
       config:
         platform: linux
@@ -117,6 +119,7 @@ jobs:
 
 - name: DistributedTest
   serial: false
+  max_in_flight: (( grab metadata.max_in_flight ))
   public: true
   plan:
   - aggregate:
@@ -146,7 +149,7 @@ jobs:
 
     - task: run-distributed-core
       image: docker-geode-build-image
-      tags: [large]
+      tags: [pr-large]
       privileged: true
       timeout: 8h
       config:
@@ -189,7 +192,7 @@ jobs:
               path: geode/ci/scripts/test-archive.sh
     - task: run-distributed-everything-else
       image: docker-geode-build-image
-      tags: [large]
+      tags: [pr-large]
       privileged: true
       timeout: 8h
       config:

--- a/ci/pipelines/pull-request/base.yml
+++ b/ci/pipelines/pull-request/base.yml
@@ -149,7 +149,7 @@ jobs:
 
     - task: run-distributed-core
       image: docker-geode-build-image
-      tags: [pr-large]
+      tags: [pr_large]
       privileged: true
       timeout: 8h
       config:
@@ -192,7 +192,7 @@ jobs:
               path: geode/ci/scripts/test-archive.sh
     - task: run-distributed-everything-else
       image: docker-geode-build-image
-      tags: [pr-large]
+      tags: [pr_large]
       privileged: true
       timeout: 8h
       config:

--- a/ci/pipelines/pull-request/deploy_pr_pipeline.sh
+++ b/ci/pipelines/pull-request/deploy_pr_pipeline.sh
@@ -47,6 +47,7 @@ if [ "${GEODE_BRANCH}" = "HEAD" ]; then
 fi
 
 SANITIZED_GEODE_BRANCH=$(echo ${GEODE_BRANCH} | tr "/" "-")
+MAX_IN_FLIGHT=5
 
 BIN_DIR=${OUTPUT_DIRECTORY}/bin
 TMP_DIR=${OUTPUT_DIRECTORY}/tmp
@@ -62,7 +63,8 @@ for i in ${GEODEBUILDDIR}/test-stubs/*.yml; do
   ${SPRUCE} merge --prune metadata \
     <(echo "metadata:"; \
       echo "  geode-build-branch: ${GEODE_BRANCH}"; \
-      echo "  geode-fork: ${GEODE_FORK}") \
+      echo "  geode-fork: ${GEODE_FORK}"; \
+      echo "  max_in_flight: ${MAX_IN_FLIGHT}") \
     ${SCRIPTDIR}/pr-template.yml \
     ${i} > ${TMP_DIR}/${X}
 done
@@ -73,6 +75,7 @@ ${SPRUCE} merge --prune metadata \
   <(echo "metadata:"; \
     echo "  geode-build-branch: ${GEODE_BRANCH}"; \
     echo "  geode-fork: ${GEODE_FORK}"; \
+    echo "  max_in_flight: ${MAX_IN_FLIGHT}"; \
     echo "  ") \
   ${TMP_DIR}/*.yml > ${TMP_DIR}/final.yml
 

--- a/ci/pipelines/pull-request/pr-template.yml
+++ b/ci/pipelines/pull-request/pr-template.yml
@@ -19,6 +19,7 @@
 jobs:
 - name: (( grab metadata.job.name ))
   serial: false
+  max_in_flight: (( grab metadata.max_in_flight ))
   public: true
   plan:
     - aggregate:
@@ -47,7 +48,7 @@ jobs:
 
       - task: runtests
         image: docker-geode-build-image
-        tags: (( grab metadata.job.size ))
+        tags: [pr]
         privileged: true
         timeout: (( grab metadata.job.timeout ))
         config:


### PR DESCRIPTION
Add tags to PR pipeline jobs so that they will run on separately
allocated workers. Also limit the number of instances of a given job in
the PR pipeline to 5.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
