### PR TITLE
 GEODE-5292: Flushing to disk in test before introducing spy in test

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/cache/ConcurrentRegionOperationIntegrationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/ConcurrentRegionOperationIntegrationTest.java
@@ -26,7 +26,6 @@ import java.util.concurrent.TimeUnit;
 import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -59,7 +58,6 @@ public class ConcurrentRegionOperationIntegrationTest {
   }
 
   @Test
-  @Ignore("GEODE-5292: Test is failing in CI")
   public void replaceWithClearAndDestroy() throws RegionClearedException {
     Region<Integer, String> region = createRegion();
 
@@ -79,12 +77,12 @@ public class ConcurrentRegionOperationIntegrationTest {
       // If we invoke clear in the replace thread, it can get locks which it will not
       // be able to get in a separate thread.
       CompletableFuture.runAsync(region::clear).get();
-      throw new RegionDestroyedException("Fake Exception", "/region");
+      CompletableFuture.runAsync(region::destroyRegion).get();
+      return invocation.callRealMethod();
     }).when(spyEntry).setValueWithTombstoneCheck(any(), any());
 
     assertThatExceptionOfType(RegionDestroyedException.class)
-        .isThrownBy(() -> region.replace(1, "value", "newvalue"))
-        .withMessageContaining("Fake Exception");
+        .isThrownBy(() -> region.replace(1, "value", "newvalue"));
 
     Awaitility.await().pollDelay(0, TimeUnit.MICROSECONDS)
         .pollInterval(1, TimeUnit.MILLISECONDS)

--- a/geode-core/src/test/java/org/apache/geode/cache/ConcurrentRegionOperationIntegrationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/ConcurrentRegionOperationIntegrationTest.java
@@ -64,6 +64,9 @@ public class ConcurrentRegionOperationIntegrationTest {
     region.put(1, "value");
     region.put(2, "value");
 
+    DiskStore diskStore = cache.findDiskStore(DiskStoreFactory.DEFAULT_DISK_STORE_NAME);
+    diskStore.flush();
+
     ConcurrentMapWithReusableEntries<Object, Object> underlyingMap =
         ((LocalRegion) region).getRegionMap().getCustomEntryConcurrentHashMap();
     RegionEntry spyEntry = spy((RegionEntry) underlyingMap.get(1));


### PR DESCRIPTION
This test was modifying the concurrent region map to introduce a spy,
but there was a concurrent thread overflowing entries to disk at the
same time. An interaction between the spy and the async flush caused the
ref count to go to 0, and the test to fail before it even got to the
point of clearing the region.

Flushing the disk before introducing the spy.

@balesh2 @FSOUTHERLAND 