### PR TITLE
GEODE_5402 Disk recovery hangs after killing members

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/BucketPersistenceAdvisor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/BucketPersistenceAdvisor.java
@@ -297,7 +297,7 @@ public class BucketPersistenceAdvisor extends PersistenceAdvisorImpl {
     if (id == null) {
       return id;
     } else {
-      id = new PersistentMemberID(id.diskStoreId, id.host, id.directory,
+      id = new PersistentMemberID(id.getDiskStoreId(), id.getHost(), id.getDirectory(),
           this.proxyBucket.getPartitionedRegion().getBirthTime(), version++);
       return id;
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/CacheDistributionAdvisor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/CacheDistributionAdvisor.java
@@ -1175,7 +1175,7 @@ public class CacheDistributionAdvisor extends DistributionAdvisor {
       isPersistent = true;
       CacheProfile profile = (CacheProfile) getProfile(memberId);
       if (profile != null && profile.persistentID != null) {
-        persistentId = ((CacheProfile) getProfile(memberId)).persistentID.diskStoreId;
+        persistentId = ((CacheProfile) getProfile(memberId)).persistentID.getDiskStoreId();
       }
     }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DiskInitFile.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DiskInitFile.java
@@ -2573,13 +2573,13 @@ public class DiskInitFile implements DiskInitFileInterpreter {
       Map<DiskStoreID, String> equal = new HashMap<DiskStoreID, String>();
       for (PlaceHolderDiskRegion region : regions) {
         for (PersistentMemberID mem : region.getOnlineMembers()) {
-          online.put(mem.diskStoreId, mem.host + ":" + mem.directory);
+          online.put(mem.getDiskStoreId(), mem.getHost() + ":" + mem.getDirectory());
         }
         for (PersistentMemberID mem : region.getOfflineMembers()) {
-          offline.put(mem.diskStoreId, mem.host + ":" + mem.directory);
+          offline.put(mem.getDiskStoreId(), mem.getHost() + ":" + mem.getDirectory());
         }
         for (PersistentMemberID mem : region.getOfflineAndEqualMembers()) {
-          equal.put(mem.diskStoreId, mem.host + ":" + mem.directory);
+          equal.put(mem.getDiskStoreId(), mem.getHost() + ":" + mem.getDirectory());
         }
       }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/PersistentMemberID.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/PersistentMemberID.java
@@ -26,12 +26,12 @@ import org.apache.geode.internal.cache.versions.VersionSource;
 public class PersistentMemberID implements DataSerializable {
   private static final long serialVersionUID = 7037022320499508045L;
 
-  public InetAddress host;
-  public String directory;
-  public long timeStamp;
-  public short version;
-  public DiskStoreID diskStoreId;
-  public String name;
+  private InetAddress host;
+  private String directory;
+  private long timeStamp;
+  private short version;
+  private DiskStoreID diskStoreId;
+  private String name;
 
   public PersistentMemberID() {
 
@@ -161,5 +161,29 @@ public class PersistentMemberID implements DataSerializable {
 
   public VersionSource getVersionMember() {
     return this.diskStoreId;
+  }
+
+  public InetAddress getHost() {
+    return host;
+  }
+
+  public String getDirectory() {
+    return directory;
+  }
+
+  public long getTimeStamp() {
+    return timeStamp;
+  }
+
+  public short getVersion() {
+    return version;
+  }
+
+  public DiskStoreID getDiskStoreId() {
+    return diskStoreId;
+  }
+
+  public String getName() {
+    return name;
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/PersistentMemberPattern.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/PersistentMemberPattern.java
@@ -40,7 +40,7 @@ public class PersistentMemberPattern implements PersistentID, Comparable<Persist
   private long revokedTime;
 
   public PersistentMemberPattern(PersistentMemberID id) {
-    this(id.host, id.directory, id.diskStoreId.toUUID(), 0);
+    this(id.getHost(), id.getDirectory(), id.getDiskStoreId().toUUID(), 0);
   }
 
   public PersistentMemberPattern(InetAddress host, String directory) {
@@ -72,11 +72,12 @@ public class PersistentMemberPattern implements PersistentID, Comparable<Persist
       return false;
     }
     boolean matches = true;
-    matches &= host == null || host.equals(id.host);
-    matches &= directory == null || directory.equals(id.directory);
+    matches &= host == null || host.equals(id.getHost());
+    matches &= directory == null || directory.equals(id.getDirectory());
     matches &= diskStoreID == null
-        || id.diskStoreId.getMostSignificantBits() == diskStoreID.getMostSignificantBits()
-            && id.diskStoreId.getLeastSignificantBits() == diskStoreID.getLeastSignificantBits();
+        || id.getDiskStoreId().getMostSignificantBits() == diskStoreID.getMostSignificantBits()
+            && id.getDiskStoreId().getLeastSignificantBits() == diskStoreID
+                .getLeastSignificantBits();
 
     // Safety measure. Id's which are generated after this pattern was revoked
     // should not be revoked. For example, if someone loses the disk for server A
@@ -84,7 +85,7 @@ public class PersistentMemberPattern implements PersistentID, Comparable<Persist
     // if they then close the region everywhere and then reopen it, we don't want
     // the new pattern to be revoked.
     if (diskStoreID == null) {
-      matches &= revokedTime > id.timeStamp;
+      matches &= revokedTime > id.getTimeStamp();
     }
     return matches;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/PersistentStateQueryMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/PersistentStateQueryMessage.java
@@ -66,16 +66,12 @@ public class PersistentStateQueryMessage extends HighPriorityDistributionMessage
     this.processorId = processorId;
   }
 
-  public static PersistentStateQueryResults send(Set<InternalDistributedMember> members,
-      DistributionManager dm, String regionPath, PersistentMemberID persistentId,
-      PersistentMemberID initializingId) throws ReplyException {
-    PersistentStateQueryReplyProcessor processor =
-        new PersistentStateQueryReplyProcessor(dm, members);
-    PersistentStateQueryMessage msg = new PersistentStateQueryMessage(regionPath, persistentId,
-        initializingId, processor.getProcessorId());
-    msg.setRecipients(members);
+  PersistentStateQueryResults send(Set<InternalDistributedMember> members, DistributionManager dm,
+      PersistentStateQueryReplyProcessor processor) {
+    setRecipients(members);
 
-    dm.putOutgoing(msg);
+    dm.putOutgoing(this);
+
     processor.waitForRepliesUninterruptibly();
     return processor.results;
   }
@@ -200,7 +196,7 @@ public class PersistentStateQueryMessage extends HighPriorityDistributionMessage
         + initializingId;
   }
 
-  private static class PersistentStateQueryReplyProcessor extends ReplyProcessor21 {
+  static class PersistentStateQueryReplyProcessor extends ReplyProcessor21 {
     PersistentStateQueryResults results = new PersistentStateQueryResults();
 
     public PersistentStateQueryReplyProcessor(DistributionManager dm, Collection initMembers) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/PersistentStateQueryMessageSenderFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/PersistentStateQueryMessageSenderFactory.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.persistence;
+
+import java.util.Collection;
+
+import org.apache.geode.distributed.internal.DistributionManager;
+import org.apache.geode.internal.cache.persistence.PersistentStateQueryMessage.PersistentStateQueryReplyProcessor;
+
+class PersistentStateQueryMessageSenderFactory {
+
+  PersistentStateQueryReplyProcessor createPersistentStateQueryReplyProcessor(
+      DistributionManager dm, Collection initMembers) {
+    return new PersistentStateQueryReplyProcessor(dm, initMembers);
+  }
+
+  PersistentStateQueryMessage createPersistentStateQueryMessage(String regionPath,
+      PersistentMemberID persistentId, PersistentMemberID initializingId, int processorId) {
+    return new PersistentStateQueryMessage(regionPath, persistentId, initializingId, processorId);
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/PersistentStateQueryResults.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/PersistentStateQueryResults.java
@@ -26,15 +26,15 @@ import org.apache.geode.distributed.internal.membership.InternalDistributedMembe
  *
  */
 class PersistentStateQueryResults {
-  public final Map<InternalDistributedMember, PersistentMemberState> stateOnPeers =
+  private final Map<InternalDistributedMember, PersistentMemberState> stateOnPeers =
       new HashMap<InternalDistributedMember, PersistentMemberState>();
-  public final Map<InternalDistributedMember, PersistentMemberID> initializingIds =
+  private final Map<InternalDistributedMember, PersistentMemberID> initializingIds =
       new HashMap<InternalDistributedMember, PersistentMemberID>();
-  public final Map<InternalDistributedMember, PersistentMemberID> persistentIds =
+  private final Map<InternalDistributedMember, PersistentMemberID> persistentIds =
       new HashMap<InternalDistributedMember, PersistentMemberID>();
-  public final Map<InternalDistributedMember, Set<PersistentMemberID>> onlineMemberMap =
+  private final Map<InternalDistributedMember, Set<PersistentMemberID>> onlineMemberMap =
       new HashMap<InternalDistributedMember, Set<PersistentMemberID>>();
-  public final Map<InternalDistributedMember, DiskStoreID> diskStoreIds =
+  private final Map<InternalDistributedMember, DiskStoreID> diskStoreIds =
       new HashMap<InternalDistributedMember, DiskStoreID>();
 
   public synchronized void addResult(PersistentMemberState persistedStateOfPeer,
@@ -56,4 +56,23 @@ class PersistentStateQueryResults {
     }
   }
 
+  Map<InternalDistributedMember, PersistentMemberState> getStateOnPeers() {
+    return stateOnPeers;
+  }
+
+  Map<InternalDistributedMember, PersistentMemberID> getInitializingIds() {
+    return initializingIds;
+  }
+
+  Map<InternalDistributedMember, PersistentMemberID> getPersistentIds() {
+    return persistentIds;
+  }
+
+  Map<InternalDistributedMember, Set<PersistentMemberID>> getOnlineMemberMap() {
+    return onlineMemberMap;
+  }
+
+  Map<InternalDistributedMember, DiskStoreID> getDiskStoreIds() {
+    return diskStoreIds;
+  }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/sequencelog/RegionLogger.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/sequencelog/RegionLogger.java
@@ -41,7 +41,7 @@ public class RegionLogger {
     GRAPH_LOGGER.logTransition(GraphType.REGION, regionName, "GII", "created", source, dest);
     if (persistentMemberID != null) {
       GRAPH_LOGGER.logTransition(GraphType.REGION, regionName, "persist", "persisted", dest,
-          persistentMemberID.diskStoreId);
+          persistentMemberID.getDiskStoreId());
     }
   }
 
@@ -51,7 +51,7 @@ public class RegionLogger {
   public static void logPersistence(String regionName, InternalDistributedMember source,
       PersistentMemberID disk) {
     GRAPH_LOGGER.logTransition(GraphType.REGION, regionName, "persist", "persisted", source,
-        disk.diskStoreId);
+        disk.getDiskStoreId());
   }
 
   /**
@@ -59,7 +59,8 @@ public class RegionLogger {
    */
   public static void logRecovery(String regionName, PersistentMemberID disk,
       InternalDistributedMember memberId) {
-    GRAPH_LOGGER.logTransition(GraphType.REGION, regionName, "recover", "created", disk.diskStoreId,
+    GRAPH_LOGGER.logTransition(GraphType.REGION, regionName, "recover", "created",
+        disk.getDiskStoreId(),
         memberId);
 
   }
@@ -74,9 +75,9 @@ public class RegionLogger {
           memberId);
       if (!isClose && persistentID != null) {
         GRAPH_LOGGER.logTransition(GraphType.REGION, regionName, "destroy", "destroyed", memberId,
-            persistentID.diskStoreId);
+            persistentID.getDiskStoreId());
         GRAPH_LOGGER.logTransition(GraphType.KEY, ALL_REGION_KEYS, "destroy", "destroyed", memberId,
-            persistentID.diskStoreId);
+            persistentID.getDiskStoreId());
       }
     }
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/util/TransformUtils.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/util/TransformUtils.java
@@ -60,28 +60,28 @@ public class TransformUtils {
           StringBuilder builder = new StringBuilder();
 
           if (null != memberId) {
-            if (null != memberId.diskStoreId) {
+            if (null != memberId.getDiskStoreId()) {
               builder.append("\n  DiskStore ID: ");
-              builder.append(memberId.diskStoreId.toUUID().toString());
+              builder.append(memberId.getDiskStoreId().toUUID().toString());
             }
 
-            if (null != memberId.name) {
+            if (null != memberId.getName()) {
               builder.append("\n  Name: ");
-              builder.append(memberId.name);
+              builder.append(memberId.getName());
             }
 
-            if ((null != memberId.host) && (null != memberId.directory)) {
+            if ((null != memberId.getHost()) && (null != memberId.getDirectory())) {
               builder.append("\n  Location: ");
             }
 
-            if (null != memberId.host) {
+            if (null != memberId.getHost()) {
               builder.append("/");
-              builder.append(memberId.host.getHostAddress());
+              builder.append(memberId.getHost().getHostAddress());
               builder.append(":");
             }
 
-            if (null != memberId.directory) {
-              builder.append(memberId.directory);
+            if (null != memberId.getDirectory()) {
+              builder.append(memberId.getDirectory());
             }
 
             builder.append("\n");

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/persistence/PersistenceAdvisorImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/persistence/PersistenceAdvisorImplTest.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
+import org.apache.geode.internal.cache.CacheDistributionAdvisor;
+import org.apache.geode.internal.cache.DiskRegion;
+import org.apache.geode.internal.cache.persistence.PersistentStateQueryMessage.PersistentStateQueryReplyProcessor;
+import org.apache.geode.test.junit.categories.UnitTest;
+
+@Category(UnitTest.class)
+public class PersistenceAdvisorImplTest {
+
+  public static final long TIME_STAMP_1 = 1530300988488L;
+  public static final long TIME_STAMP_2 = 1530301340401L;
+  public static final long TIME_STAMP_3 = 1530301598541L;
+  public static final long TIME_STAMP_4 = 1530301598616L;
+  private CacheDistributionAdvisor cacheDistributionAdvisor;
+  private PersistentMemberView persistentMemberView;
+  private PersistentStateQueryMessageSenderFactory persistentStateQueryMessageSenderFactory;
+  private PersistentStateQueryMessage persistentStateQueryMessage;
+  private PersistentStateQueryResults persistentStateQueryResults;
+
+  private PersistenceAdvisorImpl persistenceAdvisorImpl;
+
+  private int diskStoreIDIndex = 92837487; // some random number
+
+  @Before
+  public void setUp() throws Exception {
+    cacheDistributionAdvisor = mock(CacheDistributionAdvisor.class);
+    persistentMemberView = mock(DiskRegion.class);
+    persistentStateQueryMessageSenderFactory = mock(PersistentStateQueryMessageSenderFactory.class);
+    persistentStateQueryMessage = mock(PersistentStateQueryMessage.class);
+    persistentStateQueryResults = mock(PersistentStateQueryResults.class);
+
+    when(persistentStateQueryMessageSenderFactory.createPersistentStateQueryReplyProcessor(any(),
+        any())).thenReturn(mock(PersistentStateQueryReplyProcessor.class));
+    when(persistentStateQueryMessageSenderFactory.createPersistentStateQueryMessage(any(), any(),
+        any(), anyInt())).thenReturn(persistentStateQueryMessage);
+    when(persistentStateQueryMessage.send(any(), any(), any()))
+        .thenReturn(persistentStateQueryResults);
+
+    persistenceAdvisorImpl =
+        new PersistenceAdvisorImpl(cacheDistributionAdvisor, null, persistentMemberView, null, null,
+            null, persistentStateQueryMessageSenderFactory);
+  }
+
+  /**
+   * GEODE-5402: This test creates a scenario where a member has two versions (based on timeStamp)
+   * of another member. The call to getMembersToWaitFor should return that we wait for neither of
+   * them.
+   */
+  @Test
+  public void getMembersToWaitForRemovesAllMembersWhenDiskStoreListedTwice() {
+    DiskStoreID diskStoreID = getNewDiskStoreID();
+    InternalDistributedMember member = createInternalDistributedMember();
+
+    Set<PersistentMemberID> previouslyOnlineMembers = new HashSet<>();
+    Map<InternalDistributedMember, PersistentMemberState> stateOnPeers = new HashMap<>();
+    Map<InternalDistributedMember, PersistentMemberID> persistentIds = new HashMap<>();
+    Map<InternalDistributedMember, PersistentMemberID> initializingIds = new HashMap<>();
+    Map<InternalDistributedMember, DiskStoreID> diskStoreIds = new HashMap<>();
+
+    previouslyOnlineMembers.add(createPersistentMemberID(diskStoreID, TIME_STAMP_1));
+    previouslyOnlineMembers.add(createPersistentMemberID(diskStoreID, TIME_STAMP_3));
+
+    stateOnPeers.put(member, PersistentMemberState.ONLINE);
+    persistentIds.put(member, createPersistentMemberID(diskStoreID, TIME_STAMP_2));
+    initializingIds.put(member, createPersistentMemberID(diskStoreID, TIME_STAMP_3));
+    diskStoreIds.put(member, diskStoreID);
+
+    when(cacheDistributionAdvisor.adviseGeneric()).thenReturn(createMemberSet(member));
+    when(persistentMemberView.getMyPersistentID())
+        .thenReturn(createPersistentMemberID(getNewDiskStoreID(),
+            TIME_STAMP_4));
+    when(persistentStateQueryResults.getDiskStoreIds()).thenReturn(diskStoreIds);
+    when(persistentStateQueryResults.getInitializingIds()).thenReturn(initializingIds);
+    when(persistentStateQueryResults.getPersistentIds()).thenReturn(persistentIds);
+    when(persistentStateQueryResults.getStateOnPeers()).thenReturn(stateOnPeers);
+
+    Set<PersistentMemberID> membersToWaitFor =
+        persistenceAdvisorImpl.getMembersToWaitFor(previouslyOnlineMembers, new HashSet<>());
+
+    assertThat(membersToWaitFor).isEmpty();
+  }
+
+  private Set<InternalDistributedMember> createMemberSet(InternalDistributedMember... member) {
+    Set<InternalDistributedMember> members = new HashSet<>();
+    members.addAll(Arrays.asList(member));
+    return members;
+  }
+
+  private PersistentMemberID createPersistentMemberID(DiskStoreID diskStoreID, long timeStamp) {
+    return new PersistentMemberID(diskStoreID, null, null, timeStamp, (short) 0);
+  }
+
+  private InternalDistributedMember createInternalDistributedMember() {
+    return mock(InternalDistributedMember.class);
+  }
+
+  private DiskStoreID getNewDiskStoreID() {
+    UUID uuid = new UUID(diskStoreIDIndex++, diskStoreIDIndex++);
+    return new DiskStoreID(uuid);
+  }
+}


### PR DESCRIPTION
Disk recovery can hang when every member is waiting for other members to recover first and no member will proceed. 

When the last known state of a member is written to the oplogs and the member is killed before the older state of the member is removed from the oplogs, then on recovery there is more than one state for a persistent member. Recovery was stuck waiting for the persistent member with the older timestamp.

There are 3 changes:
1) In PersistenceAdvisorImpl make equalMembers thread safe by making it a CopyOnWriteHashSet.
2) If a remote member is initializing and the current member believes the remote member should wait for the current member, then the current member removes the remote member from the set of members to wait for.
3) If the set of members to wait for contains multiple entries of the same persistent member but with different timestamps, remove the entries with the older timestamps from the set of members to wait for, leaving only the most recent.