### PR TITLE
GEODE-5388: Fixing repeatTest task after splitting test source sets

### DIFF
--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -165,6 +165,11 @@ subprojects {
     useJUnit {}
 
     outputs.upToDateWhen{false}
+
+    classpath += project.sourceSets.distributedTest.runtimeClasspath
+    testClassesDirs += project.sourceSets.distributedTest.output.classesDirs
+    classpath += project.sourceSets.integrationTest.runtimeClasspath
+    testClassesDirs += project.sourceSets.integrationTest.output.classesDirs
   }
 
   task flakyTest(type:Test) {


### PR DESCRIPTION
This task was broken after we split the test source into multiple source
sets

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
