### PR TITLE
GEODE-5450: Added protection for NPE in GemFireBasicDataSource with no credentials

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/datasource/GemFireBasicDataSource.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/datasource/GemFireBasicDataSource.java
@@ -89,10 +89,21 @@ public class GemFireBasicDataSource extends AbstractDataSource {
           loadDriver();
       }
     }
+
     if (url != null) {
       Properties props = new Properties();
-      props.put("user", user);
-      props.put("password", password);
+
+      // If no default username or password is specified don't add these properties - the user may
+      // be connecting to a system which does not require authentication
+      if (user != null) {
+        props.put("user", user);
+      }
+
+      // check for password separately from username - some drivers may throw different error
+      // messages we want to capture
+      if (password != null) {
+        props.put("password", password);
+      }
       connection = driverObject.connect(url, props);
     } else {
       StringId exception =
@@ -109,7 +120,6 @@ public class GemFireBasicDataSource extends AbstractDataSource {
    *
    * @param clUsername The username for the database connection.
    * @param clPassword The password for the database connection.
-   * @return ???
    */
   @Override
   public Connection getConnection(String clUsername, String clPassword) throws SQLException {

--- a/geode-core/src/test/java/org/apache/geode/internal/datasource/GemFireBasicDataSourceJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/datasource/GemFireBasicDataSourceJUnitTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.internal.datasource;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+
+public class GemFireBasicDataSourceJUnitTest {
+  private GemFireBasicDataSource dataSource;
+  private Map params = new HashMap();
+
+  @Before
+  public void setUp() {
+    params.put("connection-url", "jdbc:postgresql://myurl:5432");
+    params.put("jdbc-driver-class", "org.apache.geode.internal.datasource.TestDriver");
+    params.put("jndi-name", "datasource");
+  }
+
+  @After
+  public void cleanUp() {
+    params.clear();
+  }
+
+  @Test
+  public void connectWithoutUsernameOrPassword() throws DataSourceCreateException {
+    dataSource = (GemFireBasicDataSource) DataSourceFactory.getSimpleDataSource(params);
+
+    assertThatThrownBy(() -> dataSource.getConnection())
+        .hasMessage("Test Driver Connection attempted!");
+  }
+
+  @Test
+  public void connectWithUsernameButNoPassword() throws DataSourceCreateException {
+    params.put("user-name", "myUser");
+
+    dataSource = (GemFireBasicDataSource) DataSourceFactory.getSimpleDataSource(params);
+
+    assertThatThrownBy(() -> dataSource.getConnection())
+        .hasMessage("Test Driver Connection attempted!");
+  }
+
+
+  @Test
+  public void connectWithPasswordButNoUsername() throws DataSourceCreateException {
+    params.put("password", "myPassword");
+
+    dataSource = (GemFireBasicDataSource) DataSourceFactory.getSimpleDataSource(params);
+
+    assertThatThrownBy(() -> dataSource.getConnection())
+        .hasMessage("Test Driver Connection attempted!");
+
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/datasource/TestDriver.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/datasource/TestDriver.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.internal.datasource;
+
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.DriverPropertyInfo;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+public class TestDriver implements Driver {
+
+  @Override
+  public Connection connect(String url, Properties info) throws SQLException {
+    throw new SQLException("Test Driver Connection attempted!");
+  }
+
+  @Override
+  public boolean acceptsURL(String url) throws SQLException {
+    return false;
+  }
+
+  @Override
+  public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) throws SQLException {
+    return new DriverPropertyInfo[0];
+  }
+
+  @Override
+  public int getMajorVersion() {
+    return 0;
+  }
+
+  @Override
+  public int getMinorVersion() {
+    return 0;
+  }
+
+  @Override
+  public boolean jdbcCompliant() {
+    return false;
+  }
+
+  @Override
+  public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+    return null;
+  }
+}


### PR DESCRIPTION
Added protection against NullPointerExceptions being thrown by
GemFireBasicDataSource.getConnection() in the event the default username or password
were null. Also added tests to confirm this is working as intended.

[GEODE-5450]

Co-authored-by: Benjamin Ross <bross@pivotal.io>
Co-authored-by: Patrick Johnson <kcirtap1324@gmail.com>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
