### PR TITLE
GEODE-567: Wait for async datastore creation to reach appropriate point

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/partitioned/fixed/FixedPartitioningDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/partitioned/fixed/FixedPartitioningDUnitTest.java
@@ -36,8 +36,8 @@ import org.apache.geode.test.dunit.Assert;
 import org.apache.geode.test.dunit.AsyncInvocation;
 import org.apache.geode.test.dunit.Host;
 import org.apache.geode.test.dunit.IgnoredException;
+import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.Wait;
-import org.apache.geode.test.junit.categories.FlakyTest;
 import org.apache.geode.test.junit.categories.PartitioningTest;
 
 /**
@@ -102,8 +102,9 @@ public class FixedPartitioningDUnitTest extends FixedPartitioningTestBase {
       List<FixedPartitionAttributes> fpaList = new ArrayList<FixedPartitionAttributes>();
       fpaList.add(fpa1);
       fpaList.add(fpa2);
-      member1.invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes("Quarter",
-          fpaList, 0, 40, 3, new QuarterPartitionResolver(), null, false));
+      member1
+          .invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes(REGION_NAME,
+              fpaList, 0, 40, 3, new QuarterPartitionResolver(), null, false));
       fail("IllegalStateException Expected");
     } catch (Exception illegal) {
       if (!((illegal.getCause() instanceof IllegalStateException) && (illegal.getCause()
@@ -127,8 +128,9 @@ public class FixedPartitioningDUnitTest extends FixedPartitioningTestBase {
       List<FixedPartitionAttributes> fpaList = new ArrayList<FixedPartitionAttributes>();
       fpaList.add(fpa1);
       fpaList.add(fpa2);
-      member1.invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes("Quarter",
-          fpaList, 0, 0, 3, new QuarterPartitionResolver(), null, false));
+      member1
+          .invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes(REGION_NAME,
+              fpaList, 0, 0, 3, new QuarterPartitionResolver(), null, false));
       fail("IllegalStateException Expected");
     } catch (Exception illegal) {
       if (!((illegal.getCause() instanceof IllegalStateException)
@@ -154,22 +156,25 @@ public class FixedPartitioningDUnitTest extends FixedPartitioningTestBase {
           FixedPartitionAttributes.createFixedPartition(Quarter1, true, 3);
       List<FixedPartitionAttributes> fpaList = new ArrayList<FixedPartitionAttributes>();
       fpaList.add(fpa1);
-      member1.invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes("Quarter",
-          fpaList, 0, 40, 9, new QuarterPartitionResolver(), null, false));
+      member1
+          .invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes(REGION_NAME,
+              fpaList, 0, 40, 9, new QuarterPartitionResolver(), null, false));
 
       member2.invoke(() -> FixedPartitioningTestBase.createCacheOnMember());
       fpa1 = FixedPartitionAttributes.createFixedPartition(Quarter2, true, 3);
       fpaList.clear();
       fpaList.add(fpa1);
-      member2.invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes("Quarter",
-          fpaList, 0, 40, 9, new QuarterPartitionResolver(), null, false));
+      member2
+          .invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes(REGION_NAME,
+              fpaList, 0, 40, 9, new QuarterPartitionResolver(), null, false));
 
       member3.invoke(() -> FixedPartitioningTestBase.createCacheOnMember());
       fpa1 = FixedPartitionAttributes.createFixedPartition(Quarter2, true, 3);
       fpaList.clear();
       fpaList.add(fpa1);
-      member3.invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes("Quarter",
-          fpaList, 0, 40, 9, new QuarterPartitionResolver(), null, false));
+      member3
+          .invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes(REGION_NAME,
+              fpaList, 0, 40, 9, new QuarterPartitionResolver(), null, false));
       fail("DuplicatePrimaryPartitionException Expected");
     } catch (Exception duplicate) {
       if (!((duplicate.getCause() instanceof DuplicatePrimaryPartitionException)
@@ -199,8 +204,9 @@ public class FixedPartitioningDUnitTest extends FixedPartitioningTestBase {
       List<FixedPartitionAttributes> fpaList = new ArrayList<FixedPartitionAttributes>();
       fpaList.add(fpa1);
       fpaList.add(fpa2);
-      member1.invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes("Quarter",
-          fpaList, 1, 40, 9, new QuarterPartitionResolver(), null, false));
+      member1
+          .invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes(REGION_NAME,
+              fpaList, 1, 40, 9, new QuarterPartitionResolver(), null, false));
 
       member2.invoke(() -> FixedPartitioningTestBase.createCacheOnMember());
       fpa1 = FixedPartitionAttributes.createFixedPartition(Quarter2, true, 3);
@@ -208,8 +214,9 @@ public class FixedPartitioningDUnitTest extends FixedPartitioningTestBase {
       fpaList.clear();
       fpaList.add(fpa1);
       fpaList.add(fpa2);
-      member2.invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes("Quarter",
-          fpaList, 1, 40, 9, new QuarterPartitionResolver(), null, false));
+      member2
+          .invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes(REGION_NAME,
+              fpaList, 1, 40, 9, new QuarterPartitionResolver(), null, false));
       fail("IllegalStateException Expected");
     } catch (Exception illegal) {
       if (!((illegal.getCause() instanceof IllegalStateException)
@@ -232,8 +239,9 @@ public class FixedPartitioningDUnitTest extends FixedPartitioningTestBase {
     IgnoredException expected = IgnoredException.addIgnoredException("IllegalStateException");
     try {
       member1.invoke(() -> FixedPartitioningTestBase.createCacheOnMember());
-      member1.invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes("Quarter",
-          null, 1, 0, 9, new QuarterPartitionResolver(), null, false));
+      member1
+          .invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes(REGION_NAME,
+              null, 1, 0, 9, new QuarterPartitionResolver(), null, false));
 
       member2.invoke(() -> FixedPartitioningTestBase.createCacheOnMember());
       FixedPartitionAttributes fpa1 = FixedPartitionAttributes.createFixedPartition("Q11", true, 3);
@@ -242,8 +250,9 @@ public class FixedPartitioningDUnitTest extends FixedPartitioningTestBase {
       List<FixedPartitionAttributes> fpaList = new ArrayList<FixedPartitionAttributes>();
       fpaList.add(fpa1);
       fpaList.add(fpa2);
-      member2.invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes("Quarter",
-          fpaList, 1, 40, 9, new QuarterPartitionResolver(), null, false));
+      member2
+          .invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes(REGION_NAME,
+              fpaList, 1, 40, 9, new QuarterPartitionResolver(), null, false));
 
       member3.invoke(() -> FixedPartitioningTestBase.createCacheOnMember());
       fpa1 = FixedPartitionAttributes.createFixedPartition("Q12", true, 3);
@@ -254,8 +263,9 @@ public class FixedPartitioningDUnitTest extends FixedPartitioningTestBase {
       fpaList.add(fpa1);
       fpaList.add(fpa2);
       fpaList.add(fpa3);
-      member3.invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes("Quarter",
-          fpaList, 1, 40, 9, new QuarterPartitionResolver(), null, false));
+      member3
+          .invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes(REGION_NAME,
+              fpaList, 1, 40, 9, new QuarterPartitionResolver(), null, false));
 
       member4.invoke(() -> FixedPartitioningTestBase.createCacheOnMember());
       fpa1 = FixedPartitionAttributes.createFixedPartition("Q13", true, 3);
@@ -263,8 +273,9 @@ public class FixedPartitioningDUnitTest extends FixedPartitioningTestBase {
       fpaList.clear();
       fpaList.add(fpa1);
       fpaList.add(fpa2);
-      member4.invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes("Quarter",
-          fpaList, 1, 40, 9, new QuarterPartitionResolver(), null, false));
+      member4
+          .invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes(REGION_NAME,
+              fpaList, 1, 40, 9, new QuarterPartitionResolver(), null, false));
       fail("IllegalStateException expected");
     } catch (Exception ex) {
       if (!((ex.getCause() instanceof IllegalStateException) && (ex.getCause().getMessage()
@@ -285,8 +296,9 @@ public class FixedPartitioningDUnitTest extends FixedPartitioningTestBase {
     IgnoredException expected = IgnoredException.addIgnoredException("IllegalStateException");
     try {
       member1.invoke(() -> FixedPartitioningTestBase.createCacheOnMember());
-      member1.invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes("Quarter",
-          null, 1, 0, 5, new QuarterPartitionResolver(), null, false));
+      member1
+          .invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes(REGION_NAME,
+              null, 1, 0, 5, new QuarterPartitionResolver(), null, false));
 
       member2.invoke(() -> FixedPartitioningTestBase.createCacheOnMember());
       FixedPartitionAttributes fpa1 =
@@ -296,8 +308,9 @@ public class FixedPartitioningDUnitTest extends FixedPartitioningTestBase {
       List<FixedPartitionAttributes> fpaList = new ArrayList<FixedPartitionAttributes>();
       fpaList.add(fpa1);
       fpaList.add(fpa2);
-      member2.invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes("Quarter",
-          fpaList, 1, 40, 5, new QuarterPartitionResolver(), null, false));
+      member2
+          .invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes(REGION_NAME,
+              fpaList, 1, 40, 5, new QuarterPartitionResolver(), null, false));
 
       member3.invoke(() -> FixedPartitioningTestBase.createCacheOnMember());
       fpa1 = FixedPartitionAttributes.createFixedPartition(Quarter2, true, 3);
@@ -305,8 +318,9 @@ public class FixedPartitioningDUnitTest extends FixedPartitioningTestBase {
       fpaList.clear();
       fpaList.add(fpa1);
       fpaList.add(fpa2);
-      member3.invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes("Quarter",
-          fpaList, 1, 40, 5, new QuarterPartitionResolver(), null, false));
+      member3
+          .invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes(REGION_NAME,
+              fpaList, 1, 40, 5, new QuarterPartitionResolver(), null, false));
 
       fail("IllegalStateException expected");
     } catch (Exception ex) {
@@ -329,25 +343,28 @@ public class FixedPartitioningDUnitTest extends FixedPartitioningTestBase {
   public void testPut_PartitionNotAvailableException() {
     try {
       member1.invoke(() -> FixedPartitioningTestBase.createCacheOnMember());
-      member1.invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes("Quarter",
-          null, 1, 0, 12, new QuarterPartitionResolver(), null, false));
+      member1
+          .invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes(REGION_NAME,
+              null, 1, 0, 12, new QuarterPartitionResolver(), null, false));
 
       member2.invoke(() -> FixedPartitioningTestBase.createCacheOnMember());
       FixedPartitionAttributes fpa1 =
           FixedPartitionAttributes.createFixedPartition(Quarter1, true, 3);
       List<FixedPartitionAttributes> fpaList = new ArrayList<FixedPartitionAttributes>();
       fpaList.add(fpa1);
-      member2.invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes("Quarter",
-          fpaList, 1, 40, 12, new QuarterPartitionResolver(), null, false));
+      member2
+          .invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes(REGION_NAME,
+              fpaList, 1, 40, 12, new QuarterPartitionResolver(), null, false));
 
       member3.invoke(() -> FixedPartitioningTestBase.createCacheOnMember());
       fpa1 = FixedPartitionAttributes.createFixedPartition(Quarter2, true, 3);
       fpaList.clear();
       fpaList.add(fpa1);
-      member3.invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes("Quarter",
-          fpaList, 1, 40, 12, new QuarterPartitionResolver(), null, false));
+      member3
+          .invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes(REGION_NAME,
+              fpaList, 1, 40, 12, new QuarterPartitionResolver(), null, false));
 
-      member1.invoke(() -> FixedPartitioningTestBase.putThorughAccessor("Quarter"));
+      member1.invoke(() -> FixedPartitioningTestBase.putThroughAccessor(REGION_NAME));
       fail("PartitionNotAvailableException Expected");
     } catch (Exception ex) {
       if (!((ex.getCause() instanceof PartitionNotAvailableException))) {
@@ -366,16 +383,18 @@ public class FixedPartitioningDUnitTest extends FixedPartitioningTestBase {
     IgnoredException expected = IgnoredException.addIgnoredException("IllegalStateException");
     try {
       member1.invoke(() -> FixedPartitioningTestBase.createCacheOnMember());
-      member1.invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes("Quarter",
-          null, 1, 40, 12, new QuarterPartitionResolver(), null, false));
+      member1
+          .invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes(REGION_NAME,
+              null, 1, 40, 12, new QuarterPartitionResolver(), null, false));
 
       member2.invoke(() -> FixedPartitioningTestBase.createCacheOnMember());
       FixedPartitionAttributes fpa1 =
           FixedPartitionAttributes.createFixedPartition(Quarter1, true, 3);
       List<FixedPartitionAttributes> fpaList = new ArrayList<FixedPartitionAttributes>();
       fpaList.add(fpa1);
-      member2.invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes("Quarter",
-          fpaList, 1, 40, 12, new QuarterPartitionResolver(), null, false));
+      member2
+          .invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes(REGION_NAME,
+              fpaList, 1, 40, 12, new QuarterPartitionResolver(), null, false));
     } catch (Exception ex) {
       if (!((ex.getCause() instanceof IllegalStateException))) {
         Assert.fail("Expected IllegalStateException ", ex);
@@ -399,12 +418,14 @@ public class FixedPartitioningDUnitTest extends FixedPartitioningTestBase {
           FixedPartitionAttributes.createFixedPartition(Quarter1, true, 3);
       List<FixedPartitionAttributes> fpaList = new ArrayList<FixedPartitionAttributes>();
       fpaList.add(fpa1);
-      member2.invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes("Quarter",
-          fpaList, 1, 40, 12, new QuarterPartitionResolver(), null, false));
+      member2
+          .invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes(REGION_NAME,
+              fpaList, 1, 40, 12, new QuarterPartitionResolver(), null, false));
 
       member1.invoke(() -> FixedPartitioningTestBase.createCacheOnMember());
-      member1.invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes("Quarter",
-          null, 1, 40, 12, new QuarterPartitionResolver(), null, false));
+      member1
+          .invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes(REGION_NAME,
+              null, 1, 40, 12, new QuarterPartitionResolver(), null, false));
     } catch (Exception ex) {
       if (!((ex.getCause() instanceof IllegalStateException))) {
         Assert.fail("Expected IllegalStateException ", ex);
@@ -421,7 +442,7 @@ public class FixedPartitioningDUnitTest extends FixedPartitioningTestBase {
   @Test
   public void testPut_ValidateDataOnMember_OnlyPrimary_Accessor() {
     member1.invoke(() -> FixedPartitioningTestBase.createCacheOnMember());
-    member1.invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes("Quarter",
+    member1.invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes(REGION_NAME,
         null, 0, 0, 12, new QuarterPartitionResolver(), null, false));
 
     member2.invoke(() -> FixedPartitioningTestBase.createCacheOnMember());
@@ -429,24 +450,24 @@ public class FixedPartitioningDUnitTest extends FixedPartitioningTestBase {
         FixedPartitionAttributes.createFixedPartition(Quarter1, true, 3);
     List<FixedPartitionAttributes> fpaList = new ArrayList<FixedPartitionAttributes>();
     fpaList.add(fpa1);
-    member2.invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes("Quarter",
+    member2.invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes(REGION_NAME,
         fpaList, 0, 40, 12, new QuarterPartitionResolver(), null, false));
 
     member3.invoke(() -> FixedPartitioningTestBase.createCacheOnMember());
     fpa1 = FixedPartitionAttributes.createFixedPartition(Quarter2, true, 3);
     fpaList.clear();
     fpaList.add(fpa1);
-    member3.invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes("Quarter",
+    member3.invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes(REGION_NAME,
         fpaList, 0, 40, 12, new QuarterPartitionResolver(), null, false));
 
     member4.invoke(() -> FixedPartitioningTestBase.createCacheOnMember());
     fpa1 = FixedPartitionAttributes.createFixedPartition(Quarter3, true, 3);
     fpaList.clear();
     fpaList.add(fpa1);
-    member4.invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes("Quarter",
+    member4.invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes(REGION_NAME,
         fpaList, 0, 40, 12, new QuarterPartitionResolver(), null, false));
 
-    member1.invoke(() -> FixedPartitioningTestBase.putThorughAccessor("Quarter"));
+    member1.invoke(() -> FixedPartitioningTestBase.putThroughAccessor(REGION_NAME));
 
     member2.invoke(() -> FixedPartitioningTestBase.checkPrimaryData(Quarter1));
     member3.invoke(() -> FixedPartitioningTestBase.checkPrimaryData(Quarter2));
@@ -456,46 +477,47 @@ public class FixedPartitioningDUnitTest extends FixedPartitioningTestBase {
 
   @Test
   public void putWhileDataStoresAreBeingCreatedFails() throws Exception {
-    member1.invoke(() -> FixedPartitioningTestBase.createCacheOnMember());
-    member2.invoke(() -> FixedPartitioningTestBase.createCacheOnMember());
-    member3.invoke(() -> FixedPartitioningTestBase.createCacheOnMember());
-    member4.invoke(() -> FixedPartitioningTestBase.createCacheOnMember());
+
+    VM accessor = VM.getVM(0);
+    VM datastore1 = VM.getVM(1);
+    VM datastore2 = VM.getVM(2);
+    VM datastore3 = VM.getVM(3);
+    accessor.invoke(() -> FixedPartitioningTestBase.createCacheOnMember());
+    datastore1.invoke(() -> FixedPartitioningTestBase.createCacheOnMember());
+    datastore2.invoke(() -> FixedPartitioningTestBase.createCacheOnMember());
+    datastore3.invoke(() -> FixedPartitioningTestBase.createCacheOnMember());
 
     getBlackboard().initBlackboard();
 
-    member1.invoke(() -> FixedPartitioningTestBase.setPRObserverBeforeCalculateStartingBucketId());
-    member2.invoke(() -> FixedPartitioningTestBase.setPRObserverBeforeCalculateStartingBucketId());
-    member3.invoke(() -> FixedPartitioningTestBase.setPRObserverBeforeCalculateStartingBucketId());
+    // Create an accessor for the PR
+    accessor.invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes(REGION_NAME,
+        null, 0, 0, 12, new QuarterPartitionResolver(), null, false));
+
+    // Set an observer in datastore 1 that will wait in the middle of PR creation
+    datastore1
+        .invoke(() -> FixedPartitioningTestBase.setPRObserverBeforeCalculateStartingBucketId());
     try {
+      // Start datstore1 asynchronously. This will get stuck waiting in the PR observer
+      AsyncInvocation inv1 = datastore1.invokeAsync(() -> createRegionWithQuarter(Quarter1));
 
-      member4.invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes("Quarter",
-          null, 0, 0, 12, new QuarterPartitionResolver(), null, false));
-
-      FixedPartitionAttributes fpa1 =
-          FixedPartitionAttributes.createFixedPartition(Quarter1, true, 3);
-      AsyncInvocation inv1 = member1.invokeAsync(
-          () -> FixedPartitioningTestBase.createRegionWithPartitionAttributes("Quarter",
-              Arrays.asList(fpa1), 0,
-              40, 12, new QuarterPartitionResolver(), null, false));
-
-      FixedPartitionAttributes fpa2 =
-          FixedPartitionAttributes.createFixedPartition(Quarter2, true, 3);
-      AsyncInvocation inv2 = member2.invokeAsync(
-          () -> FixedPartitioningTestBase.createRegionWithPartitionAttributes("Quarter",
-              Arrays.asList(fpa2), 0,
-              40, 12, new QuarterPartitionResolver(), null, false));
-
-      FixedPartitionAttributes fpa3 =
-          FixedPartitionAttributes.createFixedPartition(Quarter3, true, 3);
-      AsyncInvocation inv3 = member3.invokeAsync(
-          () -> FixedPartitioningTestBase.createRegionWithPartitionAttributes("Quarter",
-              Arrays.asList(fpa3), 0,
-              40, 12, new QuarterPartitionResolver(), null, false));
-
+      // Make sure datastore 1 gets stuck waiting on the observer
       getBlackboard().waitForGate("waiting", 1, TimeUnit.MINUTES);
 
-      Assertions.assertThatThrownBy(() -> member4
-          .invoke(() -> FixedPartitioningTestBase.putThorughAccessor_Immediate("Quarter")))
+      // Start two more data stores asynchronously. These will get stuck waiting for a dlock behind
+      // datatstore1
+      AsyncInvocation inv2 = datastore2.invokeAsync(() -> createRegionWithQuarter(Quarter2));
+      AsyncInvocation inv3 = datastore3.invokeAsync(() -> createRegionWithQuarter(Quarter3));
+
+
+      // Make sure a put to datastore1, which is in the middle of pr initialization, fails correctly
+      Assertions.assertThatThrownBy(() -> accessor
+          .invoke(() -> FixedPartitioningTestBase.putForQuarter(REGION_NAME, Quarter1)))
+          .hasCauseInstanceOf(PartitionedRegionStorageException.class);
+
+      // Make sure a put to datastore2, which stuck behind datastore1 in initialization, fails
+      // correctly
+      Assertions.assertThatThrownBy(() -> accessor
+          .invoke(() -> FixedPartitioningTestBase.putForQuarter(REGION_NAME, Quarter2)))
           .hasCauseInstanceOf(PartitionedRegionStorageException.class);
 
       getBlackboard().signalGate("done");
@@ -504,14 +526,18 @@ public class FixedPartitioningDUnitTest extends FixedPartitioningTestBase {
       inv2.get();
       inv3.get();
     } finally {
-      member1
-          .invoke(() -> FixedPartitioningTestBase.resetPRObserverBeforeCalculateStartingBucketId());
-      member2
-          .invoke(() -> FixedPartitioningTestBase.resetPRObserverBeforeCalculateStartingBucketId());
-      member3
+      datastore1
           .invoke(() -> FixedPartitioningTestBase.resetPRObserverBeforeCalculateStartingBucketId());
     }
 
+  }
+
+  private void createRegionWithQuarter(String quarter) {
+    FixedPartitionAttributes partition =
+        FixedPartitionAttributes.createFixedPartition(quarter, true, 3);
+    FixedPartitioningTestBase.createRegionWithPartitionAttributes("Quarter",
+        Arrays.asList(partition), 0,
+        40, 12, new QuarterPartitionResolver(), null, false);
   }
 
   /**

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/partitioned/fixed/FixedPartitioningDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/partitioned/fixed/FixedPartitioningDUnitTest.java
@@ -46,6 +46,8 @@ import org.apache.geode.test.junit.categories.PartitioningTest;
 @Category({PartitioningTest.class})
 public class FixedPartitioningDUnitTest extends FixedPartitioningTestBase {
 
+  public static final String REGION_NAME = "Quarter";
+
   public FixedPartitioningDUnitTest() {
     super();
   }
@@ -71,7 +73,8 @@ public class FixedPartitioningDUnitTest extends FixedPartitioningTestBase {
       FixedPartitionAttributes fpa = FixedPartitionAttributes.createFixedPartition(null, true, 3);
       List<FixedPartitionAttributes> fpaList = new ArrayList<FixedPartitionAttributes>();
       fpaList.add(fpa);
-      member1.invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes("Quarter",
+      member1.invoke(() -> FixedPartitioningTestBase.createRegionWithPartitionAttributes(
+          REGION_NAME,
           fpaList, 0, 40, 3, new QuarterPartitionResolver(), null, false));
       fail("IllegalStateException Expected");
     } catch (Exception illegal) {
@@ -459,7 +462,7 @@ public class FixedPartitioningDUnitTest extends FixedPartitioningTestBase {
     member4.invoke(() -> FixedPartitioningTestBase.createCacheOnMember());
 
     getBlackboard().initBlackboard();
-    //
+
     member1.invoke(() -> FixedPartitioningTestBase.setPRObserverBeforeCalculateStartingBucketId());
     member2.invoke(() -> FixedPartitioningTestBase.setPRObserverBeforeCalculateStartingBucketId());
     member3.invoke(() -> FixedPartitioningTestBase.setPRObserverBeforeCalculateStartingBucketId());

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/partitioned/fixed/FixedPartitioningTestBase.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/partitioned/fixed/FixedPartitioningTestBase.java
@@ -204,7 +204,7 @@ public class FixedPartitioningTestBase extends JUnit4DistributedTestCase {
     return dir;
   }
 
-  public static void putThorughAccessor(String regionName) {
+  public static void putThroughAccessor(String regionName) {
     region_FPR = (PartitionedRegion) cache.getRegion(regionName);
     assertNotNull(region_FPR);
     for (Months_Accessor month : Months_Accessor.values()) {
@@ -216,7 +216,7 @@ public class FixedPartitioningTestBase extends JUnit4DistributedTestCase {
     }
   }
 
-  public static void putThorughAccessor_Immediate(String regionName) {
+  public static void putThroughAccessor_Immediate(String regionName) {
     region_FPR = (PartitionedRegion) cache.getRegion(regionName);
     assertNotNull(region_FPR);
     for (int i = 1; i < 10; i++) {
@@ -1192,7 +1192,8 @@ public class FixedPartitioningTestBase extends JUnit4DistributedTestCase {
             try {
               getBlackboard().waitForGate("done", 1, TimeUnit.MINUTES);
             } catch (Exception e) {
-              throw new RuntimeException(e);
+              throw new RuntimeException("Failed waiting to be signaled to continue in PR observer",
+                  e);
             }
           }
         });

--- a/geode-core/src/integrationTest/java/org/apache/geode/test/dunit/internal/JUnit4DistributedTestCase.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/test/dunit/internal/JUnit4DistributedTestCase.java
@@ -333,7 +333,7 @@ public abstract class JUnit4DistributedTestCase implements DistributedTestFixtur
    *
    * @return the blackboard
    */
-  public DUnitBlackboard getBlackboard() {
+  public static DUnitBlackboard getBlackboard() {
     return blackboard;
   }
 


### PR DESCRIPTION
This test appears like it was trying to test what happens if a put
happens when data store creation is at a particular point.

Unfortunately, it failed to do so correctly because it just spun off the
data store creation in separate threads and then did the put. The wait
criterion used was also completely wrong, so the test would always wait
for 1 minute.

Finally, there were some race conditions caused by passing the same
array list to multiple async task.

Changed the code to wait until the data stores are at the given point in
region creation and then do the put.

Thank you for submitting a contribution to Apache Geode.

@balesh2 @mhansonp 
