### PR TITLE
GEODE-5474: Fix test flakiness in DiskRegionAsyncRecoveryJUnitTest an…

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/DiskOldAPIsJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/DiskOldAPIsJUnitTest.java
@@ -82,7 +82,7 @@ public class DiskOldAPIsJUnitTest {
     doSyncBitTest(true);
   }
 
-  private void doSyncBitTest(boolean destroyRegion) {
+  private void doSyncBitTest(boolean destroyRegion) throws Exception {
     DiskWriteAttributesFactory dwaf = new DiskWriteAttributesFactory();
     dwaf.setSynchronous(true);
     AttributesFactory af = new AttributesFactory();
@@ -96,6 +96,7 @@ public class DiskOldAPIsJUnitTest {
       r.close();
     }
 
+    Thread.sleep(1);
     dwaf.setSynchronous(false);
     af.setDiskWriteAttributes(dwaf.create());
     r = cache.createRegion("r", af.create());

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/DiskRegionAsyncRecoveryJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/DiskRegionAsyncRecoveryJUnitTest.java
@@ -360,6 +360,8 @@ public class DiskRegionAsyncRecoveryJUnitTest extends DiskRegionTestingBase {
         recoveryDone.countDown();
       }
     });
+
+    Thread.sleep(1);
     try {
       region = createRegion();
 


### PR DESCRIPTION
…d DiskOldAPIsJUnitTest

- Occasionally these tests will fail if the time between region close and
  re-creation is so short that the PersistenceMemberID is equivalent between
  the old and new values.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
