### PR TITLE
Tell intellij to consider all source code as production code

### DIFF
--- a/gradle/ide.gradle
+++ b/gradle/ide.gradle
@@ -76,6 +76,7 @@ subprojects {
   idea {
     module {
       downloadSources = true
+      testSourceDirs = Collections.emptySet()
     }
   }
 }


### PR DESCRIPTION
Intellij currently can't compile test files because it doesn't recognize
the dependency from one test source set to another test source set.

To work around this we can make intellij consider everything production
source code until we can fix the actual source layout.