### PR TITLE
GEODE-1703: Lengthened a timeout to fix a flakey test.

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/persistence/PersistentRecoveryOrderDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/persistence/PersistentRecoveryOrderDUnitTest.java
@@ -88,7 +88,6 @@ import org.apache.geode.test.dunit.SerializableRunnable;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.Wait;
 import org.apache.geode.test.dunit.WaitCriterion;
-import org.apache.geode.test.junit.categories.FlakyTest;
 import org.apache.geode.test.junit.categories.PersistenceTest;
 
 /**
@@ -1264,7 +1263,6 @@ public class PersistentRecoveryOrderDUnitTest extends PersistentReplicatedTestBa
     });
   }
 
-  @Category(FlakyTest.class) // GEODE-1703: fails assertion: Region not created within30000
   @Test
   public void testCrashDuringPreparePersistentId() throws Exception {
     Host host = Host.getHost(0);

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/persistence/PersistentReplicatedTestBase.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/persistence/PersistentReplicatedTestBase.java
@@ -41,7 +41,7 @@ import org.apache.geode.test.dunit.cache.internal.JUnit4CacheTestCase;
 
 public abstract class PersistentReplicatedTestBase extends JUnit4CacheTestCase {
 
-  protected static final int MAX_WAIT = 30 * 1000;
+  protected static final int MAX_WAIT = 60 * 1000;
   protected static String REGION_NAME = "region";
   protected File diskDir;
   protected static String SAVED_ACK_WAIT_THRESHOLD;
@@ -180,7 +180,7 @@ public abstract class PersistentReplicatedTestBase extends JUnit4CacheTestCase {
       fail("Region not created within" + MAX_WAIT);
     }
     if (!future.isAlive() && wait) {
-      fail("Did not expecte region creation to complete");
+      fail("Did not expect region creation to complete");
     }
     if (!wait && future.exceptionOccurred()) {
       throw new RuntimeException(future.getException());


### PR DESCRIPTION
The test was not allowing enough time to wait in in some circumstances.
Doubled the time to ensure there is enough the next time and with GC etc.

Co-authored-by: Finn Southerland <fsoutherland@pivotal.io>
Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
