### PR TITLE
GEODE-5477 Fix `distTomcat` dependencies in geode assembly

### DIFF
--- a/extensions/geode-modules-assembly/build.gradle
+++ b/extensions/geode-modules-assembly/build.gradle
@@ -147,7 +147,7 @@ def configureTcServer30Assembly = {
   }
 }
 
-task distTomcat(type: Zip, dependsOn: ':extensions/geode-modules:assemble') {
+task distTomcat(type: Zip, dependsOn: [':extensions/geode-modules:jar', ':extensions/geode-modules-tomcat7:jar', ':extensions/geode-modules-tomcat8:jar']) {
   baseName = moduleBaseName
   classifier = "Tomcat"
 
@@ -171,7 +171,7 @@ task distTomcat(type: Zip, dependsOn: ':extensions/geode-modules:assemble') {
   }
 }
 
-task distAppServer(type: Zip, dependsOn: ':extensions/geode-modules-session:assemble') {
+task distAppServer(type: Zip, dependsOn: [':extensions/geode-modules-session:jar', ':extensions/geode-modules-tomcat7:jar', ':extensions/geode-modules-tomcat8:jar']) {
   baseName = moduleBaseName
   classifier = "AppServer"
 


### PR DESCRIPTION
Task depends on jars for tomcat7 and tomcat8, but did not wait for those
tasks to execute.

Signed-off-by: Finn Southerland <fsoutherland@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
