### PR TITLE
GEODE-5428: Fix test and cleanup of warnings.

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/ClientServerMiscDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/ClientServerMiscDUnitTest.java
@@ -760,8 +760,8 @@ public class ClientServerMiscDUnitTest extends JUnit4CacheTestCase {
     prop.setProperty(LOCATORS, "");
     ds = getSystem(prop);
 
-    final Cache cache2 = getCache();
-    assertNotNull(cache2);
+    final Cache cacheForLamda = getCache();
+    assertNotNull(cacheForLamda);
 
     AttributesFactory factory1 = new AttributesFactory();
     factory1.setScope(Scope.DISTRIBUTED_ACK);
@@ -769,7 +769,7 @@ public class ClientServerMiscDUnitTest extends JUnit4CacheTestCase {
     factory1.setPoolName(p.getName());
 
     final RegionAttributes attrs1 = factory1.create();
-    assertThatThrownBy(() -> cache2.createRegion(REGION_NAME1, attrs1))
+    assertThatThrownBy(() -> cacheForLamda.createRegion(REGION_NAME1, attrs1))
         .isInstanceOfAny(IllegalStateException.class, DistributedSystemDisconnectedException.class);
   }
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/ClientServerMiscDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/ClientServerMiscDUnitTest.java
@@ -28,7 +28,6 @@ import static org.junit.Assert.fail;
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -84,7 +83,6 @@ import org.apache.geode.test.dunit.IgnoredException;
 import org.apache.geode.test.dunit.NetworkUtils;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.Wait;
-import org.apache.geode.test.dunit.WaitCriterion;
 import org.apache.geode.test.dunit.cache.internal.JUnit4CacheTestCase;
 import org.apache.geode.test.dunit.standalone.VersionManager;
 import org.apache.geode.test.junit.categories.ClientServerTest;
@@ -771,7 +769,8 @@ public class ClientServerMiscDUnitTest extends JUnit4CacheTestCase {
     factory1.setPoolName(p.getName());
 
     final RegionAttributes attrs1 = factory1.create();
-    assertThatThrownBy(() -> cache2.createRegion(REGION_NAME1, attrs1)).isInstanceOfAny(IllegalStateException.class, DistributedSystemDisconnectedException.class);
+    assertThatThrownBy(() -> cache2.createRegion(REGION_NAME1, attrs1))
+        .isInstanceOfAny(IllegalStateException.class, DistributedSystemDisconnectedException.class);
   }
 
   @Test(expected = GemFireConfigException.class)

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/ClientServerMiscDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/ClientServerMiscDUnitTest.java
@@ -16,6 +16,7 @@ package org.apache.geode.internal.cache.tier.sockets;
 
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -76,11 +77,10 @@ import org.apache.geode.internal.cache.CacheServerImpl;
 import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.cache.LocalRegion;
 import org.apache.geode.internal.cache.ha.ThreadIdentifier;
-import org.apache.geode.test.dunit.Assert;
+import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.test.dunit.DistributedTestUtils;
 import org.apache.geode.test.dunit.Host;
 import org.apache.geode.test.dunit.IgnoredException;
-import org.apache.geode.test.dunit.LogWriterUtils;
 import org.apache.geode.test.dunit.NetworkUtils;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.Wait;
@@ -171,14 +171,14 @@ public class ClientServerMiscDUnitTest extends JUnit4CacheTestCase {
   public void testConcurrentOperationsWithDRandPR() {
     int port1 = initServerCache(true); // vm0
     int port2 = initServerCache2(); // vm1
-    String serverName = NetworkUtils.getServerHostName(Host.getHost(0));
+    String serverName = NetworkUtils.getServerHostName();
     host.getVM(testVersion, 0).invoke(() -> createClientCacheV(serverName, port1));
     host.getVM(testVersion, 1).invoke(() -> createClientCacheV(serverName, port2));
-    LogWriterUtils.getLogWriter()
+    LogService.getLogger()
         .info("Testing concurrent map operations from a client with a distributed region");
     concurrentMapTest(host.getVM(testVersion, 0), "/" + REGION_NAME1);
     // TODO add verification in vm1
-    LogWriterUtils.getLogWriter()
+    LogService.getLogger()
         .info("Testing concurrent map operations from a client with a partitioned region");
     concurrentMapTest(host.getVM(testVersion, 0), "/" + PR_REGION_NAME);
     // TODO add verification in vm1
@@ -196,7 +196,7 @@ public class ClientServerMiscDUnitTest extends JUnit4CacheTestCase {
     VM clientVM = Host.getHost(0).getVM(testVersion, 0);
 
     final int port = initServerCache(true);
-    final String host = NetworkUtils.getServerHostName(server1.getHost());
+    final String host = NetworkUtils.getServerHostName();
 
     clientVM.invoke("create client cache and verify", () -> {
       createClientCacheAndVerifyPingIntervalIsSet(host, port);
@@ -237,14 +237,14 @@ public class ClientServerMiscDUnitTest extends JUnit4CacheTestCase {
   public void testConcurrentOperationsWithDRandPRandEmptyClient() {
     int port1 = initServerCache(true); // vm0
     int port2 = initServerCache2(); // vm1
-    String serverName = NetworkUtils.getServerHostName(Host.getHost(0));
+    String serverName = NetworkUtils.getServerHostName();
     host.getVM(testVersion, 0).invoke(() -> createEmptyClientCache(serverName, port1));
     host.getVM(testVersion, 1).invoke(() -> createClientCacheV(serverName, port2));
-    LogWriterUtils.getLogWriter()
+    LogService.getLogger()
         .info("Testing concurrent map operations from a client with a distributed region");
     concurrentMapTest(host.getVM(testVersion, 0), "/" + REGION_NAME1);
     // TODO add verification in vm1
-    LogWriterUtils.getLogWriter()
+    LogService.getLogger()
         .info("Testing concurrent map operations from a client with a partitioned region");
     concurrentMapTest(host.getVM(testVersion, 0), "/" + PR_REGION_NAME);
     // TODO add verification in vm1
@@ -359,7 +359,7 @@ public class ClientServerMiscDUnitTest extends JUnit4CacheTestCase {
         for (int i = putRange_1Start; i <= putRange_1End; i++) {
           boolean removeResult = pr.remove(Integer.toString(i), "twice replaced" + i);
           assertTrue("for i=" + i, removeResult);
-          assertEquals("for i=" + i, null, pr.get(Integer.toString(i)));
+          assertNull("for i=" + i, pr.get(Integer.toString(i)));
         }
         if (!isEmpty) {
           size = pr.size();
@@ -403,18 +403,12 @@ public class ClientServerMiscDUnitTest extends JUnit4CacheTestCase {
         assertTrue(pr.replace("keyForNull", null, "no longer invalid"));
 
         // replace does not allow null value for new value
-        try {
-          pr.replace("keyForNull", "no longer invalid", null);
-          fail("expected a NullPointerException");
-        } catch (NullPointerException expected) {
-        }
+        assertThatThrownBy(() -> pr.replace("keyForNull", "no longer invalid", null))
+            .isExactlyInstanceOf(NullPointerException.class);
 
         // other variant of replace does not allow null value for new value
-        try {
-          pr.replace("keyForNull", null);
-          fail("expected a NullPointerException");
-        } catch (NullPointerException expected) {
-        }
+        assertThatThrownBy(() -> pr.replace("keyForNull", null))
+            .isExactlyInstanceOf(NullPointerException.class);
 
         // replace with null oldvalue matches invalidated entry
         pr.putIfAbsent("otherKeyForNull", null);
@@ -422,7 +416,7 @@ public class ClientServerMiscDUnitTest extends JUnit4CacheTestCase {
         boolean success = pr.replace("otherKeyForNull", null, "no longer invalid");
         assertTrue(success);
         int newputs = ((GemFireCacheImpl) pr.getCache()).getCachePerfStats().getPuts();
-        assertTrue("stats not updated properly or replace malfunctioned", newputs == puts + 1);
+        assertEquals("stats not updated properly or replace malfunctioned", newputs, puts + 1);
 
       }
     });
@@ -435,12 +429,12 @@ public class ClientServerMiscDUnitTest extends JUnit4CacheTestCase {
    * update.
    */
   @Test
-  public void testForTwoRegionHavingDifferentInterestList() throws Exception {
+  public void testForTwoRegionHavingDifferentInterestList() {
     // start server first
     PORT1 = initServerCache(true);
     int serverPort = PORT1;
     VM client1 = Host.getHost(0).getVM(testVersion, 1);
-    String hostname = NetworkUtils.getServerHostName(Host.getHost(0));
+    String hostname = NetworkUtils.getServerHostName();
     client1.invoke("create client1 cache", () -> {
       createClientCache(hostname, serverPort);
       populateCache();
@@ -464,7 +458,7 @@ public class ClientServerMiscDUnitTest extends JUnit4CacheTestCase {
   public void testForTwoRegionHavingALLKEYSInterest() throws Exception {
     // start server first
     PORT1 = initServerCache(true);
-    createClientCache(NetworkUtils.getServerHostName(Host.getHost(0)), PORT1);
+    createClientCache(NetworkUtils.getServerHostName(), PORT1);
     populateCache();
     registerInterestInBothTheRegions();
     closeRegion1();
@@ -485,14 +479,14 @@ public class ClientServerMiscDUnitTest extends JUnit4CacheTestCase {
   public void testRegionClose() throws Exception {
     // start server first
     PORT1 = initServerCache(true);
-    pool = (PoolImpl) createClientCache(NetworkUtils.getServerHostName(Host.getHost(0)), PORT1);
+    pool = (PoolImpl) createClientCache(NetworkUtils.getServerHostName(), PORT1);
     populateCache();
     registerInterestInBothTheRegions();
     closeBothRegions();
 
-    assertEquals(false, pool.isDestroyed());
+    assertFalse(pool.isDestroyed());
     pool.destroy();
-    assertEquals(true, pool.isDestroyed());
+    assertTrue(pool.isDestroyed());
     server1.invoke(() -> ClientServerMiscDUnitTest.verifyNoCacheClientProxyOnServer());
 
   }
@@ -509,28 +503,26 @@ public class ClientServerMiscDUnitTest extends JUnit4CacheTestCase {
   public void testCCPDestroyOnLastDestroyRegion() throws Exception {
     PORT1 = initServerCache(true);
     PoolImpl pool =
-        (PoolImpl) createClientCache(NetworkUtils.getServerHostName(Host.getHost(0)), PORT1);
+        (PoolImpl) createClientCache(NetworkUtils.getServerHostName(), PORT1);
     destroyRegion1();
     // pause(5000);
     server1.invoke(
-        () -> ClientServerMiscDUnitTest.verifyCacheClientProxyOnServer(new String(REGION_NAME1)));
+        () -> ClientServerMiscDUnitTest.verifyCacheClientProxyOnServer(REGION_NAME1));
     Connection conn = pool.acquireConnection();
     assertNotNull(conn);
     assertEquals(1, pool.getConnectedServerCount());
-    assertEquals(false, pool.isDestroyed());
+    assertFalse(pool.isDestroyed());
     destroyRegion2();
-    assertEquals(false, pool.isDestroyed());
+    assertFalse(pool.isDestroyed());
     destroyPRRegion();
-    assertEquals(false, pool.isDestroyed());
+    assertFalse(pool.isDestroyed());
     pool.destroy();
-    assertEquals(true, pool.isDestroyed());
+    assertTrue(pool.isDestroyed());
     // pause(5000);
     server1.invoke(() -> ClientServerMiscDUnitTest.verifyNoCacheClientProxyOnServer());
-    try {
-      getCache().createRegion(REGION_NAME2, attrs);
-      fail("expected IllegalStateException");
-    } catch (IllegalStateException expected) {
-    }
+
+    assertThatThrownBy(() -> getCache().createRegion(REGION_NAME2, attrs))
+        .isExactlyInstanceOf(IllegalStateException.class);
   }
 
   /**
@@ -542,7 +534,7 @@ public class ClientServerMiscDUnitTest extends JUnit4CacheTestCase {
   public void testInvalidatesPropagateOnTwoRegions() throws Exception {
     // start server first
     PORT1 = initServerCache(false);
-    createClientCache(NetworkUtils.getServerHostName(Host.getHost(0)), PORT1);
+    createClientCache(NetworkUtils.getServerHostName(), PORT1);
     registerInterestForInvalidatesInBothTheRegions();
     populateCache();
     server1.invoke(() -> ClientServerMiscDUnitTest.put());
@@ -561,7 +553,7 @@ public class ClientServerMiscDUnitTest extends JUnit4CacheTestCase {
   public void testGetInClientCreatesEntry() throws Exception {
     // start server first
     PORT1 = initServerCache(false);
-    createClientCache(NetworkUtils.getServerHostName(Host.getHost(0)), PORT1);
+    createClientCache(NetworkUtils.getServerHostName(), PORT1);
     registerInterestForInvalidatesInBothTheRegions();
     Region region = static_cache.getRegion(REGION_NAME1);
     populateCache();
@@ -595,7 +587,7 @@ public class ClientServerMiscDUnitTest extends JUnit4CacheTestCase {
   @Test
   public void testLargeMessageIsRejected() throws Exception {
     PORT1 = initServerCache(false);
-    createClientCache(NetworkUtils.getServerHostName(Host.getHost(0)), PORT1);
+    createClientCache(NetworkUtils.getServerHostName(), PORT1);
     Region region = static_cache.getRegion(REGION_NAME1);
     Op operation = new Op() {
       @Override
@@ -623,14 +615,14 @@ public class ClientServerMiscDUnitTest extends JUnit4CacheTestCase {
    * server. Update the entries on server the client. The client should not have entry invalidate.
    */
   @Test
-  public void testInvalidatesPropagateOnRegionHavingNoPool() throws Exception {
+  public void testInvalidatesPropagateOnRegionHavingNoPool() {
     // start server first
     PORT1 = initServerCache(false);
     Properties props = new Properties();
     props.setProperty(MCAST_PORT, "0");
     props.setProperty(LOCATORS, "");
     new ClientServerMiscDUnitTest().createCache(props);
-    String host = NetworkUtils.getServerHostName(server1.getHost());
+    String host = NetworkUtils.getServerHostName();
     PoolImpl p =
         (PoolImpl) PoolManager.createFactory().addServer(host, PORT1).setSubscriptionEnabled(true)
             .setThreadLocalConnections(true).setReadTimeout(1000).setSocketBufferSize(32768)
@@ -687,7 +679,7 @@ public class ClientServerMiscDUnitTest extends JUnit4CacheTestCase {
    */
 
   @Test
-  public void testProxyCreationBeforeCacheCreation() throws Exception {
+  public void testProxyCreationBeforeCacheCreation() {
     Properties props = new Properties();
     props.setProperty(MCAST_PORT, "0");
     props.setProperty(LOCATORS, "");
@@ -696,7 +688,7 @@ public class ClientServerMiscDUnitTest extends JUnit4CacheTestCase {
     ds.disconnect();
     ds = getSystem(props);
     PORT1 = initServerCache(true);
-    String host = NetworkUtils.getServerHostName(server1.getHost());
+    String host = NetworkUtils.getServerHostName();
     Pool p = PoolManager.createFactory().addServer(host, PORT1).setSubscriptionEnabled(true)
         .setSubscriptionRedundancy(-1)
         // .setRetryAttempts(5)
@@ -734,7 +726,7 @@ public class ClientServerMiscDUnitTest extends JUnit4CacheTestCase {
    *
    */
   @Test
-  public void testSystemCanBeCycledWithAnInitializedPool() throws Exception {
+  public void testSystemCanBeCycledWithAnInitializedPool() {
     // work around GEODE-477
     IgnoredException.addIgnoredException("Connection reset");
     Properties props = new Properties();
@@ -744,7 +736,7 @@ public class ClientServerMiscDUnitTest extends JUnit4CacheTestCase {
     assertNotNull(ds);
 
     PORT1 = initServerCache(true);
-    String host = NetworkUtils.getServerHostName(server1.getHost());
+    String host = NetworkUtils.getServerHostName();
     Pool p = PoolManager.createFactory().addServer(host, PORT1).setSubscriptionEnabled(true)
         .setSubscriptionRedundancy(-1)
         // .setRetryAttempts(5)
@@ -770,25 +762,20 @@ public class ClientServerMiscDUnitTest extends JUnit4CacheTestCase {
     prop.setProperty(LOCATORS, "");
     ds = getSystem(prop);
 
-    cache = getCache();
-    assertNotNull(cache);
+    final Cache cache2 = getCache();
+    assertNotNull(cache2);
 
     AttributesFactory factory1 = new AttributesFactory();
     factory1.setScope(Scope.DISTRIBUTED_ACK);
     // reuse writer from prev DS
     factory1.setPoolName(p.getName());
 
-    RegionAttributes attrs1 = factory1.create();
-    try {
-      cache.createRegion(REGION_NAME1, attrs1);
-      fail("expected ShutdownException");
-    } catch (IllegalStateException expected) {
-    } catch (DistributedSystemDisconnectedException expected) {
-    }
+    final RegionAttributes attrs1 = factory1.create();
+    assertThatThrownBy(() -> cache2.createRegion(REGION_NAME1, attrs1)).isInstanceOfAny(IllegalStateException.class, DistributedSystemDisconnectedException.class);
   }
 
   @Test(expected = GemFireConfigException.class)
-  public void clientIsPreventedFromConnectingToLocatorAsServer() throws Exception {
+  public void clientIsPreventedFromConnectingToLocatorAsServer() {
     IgnoredException.addIgnoredException("Improperly configured client detected");
     ClientCacheFactory clientCacheFactory = new ClientCacheFactory();
     clientCacheFactory.addPoolServer("localhost", DistributedTestUtils.getDUnitLocatorPort());
@@ -800,11 +787,11 @@ public class ClientServerMiscDUnitTest extends JUnit4CacheTestCase {
   }
 
 
-  private void createCache(Properties props) throws Exception {
+  private void createCache(Properties props) {
     createCacheV(props);
   }
 
-  private Cache createCacheV(Properties props) throws Exception {
+  private Cache createCacheV(Properties props) {
     DistributedSystem ds = getSystem(props);
     assertNotNull(ds);
     ds.disconnect();
@@ -814,20 +801,20 @@ public class ClientServerMiscDUnitTest extends JUnit4CacheTestCase {
     return cache;
   }
 
-  public static void createClientCacheV(String h, int port) throws Exception {
+  public static void createClientCacheV(String h, int port) {
     _createClientCache(h, false, -1, port);
   }
 
-  public static void createEmptyClientCache(String h, int... ports) throws Exception {
+  public static void createEmptyClientCache(String h, int... ports) {
     _createClientCache(h, false, -1, ports);
   }
 
-  public static Pool createClientCache(String h, int... ports) throws Exception {
+  public static Pool createClientCache(String h, int... ports) {
     return _createClientCache(h, false, -1, ports);
   }
 
   public static Pool createClientCache(String h, int subscriptionAckInterval, boolean empty,
-      int... ports) throws Exception {
+      int... ports) {
     return _createClientCache(h, empty, subscriptionAckInterval, ports);
   }
 
@@ -839,7 +826,7 @@ public class ClientServerMiscDUnitTest extends JUnit4CacheTestCase {
   }
 
   public static Pool _createClientCache(String h, boolean empty, int subscriptionAckInterval,
-      int... ports) throws Exception {
+      int... ports) {
     Properties props = new Properties();
     props.setProperty(MCAST_PORT, "0");
     props.setProperty(LOCATORS, "");
@@ -884,10 +871,7 @@ public class ClientServerMiscDUnitTest extends JUnit4CacheTestCase {
     Awaitility.await().atMost(60, TimeUnit.SECONDS).pollInterval(1, TimeUnit.SECONDS).until(() -> {
       try {
         conn = pool.acquireConnection();
-        if (conn == null) {
-          return false;
-        }
-        return true;
+        return conn != null;
       } catch (NoAvailableServersException e) {
         return false;
       }
@@ -928,8 +912,8 @@ public class ClientServerMiscDUnitTest extends JUnit4CacheTestCase {
     PoolImpl pool = (PoolImpl) PoolManager.find("ClientServerMiscDUnitTestPool");
 
     Map seqMap = pool.getThreadIdToSequenceIdMap();
-    for (Iterator it = seqMap.keySet().iterator(); it.hasNext();) {
-      ThreadIdentifier tid = (ThreadIdentifier) it.next();
+    for (Object o : seqMap.keySet()) {
+      ThreadIdentifier tid = (ThreadIdentifier) o;
       byte[] memberBytes = tid.getMembershipID();
       dumpMemberId(tid, memberBytes);
     }
@@ -941,11 +925,10 @@ public class ClientServerMiscDUnitTest extends JUnit4CacheTestCase {
     ByteArrayInputStream bais = new ByteArrayInputStream(newBytes);
     DataInputStream dataIn = new DataInputStream(bais);
     InternalDistributedMember memberId = InternalDistributedMember.readEssentialData(dataIn);
-    StringBuilder sb = new StringBuilder(300);
-    sb.append('<').append(Thread.currentThread().getName()).append("> ").append(holder)
-        .append(" is ").append(memberId).append(" byte count = ").append(memberBytes.length)
-        .append(" bytes = ").append(Arrays.toString(memberBytes));
-    System.out.println(sb.toString());
+    String sb = "<" + Thread.currentThread().getName() + "> " + holder
+        + " is " + memberId + " byte count = " + memberBytes.length
+        + " bytes = " + Arrays.toString(memberBytes);
+    System.out.println(sb);
   }
 
 
@@ -978,12 +961,12 @@ public class ClientServerMiscDUnitTest extends JUnit4CacheTestCase {
     int port = AvailablePort.getRandomAvailablePort(AvailablePort.SOCKET);
     r1.getCache().getDistributedSystem().getLogWriter().info("Starting server on port " + port);
     server.setPort(port);
-    server.setMaxThreads(maxThreads.intValue());
-    server.setNotifyBySubscription(notifyBySubscription.booleanValue());
+    server.setMaxThreads(maxThreads);
+    server.setNotifyBySubscription(notifyBySubscription);
     server.start();
     r1.getCache().getDistributedSystem().getLogWriter()
         .info("Started server on port " + server.getPort());
-    return new Integer(server.getPort());
+    return server.getPort();
 
   }
 
@@ -991,7 +974,7 @@ public class ClientServerMiscDUnitTest extends JUnit4CacheTestCase {
     return 0;
   }
 
-  public static void registerInterest() throws Exception {
+  public static void registerInterest() {
     Cache cache = new ClientServerMiscDUnitTest().getCache();
     Region r = cache.getRegion(Region.SEPARATOR + REGION_NAME2);
     assertNotNull(r);
@@ -1010,7 +993,7 @@ public class ClientServerMiscDUnitTest extends JUnit4CacheTestCase {
       r2.registerInterest("ALL_KEYS", false, false);
     } catch (CacheWriterException e) {
       e.printStackTrace();
-      Assert.fail("Test failed due to CacheWriterException during registerInterestnBothRegions", e);
+      fail("Test failed due to CacheWriterException during registerInterestnBothRegions" + e);
     }
   }
 
@@ -1025,19 +1008,19 @@ public class ClientServerMiscDUnitTest extends JUnit4CacheTestCase {
       r2.registerInterestForAllKeys();
     } catch (CacheWriterException e) {
       e.printStackTrace();
-      Assert.fail("Test failed due to CacheWriterException during registerInterestnBothRegions", e);
+      fail("Test failed due to CacheWriterException during registerInterestnBothRegions" + e);
     }
   }
 
   private static void closeRegion1() {
     try {
       Cache cache = new ClientServerMiscDUnitTest().getCache();
-      Region r1 = cache.getRegion(Region.SEPARATOR + REGION_NAME1);
+      Region<String, String> r1 = cache.getRegion(Region.SEPARATOR + REGION_NAME1);
       assertNotNull(r1);
       r1.close();
     } catch (Exception e) {
       e.printStackTrace();
-      Assert.fail("Test failed due to Exception during closeRegion1", e);
+      fail("Test failed due to Exception during closeRegion1" + e);
     }
   }
 
@@ -1055,7 +1038,7 @@ public class ClientServerMiscDUnitTest extends JUnit4CacheTestCase {
       pr.close();
     } catch (Exception e) {
       e.printStackTrace();
-      Assert.fail("Test failed due to Exception during closeBothRegions", e);
+      fail("Test failed due to Exception during closeBothRegions" + e);
     }
   }
 
@@ -1067,7 +1050,7 @@ public class ClientServerMiscDUnitTest extends JUnit4CacheTestCase {
       r1.destroyRegion();
     } catch (Exception e) {
       e.printStackTrace();
-      Assert.fail("Test failed due to Exception during closeBothRegions", e);
+      fail("Test failed due to Exception during closeBothRegions" + e);
     }
   }
 
@@ -1079,7 +1062,7 @@ public class ClientServerMiscDUnitTest extends JUnit4CacheTestCase {
       r2.destroyRegion();
     } catch (Exception e) {
       e.printStackTrace();
-      Assert.fail("Test failed due to Exception during closeBothRegions", e);
+      fail("Test failed due to Exception during closeBothRegions" + e);
     }
   }
 
@@ -1091,7 +1074,7 @@ public class ClientServerMiscDUnitTest extends JUnit4CacheTestCase {
       r2.destroyRegion();
     } catch (Exception e) {
       // e.printStackTrace();
-      Assert.fail("Test failed due to Exception during closeBothRegions", e);
+      fail("Test failed due to Exception during closeBothRegions" + e);
     }
   }
 
@@ -1103,10 +1086,7 @@ public class ClientServerMiscDUnitTest extends JUnit4CacheTestCase {
       assertNotNull(bs);
       assertNotNull(bs.getAcceptor());
       assertNotNull(bs.getAcceptor().getCacheClientNotifier());
-      Iterator<CacheClientProxy> iter_prox =
-          bs.getAcceptor().getCacheClientNotifier().getClientProxies().iterator();
-      while (iter_prox.hasNext()) {
-        CacheClientProxy ccp = iter_prox.next();
+      for (CacheClientProxy ccp : bs.getAcceptor().getCacheClientNotifier().getClientProxies()) {
         // CCP should not contain region1
         Set<String> akr = ccp.cils[RegisterInterestTracker.interestListIndex].regions;
         assertNotNull(akr);
@@ -1267,82 +1247,20 @@ public class ClientServerMiscDUnitTest extends JUnit4CacheTestCase {
       assertNotNull(r1);
       assertNotNull(r2);
 
-      WaitCriterion wc = new WaitCriterion() {
-        String excuse;
+      Awaitility.waitAtMost(90, TimeUnit.SECONDS).pollInterval(1, TimeUnit.SECONDS)
+          .until(() -> r1.getEntry(k1).getValue() == null);
 
-        public boolean done() {
-          Object val = r1.getEntry(k1).getValue();
-          return val == null;
-        }
+      Awaitility.waitAtMost(90, TimeUnit.SECONDS).pollInterval(1, TimeUnit.SECONDS)
+          .until(() -> r1.getEntry(k2).getValue() == null);
 
-        public String description() {
-          return excuse;
-        }
-      };
-      Wait.waitForCriterion(wc, 90 * 1000, 1000, true);
+      Awaitility.waitAtMost(90, TimeUnit.SECONDS).pollInterval(1, TimeUnit.SECONDS)
+          .until(() -> r2.getEntry(k1).getValue() == null);
 
-      // assertNull(r1.getEntry(k1).getValue());
-      wc = new WaitCriterion() {
-        String excuse;
+      Awaitility.waitAtMost(90, TimeUnit.SECONDS).pollInterval(1, TimeUnit.SECONDS)
+          .until(() -> r2.getEntry(k2).getValue() == null);
 
-        public boolean done() {
-          Object val = r1.getEntry(k1).getValue();
-          return val == null;
-        }
-
-        public String description() {
-          return excuse;
-        }
-      };
-      Wait.waitForCriterion(wc, 90 * 1000, 1000, true);
-
-      // assertNull(r1.getEntry(k2).getValue());
-      wc = new WaitCriterion() {
-        String excuse;
-
-        public boolean done() {
-          Object val = r1.getEntry(k2).getValue();
-          return val == null;
-        }
-
-        public String description() {
-          return excuse;
-        }
-      };
-      Wait.waitForCriterion(wc, 90 * 1000, 1000, true);
-
-
-      // assertNull(r2.getEntry(k1).getValue());
-      wc = new WaitCriterion() {
-        String excuse;
-
-        public boolean done() {
-          Object val = r2.getEntry(k1).getValue();
-          return val == null;
-        }
-
-        public String description() {
-          return excuse;
-        }
-      };
-      Wait.waitForCriterion(wc, 90 * 1000, 1000, true);
-
-      // assertNull(r2.getEntry(k2).getValue());
-      wc = new WaitCriterion() {
-        String excuse;
-
-        public boolean done() {
-          Object val = r2.getEntry(k2).getValue();
-          return val == null;
-        }
-
-        public String description() {
-          return excuse;
-        }
-      };
-      Wait.waitForCriterion(wc, 90 * 1000, 1000, true);
     } catch (Exception ex) {
-      Assert.fail("failed while verifyInvalidatesOnBothRegions()", ex);
+      fail("failed while verifyInvalidatesOnBothRegions()" + ex);
     }
   }
 
@@ -1351,38 +1269,16 @@ public class ClientServerMiscDUnitTest extends JUnit4CacheTestCase {
       Cache cache = new ClientServerMiscDUnitTest().getCache();
       final Region r2 = cache.getRegion(Region.SEPARATOR + REGION_NAME2);
       assertNotNull(r2);
-      WaitCriterion wc = new WaitCriterion() {
-        String excuse;
 
-        public boolean done() {
-          Object val = r2.getEntry(k1).getValue();
-          return server_k1.equals(val);
-        }
+      Awaitility.waitAtMost(60, TimeUnit.SECONDS).pollInterval(1, TimeUnit.SECONDS)
+          .until(() -> server_k1.equals(r2.getEntry(k1).getValue()));
 
-        public String description() {
-          return excuse;
-        }
-      };
-      Wait.waitForCriterion(wc, 60 * 1000, 1000, true);
-
-      // assertIndexDetailsEquals(server_k1, r2.getEntry(k1).getValue());
-      wc = new WaitCriterion() {
-        String excuse;
-
-        public boolean done() {
-          Object val = r2.getEntry(k2).getValue();
-          return server_k2.equals(val);
-        }
-
-        public String description() {
-          return excuse;
-        }
-      };
-      Wait.waitForCriterion(wc, 60 * 1000, 1000, true);
+      Awaitility.waitAtMost(60, TimeUnit.SECONDS).pollInterval(1, TimeUnit.SECONDS)
+          .until(() -> server_k2.equals(r2.getEntry(k2).getValue()));
 
       // assertIndexDetailsEquals(server_k2, r2.getEntry(k2).getValue());
     } catch (Exception ex) {
-      Assert.fail("failed while verifyUpdatesOnRegion2()", ex);
+      fail("failed while verifyUpdatesOnRegion2()" + ex);
     }
   }
 
@@ -1418,7 +1314,7 @@ public class ClientServerMiscDUnitTest extends JUnit4CacheTestCase {
   private void testOnServerMethods(boolean isCachingProxy, boolean isHA) throws Exception {
     int port1 = initServerCache(true, isHA); // vm0
     int port2 = initServerCache2(isHA); // vm1
-    String serverName = NetworkUtils.getServerHostName(Host.getHost(0));
+    String serverName = NetworkUtils.getServerHostName();
     if (isCachingProxy) {
       createClientCache(serverName, port1, port2);
     } else {

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/tier/sockets/CacheServerTestUtil.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/tier/sockets/CacheServerTestUtil.java
@@ -483,7 +483,9 @@ public class CacheServerTestUtil extends JUnit4DistributedTestCase {
     return cache;
   }
 
-  public static ClientCache getClientCache() { return (ClientCache) cache; }
+  public static ClientCache getClientCache() {
+    return (ClientCache) cache;
+  }
 
   public static PoolImpl getPool() {
     return pool;

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/tier/sockets/CacheServerTestUtil.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/tier/sockets/CacheServerTestUtil.java
@@ -483,6 +483,8 @@ public class CacheServerTestUtil extends JUnit4DistributedTestCase {
     return cache;
   }
 
+  public static ClientCache getClientCache() { return (ClientCache) cache; }
+
   public static PoolImpl getPool() {
     return pool;
   }

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/EndpointManager.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/EndpointManager.java
@@ -65,7 +65,7 @@ public interface EndpointManager {
    *
    * @return a map of ServerLocation-> ConnectionStats
    */
-  Map getAllStats();
+  Map<ServerLocation, ConnectionStats> getAllStats();
 
   /**
    * Test hook that returns the number of servers we currently have connections to.

--- a/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientCrashDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientCrashDUnitTest.java
@@ -32,12 +32,12 @@ import org.apache.geode.test.junit.categories.ClientSubscriptionTest;
 public class DurableClientCrashDUnitTest extends DurableClientTestCase {
 
   @Override
-  protected final void postSetUpDurableClientTestCase() throws Exception {
+  protected final void postSetUpDurableClientTestCase() {
     configureClientStop1();
   }
 
   public void configureClientStop1() {
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.setClientCrash(new Boolean(true)));
+    this.durableClientVM.invoke(() -> CacheServerTestUtil.setClientCrash(Boolean.TRUE));
   }
 
   @Override
@@ -46,7 +46,7 @@ public class DurableClientCrashDUnitTest extends DurableClientTestCase {
   }
 
   public void configureClientStop2() {
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.setClientCrash(new Boolean(false)));
+    this.durableClientVM.invoke(() -> CacheServerTestUtil.setClientCrash(Boolean.FALSE));
   }
 
   @Override

--- a/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientSimpleDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientSimpleDUnitTest.java
@@ -1238,13 +1238,13 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
           @Override
           public void run2() throws CacheException {
             PoolImpl.BEFORE_SENDING_CLIENT_ACK_CALLBACK_FLAG = true;
-                ClientServerObserverHolder.setInstance(new ClientServerObserverAdapter() {
-                  @Override
-                  public void beforeSendingClientAck() {
-                    LogWriterUtils.getLogWriter().info("beforeSendingClientAck invoked");
+            ClientServerObserverHolder.setInstance(new ClientServerObserverAdapter() {
+              @Override
+              public void beforeSendingClientAck() {
+                LogWriterUtils.getLogWriter().info("beforeSendingClientAck invoked");
 
-                  }
-                });
+              }
+            });
 
           }
         };
@@ -2861,8 +2861,8 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
         public void run2() throws CacheException {
           Awaitility.waitAtMost(10, TimeUnit.SECONDS).pollInterval(200, TimeUnit.MILLISECONDS)
               .until(() -> CacheClientProxy.testHook != null
-              && (((RejectClientReconnectTestHook) CacheClientProxy.testHook)
-              .wasClientRejected()));
+                  && (((RejectClientReconnectTestHook) CacheClientProxy.testHook)
+                      .wasClientRejected()));
           assertTrue(
               ((RejectClientReconnectTestHook) CacheClientProxy.testHook).wasClientRejected());
         }
@@ -3429,11 +3429,11 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
   public void testGetAllDurableCqsFromServer() {
     // Start server 1
     final int server1Port = this.server1VM.invoke(CacheServerTestUtil.class,
-        "createCacheServer", new Object[]{regionName, Boolean.TRUE});
+        "createCacheServer", new Object[] {regionName, Boolean.TRUE});
 
     // Start server 2
     final int server2Port = this.server2VM.invoke(CacheServerTestUtil.class,
-        "createCacheServer", new Object[]{regionName, Boolean.TRUE});
+        "createCacheServer", new Object[] {regionName, Boolean.TRUE});
 
     // Start a durable client
     final String durableClientId = getName() + "_client";

--- a/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientSimpleDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientSimpleDUnitTest.java
@@ -18,10 +18,10 @@ import static org.apache.geode.internal.cache.tier.sockets.CacheServerTestUtil.T
 import static org.apache.geode.test.dunit.Assert.fail;
 import static org.apache.geode.test.dunit.NetworkUtils.getServerHostName;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -51,20 +51,18 @@ import org.apache.geode.cache.query.RegionNotFoundException;
 import org.apache.geode.cache30.CacheSerializableRunnable;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.ServerLocation;
-import org.apache.geode.internal.cache.ClientServerObserver;
 import org.apache.geode.internal.cache.ClientServerObserverAdapter;
 import org.apache.geode.internal.cache.ClientServerObserverHolder;
 import org.apache.geode.internal.cache.PoolFactoryImpl;
 import org.apache.geode.internal.cache.ha.HARegionQueue;
 import org.apache.geode.internal.cache.ha.HARegionQueueStats;
 import org.apache.geode.internal.i18n.LocalizedStrings;
-import org.apache.geode.test.dunit.Assert;
 import org.apache.geode.test.dunit.AsyncInvocation;
 import org.apache.geode.test.dunit.IgnoredException;
 import org.apache.geode.test.dunit.LogWriterUtils;
+import org.apache.geode.test.dunit.SerializableRunnableIF;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.Wait;
-import org.apache.geode.test.dunit.WaitCriterion;
 import org.apache.geode.test.junit.categories.ClientSubscriptionTest;
 
 @Category({ClientSubscriptionTest.class})
@@ -76,22 +74,21 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
   @Test
   public void testSimpleDurableClientUpdate() {
     // Start a server
-    int serverPort = ((Integer) this.server1VM
-        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, new Boolean(true))))
-            .intValue();
+    int serverPort = this.server1VM
+        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, Boolean.TRUE));
 
     // Start a durable client that is not kept alive on the server when it stops
     // normally
     final String durableClientId = getName() + "_client";
     this.durableClientVM.invoke(() -> CacheServerTestUtil.createCacheClient(
-        getClientPool(getServerHostName(durableClientVM.getHost()), serverPort, true), regionName,
+        getClientPool(getServerHostName(), serverPort, true), regionName,
         getClientDistributedSystemProperties(durableClientId), Boolean.TRUE));
 
     // Send clientReady message
     this.durableClientVM.invoke(new CacheSerializableRunnable("Send clientReady") {
       @Override
       public void run2() throws CacheException {
-        CacheServerTestUtil.getCache().readyForEvents();
+        CacheServerTestUtil.getClientCache().readyForEvents();
       }
     });
 
@@ -110,7 +107,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
 
     // Start normal publisher client
     this.publisherClientVM.invoke(() -> CacheServerTestUtil.createCacheClient(
-        getClientPool(getServerHostName(publisherClientVM.getHost()), serverPort, false),
+        getClientPool(getServerHostName(), serverPort, false),
         regionName));
 
     // Publish some entries
@@ -121,13 +118,13 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     verifyDurableClientEvents(this.durableClientVM, numberOfEntries);
 
     // Stop the durable client
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.durableClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the publisher client
-    this.publisherClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.publisherClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the server
-    this.server1VM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.server1VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
   }
 
   /**
@@ -136,9 +133,8 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
   @Test
   public void testMultipleBridgeClientsInSingleDurableVM() {
     // Start a server
-    int serverPort = ((Integer) this.server1VM
-        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, new Boolean(true))))
-            .intValue();
+    int serverPort = this.server1VM
+        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, Boolean.TRUE));
 
     // Start a durable client with 2 regions (and 2 BridgeClients) that is not
     // kept alive on the server when it stops normally
@@ -146,7 +142,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     final String regionName1 = regionName + "1";
     final String regionName2 = regionName + "2";
     this.durableClientVM.invoke(() -> CacheServerTestUtil.createCacheClients(
-        getClientPool(getServerHostName(durableClientVM.getHost()), serverPort, true), regionName1,
+        getClientPool(getServerHostName(), serverPort, true), regionName1,
         regionName2, getClientDistributedSystemProperties(durableClientId)));
 
     // Send clientReady message
@@ -154,7 +150,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
       @Override
       public void run2() throws CacheException {
         assertEquals(2, PoolManager.getAll().size());
-        CacheServerTestUtil.getCache().readyForEvents();
+        CacheServerTestUtil.getClientCache().readyForEvents();
       }
     });
 
@@ -168,8 +164,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
         // Iterate the CacheClientProxies
         checkNumberOfClientProxies(2);
         String firstProxyRegionName = null;
-        for (Iterator i = notifier.getClientProxies().iterator(); i.hasNext();) {
-          CacheClientProxy proxy = (CacheClientProxy) i.next();
+        for (CacheClientProxy proxy : notifier.getClientProxies()) {
           assertTrue(proxy.isDurable());
           assertEquals(durableClientId, proxy.getDurableId());
           assertEquals(DistributionConfig.DEFAULT_DURABLE_CLIENT_TIMEOUT,
@@ -186,7 +181,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     });
 
     // Stop the durable client
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.durableClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Verify the durable client is no longer on the server
     this.server1VM.invoke(new CacheSerializableRunnable("Verify durable client") {
@@ -198,7 +193,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     });
 
     // Stop the server
-    this.server1VM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.server1VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
   }
 
   /**
@@ -210,22 +205,21 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
   @Test
   public void testMultipleVMsWithSameDurableId() {
     // Start a server
-    final int serverPort = ((Integer) this.server1VM
-        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, new Boolean(true))))
-            .intValue();
+    final int serverPort = this.server1VM
+        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, Boolean.TRUE));
 
     // Start a durable client that is not kept alive on the server when it
     // stops normally
     final String durableClientId = getName() + "_client";
     this.durableClientVM.invoke(() -> CacheServerTestUtil.createCacheClient(
-        getClientPool(getServerHostName(durableClientVM.getHost()), serverPort, true), regionName,
+        getClientPool(getServerHostName(), serverPort, true), regionName,
         getClientDistributedSystemProperties(durableClientId), Boolean.TRUE));
 
     // Send clientReady message
     this.durableClientVM.invoke(new CacheSerializableRunnable("Send clientReady") {
       @Override
       public void run2() throws CacheException {
-        CacheServerTestUtil.getCache().readyForEvents();
+        CacheServerTestUtil.getClientCache().readyForEvents();
       }
     });
 
@@ -248,7 +242,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
       public void run2() throws CacheException {
         getSystem(getClientDistributedSystemProperties(durableClientId));
         PoolFactoryImpl pf = (PoolFactoryImpl) PoolManager.createFactory();
-        pf.init(getClientPool(getServerHostName(publisherClientVM.getHost()), serverPort, true));
+        pf.init(getClientPool(getServerHostName(), serverPort, true));
         try {
           pf.create("uncreatablePool");
           fail("Should not have been able to create the pool");
@@ -256,7 +250,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
           // expected exception
           disconnectFromDS();
         } catch (Exception e) {
-          Assert.fail("Should not have gotten here", e);
+          fail("Should not have gotten here", e);
         }
       }
     });
@@ -279,7 +273,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
 
     // Start normal publisher client
     this.publisherClientVM.invoke(() -> CacheServerTestUtil.createCacheClient(
-        getClientPool(getServerHostName(publisherClientVM.getHost()), serverPort, false),
+        getClientPool(getServerHostName(), serverPort, false),
         regionName));
 
     // Publish some entries
@@ -290,13 +284,13 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     verifyDurableClientEvents(this.durableClientVM, numberOfEntries);
 
     // Stop the publisher client
-    this.publisherClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.publisherClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the durable client
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.durableClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the server
-    this.server1VM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.server1VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
   }
 
   /**
@@ -305,22 +299,21 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
   @Test
   public void testSimpleTwoDurableClients() {
     // Start a server
-    int serverPort = ((Integer) this.server1VM
-        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, new Boolean(true))))
-            .intValue();
+    int serverPort = this.server1VM
+        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, Boolean.TRUE));
 
     // Start a durable client that is not kept alive on the server when it
     // stops normally
     final String durableClientId = getName() + "_client";
     this.durableClientVM.invoke(() -> CacheServerTestUtil.createCacheClient(
-        getClientPool(getServerHostName(durableClientVM.getHost()), serverPort, true), regionName,
+        getClientPool(getServerHostName(), serverPort, true), regionName,
         getClientDistributedSystemProperties(durableClientId)));
 
     // Send clientReady message
     this.durableClientVM.invoke(new CacheSerializableRunnable("Send clientReady") {
       @Override
       public void run2() throws CacheException {
-        CacheServerTestUtil.getCache().readyForEvents();
+        CacheServerTestUtil.getClientCache().readyForEvents();
       }
     });
 
@@ -329,14 +322,14 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     VM durableClient2VM = this.publisherClientVM;
     final String durableClientId2 = getName() + "_client2";
     durableClient2VM.invoke(() -> CacheServerTestUtil.createCacheClient(
-        getClientPool(getServerHostName(durableClient2VM.getHost()), serverPort, true), regionName,
+        getClientPool(getServerHostName(), serverPort, true), regionName,
         getClientDistributedSystemProperties(durableClientId2)));
 
     // Send clientReady message
     durableClient2VM.invoke(new CacheSerializableRunnable("Send clientReady") {
       @Override
       public void run2() throws CacheException {
-        CacheServerTestUtil.getCache().readyForEvents();
+        CacheServerTestUtil.getClientCache().readyForEvents();
       }
     });
 
@@ -350,8 +343,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
         // Iterate the CacheClientProxies and verify they are correct
         checkNumberOfClientProxies(2);
         boolean durableClient1Found = false, durableClient2Found = false;
-        for (Iterator i = notifier.getClientProxies().iterator(); i.hasNext();) {
-          CacheClientProxy proxy = (CacheClientProxy) i.next();
+        for (CacheClientProxy proxy : notifier.getClientProxies()) {
           assertTrue(proxy.isDurable());
           if (proxy.getDurableId().equals(durableClientId)) {
             durableClient1Found = true;
@@ -368,11 +360,11 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     });
 
     // Stop the durable clients
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache());
-    durableClient2VM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.durableClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
+    durableClient2VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the server
-    this.server1VM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.server1VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
   }
 
   /**
@@ -383,17 +375,15 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
   @Test
   public void testDurableClientMultipleServersOneLive() {
     // Start server 1
-    final int server1Port = ((Integer) this.server1VM
-        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, new Boolean(true))))
-            .intValue();
+    final int server1Port = this.server1VM
+        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, Boolean.TRUE));
 
     // Start server 2
-    final int server2Port = ((Integer) this.server2VM
-        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, new Boolean(true))))
-            .intValue();
+    final int server2Port = this.server2VM
+        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, Boolean.TRUE));
 
     // Stop server 2
-    this.server2VM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.server2VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Start a durable client that is kept alive on the server when it stops
     // normally
@@ -401,7 +391,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     final int durableClientTimeout = 60; // keep the client alive for 60 seconds
     // final boolean durableClientKeepAlive = true; // keep the client alive when it stops normally
     this.durableClientVM.invoke(() -> CacheServerTestUtil.createCacheClient(
-        getClientPool(getServerHostName(durableClientVM.getHost()), server1Port, server2Port, true),
+        getClientPool(getServerHostName(), server1Port, server2Port, true),
         regionName, getClientDistributedSystemProperties(durableClientId, durableClientTimeout),
         Boolean.TRUE));
 
@@ -409,7 +399,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     this.durableClientVM.invoke(new CacheSerializableRunnable("Send clientReady") {
       @Override
       public void run2() throws CacheException {
-        CacheServerTestUtil.getCache().readyForEvents();
+        CacheServerTestUtil.getClientCache().readyForEvents();
       }
     });
 
@@ -444,7 +434,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
 
     // Start normal publisher client
     this.publisherClientVM.invoke(() -> CacheServerTestUtil
-        .createCacheClient(getClientPool(getServerHostName(publisherClientVM.getHost()),
+        .createCacheClient(getClientPool(getServerHostName(),
             server1Port, server2Port, false), regionName));
 
     // Publish some entries
@@ -474,7 +464,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     }
 
     // Stop the durable client
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache(new Boolean(true)));
+    this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache(Boolean.TRUE));
 
     // Verify the durable client still exists on the server
     this.server1VM.invoke(new CacheSerializableRunnable("Verify durable client") {
@@ -491,14 +481,14 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
 
     // Re-start the durable client
     this.durableClientVM.invoke(() -> CacheServerTestUtil.createCacheClient(
-        getClientPool(getServerHostName(durableClientVM.getHost()), server1Port, server2Port, true),
+        getClientPool(getServerHostName(), server1Port, server2Port, true),
         regionName, getClientDistributedSystemProperties(durableClientId), Boolean.TRUE));
 
     // Send clientReady message
     this.durableClientVM.invoke(new CacheSerializableRunnable("Send clientReady") {
       @Override
       public void run2() throws CacheException {
-        CacheServerTestUtil.getCache().readyForEvents();
+        CacheServerTestUtil.getClientCache().readyForEvents();
       }
     });
 
@@ -534,13 +524,13 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     });
 
     // Stop the durable client
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.durableClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the publisher client
-    this.publisherClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.publisherClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop server 1
-    this.server1VM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.server1VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
   }
 
   /**
@@ -549,9 +539,8 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
   @Test
   public void testTwoDurableClientsStartStopUpdate() {
     // Start a server
-    int serverPort = ((Integer) this.server1VM
-        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, new Boolean(true))))
-            .intValue();
+    int serverPort = this.server1VM
+        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, Boolean.TRUE));
 
     // Start a durable client that is kept alive on the server when it stops
     // normally
@@ -559,14 +548,14 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     final int durableClientTimeout = 60; // keep the client alive for 60 seconds
     // final boolean durableClientKeepAlive = true; // keep the client alive when it stops normally
     this.durableClientVM.invoke(() -> CacheServerTestUtil.createCacheClient(
-        getClientPool(getServerHostName(durableClientVM.getHost()), serverPort, true), regionName,
+        getClientPool(getServerHostName(), serverPort, true), regionName,
         getClientDistributedSystemProperties(durableClientId, durableClientTimeout), Boolean.TRUE));
 
     // Send clientReady message
     this.durableClientVM.invoke(new CacheSerializableRunnable("Send clientReady") {
       @Override
       public void run2() throws CacheException {
-        CacheServerTestUtil.getCache().readyForEvents();
+        CacheServerTestUtil.getClientCache().readyForEvents();
       }
     });
 
@@ -588,7 +577,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     VM durableClient2VM = this.server2VM;
     final String durableClientId2 = getName() + "_client2";
     durableClient2VM.invoke(() -> CacheServerTestUtil.createCacheClient(
-        getClientPool(getServerHostName(durableClient2VM.getHost()), serverPort, true), regionName,
+        getClientPool(getServerHostName(), serverPort, true), regionName,
         getClientDistributedSystemProperties(durableClientId2, durableClientTimeout),
         Boolean.TRUE));
 
@@ -596,7 +585,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     durableClient2VM.invoke(new CacheSerializableRunnable("Send clientReady") {
       @Override
       public void run2() throws CacheException {
-        CacheServerTestUtil.getCache().readyForEvents();
+        CacheServerTestUtil.getClientCache().readyForEvents();
       }
     });
 
@@ -623,8 +612,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
         // Iterate the CacheClientProxies and verify they are correct
         checkNumberOfClientProxies(2);
         boolean durableClient1Found = false, durableClient2Found = false;
-        for (Iterator i = notifier.getClientProxies().iterator(); i.hasNext();) {
-          CacheClientProxy proxy = (CacheClientProxy) i.next();
+        for (CacheClientProxy proxy : notifier.getClientProxies()) {
           assertTrue(proxy.isDurable());
           if (proxy.getDurableId().equals(durableClientId)) {
             durableClient1Found = true;
@@ -641,7 +629,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
 
     // Start normal publisher client
     this.publisherClientVM.invoke(() -> CacheServerTestUtil.createCacheClient(
-        getClientPool(getServerHostName(publisherClientVM.getHost()), serverPort, false),
+        getClientPool(getServerHostName(), serverPort, false),
         regionName));
 
     // Publish some entries
@@ -662,8 +650,8 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     }
 
     // Stop the durable clients
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache(new Boolean(true)));
-    durableClient2VM.invoke(() -> CacheServerTestUtil.closeCache(new Boolean(true)));
+    this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache(Boolean.TRUE));
+    durableClient2VM.invoke(() -> CacheServerTestUtil.closeCache(Boolean.TRUE));
 
     // Verify the durable clients still exist on the server
     this.server1VM.invoke(new CacheSerializableRunnable("Verify durable client") {
@@ -675,8 +663,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
         // Iterate the CacheClientProxies and verify they are correct
         checkNumberOfClientProxies(2);
         boolean durableClient1Found = false, durableClient2Found = false;
-        for (Iterator i = notifier.getClientProxies().iterator(); i.hasNext();) {
-          CacheClientProxy proxy = (CacheClientProxy) i.next();
+        for (CacheClientProxy proxy : notifier.getClientProxies()) {
           assertTrue(proxy.isDurable());
           if (proxy.getDurableId().equals(durableClientId)) {
             durableClient1Found = true;
@@ -709,8 +696,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
 
         // Iterate the CacheClientProxies and verify the queue sizes
         checkNumberOfClientProxies(2);
-        for (Iterator i = notifier.getClientProxies().iterator(); i.hasNext();) {
-          CacheClientProxy proxy = (CacheClientProxy) i.next();
+        for (CacheClientProxy proxy : notifier.getClientProxies()) {
           assertEquals(numberOfEntries, proxy.getQueueSize());
         }
       }
@@ -718,27 +704,27 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
 
     // Re-start durable client 1
     this.durableClientVM.invoke(() -> CacheServerTestUtil.createCacheClient(
-        getClientPool(getServerHostName(durableClientVM.getHost()), serverPort, true), regionName,
+        getClientPool(getServerHostName(), serverPort, true), regionName,
         getClientDistributedSystemProperties(durableClientId), Boolean.TRUE));
 
     // Send clientReady message
     this.durableClientVM.invoke(new CacheSerializableRunnable("Send clientReady") {
       @Override
       public void run2() throws CacheException {
-        CacheServerTestUtil.getCache().readyForEvents();
+        CacheServerTestUtil.getClientCache().readyForEvents();
       }
     });
 
     // Re-start durable client 2
     durableClient2VM.invoke(() -> CacheServerTestUtil.createCacheClient(
-        getClientPool(getServerHostName(durableClient2VM.getHost()), serverPort, true), regionName,
+        getClientPool(getServerHostName(), serverPort, true), regionName,
         getClientDistributedSystemProperties(durableClientId2), Boolean.TRUE));
 
     // Send clientReady message
     durableClient2VM.invoke(new CacheSerializableRunnable("Send clientReady") {
       @Override
       public void run2() throws CacheException {
-        CacheServerTestUtil.getCache().readyForEvents();
+        CacheServerTestUtil.getClientCache().readyForEvents();
       }
     });
 
@@ -749,16 +735,16 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     verifyDurableClientEvents(durableClient2VM, numberOfEntries);
 
     // Stop durable client 1
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.durableClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop durable client 2
-    durableClient2VM.invoke(() -> CacheServerTestUtil.closeCache());
+    durableClient2VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the publisher client
-    this.publisherClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.publisherClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the server
-    this.server1VM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.server1VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
   }
 
   /**
@@ -767,22 +753,21 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
   @Test
   public void testDurableClientReconnectTwoServers() {
     // Start server 1
-    Integer[] ports = ((Integer[]) this.server1VM.invoke(
-        () -> CacheServerTestUtil.createCacheServerReturnPorts(regionName, new Boolean(true))));
+    Integer[] ports = this.server1VM.invoke(
+        () -> CacheServerTestUtil.createCacheServerReturnPorts(regionName, Boolean.TRUE));
 
     // on test flag for periodic ack
     this.server1VM
-        .invoke(() -> DurableClientTestCase.setTestFlagToVerifyActForMarker(new Boolean(true)));
+        .invoke(() -> DurableClientTestCase.setTestFlagToVerifyActForMarker(Boolean.TRUE));
 
-    final int server1Port = ports[0].intValue();
+    final int server1Port = ports[0];
 
     // Start server 2 using the same mcast port as server 1
-    final int server2Port = ((Integer) this.server2VM
-        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, new Boolean(true))))
-            .intValue();
+    final int server2Port = this.server2VM
+        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, Boolean.TRUE));
 
     // Stop server 2
-    this.server2VM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.server2VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Start a durable client that is kept alive on the server when it stops
     // normally
@@ -790,7 +775,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     final int durableClientTimeout = 60; // keep the client alive for 60 seconds
     // final boolean durableClientKeepAlive = true; // keep the client alive when it stops normally
     this.durableClientVM.invoke(() -> CacheServerTestUtil.createCacheClient(
-        getClientPool(getServerHostName(durableClientVM.getHost()), server1Port, server2Port, true),
+        getClientPool(getServerHostName(), server1Port, server2Port, true),
         regionName, getClientDistributedSystemProperties(durableClientId, durableClientTimeout),
         Boolean.TRUE));
 
@@ -798,7 +783,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     this.durableClientVM.invoke(new CacheSerializableRunnable("Send clientReady") {
       @Override
       public void run2() throws CacheException {
-        CacheServerTestUtil.getCache().readyForEvents();
+        CacheServerTestUtil.getClientCache().readyForEvents();
       }
     });
 
@@ -836,7 +821,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     Wait.pause(5000);
 
     // Stop the durable client
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache(new Boolean(true)));
+    this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache(Boolean.TRUE));
 
     // Verify durable client on server 1
     this.server1VM.invoke(new CacheSerializableRunnable("Verify durable client") {
@@ -850,12 +835,12 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     });
 
     // Re-start server2
-    this.server2VM.invoke(() -> CacheServerTestUtil.createCacheServer(regionName, new Boolean(true),
-        new Integer(server2Port)));
+    this.server2VM.invoke(() -> CacheServerTestUtil.createCacheServer(regionName, Boolean.TRUE,
+        server2Port));
 
     // Start normal publisher client
     this.publisherClientVM.invoke(() -> CacheServerTestUtil
-        .createCacheClient(getClientPool(getServerHostName(publisherClientVM.getHost()),
+        .createCacheClient(getClientPool(getServerHostName(),
             server1Port, server2Port, false), regionName));
 
     // Publish some entries
@@ -884,7 +869,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     // Re-start the durable client that is kept alive on the server when it stops
     // normally
     this.durableClientVM.invoke(() -> CacheServerTestUtil.createCacheClient(
-        getClientPool(getServerHostName(durableClientVM.getHost()), server1Port, server2Port, true),
+        getClientPool(getServerHostName(), server1Port, server2Port, true),
         regionName, getClientDistributedSystemProperties(durableClientId, durableClientTimeout),
         Boolean.TRUE));
 
@@ -892,7 +877,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     this.durableClientVM.invoke(new CacheSerializableRunnable("Send clientReady") {
       @Override
       public void run2() throws CacheException {
-        CacheServerTestUtil.getCache().readyForEvents();
+        CacheServerTestUtil.getClientCache().readyForEvents();
       }
     });
 
@@ -930,44 +915,43 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
 
     // Verify the HA region names are the same on both servers
     String server1HARegionQueueName =
-        (String) this.server1VM.invoke(() -> DurableClientTestCase.getHARegionQueueName());
+        this.server1VM.invoke(DurableClientTestCase::getHARegionQueueName);
     String server2HARegionQueueName =
-        (String) this.server2VM.invoke(() -> DurableClientTestCase.getHARegionQueueName());
+        this.server2VM.invoke(DurableClientTestCase::getHARegionQueueName);
     assertEquals(server1HARegionQueueName, server2HARegionQueueName);
 
     // Verify the durable client received the updates
     verifyDurableClientEvents(this.durableClientVM, numberOfEntries);
 
     // Stop the durable client
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.durableClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the publisher client
-    this.publisherClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.publisherClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // off test flag for periodic ack
     this.server1VM
-        .invoke(() -> DurableClientTestCase.setTestFlagToVerifyActForMarker(new Boolean(false)));
+        .invoke(() -> DurableClientTestCase.setTestFlagToVerifyActForMarker(Boolean.FALSE));
 
     // Stop server 1
-    this.server1VM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.server1VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop server 2
-    this.server2VM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.server2VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
   }
 
   @Test
   public void testReadyForEventsNotCalledImplicitly() {
     // Start a server
-    int serverPort = ((Integer) this.server1VM
-        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, new Boolean(true))))
-            .intValue();
+    int serverPort = this.server1VM
+        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, Boolean.TRUE));
 
     // Start a durable client that is not kept alive on the server when it
     // stops normally
     final String durableClientId = getName() + "_client";
     // make the client use ClientCacheFactory so it will have a default pool
     this.durableClientVM.invoke(() -> CacheServerTestUtil.createClientCache(
-        getClientPool(getServerHostName(durableClientVM.getHost()), serverPort, true), regionName,
+        getClientPool(getServerHostName(), serverPort, true), regionName,
         getClientDistributedSystemProperties(durableClientId)));
 
     // verify that readyForEvents has not yet been called on the client's default pool
@@ -975,7 +959,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
       @Override
       public void run2() throws CacheException {
         for (Pool p : PoolManager.getAll().values()) {
-          assertEquals(false, ((PoolImpl) p).getReadyForEventsCalled());
+          assertFalse(((PoolImpl) p).getReadyForEventsCalled());
         }
       }
     });
@@ -984,7 +968,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     this.durableClientVM.invoke(new CacheSerializableRunnable("Send clientReady") {
       @Override
       public void run2() throws CacheException {
-        CacheServerTestUtil.getCache().readyForEvents();
+        CacheServerTestUtil.getClientCache().readyForEvents();
       }
     });
 
@@ -997,9 +981,8 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
 
         // Iterate the CacheClientProxies and verify they are correct
         checkNumberOfClientProxies(1);
-        boolean durableClient1Found = false, durableClient2Found = false;
-        for (Iterator i = notifier.getClientProxies().iterator(); i.hasNext();) {
-          CacheClientProxy proxy = (CacheClientProxy) i.next();
+        boolean durableClient1Found = false;
+        for (CacheClientProxy proxy : notifier.getClientProxies()) {
           assertTrue(proxy.isDurable());
           if (proxy.getDurableId().equals(durableClientId)) {
             durableClient1Found = true;
@@ -1012,10 +995,10 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     });
 
     // Stop the durable clients
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.durableClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the server
-    this.server1VM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.server1VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
   }
 
   /**
@@ -1029,7 +1012,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
       final String cqName = "cqTest";
       // Start a server
       int serverPort =
-          (Integer) this.server1VM.invoke(() -> CacheServerTestUtil.createCacheServerFromXml(
+          this.server1VM.invoke(() -> CacheServerTestUtil.createCacheServerFromXml(
               DurableClientTestCase.class.getResource("durablecq-server-cache.xml")));
 
       // Start a durable client that is not kept alive on the server when it
@@ -1046,7 +1029,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
         @Override
         public void run2() throws CacheException {
           for (Pool p : PoolManager.getAll().values()) {
-            assertEquals(false, ((PoolImpl) p).getReadyForEventsCalled());
+            assertFalse(((PoolImpl) p).getReadyForEventsCalled());
           }
         }
       });
@@ -1055,7 +1038,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
       this.durableClientVM.invoke(new CacheSerializableRunnable("Send clientReady") {
         @Override
         public void run2() throws CacheException {
-          CacheServerTestUtil.getCache().readyForEvents();
+          CacheServerTestUtil.getClientCache().readyForEvents();
         }
       });
       registerDurableCq(cqName);
@@ -1077,7 +1060,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
 
       // Start normal publisher client
       this.publisherClientVM.invoke(() -> CacheServerTestUtil.createCacheClient(
-          getClientPool(getServerHostName(publisherClientVM.getHost()), serverPort, false),
+          getClientPool(getServerHostName(), serverPort, false),
           regionName));
 
       // Publish some entries
@@ -1109,7 +1092,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
       }
 
       // Stop the durable client
-      this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache(new Boolean(true)));
+      this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache(Boolean.TRUE));
 
       // Verify the durable client still exists on the server
       this.server1VM.invoke(new CacheSerializableRunnable("Verify durable client") {
@@ -1124,7 +1107,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
       // Publish some more entries
       publishEntries(numberOfEntries);
 
-      this.publisherClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+      this.publisherClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
       // Re-start the durable client
       this.durableClientVM.invoke(() -> CacheServerTestUtil.createCacheClientFromXml(
@@ -1155,9 +1138,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
           try {
             CqQuery query = queryService.newCq(cqName, "Select * from /" + regionName, cqa, true);
             query.execute();
-          } catch (CqExistsException e) {
-            fail("Failed due to ", e);
-          } catch (CqException e) {
+          } catch (CqExistsException | CqException e) {
             fail("Failed due to ", e);
           } catch (RegionNotFoundException e) {
             fail("Could not find specified region:" + regionName + ":", e);
@@ -1170,7 +1151,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
       this.durableClientVM.invoke(new CacheSerializableRunnable("Send clientReady") {
         @Override
         public void run2() throws CacheException {
-          CacheServerTestUtil.getCache().readyForEvents();
+          CacheServerTestUtil.getClientCache().readyForEvents();
         }
       });
 
@@ -1209,10 +1190,10 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
       });
 
       // Stop the durable client
-      this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+      this.durableClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
       // Stop the server
-      this.server1VM.invoke(() -> CacheServerTestUtil.closeCache());
+      this.server1VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
     } finally {
       unsetPeriodicACKObserver(durableClientVM);
     }
@@ -1242,9 +1223,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
         try {
           CqQuery query = queryService.newCq(cqName, "Select * from /" + regionName, cqa, true);
           query.execute();
-        } catch (CqExistsException e) {
-          fail("Failed due to ", e);
-        } catch (CqException e) {
+        } catch (CqExistsException | CqException e) {
           fail("Failed due to ", e);
         } catch (RegionNotFoundException e) {
           fail("Could not find specified region:" + regionName + ":", e);
@@ -1259,7 +1238,6 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
           @Override
           public void run2() throws CacheException {
             PoolImpl.BEFORE_SENDING_CLIENT_ACK_CALLBACK_FLAG = true;
-            ClientServerObserver origObserver =
                 ClientServerObserverHolder.setInstance(new ClientServerObserverAdapter() {
                   @Override
                   public void beforeSendingClientAck() {
@@ -1286,11 +1264,10 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
 
   @Test
   public void testReadyForEventsNotCalledImplicitlyForRegisterInterestWithCacheXML() {
-    final String cqName = "cqTest";
     regionName = "testReadyForEventsNotCalledImplicitlyWithCacheXML_region";
     // Start a server
     int serverPort =
-        (Integer) this.server1VM.invoke(() -> CacheServerTestUtil.createCacheServerFromXmlN(
+        this.server1VM.invoke(() -> CacheServerTestUtil.createCacheServerFromXmlN(
             DurableClientTestCase.class.getResource("durablecq-server-cache.xml")));
 
     // Start a durable client that is not kept alive on the server when it
@@ -1307,7 +1284,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
       @Override
       public void run2() throws CacheException {
         for (Pool p : PoolManager.getAll().values()) {
-          assertEquals(false, ((PoolImpl) p).getReadyForEventsCalled());
+          assertFalse(((PoolImpl) p).getReadyForEventsCalled());
         }
       }
     });
@@ -1316,7 +1293,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     this.durableClientVM.invoke(new CacheSerializableRunnable("Send clientReady") {
       @Override
       public void run2() throws CacheException {
-        CacheServerTestUtil.getCache().readyForEvents();
+        CacheServerTestUtil.getClientCache().readyForEvents();
       }
     });
 
@@ -1350,7 +1327,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
 
     // Start normal publisher client
     this.publisherClientVM.invoke(() -> CacheServerTestUtil.createCacheClient(
-        getClientPool(getServerHostName(publisherClientVM.getHost()), serverPort, false),
+        getClientPool(getServerHostName(), serverPort, false),
         regionName));
 
     // Publish some entries
@@ -1378,7 +1355,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
       fail("interrupted", e);
     }
     // Stop the durable client
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache(new Boolean(true)));
+    this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache(Boolean.TRUE));
 
     // Verify the durable client still exists on the server
     this.server1VM.invoke(new CacheSerializableRunnable("Verify durable client") {
@@ -1395,7 +1372,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
       @Override
       public void run2() throws CacheException {
         // Get the region
-        Region region = CacheServerTestUtil.getCache().getRegion(regionName);
+        Region<String, String> region = CacheServerTestUtil.getCache().getRegion(regionName);
         assertNotNull(region);
 
         // Publish some entries
@@ -1405,7 +1382,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
         }
       }
     });
-    this.publisherClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.publisherClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Re-start the durable client
     this.durableClientVM.invoke(() -> CacheServerTestUtil.createCacheClientFromXmlN(
@@ -1430,7 +1407,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     this.durableClientVM.invoke(new CacheSerializableRunnable("Send clientReady") {
       @Override
       public void run2() throws CacheException {
-        CacheServerTestUtil.getCache().readyForEvents();
+        CacheServerTestUtil.getClientCache().readyForEvents();
       }
     });
 
@@ -1466,10 +1443,10 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     });
 
     // Stop the durable client
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.durableClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the server
-    this.server1VM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.server1VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
   }
 
   /**
@@ -1479,15 +1456,15 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
    * rechecked
    */
   @Test
-  public void testHAQueueSizeStat() throws Exception {
+  public void testHAQueueSizeStat() {
     String greaterThan5Query = "select * from /" + regionName + " p where p.ID > 5";
     String allQuery = "select * from /" + regionName + " p where p.ID > -1";
     String lessThan5Query = "select * from /" + regionName + " p where p.ID < 5";
 
     // Start server 1
-    Integer[] ports = ((Integer[]) this.server1VM.invoke(
-        () -> CacheServerTestUtil.createCacheServerReturnPorts(regionName, new Boolean(true))));
-    final int serverPort = ports[0].intValue();
+    Integer[] ports = this.server1VM.invoke(
+        () -> CacheServerTestUtil.createCacheServerReturnPorts(regionName, Boolean.TRUE));
+    final int serverPort = ports[0];
 
     final String durableClientId = getName() + "_client";
 
@@ -1542,13 +1519,13 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     checkHAQueueSize(server1VM, durableClientId, 0, 1);
 
     // Stop the durable client
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.durableClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the publisher client
-    this.publisherClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.publisherClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the server
-    this.server1VM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.server1VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
   }
 
   /**
@@ -1558,16 +1535,16 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
    * client is then reconnected, no events should exist and stats are rechecked
    */
   @Test
-  public void testHAQueueSizeStatExpired() throws Exception {
+  public void testHAQueueSizeStatExpired() {
     int timeoutInSeconds = 20;
     String greaterThan5Query = "select * from /" + regionName + " p where p.ID > 5";
     String allQuery = "select * from /" + regionName + " p where p.ID > -1";
     String lessThan5Query = "select * from /" + regionName + " p where p.ID < 5";
 
     // Start server 1
-    Integer[] ports = ((Integer[]) this.server1VM.invoke(
-        () -> CacheServerTestUtil.createCacheServerReturnPorts(regionName, new Boolean(true))));
-    final int serverPort = ports[0].intValue();
+    Integer[] ports = this.server1VM.invoke(
+        () -> CacheServerTestUtil.createCacheServerReturnPorts(regionName, Boolean.TRUE));
+    final int serverPort = ports[0];
 
     final String durableClientId = getName() + "_client";
 
@@ -1628,13 +1605,13 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     checkHAQueueSize(server1VM, durableClientId, 0, 1);
 
     // Stop the durable client
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.durableClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the publisher client
-    this.publisherClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.publisherClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the server
-    this.server1VM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.server1VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
   }
 
   /**
@@ -1645,26 +1622,25 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
    * reregisters cqs and sends ready for events
    */
   @Test
-  public void testHAQueueSizeStatForGII() throws Exception {
+  public void testHAQueueSizeStatForGII() {
     String greaterThan5Query = "select * from /" + regionName + " p where p.ID > 5";
     String allQuery = "select * from /" + regionName + " p where p.ID > -1";
     String lessThan5Query = "select * from /" + regionName + " p where p.ID < 5";
 
     // Start server 1
-    Integer[] ports = ((Integer[]) this.server1VM.invoke(
-        () -> CacheServerTestUtil.createCacheServerReturnPorts(regionName, new Boolean(true))));
-    final int serverPort = ports[0].intValue();
+    Integer[] ports = this.server1VM.invoke(
+        () -> CacheServerTestUtil.createCacheServerReturnPorts(regionName, Boolean.TRUE));
+    final int serverPort = ports[0];
 
     // Start server 2 using the same mcast port as server 1
-    final int serverPort2 = ((Integer) this.server2VM
-        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, new Boolean(true))))
-            .intValue();
+    final int serverPort2 = this.server2VM
+        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, Boolean.TRUE));
 
     // shut down server 2
     closeCache(server2VM);
 
     final String durableClientId = getName() + "_client";
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.disableShufflingOfEndpoints());
+    this.durableClientVM.invoke(CacheServerTestUtil::disableShufflingOfEndpoints);
 
     startDurableClient(durableClientVM, durableClientId, serverPort, serverPort2, regionName);
 
@@ -1691,8 +1667,8 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     startDurableClient(durableClientVM, durableClientId, serverPort, serverPort2, regionName);
 
     // Re-start server2, at this point it will be the first time server2 has connected to client
-    this.server2VM.invoke(() -> CacheServerTestUtil.createCacheServer(regionName, new Boolean(true),
-        new Integer(serverPort2)));
+    this.server2VM.invoke(() -> CacheServerTestUtil.createCacheServer(regionName, Boolean.TRUE,
+        serverPort2));
 
     // Verify durable client on server2
     verifyDurableClientOnServer(server2VM, durableClientId);
@@ -1729,30 +1705,29 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     checkCqStatOnServer(server2VM, durableClientId, "All", 0);
 
     // Stop the durable client
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.durableClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the publisher client
-    this.publisherClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.publisherClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the servers
-    this.server1VM.invoke(() -> CacheServerTestUtil.closeCache());
-    this.server2VM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.server1VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
+    this.server2VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
   }
 
   /**
    * Tests the ha queued cq stat
    */
   @Test
-  public void testHAQueuedCqStat() throws Exception {
+  public void testHAQueuedCqStat() {
     String greaterThan5Query = "select * from /" + regionName + " p where p.ID > 5";
     String allQuery = "select * from /" + regionName + " p where p.ID > -1";
     String lessThan5Query = "select * from /" + regionName + " p where p.ID < 5";
 
     // Start server 1
-    Integer[] ports = ((Integer[]) this.server1VM.invoke(
-        () -> CacheServerTestUtil.createCacheServerReturnPorts(regionName, new Boolean(true))));
-    final int serverPort = ports[0].intValue();
-    final int mcastPort = ports[1].intValue();
+    Integer[] ports = this.server1VM.invoke(
+        () -> CacheServerTestUtil.createCacheServerReturnPorts(regionName, Boolean.TRUE));
+    final int serverPort = ports[0];
 
     final String durableClientId = getName() + "_client";
 
@@ -1813,33 +1788,32 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     checkCqStatOnServer(server1VM, durableClientId, "All", 0);
 
     // Stop the durable client
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.durableClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the publisher client
-    this.publisherClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.publisherClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the server
-    this.server1VM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.server1VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
   }
 
   @Test
-  public void testHAQueuedCqStatOnSecondary() throws Exception {
+  public void testHAQueuedCqStatOnSecondary() {
     String greaterThan5Query = "select * from /" + regionName + " p where p.ID > 5";
     String allQuery = "select * from /" + regionName + " p where p.ID > -1";
     String lessThan5Query = "select * from /" + regionName + " p where p.ID < 5";
 
     // Start server 1
-    Integer[] ports = ((Integer[]) this.server1VM.invoke(
-        () -> CacheServerTestUtil.createCacheServerReturnPorts(regionName, new Boolean(true))));
-    final int serverPort = ports[0].intValue();
+    Integer[] ports = this.server1VM.invoke(
+        () -> CacheServerTestUtil.createCacheServerReturnPorts(regionName, Boolean.TRUE));
+    final int serverPort = ports[0];
 
     // Start server 2 using the same mcast port as server 1
-    final int serverPort2 = ((Integer) this.server2VM
-        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, new Boolean(true))))
-            .intValue();
+    final int serverPort2 = this.server2VM
+        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, Boolean.TRUE));
 
     final String durableClientId = getName() + "_client";
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.disableShufflingOfEndpoints());
+    this.durableClientVM.invoke(CacheServerTestUtil::disableShufflingOfEndpoints);
 
     startDurableClient(durableClientVM, durableClientId, serverPort, serverPort2, regionName);
 
@@ -1907,13 +1881,13 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     checkCqStatOnServer(server2VM, durableClientId, "All", 0);
 
     // Stop the durable client
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.durableClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the publisher client
-    this.publisherClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.publisherClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the server
-    this.server1VM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.server1VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
   }
 
   /**
@@ -1922,25 +1896,24 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
    * goes away client comes back and receives all events stats should still be correct
    */
   @Test
-  public void testHAQueuedCqStatForGII() throws Exception {
+  public void testHAQueuedCqStatForGII() {
     String greaterThan5Query = "select * from /" + regionName + " p where p.ID > 5";
     String allQuery = "select * from /" + regionName + " p where p.ID > -1";
     String lessThan5Query = "select * from /" + regionName + " p where p.ID < 5";
 
     // Start server 1
-    Integer[] ports = ((Integer[]) this.server1VM.invoke(
-        () -> CacheServerTestUtil.createCacheServerReturnPorts(regionName, new Boolean(true))));
-    final int serverPort = ports[0].intValue();
+    Integer[] ports = this.server1VM.invoke(
+        () -> CacheServerTestUtil.createCacheServerReturnPorts(regionName, Boolean.TRUE));
+    final int serverPort = ports[0];
 
     // Start server 2 using the same mcast port as server 1
-    final int serverPort2 = ((Integer) this.server2VM
-        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, new Boolean(true))))
-            .intValue();
+    final int serverPort2 = this.server2VM
+        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, Boolean.TRUE));
 
     // Start a durable client that is kept alive on the server when it stops
     // normally
     final String durableClientId = getName() + "_client";
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.disableShufflingOfEndpoints());
+    this.durableClientVM.invoke(CacheServerTestUtil::disableShufflingOfEndpoints);
 
     startDurableClient(durableClientVM, durableClientId, serverPort, serverPort2, regionName);
 
@@ -1972,8 +1945,8 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     publishEntries(publisherClientVM, regionName, 10);
 
     // Re-start server2, should get events through gii
-    this.server2VM.invoke(() -> CacheServerTestUtil.createCacheServer(regionName, new Boolean(true),
-        new Integer(serverPort2)));
+    this.server2VM.invoke(() -> CacheServerTestUtil.createCacheServer(regionName, Boolean.TRUE,
+        serverPort2));
 
     // Restart the durable client
     startDurableClient(durableClientVM, durableClientId, serverPort, serverPort2, regionName);
@@ -2011,11 +1984,11 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
 
 
     // Stop the durable clients
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache());
-    this.publisherClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.durableClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
+    this.publisherClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the servers
-    this.server2VM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.server2VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
   }
 
   /**
@@ -2026,26 +1999,25 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
    * Client sends ready or events and receives events Recheck stats
    */
   @Test
-  public void testHAQueuedCqStatForGII2() throws Exception {
+  public void testHAQueuedCqStatForGII2() {
     String greaterThan5Query = "select * from /" + regionName + " p where p.ID > 5";
     String allQuery = "select * from /" + regionName + " p where p.ID > -1";
     String lessThan5Query = "select * from /" + regionName + " p where p.ID < 5";
 
     // Start server 1
-    Integer[] ports = ((Integer[]) this.server1VM.invoke(
-        () -> CacheServerTestUtil.createCacheServerReturnPorts(regionName, new Boolean(true))));
-    final int serverPort = ports[0].intValue();
+    Integer[] ports = this.server1VM.invoke(
+        () -> CacheServerTestUtil.createCacheServerReturnPorts(regionName, Boolean.TRUE));
+    final int serverPort = ports[0];
 
     // Start server 2 using the same mcast port as server 1
-    final int serverPort2 = ((Integer) this.server2VM
-        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, new Boolean(true))))
-            .intValue();
+    final int serverPort2 = this.server2VM
+        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, Boolean.TRUE));
 
     // shut down server 2
     closeCache(server2VM);
 
     final String durableClientId = getName() + "_client";
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.disableShufflingOfEndpoints());
+    this.durableClientVM.invoke(CacheServerTestUtil::disableShufflingOfEndpoints);
 
     startDurableClient(durableClientVM, durableClientId, serverPort, serverPort2, regionName);
 
@@ -2072,8 +2044,8 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     startDurableClient(durableClientVM, durableClientId, serverPort, serverPort2, regionName);
 
     // Re-start server2, at this point it will be the first time server2 has connected to client
-    this.server2VM.invoke(() -> CacheServerTestUtil.createCacheServer(regionName, new Boolean(true),
-        new Integer(serverPort2)));
+    this.server2VM.invoke(() -> CacheServerTestUtil.createCacheServer(regionName, Boolean.TRUE,
+        serverPort2));
 
     // Verify durable client on server2
     verifyDurableClientOnServer(server2VM, durableClientId);
@@ -2110,14 +2082,14 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     checkCqStatOnServer(server2VM, durableClientId, "All", 0);
 
     // Stop the durable client
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.durableClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the publisher client
-    this.publisherClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.publisherClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the servers
-    this.server1VM.invoke(() -> CacheServerTestUtil.closeCache());
-    this.server2VM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.server1VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
+    this.server2VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
   }
 
   /**
@@ -2126,25 +2098,24 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
    * back and receives all events stats should still be correct
    */
   @Test
-  public void testHAQueuedCqStatForGIINoFailover() throws Exception {
+  public void testHAQueuedCqStatForGIINoFailover() {
     String greaterThan5Query = "select * from /" + regionName + " p where p.ID > 5";
     String allQuery = "select * from /" + regionName + " p where p.ID > -1";
     String lessThan5Query = "select * from /" + regionName + " p where p.ID < 5";
 
     // Start server 1
-    Integer[] ports = ((Integer[]) this.server1VM.invoke(
-        () -> CacheServerTestUtil.createCacheServerReturnPorts(regionName, new Boolean(true))));
-    final int serverPort = ports[0].intValue();
+    Integer[] ports = this.server1VM.invoke(
+        () -> CacheServerTestUtil.createCacheServerReturnPorts(regionName, Boolean.TRUE));
+    final int serverPort = ports[0];
 
     // Start server 2
-    final int serverPort2 = ((Integer) this.server2VM
-        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, new Boolean(true))))
-            .intValue();
+    final int serverPort2 = this.server2VM
+        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, Boolean.TRUE));
 
     // Start a durable client that is kept alive on the server when it stops
     // normally
     final String durableClientId = getName() + "_client";
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.disableShufflingOfEndpoints());
+    this.durableClientVM.invoke(CacheServerTestUtil::disableShufflingOfEndpoints);
 
     startDurableClient(durableClientVM, durableClientId, serverPort, serverPort2, regionName);
 
@@ -2176,8 +2147,8 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     publishEntries(publisherClientVM, regionName, 10);
 
     // Re-start server2, should get events through gii
-    this.server2VM.invoke(() -> CacheServerTestUtil.createCacheServer(regionName, new Boolean(true),
-        new Integer(serverPort2)));
+    this.server2VM.invoke(() -> CacheServerTestUtil.createCacheServer(regionName, Boolean.TRUE,
+        serverPort2));
 
     // Restart the durable client
     startDurableClient(durableClientVM, durableClientId, serverPort, serverPort2, regionName);
@@ -2215,37 +2186,36 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     checkCqStatOnServer(server1VM, durableClientId, "All", 0);
 
     // Stop the durable clients
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache());
-    this.publisherClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.durableClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
+    this.publisherClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the servers
-    this.server1VM.invoke(() -> CacheServerTestUtil.closeCache());
-    this.server2VM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.server1VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
+    this.server2VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
   }
 
   /**
    * server 1 and 2 both get events server 1 goes down dc reconnects server 2 behaves accordingly
    */
   @Test
-  public void testHAQueuedCqStatForFailover() throws Exception {
+  public void testHAQueuedCqStatForFailover() {
     String greaterThan5Query = "select * from /" + regionName + " p where p.ID > 5";
     String allQuery = "select * from /" + regionName + " p where p.ID > -1";
     String lessThan5Query = "select * from /" + regionName + " p where p.ID < 5";
 
     // Start server 1
-    Integer[] ports = ((Integer[]) this.server1VM.invoke(
-        () -> CacheServerTestUtil.createCacheServerReturnPorts(regionName, new Boolean(true))));
-    final int serverPort = ports[0].intValue();
+    Integer[] ports = this.server1VM.invoke(
+        () -> CacheServerTestUtil.createCacheServerReturnPorts(regionName, Boolean.TRUE));
+    final int serverPort = ports[0];
 
     // Start server 2 using the same mcast port as server 1
-    final int serverPort2 = ((Integer) this.server2VM
-        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, new Boolean(true))))
-            .intValue();
+    final int serverPort2 = this.server2VM
+        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, Boolean.TRUE));
 
     // Start a durable client that is kept alive on the server when it stops
     // normally
     final String durableClientId = getName() + "_client";
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.disableShufflingOfEndpoints());
+    this.durableClientVM.invoke(CacheServerTestUtil::disableShufflingOfEndpoints);
 
     startDurableClient(durableClientVM, durableClientId, serverPort, serverPort2, regionName);
 
@@ -2309,29 +2279,29 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     checkCqStatOnServer(server2VM, durableClientId, "All", 0);
 
     // Stop the durable client
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.durableClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the publisher client
-    this.publisherClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.publisherClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the server
-    this.server2VM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.server2VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
   }
 
   /**
    * Tests the ha queued cq stat
    */
   @Test
-  public void testHAQueuedCqStatWithTimeOut() throws Exception {
+  public void testHAQueuedCqStatWithTimeOut() {
     String greaterThan5Query = "select * from /" + regionName + " p where p.ID > 5";
     String allQuery = "select * from /" + regionName + " p where p.ID > -1";
     String lessThan5Query = "select * from /" + regionName + " p where p.ID < 5";
 
     int timeoutInSeconds = 20;
     // Start server 1
-    Integer[] ports = ((Integer[]) this.server1VM.invoke(
-        () -> CacheServerTestUtil.createCacheServerReturnPorts(regionName, new Boolean(true))));
-    final int serverPort = ports[0].intValue();
+    Integer[] ports = this.server1VM.invoke(
+        () -> CacheServerTestUtil.createCacheServerReturnPorts(regionName, Boolean.TRUE));
+    final int serverPort = ports[0];
 
     final String durableClientId = getName() + "_client";
 
@@ -2399,28 +2369,27 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     checkCqStatOnServer(server1VM, durableClientId, "All", 0);
 
     // Stop the durable client
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.durableClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the publisher client
-    this.publisherClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.publisherClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the server
-    this.server1VM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.server1VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
   }
 
   /**
    * Test functionality to close the cq and drain all events from the ha queue from the server
    */
   @Test
-  public void testCloseCqAndDrainEvents() throws Exception {
+  public void testCloseCqAndDrainEvents() {
     String greaterThan5Query = "select * from /" + regionName + " p where p.ID > 5";
     String allQuery = "select * from /" + regionName + " p where p.ID > -1";
     String lessThan5Query = "select * from /" + regionName + " p where p.ID < 5";
 
     // Start a server
-    int serverPort = ((Integer) this.server1VM
-        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, new Boolean(true))))
-            .intValue();
+    int serverPort = this.server1VM
+        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, Boolean.TRUE));
 
     // Start a durable client that is kept alive on the server when it stops
     // normally
@@ -2451,8 +2420,6 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
       public void run2() throws CacheException {
 
         final CacheClientNotifier ccnInstance = CacheClientNotifier.getInstance();
-        final CacheClientProxy clientProxy = ccnInstance.getClientProxy(durableClientId);
-        ClientProxyMembershipID proxyId = clientProxy.getProxyID();
 
         try {
           ccnInstance.closeClientCq(durableClientId, "All");
@@ -2484,13 +2451,13 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
 
 
     // Stop the durable client
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.durableClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the publisher client
-    this.publisherClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.publisherClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the server
-    this.server1VM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.server1VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
   }
 
   /**
@@ -2499,15 +2466,15 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
    *
    */
   @Test
-  public void testCloseAllCqsAndDrainEvents() throws Exception {
+  public void testCloseAllCqsAndDrainEvents() {
     String greaterThan5Query = "select * from /" + regionName + " p where p.ID > 5";
     String allQuery = "select * from /" + regionName + " p where p.ID > -1";
     String lessThan5Query = "select * from /" + regionName + " p where p.ID < 5";
 
     // Start server 1
-    Integer[] ports = ((Integer[]) this.server1VM.invoke(
-        () -> CacheServerTestUtil.createCacheServerReturnPorts(regionName, new Boolean(true))));
-    final int serverPort = ports[0].intValue();
+    Integer[] ports = this.server1VM.invoke(
+        () -> CacheServerTestUtil.createCacheServerReturnPorts(regionName, Boolean.TRUE));
+    final int serverPort = ports[0];
 
     final String durableClientId = getName() + "_client";
 
@@ -2538,8 +2505,6 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
       public void run2() throws CacheException {
 
         final CacheClientNotifier ccnInstance = CacheClientNotifier.getInstance();
-        final CacheClientProxy clientProxy = ccnInstance.getClientProxy(durableClientId);
-        ClientProxyMembershipID proxyId = clientProxy.getProxyID();
 
         try {
           ccnInstance.closeClientCq(durableClientId, "All");
@@ -2573,13 +2538,13 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     checkInterestEvents(durableClientVM, regionName, 10);
 
     // Stop the durable client
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.durableClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the publisher client
-    this.publisherClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.publisherClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the server
-    this.server1VM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.server1VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
   }
 
   /**
@@ -2588,15 +2553,15 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
    * to verify that stats are correct
    */
   @Test
-  public void testCloseAllCqsAndDrainEventsNoInterestRegistered() throws Exception {
+  public void testCloseAllCqsAndDrainEventsNoInterestRegistered() {
     String greaterThan5Query = "select * from /" + regionName + " p where p.ID > 5";
     String allQuery = "select * from /" + regionName + " p where p.ID > -1";
     String lessThan5Query = "select * from /" + regionName + " p where p.ID < 5";
 
     // Start server 1
-    Integer[] ports = ((Integer[]) this.server1VM.invoke(
-        () -> CacheServerTestUtil.createCacheServerReturnPorts(regionName, new Boolean(true))));
-    final int serverPort = ports[0].intValue();
+    Integer[] ports = this.server1VM.invoke(
+        () -> CacheServerTestUtil.createCacheServerReturnPorts(regionName, Boolean.TRUE));
+    final int serverPort = ports[0];
 
     final String durableClientId = getName() + "_client";
 
@@ -2626,8 +2591,6 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
       public void run2() throws CacheException {
 
         final CacheClientNotifier ccnInstance = CacheClientNotifier.getInstance();
-        final CacheClientProxy clientProxy = ccnInstance.getClientProxy(durableClientId);
-        ClientProxyMembershipID proxyId = clientProxy.getProxyID();
 
         try {
           ccnInstance.closeClientCq(durableClientId, "All");
@@ -2689,13 +2652,13 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     this.checkHAQueueSize(server1VM, durableClientId, 0, 1);
 
     // Stop the durable client
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.durableClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the publisher client
-    this.publisherClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.publisherClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the server
-    this.server1VM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.server1VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
   }
 
   /**
@@ -2703,15 +2666,15 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
    * durable clients, one will have a cq be closed, the other should be unaffected
    */
   @Test
-  public void testCloseCqAndDrainEvents2Client() throws Exception {
+  public void testCloseCqAndDrainEvents2Client() {
     String greaterThan5Query = "select * from /" + regionName + " p where p.ID > 5";
     String allQuery = "select * from /" + regionName + " p where p.ID > -1";
     String lessThan5Query = "select * from /" + regionName + " p where p.ID < 5";
 
     // Start server 1
-    Integer[] ports = ((Integer[]) this.server1VM.invoke(
-        () -> CacheServerTestUtil.createCacheServerReturnPorts(regionName, new Boolean(true))));
-    final int serverPort = ports[0].intValue();
+    Integer[] ports = this.server1VM.invoke(
+        () -> CacheServerTestUtil.createCacheServerReturnPorts(regionName, Boolean.TRUE));
+    final int serverPort = ports[0];
 
     final String durableClientId = getName() + "_client";
     final String durableClientId2 = getName() + "_client2";
@@ -2760,8 +2723,6 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
       public void run2() throws CacheException {
 
         final CacheClientNotifier ccnInstance = CacheClientNotifier.getInstance();
-        final CacheClientProxy clientProxy = ccnInstance.getClientProxy(durableClientId);
-        ClientProxyMembershipID proxyId = clientProxy.getProxyID();
 
         try {
           ccnInstance.closeClientCq(durableClientId, "All");
@@ -2815,13 +2776,13 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
         10/* numEventsToWaitFor */, 15/* secondsToWait */);
 
     // Stop the durable client
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.durableClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the publisher client
-    this.publisherClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.publisherClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the server
-    this.server1VM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.server1VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
   }
 
   /**
@@ -2829,7 +2790,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
    * should be rejected until no cqs are currently being drained
    */
   @Test
-  public void testRejectClientWhenDrainingCq() throws Exception {
+  public void testRejectClientWhenDrainingCq() {
     try {
       IgnoredException.addIgnoredException(
           LocalizedStrings.CacheClientNotifier_COULD_NOT_CONNECT_DUE_TO_CQ_BEING_DRAINED
@@ -2842,12 +2803,12 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
       String lessThan5Query = "select * from /" + regionName + " p where p.ID < 5";
 
       // Start server 1
-      Integer[] ports = ((Integer[]) this.server1VM.invoke(
-          () -> CacheServerTestUtil.createCacheServerReturnPorts(regionName, new Boolean(true))));
-      final int serverPort = ports[0].intValue();
+      Integer[] ports = this.server1VM.invoke(
+          () -> CacheServerTestUtil.createCacheServerReturnPorts(regionName, Boolean.TRUE));
+      final int serverPort = ports[0];
 
       final String durableClientId = getName() + "_client";
-      this.durableClientVM.invoke(() -> CacheServerTestUtil.disableShufflingOfEndpoints());
+      this.durableClientVM.invoke(CacheServerTestUtil::disableShufflingOfEndpoints);
 
       startDurableClient(durableClientVM, durableClientId, serverPort, regionName);
 
@@ -2883,8 +2844,6 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
         public void run2() throws CacheException {
 
           final CacheClientNotifier ccnInstance = CacheClientNotifier.getInstance();
-          final CacheClientProxy clientProxy = ccnInstance.getClientProxy(durableClientId);
-          ClientProxyMembershipID proxyId = clientProxy.getProxyID();
 
           try {
             ccnInstance.closeClientCq(durableClientId, "All");
@@ -2900,20 +2859,10 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
       this.server1VM.invoke(new CacheSerializableRunnable("verify was rejected at least once") {
         @Override
         public void run2() throws CacheException {
-          WaitCriterion ev = new WaitCriterion() {
-            @Override
-            public boolean done() {
-              return CacheClientProxy.testHook != null
-                  && (((RejectClientReconnectTestHook) CacheClientProxy.testHook)
-                      .wasClientRejected());
-            }
-
-            @Override
-            public String description() {
-              return null;
-            }
-          };
-          Wait.waitForCriterion(ev, 10 * 1000, 200, true);
+          Awaitility.waitAtMost(10, TimeUnit.SECONDS).pollInterval(200, TimeUnit.MILLISECONDS)
+              .until(() -> CacheClientProxy.testHook != null
+              && (((RejectClientReconnectTestHook) CacheClientProxy.testHook)
+              .wasClientRejected()));
           assertTrue(
               ((RejectClientReconnectTestHook) CacheClientProxy.testHook).wasClientRejected());
         }
@@ -2941,13 +2890,13 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
           1/* numEventsToWaitFor */, 5/* secondsToWait */);
 
       // Stop the durable client
-      this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+      this.durableClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
       // Stop the publisher client
-      this.publisherClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+      this.publisherClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
       // Stop the server
-      this.server1VM.invoke(() -> CacheServerTestUtil.closeCache());
+      this.server1VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
     } finally {
       this.server1VM.invoke(new CacheSerializableRunnable("unset test hook") {
         @Override
@@ -2970,9 +2919,9 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
       String lessThan5Query = "select * from /" + regionName + " p where p.ID < 5";
 
       // Start server 1
-      Integer[] ports = ((Integer[]) this.server1VM.invoke(
-          () -> CacheServerTestUtil.createCacheServerReturnPorts(regionName, new Boolean(true))));
-      final int serverPort = ports[0].intValue();
+      Integer[] ports = this.server1VM.invoke(
+          () -> CacheServerTestUtil.createCacheServerReturnPorts(regionName, Boolean.TRUE));
+      final int serverPort = ports[0];
 
       final String durableClientId = getName() + "_client";
 
@@ -3018,7 +2967,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
                     LocalizedStrings.CacheClientProxy_COULD_NOT_DRAIN_CQ_DUE_TO_RESTARTING_DURABLE_CLIENT
                         .toLocalizedString("All", proxyId.getDurableId());
                 if (!e.getMessage().equals(expected)) {
-                  Assert.fail("Not the expected exception, was expecting "
+                  fail("Not the expected exception, was expecting "
                       + (LocalizedStrings.CacheClientProxy_COULD_NOT_DRAIN_CQ_DUE_TO_RESTARTING_DURABLE_CLIENT
                           .toLocalizedString("All", proxyId.getDurableId())
                           + " instead of exception: " + e.getMessage()),
@@ -3041,8 +2990,8 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
       sendClientReady(durableClientVM);
 
       async.join();
-      assertEquals(async.getException() != null ? async.getException().toString() : "No error",
-          false, async.exceptionOccurred());
+      assertFalse(async.getException() != null ? async.getException().toString() : "No error",
+          async.exceptionOccurred());
 
       // verify cq listener events
       checkCqListenerEvents(durableClientVM, "GreaterThan5", 4 /* numEventsExpected */,
@@ -3053,13 +3002,13 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
           10/* numEventsToWaitFor */, 15/* secondsToWait */);
 
       // Stop the durable client
-      this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+      this.durableClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
       // Stop the publisher client
-      this.publisherClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+      this.publisherClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
       // Stop the server
-      this.server1VM.invoke(() -> CacheServerTestUtil.closeCache());
+      this.server1VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
     } finally {
       this.server1VM.invoke(new CacheSerializableRunnable("unset test hook") {
         @Override
@@ -3074,15 +3023,14 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
    * Tests situation where a client is trying to reconnect while a cq is being drained
    */
   @Test
-  public void testCqCloseExceptionDueToActiveConnection() throws Exception {
+  public void testCqCloseExceptionDueToActiveConnection() {
     String greaterThan5Query = "select * from /" + regionName + " p where p.ID > 5";
     String allQuery = "select * from /" + regionName + " p where p.ID > -1";
     String lessThan5Query = "select * from /" + regionName + " p where p.ID < 5";
 
     // Start a server
-    int serverPort = ((Integer) this.server1VM
-        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, new Boolean(true))))
-            .intValue();
+    int serverPort = this.server1VM
+        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, Boolean.TRUE));
 
     // Start a durable client that is kept alive on the server when it stops
     // normally
@@ -3141,13 +3089,13 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
         10/* numEventsToWaitFor */, 15/* secondsToWait */);
 
     // Stop the durable client
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.durableClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the publisher client
-    this.publisherClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.publisherClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the server
-    this.server1VM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.server1VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
   }
 
   /**
@@ -3155,15 +3103,14 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
    * server
    */
   @Test
-  public void testCloseCacheProxy() throws Exception {
+  public void testCloseCacheProxy() {
     String greaterThan5Query = "select * from /" + regionName + " p where p.ID > 5";
     String allQuery = "select * from /" + regionName + " p where p.ID > -1";
     String lessThan5Query = "select * from /" + regionName + " p where p.ID < 5";
 
     // Start a server
-    int serverPort = ((Integer) this.server1VM
-        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, new Boolean(true))))
-            .intValue();
+    int serverPort = this.server1VM
+        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, Boolean.TRUE));
 
     // Start a durable client that is kept alive on the server when it stops
     // normally
@@ -3201,8 +3148,6 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
           public void run2() throws CacheException {
 
             final CacheClientNotifier ccnInstance = CacheClientNotifier.getInstance();
-            final CacheClientProxy clientProxy = ccnInstance.getClientProxy(durableClientId);
-            ClientProxyMembershipID proxyId = clientProxy.getProxyID();
 
             ccnInstance.closeDurableClientProxy(durableClientId);
           }
@@ -3239,13 +3184,13 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
         1/* numEventsToWaitFor */, 5/* secondsToWait */);
 
     // Stop the durable client
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.durableClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the publisher client
-    this.publisherClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.publisherClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the server
-    this.server1VM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.server1VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
   }
 
   /**
@@ -3254,14 +3199,13 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
   @Test
   public void testSimpleDurableClientMultipleServers() {
     // Start server 1
-    Integer[] ports = ((Integer[]) this.server1VM.invoke(
-        () -> CacheServerTestUtil.createCacheServerReturnPorts(regionName, new Boolean(true))));
-    final int server1Port = ports[0].intValue();
+    Integer[] ports = this.server1VM.invoke(
+        () -> CacheServerTestUtil.createCacheServerReturnPorts(regionName, Boolean.TRUE));
+    final int server1Port = ports[0];
 
     // Start server 2 using the same mcast port as server 1
-    final int server2Port = ((Integer) this.server2VM
-        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, new Boolean(true))))
-            .intValue();
+    final int server2Port = this.server2VM
+        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, Boolean.TRUE));
 
     // Start a durable client connected to both servers that is kept alive when
     // it stops normally
@@ -3269,7 +3213,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     // final boolean durableClientKeepAlive = true; // keep the client alive when it stops normally
     final String durableClientId = getName() + "_client";
     this.durableClientVM.invoke(() -> CacheServerTestUtil.createCacheClient(
-        getClientPool(getServerHostName(durableClientVM.getHost()), server1Port, server2Port, true),
+        getClientPool(getServerHostName(), server1Port, server2Port, true),
         regionName, getClientDistributedSystemProperties(durableClientId, durableClientTimeout),
         Boolean.TRUE));
 
@@ -3277,7 +3221,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     this.durableClientVM.invoke(new CacheSerializableRunnable("Send clientReady") {
       @Override
       public void run2() throws CacheException {
-        CacheServerTestUtil.getCache().readyForEvents();
+        CacheServerTestUtil.getClientCache().readyForEvents();
       }
     });
 
@@ -3314,7 +3258,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     });
 
     // Stop the durable client
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache(new Boolean(true)));
+    this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache(Boolean.TRUE));
 
     // Verify the durable client is still on server 1
     this.server1VM.invoke(new CacheSerializableRunnable("Verify durable client") {
@@ -3341,14 +3285,14 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     // Start up the client again. This time initialize it so that it is not kept
     // alive on the servers when it stops normally.
     this.durableClientVM.invoke(() -> CacheServerTestUtil.createCacheClient(
-        getClientPool(getServerHostName(durableClientVM.getHost()), server1Port, server2Port, true),
+        getClientPool(getServerHostName(), server1Port, server2Port, true),
         regionName, getClientDistributedSystemProperties(durableClientId), Boolean.TRUE));
 
     // Send clientReady message
     this.durableClientVM.invoke(new CacheSerializableRunnable("Send clientReady") {
       @Override
       public void run2() throws CacheException {
-        CacheServerTestUtil.getCache().readyForEvents();
+        CacheServerTestUtil.getClientCache().readyForEvents();
       }
     });
 
@@ -3387,30 +3331,30 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     });
 
     // Stop the durable client
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.durableClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     this.verifySimpleDurableClientMultipleServers();
 
     // Stop server 1
-    this.server1VM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.server1VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop server 2
-    this.server2VM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.server2VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
   }
 
   @Test
   public void testDurableClientReceivedClientSessionInitialValue() {
     // Start server 1
     int server1Port = this.server1VM
-        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, new Boolean(true)));
+        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, Boolean.TRUE));
 
     // Start server 2
     int server2Port = this.server2VM
-        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, new Boolean(true)));
+        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, Boolean.TRUE));
 
     // Start normal publisher client
     this.publisherClientVM.invoke(() -> CacheServerTestUtil
-        .createCacheClient(getClientPool(getServerHostName(this.publisherClientVM.getHost()),
+        .createCacheClient(getClientPool(getServerHostName(),
             server1Port, server2Port, false), this.regionName));
 
     // Create an entry
@@ -3420,13 +3364,13 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     final String durableClientId = getName() + "_client";
     final int durableClientTimeout = 60; // keep the client alive for 60 seconds
     restartDurableClient(new Object[] {
-        getClientPool(getServerHostName(this.durableClientVM.getHost()), server1Port, server2Port,
+        getClientPool(getServerHostName(), server1Port, server2Port,
             true),
         regionName, getClientDistributedSystemProperties(durableClientId, durableClientTimeout),
         true});
 
     // Use ClientSession on the server to register interest in entry key on behalf of durable client
-    boolean server1IsPrimary = false, server2IsPrimary = false;
+    boolean server1IsPrimary = false;
     boolean registered = this.server1VM.invoke(() -> DurableClientSimpleDUnitTest
         .registerInterestWithClientSession(durableClientId, this.regionName, String.valueOf(0)));
     if (registered) {
@@ -3434,9 +3378,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     } else {
       registered = this.server2VM.invoke(() -> DurableClientSimpleDUnitTest
           .registerInterestWithClientSession(durableClientId, this.regionName, String.valueOf(0)));
-      if (registered) {
-        server2IsPrimary = true;
-      } else {
+      if (!registered) {
         fail("ClientSession interest registration failed to occur in either server.");
       }
     }
@@ -3453,7 +3395,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
 
     // Restart durable client
     restartDurableClient(new Object[] {
-        getClientPool(getServerHostName(this.durableClientVM.getHost()), server1Port, server2Port,
+        getClientPool(getServerHostName(), server1Port, server2Port,
             true),
         regionName, getClientDistributedSystemProperties(durableClientId, durableClientTimeout),
         true});
@@ -3462,13 +3404,13 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
     verifyNoDurableClientEvents(this.durableClientVM, 1, TYPE_CREATE);
 
     // Stop the durable client
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.durableClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop server 1
-    this.server1VM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.server1VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop server 2
-    this.server2VM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.server2VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
   }
 
   public static boolean registerInterestWithClientSession(String durableClientId, String regionName,
@@ -3486,25 +3428,25 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
   @Test
   public void testGetAllDurableCqsFromServer() {
     // Start server 1
-    final int server1Port = ((Integer) this.server1VM.invoke(CacheServerTestUtil.class,
-        "createCacheServer", new Object[] {regionName, new Boolean(true)})).intValue();
+    final int server1Port = this.server1VM.invoke(CacheServerTestUtil.class,
+        "createCacheServer", new Object[]{regionName, Boolean.TRUE});
 
     // Start server 2
-    final int server2Port = ((Integer) this.server2VM.invoke(CacheServerTestUtil.class,
-        "createCacheServer", new Object[] {regionName, new Boolean(true)})).intValue();
+    final int server2Port = this.server2VM.invoke(CacheServerTestUtil.class,
+        "createCacheServer", new Object[]{regionName, Boolean.TRUE});
 
     // Start a durable client
     final String durableClientId = getName() + "_client";
     this.durableClientVM.invoke(CacheServerTestUtil.class, "createCacheClient",
         new Object[] {
-            getClientPool(getServerHostName(durableClientVM.getHost()), server1Port, server2Port,
+            getClientPool(getServerHostName(), server1Port, server2Port,
                 true, 0),
             regionName, getClientDistributedSystemProperties(durableClientId, 60), Boolean.TRUE});
 
     // Send clientReady message
     this.durableClientVM.invoke(new CacheSerializableRunnable("Send clientReady") {
       public void run2() throws CacheException {
-        CacheServerTestUtil.getCache().readyForEvents();
+        CacheServerTestUtil.getClientCache().readyForEvents();
       }
     });
 
@@ -3514,16 +3456,16 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestCase {
 
     // Execute getAllDurableCqsFromServer on the client
     List<String> durableCqNames =
-        (List<String>) this.durableClientVM.invoke(() -> getAllDurableCqsFromServer());
+        this.durableClientVM.invoke(DurableClientSimpleDUnitTest::getAllDurableCqsFromServer);
 
     this.durableClientVM.invoke(() -> verifyDurableCqs(durableCqNames, cqName));
 
     // Stop the durable client
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.durableClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the servers
-    this.server1VM.invoke(() -> CacheServerTestUtil.closeCache());
-    this.server2VM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.server1VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
+    this.server2VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
   }
 
   public static List<String> getAllDurableCqsFromServer() throws CqException {

--- a/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientTestCase.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientTestCase.java
@@ -1413,6 +1413,8 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
             clientWasRejected = true;
             continueDrain.countDown();
             break;
+          default:
+            break;
         }
       } catch (InterruptedException e) {
         e.printStackTrace();

--- a/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientTestCase.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientTestCase.java
@@ -855,7 +855,7 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
             (CacheServerTestUtil.ControlListener) region.getAttributes().getCacheListeners()[0];
         listener.waitWhileNotEnoughEvents(60 * 1000, numEntries + numEntriesBeforeDisconnect);
         assertEquals(numEntries + numEntriesBeforeDisconnect, listener.events.size());
-       }
+      }
     });
   }
 

--- a/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientTestCase.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientTestCase.java
@@ -33,6 +33,7 @@ import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import org.awaitility.Awaitility;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -61,16 +62,14 @@ import org.apache.geode.internal.cache.CacheServerImpl;
 import org.apache.geode.internal.cache.ClientServerObserver;
 import org.apache.geode.internal.cache.ClientServerObserverAdapter;
 import org.apache.geode.internal.cache.ClientServerObserverHolder;
-import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.PoolFactoryImpl;
 import org.apache.geode.internal.cache.ha.HARegionQueue;
-import org.apache.geode.test.dunit.Host;
 import org.apache.geode.test.dunit.IgnoredException;
 import org.apache.geode.test.dunit.NetworkUtils;
+import org.apache.geode.test.dunit.SerializableRunnableIF;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.Wait;
-import org.apache.geode.test.dunit.WaitCriterion;
 import org.apache.geode.test.dunit.internal.JUnit4DistributedTestCase;
 import org.apache.geode.test.junit.categories.ClientSubscriptionTest;
 
@@ -82,7 +81,7 @@ import org.apache.geode.test.junit.categories.ClientSubscriptionTest;
 @Category({ClientSubscriptionTest.class})
 public class DurableClientTestCase extends JUnit4DistributedTestCase {
 
-  protected static volatile boolean isPrimaryRecovered = false;
+  private static volatile boolean isPrimaryRecovered = false;
 
   protected VM server1VM;
   protected VM server2VM;
@@ -92,11 +91,10 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
 
   @Override
   public final void postSetUp() throws Exception {
-    Host host = Host.getHost(0);
-    this.server1VM = host.getVM(0);
-    this.server2VM = host.getVM(1);
-    this.durableClientVM = host.getVM(2);
-    this.publisherClientVM = host.getVM(3);
+    this.server1VM = VM.getVM(0);
+    this.server2VM = VM.getVM(1);
+    this.durableClientVM = VM.getVM(2);
+    this.publisherClientVM = VM.getVM(3);
     this.regionName = getName() + "_region";
     // Clients see this when the servers disconnect
     IgnoredException.addIgnoredException("Could not find any server");
@@ -111,10 +109,10 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
   public final void preTearDown() throws Exception {
     preTearDownDurableClientTestCase();
 
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache());
-    this.publisherClientVM.invoke(() -> CacheServerTestUtil.closeCache());
-    this.server1VM.invoke(() -> CacheServerTestUtil.closeCache());
-    this.server2VM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.durableClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
+    this.publisherClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
+    this.server1VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
+    this.server2VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
   }
 
   protected void preTearDownDurableClientTestCase() throws Exception {}
@@ -125,21 +123,20 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
   @Test
   public void testSimpleDurableClient() {
     // Start a server
-    int serverPort = ((Integer) this.server1VM
-        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, new Boolean(true))))
-            .intValue();
+    int serverPort = this.server1VM
+        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, Boolean.TRUE));
 
     // Start a durable client that is not kept alive on the server when it
     // stops normally
     final String durableClientId = getName() + "_client";
     this.durableClientVM.invoke(() -> CacheServerTestUtil.createCacheClient(
-        getClientPool(NetworkUtils.getServerHostName(durableClientVM.getHost()), serverPort, true),
+        getClientPool(NetworkUtils.getServerHostName(), serverPort, true),
         regionName, getClientDistributedSystemProperties(durableClientId)));
 
     // Send clientReady message
     this.durableClientVM.invoke(new CacheSerializableRunnable("Send clientReady") {
       public void run2() throws CacheException {
-        CacheServerTestUtil.getCache().readyForEvents();
+        CacheServerTestUtil.getClientCache().readyForEvents();
       }
     });
 
@@ -155,8 +152,6 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
         assertTrue(proxy.isDurable());
         assertEquals(durableClientId, proxy.getDurableId());
         assertEquals(DistributionConfig.DEFAULT_DURABLE_CLIENT_TIMEOUT, proxy.getDurableTimeout());
-        // assertIndexDetailsEquals(DistributionConfig.DEFAULT_DURABLE_CLIENT_KEEP_ALIVE,
-        // proxy.getDurableKeepAlive());
       }
     });
 
@@ -167,7 +162,7 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
     this.verifySimpleDurableClient();
 
     // Stop the server
-    this.server1VM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.server1VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     this.closeDurableClient();
 
@@ -184,24 +179,23 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
 
     try {
       // Start a server
-      int serverPort = ((Integer) this.server1VM
-          .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, new Boolean(true))))
-              .intValue();
+      int serverPort = this.server1VM
+          .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, Boolean.TRUE));
 
       // Start a durable client that is not kept alive on the server when it
       // stops normally
       final String durableClientId = getName() + "_client";
 
       this.durableClientVM.invoke(() -> CacheServerTestUtil.createCacheClient(
-          getClientPool(NetworkUtils.getServerHostName(durableClientVM.getHost()), serverPort,
+          getClientPool(NetworkUtils.getServerHostName(), serverPort,
               true),
-          regionName, getClientDistributedSystemProperties(durableClientId), new Boolean(false),
+          regionName, getClientDistributedSystemProperties(durableClientId), Boolean.FALSE,
           jp));
 
       // Send clientReady message
       this.durableClientVM.invoke(new CacheSerializableRunnable("Send clientReady") {
         public void run2() throws CacheException {
-          CacheServerTestUtil.getCache().readyForEvents();
+          CacheServerTestUtil.getClientCache().readyForEvents();
         }
       });
 
@@ -218,7 +212,7 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
           assertNotSame(durableClientId, proxy.getDurableId());
 
           /*
-           * new durable id will be like this durableClientId _gem_ //separartor client pool name
+           * new durable id will be like this durableClientId _gem_ //separator client pool name
            */
           String dId = durableClientId + "_gem_" + "CacheServerTestUtil";
 
@@ -237,7 +231,7 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
       this.verifySimpleDurableClient();
 
       // Stop the server
-      this.server1VM.invoke(() -> CacheServerTestUtil.closeCache());
+      this.server1VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
       this.closeDurableClient();
     } finally {
@@ -255,14 +249,14 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
 
   public void disconnectDurableClient(boolean keepAlive) {
     printClientProxyState("Before");
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache(new Boolean(keepAlive)));
+    this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache(keepAlive));
     Wait.pause(1000);
     printClientProxyState("after");
   }
 
-  public void printClientProxyState(String st) {
+  private void printClientProxyState(String st) {
     CacheSerializableRunnable s =
-        new CacheSerializableRunnable("Loggiog CCCP and ServerConnetcion state") {
+        new CacheSerializableRunnable("Logging CCCP and ServerConnection state") {
           @Override
           public void run2() throws CacheException {
             // TODO Auto-generated method stub
@@ -275,8 +269,8 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
     server1VM.invoke(s);
   }
 
-  private static String printMap(Map m) {
-    Iterator<Map.Entry> itr = m.entrySet().iterator();
+  private static String printMap(Map<String, Object[]> m) {
+    Iterator<Map.Entry<String, Object[]>> itr = m.entrySet().iterator();
     StringBuffer sb = new StringBuffer();
     sb.append("size = ").append(m.size()).append(" ");
     while (itr.hasNext()) {
@@ -319,9 +313,8 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
   @Test
   public void testStartStopStartDurableClient() {
     // Start a server
-    int serverPort = ((Integer) this.server1VM
-        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, new Boolean(true))))
-            .intValue();
+    int serverPort = this.server1VM
+        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, Boolean.TRUE));
 
     // Start a durable client that is kept alive on the server when it stops
     // normally
@@ -329,13 +322,13 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
     final int durableClientTimeout = 60; // keep the client alive for 60 seconds
     // final boolean durableClientKeepAlive = true; // keep the client alive when it stops normally
     this.durableClientVM.invoke(() -> CacheServerTestUtil.createCacheClient(
-        getClientPool(NetworkUtils.getServerHostName(durableClientVM.getHost()), serverPort, true),
+        getClientPool(NetworkUtils.getServerHostName(), serverPort, true),
         regionName, getClientDistributedSystemProperties(durableClientId, durableClientTimeout)));
 
     // Send clientReady message
     this.durableClientVM.invoke(new CacheSerializableRunnable("Send clientReady") {
       public void run2() throws CacheException {
-        CacheServerTestUtil.getCache().readyForEvents();
+        CacheServerTestUtil.getClientCache().readyForEvents();
       }
     });
 
@@ -369,7 +362,7 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
 
     // Re-start the durable client
     this.restartDurableClient(new Object[] {
-        getClientPool(NetworkUtils.getServerHostName(durableClientVM.getHost()), serverPort, true),
+        getClientPool(NetworkUtils.getServerHostName(), serverPort, true),
         regionName, getClientDistributedSystemProperties(durableClientId, durableClientTimeout)});
 
     // Verify durable client on server
@@ -388,10 +381,10 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
     });
 
     // Stop the durable client
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.durableClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the server
-    this.server1VM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.server1VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
   }
 
   /**
@@ -401,9 +394,8 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
   @Test
   public void test39630() {
     // Start a server
-    int serverPort = ((Integer) this.server1VM
-        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, new Boolean(true))))
-            .intValue();
+    int serverPort = this.server1VM
+        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, Boolean.TRUE));
 
     // Start a durable client that is kept alive on the server when it stops
     // normally
@@ -411,15 +403,8 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
     final int durableClientTimeout = 60; // keep the client alive for 60 seconds
     // final boolean durableClientKeepAlive = true; // keep the client alive when it stops normally
     this.durableClientVM.invoke(() -> CacheServerTestUtil.createCacheClient(
-        getClientPool(NetworkUtils.getServerHostName(durableClientVM.getHost()), serverPort, true),
+        getClientPool(NetworkUtils.getServerHostName(), serverPort, true),
         regionName, getClientDistributedSystemProperties(durableClientId, durableClientTimeout)));
-
-    // // Send clientReady message
-    // this.durableClientVM.invoke(new CacheSerializableRunnable("Send clientReady") {
-    // public void run2() throws CacheException {
-    // CacheServerTestUtil.getCache().readyForEvents();
-    // }
-    // });
 
     // Verify durable client on server
     this.server1VM.invoke(new CacheSerializableRunnable("Verify durable client") {
@@ -461,14 +446,14 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
     // Re-start the durable client (this is necessary so the
     // netDown test will set the appropriate system properties.
     this.restartDurableClient(new Object[] {
-        getClientPool(NetworkUtils.getServerHostName(durableClientVM.getHost()), serverPort, true),
+        getClientPool(NetworkUtils.getServerHostName(), serverPort, true),
         regionName, getClientDistributedSystemProperties(durableClientId, durableClientTimeout)});
 
     // Stop the durable client
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.durableClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the server
-    this.server1VM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.server1VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
   }
 
   public void restartDurableClient(Object[] args) {
@@ -477,7 +462,7 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
     // Send clientReady message
     this.durableClientVM.invoke(new CacheSerializableRunnable("Send clientReady") {
       public void run2() throws CacheException {
-        CacheServerTestUtil.getCache().readyForEvents();
+        CacheServerTestUtil.getClientCache().readyForEvents();
       }
     });
   }
@@ -489,9 +474,8 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
   @Test
   public void testStartStopTimeoutDurableClient() {
     // Start a server
-    int serverPort = ((Integer) this.server1VM
-        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, new Boolean(true))))
-            .intValue();
+    int serverPort = this.server1VM
+        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, Boolean.TRUE));
 
     // Start a durable client that is kept alive on the server when it stops
     // normally
@@ -499,13 +483,13 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
     final int durableClientTimeout = 5; // keep the client alive for 5 seconds
     // final boolean durableClientKeepAlive = true; // keep the client alive when it stops normally
     this.durableClientVM.invoke(() -> CacheServerTestUtil.createCacheClient(
-        getClientPool(NetworkUtils.getServerHostName(durableClientVM.getHost()), serverPort, true),
+        getClientPool(NetworkUtils.getServerHostName(), serverPort, true),
         regionName, getClientDistributedSystemProperties(durableClientId, durableClientTimeout)));
 
     // Send clientReady message
     this.durableClientVM.invoke(new CacheSerializableRunnable("Send clientReady") {
       public void run2() throws CacheException {
-        CacheServerTestUtil.getCache().readyForEvents();
+        CacheServerTestUtil.getClientCache().readyForEvents();
       }
     });
 
@@ -537,14 +521,6 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
       }
     });
 
-    // Pause to let the client timeout. This time is 2.5 seconds longer than
-    // the durableClientTimeout set above. It should be long enough for the
-    // client to timeout and get cleaned up. There could be a race here,
-    // though.
-    // no need for the explicit pause since checkNumberOfClientProxies
-    // will wait up to 15 seconds
-    // pause(7500);
-
     // Verify it no longer exists on the server
     this.server1VM.invoke(new CacheSerializableRunnable("Verify durable client") {
       public void run2() throws CacheException {
@@ -556,14 +532,14 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
     });
 
     this.restartDurableClient(new Object[] {
-        getClientPool(NetworkUtils.getServerHostName(Host.getHost(0)), serverPort, true),
+        getClientPool(NetworkUtils.getServerHostName(), serverPort, true),
         regionName, getClientDistributedSystemProperties(durableClientId, durableClientTimeout)});
 
     // Stop the durable client
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.durableClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the server
-    this.server1VM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.server1VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
   }
 
   /**
@@ -572,9 +548,8 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
   @Test
   public void testDurableClientPrimaryUpdate() {
     // Start a server
-    int serverPort = ((Integer) this.server1VM
-        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, new Boolean(true))))
-            .intValue();
+    int serverPort = this.server1VM
+        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, Boolean.TRUE));
 
     // Start a durable client that is kept alive on the server when it stops
     // normally
@@ -582,14 +557,14 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
     final int durableClientTimeout = 120; // keep the client alive for 60 seconds
     // final boolean durableClientKeepAlive = true; // keep the client alive when it stops normally
     this.durableClientVM.invoke(() -> CacheServerTestUtil.createCacheClient(
-        getClientPool(NetworkUtils.getServerHostName(durableClientVM.getHost()), serverPort, true),
+        getClientPool(NetworkUtils.getServerHostName(), serverPort, true),
         regionName, getClientDistributedSystemProperties(durableClientId, durableClientTimeout),
         Boolean.TRUE));
 
     // Send clientReady message
     this.durableClientVM.invoke(new CacheSerializableRunnable("Send clientReady") {
       public void run2() throws CacheException {
-        CacheServerTestUtil.getCache().readyForEvents();
+        CacheServerTestUtil.getClientCache().readyForEvents();
       }
     });
 
@@ -607,7 +582,7 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
 
     // Start normal publisher client
     this.publisherClientVM.invoke(() -> CacheServerTestUtil.createCacheClient(
-        getClientPool(NetworkUtils.getServerHostName(publisherClientVM.getHost()), serverPort,
+        getClientPool(NetworkUtils.getServerHostName(), serverPort,
             false),
         regionName));
 
@@ -630,19 +605,12 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
     // Make sure the proxy is actually paused, not dispatching
     this.server1VM.invoke(new CacheSerializableRunnable("Wait for paused") {
       public void run2() throws CacheException {
-        WaitCriterion wc = new WaitCriterion() {
-          public boolean done() {
-            CacheClientProxy proxy = getClientProxy();
-            return proxy != null && proxy.isPaused();
-          }
-
-          public String description() {
-            return "Proxy was not paused: " + getClientProxy();
-          }
-        };
         // If we wait too long, the durable queue will be gone, because
         // the timeout is 120 seconds.
-        Wait.waitForCriterion(wc, 60 * 1000, 1000, true);
+        Awaitility.waitAtMost(60, TimeUnit.SECONDS).pollInterval(1, TimeUnit.SECONDS).until(() -> {
+          CacheClientProxy proxy = getClientProxy();
+          return proxy != null && proxy.isPaused();
+        });
       }
     });
 
@@ -658,31 +626,17 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
     // Verify the durable client's queue contains the entries
     this.server1VM.invoke(new CacheSerializableRunnable("Verify durable client") {
       public void run2() throws CacheException {
-        WaitCriterion wc = new WaitCriterion() {
-          String excuse;
-
-          public boolean done() {
-            CacheClientProxy proxy = getClientProxy();
-            if (proxy == null) {
-              excuse = "No CacheClientProxy";
-              return false;
-            }
-            // Verify the queue size
-            int sz = proxy.getQueueSize();
-            if (numberOfEntries != sz) {
-              excuse = "expected = " + numberOfEntries + ", actual = " + sz;
-              return false;
-            }
-            return true;
-          }
-
-          public String description() {
-            return excuse;
-          }
-        };
         // If we wait too long, the durable queue will be gone, because
         // the timeout is 120 seconds.
-        Wait.waitForCriterion(wc, 60 * 1000, 1000, true);
+        Awaitility.waitAtMost(60, TimeUnit.SECONDS).pollInterval(1, TimeUnit.SECONDS).until(() -> {
+          CacheClientProxy proxy = getClientProxy();
+          if (proxy == null) {
+            return false;
+          }
+          // Verify the queue size
+          int sz = proxy.getQueueSize();
+          return numberOfEntries == sz;
+        });
       }
     });
 
@@ -691,7 +645,7 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
 
     // Re-start the durable client
     this.restartDurableClient(new Object[] {
-        getClientPool(NetworkUtils.getServerHostName(durableClientVM.getHost()), serverPort, true),
+        getClientPool(NetworkUtils.getServerHostName(), serverPort, true),
         regionName, getClientDistributedSystemProperties(durableClientId), Boolean.TRUE});
 
     // Verify durable client on server
@@ -712,20 +666,20 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
     this.verifyListenerUpdates(numberOfEntries, numberOfEntries);
 
     // Stop the publisher client
-    this.publisherClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.publisherClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the durable client VM
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.durableClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the server
-    this.server1VM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.server1VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
   }
 
   protected void publishEntries(final int numberOfEntries) {
     this.publisherClientVM.invoke(new CacheSerializableRunnable("Publish entries") {
       public void run2() throws CacheException {
         // Get the region
-        Region region = CacheServerTestUtil.getCache().getRegion(regionName);
+        Region<String, String> region = CacheServerTestUtil.getCache().getRegion(regionName);
         assertNotNull(region);
 
         // Publish some entries
@@ -743,9 +697,8 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
   @Test
   public void testStartStopStartDurableClientUpdate() {
     // Start a server
-    int serverPort = ((Integer) this.server1VM
-        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, new Boolean(true))))
-            .intValue();
+    int serverPort = this.server1VM
+        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, Boolean.TRUE));
 
     // Start a durable client that is kept alive on the server when it stops
     // normally
@@ -753,14 +706,14 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
     final int durableClientTimeout = 60; // keep the client alive for 60 seconds
     // final boolean durableClientKeepAlive = true; // keep the client alive when it stops normally
     this.durableClientVM.invoke(() -> CacheServerTestUtil.createCacheClient(
-        getClientPool(NetworkUtils.getServerHostName(durableClientVM.getHost()), serverPort, true),
+        getClientPool(NetworkUtils.getServerHostName(), serverPort, true),
         regionName, getClientDistributedSystemProperties(durableClientId, durableClientTimeout),
         Boolean.TRUE));
 
     // Send clientReady message
     this.durableClientVM.invoke(new CacheSerializableRunnable("Send clientReady") {
       public void run2() throws CacheException {
-        CacheServerTestUtil.getCache().readyForEvents();
+        CacheServerTestUtil.getClientCache().readyForEvents();
       }
     });
 
@@ -778,7 +731,7 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
 
     // Start normal publisher client
     this.publisherClientVM.invoke(() -> CacheServerTestUtil.createCacheClient(
-        getClientPool(NetworkUtils.getServerHostName(publisherClientVM.getHost()), serverPort,
+        getClientPool(NetworkUtils.getServerHostName(), serverPort,
             false),
         regionName));
 
@@ -805,16 +758,10 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
         // Find the proxy
         final CacheClientProxy proxy = getClientProxy();
         assertNotNull(proxy);
-        WaitCriterion ev = new WaitCriterion() {
-          public boolean done() {
-            return proxy.isPaused();
-          }
 
-          public String description() {
-            return null;
-          }
-        };
-        Wait.waitForCriterion(ev, 1000, 200, true);
+        Awaitility.waitAtMost(1, TimeUnit.SECONDS).pollInterval(200, TimeUnit.MILLISECONDS)
+            .until(proxy::isPaused);
+
         assertTrue(proxy.isPaused());
       }
     });
@@ -823,7 +770,7 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
     this.publisherClientVM.invoke(new CacheSerializableRunnable("Publish more entries") {
       public void run2() throws CacheException {
         // Get the region
-        Region region = CacheServerTestUtil.getCache().getRegion(regionName);
+        Region<String, String> region = CacheServerTestUtil.getCache().getRegion(regionName);
         assertNotNull(region);
 
         // Publish some entries
@@ -857,7 +804,7 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
 
     // Re-start the durable client
     this.restartDurableClient(new Object[] {
-        getClientPool(NetworkUtils.getServerHostName(durableClientVM.getHost()), serverPort, true),
+        getClientPool(NetworkUtils.getServerHostName(), serverPort, true),
         regionName, getClientDistributedSystemProperties(durableClientId), Boolean.TRUE});
 
     // Verify durable client on server
@@ -878,13 +825,13 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
     this.verifyListenerUpdates(numberOfEntries, numberOfEntries);
 
     // Stop the publisher client
-    this.publisherClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.publisherClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the durable client VM
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.durableClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the server
-    this.server1VM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.server1VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
   }
 
   public void verifyListenerUpdates(int numEntries) {
@@ -908,11 +855,7 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
             (CacheServerTestUtil.ControlListener) region.getAttributes().getCacheListeners()[0];
         listener.waitWhileNotEnoughEvents(60 * 1000, numEntries + numEntriesBeforeDisconnect);
         assertEquals(numEntries + numEntriesBeforeDisconnect, listener.events.size());
-        // CacheServerTestUtil.getCache().getLogger().info("ARB: verify updates(): numEntries = " +
-        // numEntries);
-        // CacheServerTestUtil.getCache().getLogger().info("ARB: verify updates():
-        // listener.events.size() = " + listener.events.size());
-      }
+       }
     });
   }
 
@@ -949,21 +892,21 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
   public void testDurableClientConnectServerStopStart() {
     // Start a server
     // Start server 1
-    Integer[] ports = ((Integer[]) this.server1VM.invoke(
-        () -> CacheServerTestUtil.createCacheServerReturnPorts(regionName, new Boolean(true))));
-    final int serverPort = ports[0].intValue();
+    Integer[] ports = this.server1VM.invoke(
+        () -> CacheServerTestUtil.createCacheServerReturnPorts(regionName, Boolean.TRUE));
+    final int serverPort = ports[0];
 
     // Start a durable client that is not kept alive on the server when it
     // stops normally
     final String durableClientId = getName() + "_client";
     this.durableClientVM.invoke(() -> CacheServerTestUtil.createCacheClient(
-        getClientPool(NetworkUtils.getServerHostName(durableClientVM.getHost()), serverPort, true),
+        getClientPool(NetworkUtils.getServerHostName(), serverPort, true),
         regionName, getClientDistributedSystemProperties(durableClientId), Boolean.TRUE));
 
     // Send clientReady message
     this.durableClientVM.invoke(new CacheSerializableRunnable("Send clientReady") {
       public void run2() throws CacheException {
-        CacheServerTestUtil.getCache().readyForEvents();
+        CacheServerTestUtil.getClientCache().readyForEvents();
       }
     });
 
@@ -995,11 +938,11 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
     });
 
     // Stop the server
-    this.server1VM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.server1VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Re-start the server
-    this.server1VM.invoke(() -> CacheServerTestUtil.createCacheServer(regionName, new Boolean(true),
-        new Integer(serverPort)));
+    this.server1VM.invoke(() -> CacheServerTestUtil.createCacheServer(regionName, Boolean.TRUE,
+        serverPort));
 
     // Pause 10 seconds to allow client to reconnect to server
     // no need for the explicit pause since checkNumberOfClientProxies
@@ -1023,7 +966,7 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
 
     // Start a publisher
     this.publisherClientVM.invoke(() -> CacheServerTestUtil.createCacheClient(
-        getClientPool(NetworkUtils.getServerHostName(publisherClientVM.getHost()), serverPort,
+        getClientPool(NetworkUtils.getServerHostName(), serverPort,
             false),
         regionName));
 
@@ -1033,7 +976,7 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
     this.publisherClientVM.invoke(new CacheSerializableRunnable("Register interest") {
       public void run2() throws CacheException {
         // Get the region
-        Region region = CacheServerTestUtil.getCache().getRegion(regionName);
+        Region<String, String> region = CacheServerTestUtil.getCache().getRegion(regionName);
         assertNotNull(region);
 
         // Publish some entries
@@ -1048,13 +991,13 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
     verifyDurableClientEvents(this.durableClientVM, numberOfEntries);
 
     // Stop the durable client
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.durableClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the publisher client
-    this.publisherClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.publisherClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the server
-    this.server1VM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.server1VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
   }
 
   protected void verifyDurableClientEvents(VM durableClientVm, final int numberOfEntries) {
@@ -1089,13 +1032,13 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
   }
 
   @Test
-  public void testDurableNonHAFailover() throws InterruptedException {
+  public void testDurableNonHAFailover() {
     durableFailover(0);
     durableFailoverAfterReconnect(0);
   }
 
   @Test
-  public void testDurableHAFailover() throws InterruptedException {
+  public void testDurableHAFailover() {
     // Clients see this when the servers disconnect
     IgnoredException.addIgnoredException("Could not find any server");
     durableFailover(1);
@@ -1107,41 +1050,40 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
    * with a publisher/feeder performing operations and the client verifying updates received.
    * Redundancy level is set to 1 for this test case.
    */
-  public void durableFailover(int redundancyLevel) throws InterruptedException {
+  public void durableFailover(int redundancyLevel) {
 
     // Start server 1
-    Integer[] ports = ((Integer[]) this.server1VM.invoke(
-        () -> CacheServerTestUtil.createCacheServerReturnPorts(regionName, new Boolean(true))));
-    final int server1Port = ports[0].intValue();
+    Integer[] ports = this.server1VM.invoke(
+        () -> CacheServerTestUtil.createCacheServerReturnPorts(regionName, Boolean.TRUE));
+    final int server1Port = ports[0];
 
     // Start server 2 using the same mcast port as server 1
-    final int server2Port = ((Integer) this.server2VM
-        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, new Boolean(true))))
-            .intValue();
+    final int server2Port = this.server2VM
+        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, Boolean.TRUE));
 
     // Stop server 2
-    this.server2VM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.server2VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Start a durable client
     final String durableClientId = getName() + "_client";
     final int durableClientTimeout = 60; // keep the client alive for 60 seconds
     Pool clientPool;
     if (redundancyLevel == 1) {
-      clientPool = getClientPool(NetworkUtils.getServerHostName(Host.getHost(0)), server1Port,
+      clientPool = getClientPool(NetworkUtils.getServerHostName(), server1Port,
           server2Port, true);
     } else {
-      clientPool = getClientPool(NetworkUtils.getServerHostName(Host.getHost(0)), server1Port,
+      clientPool = getClientPool(NetworkUtils.getServerHostName(), server1Port,
           server2Port, true, 0);
     }
 
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.disableShufflingOfEndpoints());
+    this.durableClientVM.invoke(CacheServerTestUtil::disableShufflingOfEndpoints);
     this.durableClientVM.invoke(() -> CacheServerTestUtil.createCacheClient(clientPool, regionName,
         getClientDistributedSystemProperties(durableClientId, durableClientTimeout), Boolean.TRUE));
 
     // Send clientReady message
     this.durableClientVM.invoke(new CacheSerializableRunnable("Send clientReady") {
       public void run2() throws CacheException {
-        CacheServerTestUtil.getCache().readyForEvents();
+        CacheServerTestUtil.getClientCache().readyForEvents();
       }
     });
 
@@ -1158,12 +1100,12 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
     });
 
     // Re-start server2
-    this.server2VM.invoke(() -> CacheServerTestUtil.createCacheServer(regionName, new Boolean(true),
-        new Integer(server2Port)));
+    this.server2VM.invoke(() -> CacheServerTestUtil.createCacheServer(regionName, Boolean.TRUE,
+        server2Port));
 
     // Start normal publisher client
     this.publisherClientVM.invoke(() -> CacheServerTestUtil.createCacheClient(
-        getClientPool(NetworkUtils.getServerHostName(publisherClientVM.getHost()), server1Port,
+        getClientPool(NetworkUtils.getServerHostName(), server1Port,
             server2Port, false),
         regionName));
 
@@ -1208,7 +1150,7 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
     this.publisherClientVM.invoke(new CacheSerializableRunnable("Publish entries before failover") {
       public void run2() throws CacheException {
         // Get the region
-        Region region = CacheServerTestUtil.getCache().getRegion(regionName);
+        Region<String, String> region = CacheServerTestUtil.getCache().getRegion(regionName);
         assertNotNull(region);
 
         // Publish some entries
@@ -1231,7 +1173,7 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
     setPrimaryRecoveryCheck();
 
     // Stop server 1 - publisher will put 10 entries during shutdown/primary identification
-    this.server1VM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.server1VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     this.durableClientVM.invoke(new CacheSerializableRunnable("Get") {
       public void run2() throws CacheException {
@@ -1248,7 +1190,7 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
     this.publisherClientVM.invoke(new CacheSerializableRunnable("Publish entries after failover") {
       public void run2() throws CacheException {
         // Get the region
-        Region region = CacheServerTestUtil.getCache().getRegion(regionName);
+        Region<String, String> region = CacheServerTestUtil.getCache().getRegion(regionName);
         assertNotNull(region);
 
         // Publish some entries
@@ -1263,21 +1205,21 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
     this.verifyListenerUpdates(numberOfEntries + 2, numberOfEntries);
 
     // Stop the durable client
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.durableClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the publisher client
-    this.publisherClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.publisherClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop server 2
-    this.server2VM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.server2VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
   }
 
 
   public void durableFailoverAfterReconnect(int redundancyLevel) {
     // Start server 1
-    Integer[] ports = ((Integer[]) this.server1VM
-        .invoke(() -> CacheServerTestUtil.createCacheServerReturnPorts(regionName, true)));
-    final int server1Port = ports[0].intValue();
+    Integer[] ports = this.server1VM
+        .invoke(() -> CacheServerTestUtil.createCacheServerReturnPorts(regionName, true));
+    final int server1Port = ports[0];
 
     ports = this.server2VM
         .invoke(() -> CacheServerTestUtil.createCacheServerReturnPorts(regionName, true));
@@ -1288,21 +1230,21 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
     final int durableClientTimeout = 60; // keep the client alive for 60 seconds
     Pool clientPool;
     if (redundancyLevel == 1) {
-      clientPool = getClientPool(NetworkUtils.getServerHostName(Host.getHost(0)), server1Port,
+      clientPool = getClientPool(NetworkUtils.getServerHostName(), server1Port,
           server2Port, true);
     } else {
-      clientPool = getClientPool(NetworkUtils.getServerHostName(Host.getHost(0)), server1Port,
+      clientPool = getClientPool(NetworkUtils.getServerHostName(), server1Port,
           server2Port, true, 0);
     }
 
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.disableShufflingOfEndpoints());
+    this.durableClientVM.invoke(CacheServerTestUtil::disableShufflingOfEndpoints);
     this.durableClientVM.invoke(() -> CacheServerTestUtil.createCacheClient(clientPool, regionName,
         getClientDistributedSystemProperties(durableClientId, durableClientTimeout), Boolean.TRUE));
 
     // Send clientReady message
     this.durableClientVM.invoke(new CacheSerializableRunnable("Send clientReady") {
       public void run2() throws CacheException {
-        CacheServerTestUtil.getCache().readyForEvents();
+        CacheServerTestUtil.getClientCache().readyForEvents();
       }
     });
 
@@ -1320,7 +1262,7 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
 
     // Start normal publisher client
     this.publisherClientVM.invoke(() -> CacheServerTestUtil.createCacheClient(
-        getClientPool(NetworkUtils.getServerHostName(publisherClientVM.getHost()), server1Port,
+        getClientPool(NetworkUtils.getServerHostName(), server1Port,
             server2Port, false),
         regionName));
 
@@ -1353,7 +1295,7 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
     this.disconnectDurableClient(true);
 
     // Stop server 1 - publisher will put 10 entries during shutdown/primary identification
-    this.server1VM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.server1VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Publish updates during client downtime
     publishEntries(numberOfEntries);
@@ -1378,7 +1320,7 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
     this.publisherClientVM.invoke(new CacheSerializableRunnable("Publish entries before failover") {
       public void run2() throws CacheException {
         // Get the region
-        Region region = CacheServerTestUtil.getCache().getRegion(regionName);
+        Region<String, String> region = CacheServerTestUtil.getCache().getRegion(regionName);
         assertNotNull(region);
 
         // Publish some entries
@@ -1411,7 +1353,7 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
     this.publisherClientVM.invoke(new CacheSerializableRunnable("Publish entries after failover") {
       public void run2() throws CacheException {
         // Get the region
-        Region region = CacheServerTestUtil.getCache().getRegion(regionName);
+        Region<String, String> region = CacheServerTestUtil.getCache().getRegion(regionName);
         assertNotNull(region);
 
         // Publish some entries
@@ -1430,13 +1372,13 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
     }
 
     // Stop the durable client
-    this.durableClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.durableClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop the publisher client
-    this.publisherClientVM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.publisherClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // Stop server 2
-    this.server2VM.invoke(() -> CacheServerTestUtil.closeCache());
+    this.server2VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
   }
 
 
@@ -1446,29 +1388,31 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
   // Then we proceed to drain and release all locks
   // The client will then reconnect
   public class RejectClientReconnectTestHook implements CacheClientProxy.TestHook {
-    CountDownLatch reconnectLatch = new CountDownLatch(1);
-    CountDownLatch continueDrain = new CountDownLatch(1);
+    final CountDownLatch reconnectLatch = new CountDownLatch(1);
+    final CountDownLatch continueDrain = new CountDownLatch(1);
     volatile boolean clientWasRejected = false;
     CountDownLatch clientConnected = new CountDownLatch(1);
 
     public void doTestHook(String spot) {
       try {
-        if (spot.equals("CLIENT_PRE_RECONNECT")) {
-          if (!reconnectLatch.await(60, TimeUnit.SECONDS)) {
-            fail("reonnect latch was never released.");
-          }
-        } else if (spot.equals("DRAIN_IN_PROGRESS_BEFORE_DRAIN_LOCK_CHECK")) {
-          // let client try to reconnect
-          reconnectLatch.countDown();
-          // we wait until the client is rejected
-          if (!continueDrain.await(120, TimeUnit.SECONDS)) {
-            fail("Latch was never released.");
-          }
-        } else if (spot.equals("CLIENT_REJECTED_DUE_TO_CQ_BEING_DRAINED")) {
-          clientWasRejected = true;
-          continueDrain.countDown();
-        } else if (spot.equals("DRAIN_COMPLETE")) {
-
+        switch (spot) {
+          case "CLIENT_PRE_RECONNECT":
+            if (!reconnectLatch.await(60, TimeUnit.SECONDS)) {
+              fail("reonnect latch was never released.");
+            }
+            break;
+          case "DRAIN_IN_PROGRESS_BEFORE_DRAIN_LOCK_CHECK":
+            // let client try to reconnect
+            reconnectLatch.countDown();
+            // we wait until the client is rejected
+            if (!continueDrain.await(120, TimeUnit.SECONDS)) {
+              fail("Latch was never released.");
+            }
+            break;
+          case "CLIENT_REJECTED_DUE_TO_CQ_BEING_DRAINED":
+            clientWasRejected = true;
+            continueDrain.countDown();
+            break;
         }
       } catch (InterruptedException e) {
         e.printStackTrace();
@@ -1488,9 +1432,9 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
    * server is rejected and continue
    */
   public class CqExceptionDueToActivatingClientTestHook implements CacheClientProxy.TestHook {
-    CountDownLatch unblockDrain = new CountDownLatch(1);
-    CountDownLatch unblockClient = new CountDownLatch(1);
-    CountDownLatch finish = new CountDownLatch(1);
+    final CountDownLatch unblockDrain = new CountDownLatch(1);
+    final CountDownLatch unblockClient = new CountDownLatch(1);
+    final CountDownLatch finish = new CountDownLatch(1);
 
     public void doTestHook(String spot) {
       if (spot.equals("PRE_DRAIN_IN_PROGRESS")) {
@@ -1595,7 +1539,7 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
     // Get the CacheClientProxy or not (if proxy set is empty)
     CacheClientProxy proxy = null;
     Iterator<CacheClientProxy> i = notifier.getClientProxies().iterator();
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     while (i.hasNext()) {
       sb.append(" [");
       sb.append(i.next().getState());
@@ -1605,40 +1549,13 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
   }
 
   protected static void checkNumberOfClientProxies(final int expected) {
-    WaitCriterion ev = new WaitCriterion() {
-      public boolean done() {
-        return expected == getNumberOfClientProxies();
-      }
-
-      public String description() {
-        /*
-         * String result = ""; if(ClientHealthMonitor._instance != null &&
-         * ClientHealthMonitor._instance.getCleanupProxyIdTable() != null) result =
-         * ClientHealthMonitor._instance.getCleanupProxyIdTable().toString();
-         *
-         *
-         * CacheClientProxy ccp = getClientProxy();
-         *
-         * if(ccp != null) result += " ccp: " + ccp.toString();
-         */
-        return getAllClientProxyState() + " CHM state: "
-            + printMap(ClientHealthMonitor._instance.getConnectedClients(null));
-      }
-    };
-    Wait.waitForCriterion(ev, 50 * 1000, 200, true);
+    Awaitility.waitAtMost(50, TimeUnit.SECONDS).pollInterval(200, TimeUnit.MILLISECONDS)
+        .until(() -> expected == getNumberOfClientProxies());
   }
 
   protected static void checkProxyIsAlive(final CacheClientProxy proxy) {
-    WaitCriterion ev = new WaitCriterion() {
-      public boolean done() {
-        return proxy.isAlive();
-      }
-
-      public String description() {
-        return null;
-      }
-    };
-    Wait.waitForCriterion(ev, 15 * 1000, 200, true);
+    Awaitility.waitAtMost(15, TimeUnit.SECONDS).pollInterval(200, TimeUnit.MILLISECONDS)
+        .until(proxy::isAlive);
   }
 
   protected static int getNumberOfClientProxies() {
@@ -1676,18 +1593,8 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
   }
 
   public static void verifyReceivedMarkerAck(final CacheClientProxy proxy) {
-    WaitCriterion ev = new WaitCriterion() {
-      public boolean done() {
-        GemFireCacheImpl.getInstance().getLoggerI18n()
-            .fine("DurableClientDUnitTest->WaitCriterion :: done called");
-        return checkForAck(proxy);
-      }
-
-      public String description() {
-        return "never received marker ack";
-      }
-    };
-    Wait.waitForCriterion(ev, 3 * 60 * 1000, 200/* 0 */, true);
+    Awaitility.waitAtMost(3, TimeUnit.MINUTES).pollInterval(200, TimeUnit.MILLISECONDS)
+        .until(() -> checkForAck(proxy));
   }
 
   /**
@@ -1704,7 +1611,7 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
   }
 
   protected static void setTestFlagToVerifyActForMarker(Boolean flag) {
-    HARegionQueue.setUsedByTest(flag.booleanValue());
+    HARegionQueue.setUsedByTest(flag);
   }
 
   public static void setBridgeObeserverForAfterPrimaryRecovered() {
@@ -1730,30 +1637,18 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
   public void checkPrimaryRecovery() {
     this.durableClientVM.invoke(new CacheSerializableRunnable("Check observer") {
       public void run2() {
-        WaitCriterion waitForPrimaryRecovery = new WaitCriterion() {
-          public boolean done() {
-            return DurableClientTestCase.isPrimaryRecovered;
-          }
-
-          public String description() {
-            return "Did not detect primary recovery event during wait period";
-          }
-        };
-
-        // wait for primary (and interest) recovery
-        // recovery satisfier task currently uses ping interval value
-        Wait.waitForCriterion(waitForPrimaryRecovery, 30000, 1000, true);
+        Awaitility.waitAtMost(60, TimeUnit.SECONDS).pollInterval(1, TimeUnit.SECONDS)
+            .until(() -> DurableClientTestCase.isPrimaryRecovered);
       }
     });
   }
-
 
 
   protected void sendClientReady(VM vm) {
     // Send clientReady message
     vm.invoke(new CacheSerializableRunnable("Send clientReady") {
       public void run2() throws CacheException {
-        CacheServerTestUtil.getCache().readyForEvents();
+        CacheServerTestUtil.getClientCache().readyForEvents();
       }
     });
   }
@@ -1777,11 +1672,7 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
 
         try {
           createCq(cqName, cqQuery, durable).execute();
-        } catch (CqExistsException e) {
-          throw new CacheException(e) {};
-        } catch (CqException e) {
-          throw new CacheException(e) {};
-        } catch (RegionNotFoundException e) {
+        } catch (CqExistsException | CqException | RegionNotFoundException e) {
           throw new CacheException(e) {};
         }
 
@@ -1793,7 +1684,7 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
     vm.invoke(new CacheSerializableRunnable("publish " + numEntries + " entries") {
       public void run2() throws CacheException {
         // Get the region
-        Region region = CacheServerTestUtil.getCache().getRegion(regionName);
+        Region<String, Portfolio> region = CacheServerTestUtil.getCache().getRegion(regionName);
         assertNotNull(region);
 
         // Publish some entries
@@ -1825,7 +1716,7 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
       public void run2() throws CacheException {
         CqService service = ((InternalCache) CacheServerTestUtil.getCache()).getCqService();
         // Get the region
-        Region region = CacheServerTestUtil.getCache().getRegion(regionName);
+        Region<String, String> region = CacheServerTestUtil.getCache().getRegion(regionName);
         assertNotNull(region);
         region.put("LAST", "ENTRY");
       }
@@ -1847,17 +1738,8 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
         final CqQueryImpl cqQuery = (CqQueryImpl) cqService.getClientCqFromServer(proxyId, cqName);
 
         // Wait until we get the expected number of events or until 10 seconds are up
-        WaitCriterion ev = new WaitCriterion() {
-          public boolean done() {
-            return cqQuery.getVsdStats().getNumHAQueuedEvents() == expectedNumber;
-          }
-
-          public String description() {
-            return "cq numHAQueuedEvents stat was expected to be " + expectedNumber
-                + " but was instead " + cqQuery.getVsdStats().getNumHAQueuedEvents();
-          }
-        };
-        Wait.waitForCriterion(ev, 10 * 1000, 200, true);
+        Awaitility.waitAtMost(10, TimeUnit.SECONDS).pollInterval(200, TimeUnit.MILLISECONDS)
+            .until(() -> cqQuery.getVsdStats().getNumHAQueuedEvents() == expectedNumber);
 
         assertEquals(expectedNumber, cqQuery.getVsdStats().getNumHAQueuedEvents());
       }
@@ -1879,18 +1761,9 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
         ClientProxyMembershipID proxyId = clientProxy.getProxyID();
 
         // Wait until we get the expected number of events or until 10 seconds are up
-        WaitCriterion ev = new WaitCriterion() {
-          public boolean done() {
-            return clientProxy.getQueueSizeStat() == expectedNumber
-                || clientProxy.getQueueSizeStat() == remaining;
-          }
-
-          public String description() {
-            return "queue size stat was expected to be " + expectedNumber + " but was instead "
-                + clientProxy.getQueueSizeStat();
-          }
-        };
-        Wait.waitForCriterion(ev, 10 * 1000, 200, true);
+        Awaitility.waitAtMost(10, TimeUnit.SECONDS).pollInterval(200, TimeUnit.MILLISECONDS)
+            .until(() -> clientProxy.getQueueSizeStat() == expectedNumber
+                || clientProxy.getQueueSizeStat() == remaining);
 
         assertTrue(clientProxy.getQueueSizeStat() == expectedNumber
             || clientProxy.getQueueSizeStat() == remaining);
@@ -1919,9 +1792,6 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
   }
 
   /*
-   *
-   *
-   *
    * @param numEventsToWaitFor most times will be the same as numEvents, but there are times where
    * we want to wait for an event we know is not coming just to be sure an event actually isnt
    * received
@@ -1958,7 +1828,7 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
   protected void startDurableClient(VM vm, String durableClientId, int serverPort1,
       String regionName, int durableTimeoutInSeconds) {
     vm.invoke(() -> CacheServerTestUtil.createCacheClient(
-        getClientPool(NetworkUtils.getServerHostName(durableClientVM.getHost()), serverPort1, true),
+        getClientPool(NetworkUtils.getServerHostName(), serverPort1, true),
         regionName, getClientDistributedSystemProperties(durableClientId, durableTimeoutInSeconds),
         Boolean.TRUE));
   }
@@ -1966,26 +1836,26 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
   protected void startDurableClient(VM vm, String durableClientId, int serverPort1,
       String regionName) {
     vm.invoke(() -> CacheServerTestUtil.createCacheClient(
-        getClientPool(NetworkUtils.getServerHostName(durableClientVM.getHost()), serverPort1, true),
+        getClientPool(NetworkUtils.getServerHostName(), serverPort1, true),
         regionName, getClientDistributedSystemProperties(durableClientId), Boolean.TRUE));
   }
 
   protected void startDurableClient(VM vm, String durableClientId, int serverPort1, int serverPort2,
       String regionName) {
     vm.invoke(() -> CacheServerTestUtil.createCacheClient(
-        getClientPool(NetworkUtils.getServerHostName(vm.getHost()), serverPort1, serverPort2, true),
+        getClientPool(NetworkUtils.getServerHostName(), serverPort1, serverPort2, true),
         regionName, getClientDistributedSystemProperties(durableClientId), Boolean.TRUE));
   }
 
   protected void startClient(VM vm, int serverPort1, String regionName) {
     vm.invoke(() -> CacheServerTestUtil.createCacheClient(
-        getClientPool(NetworkUtils.getServerHostName(vm.getHost()), serverPort1, false),
+        getClientPool(NetworkUtils.getServerHostName(), serverPort1, false),
         regionName));
   }
 
   protected void startClient(VM vm, int serverPort1, int serverPort2, String regionName) {
     vm.invoke(() -> CacheServerTestUtil
-        .createCacheClient(getClientPool(NetworkUtils.getServerHostName(vm.getHost()), serverPort1,
+        .createCacheClient(getClientPool(NetworkUtils.getServerHostName(), serverPort1,
             serverPort2, false), regionName));
   }
 
@@ -2007,22 +1877,16 @@ public class DurableClientTestCase extends JUnit4DistributedTestCase {
   protected void checkPrimaryUpdater(VM vm) {
     vm.invoke(new CacheSerializableRunnable("Verify durable client") {
       public void run2() throws CacheException {
-        WaitCriterion wc = new WaitCriterion() {
-          public boolean done() {
-            return CacheServerTestUtil.getPool().isPrimaryUpdaterAlive();
-          }
 
-          public String description() {
-            return "No primary updater";
-          }
-        };
-        Wait.waitForCriterion(wc, 60 * 1000, 1000, true);
+        Awaitility.waitAtMost(60, TimeUnit.SECONDS).pollInterval(1, TimeUnit.SECONDS)
+            .until(() -> CacheServerTestUtil.getPool().isPrimaryUpdaterAlive());
+
         assertTrue(CacheServerTestUtil.getPool().isPrimaryUpdaterAlive());
       }
     });
   }
 
   protected void closeCache(VM vm) {
-    vm.invoke(() -> CacheServerTestUtil.closeCache());
+    vm.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
   }
 }


### PR DESCRIPTION
A test was failing due to a timeout being not long enough. Other cleanup done to remove compiler warnings and deprecations.

Co-authored-by: Finn Southerland <fsoutherland@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
