### PR TITLE
GEODE-5420: Protect events in HAContainer from premature modification

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/HARegionQueueIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/HARegionQueueIntegrationTest.java
@@ -18,31 +18,43 @@ import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mock;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import util.TestException;
 
 import org.apache.geode.CancelCriterion;
+import org.apache.geode.Statistics;
+import org.apache.geode.StatisticsType;
 import org.apache.geode.cache.AttributesFactory;
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.CacheFactory;
@@ -52,11 +64,15 @@ import org.apache.geode.cache.EvictionAttributes;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.cache.Scope;
+import org.apache.geode.distributed.internal.DSClock;
+import org.apache.geode.distributed.internal.DistributionConfig;
+import org.apache.geode.distributed.internal.DistributionManager;
+import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
+import org.apache.geode.internal.SystemTimer;
 import org.apache.geode.internal.Version;
 import org.apache.geode.internal.cache.CacheServerImpl;
 import org.apache.geode.internal.cache.CachedDeserializable;
-import org.apache.geode.internal.cache.Conflatable;
 import org.apache.geode.internal.cache.EnumListenerEvent;
 import org.apache.geode.internal.cache.EventID;
 import org.apache.geode.internal.cache.GemFireCacheImpl;
@@ -66,10 +82,13 @@ import org.apache.geode.internal.cache.InternalRegionArguments;
 import org.apache.geode.internal.cache.LocalRegion;
 import org.apache.geode.internal.cache.VMCachedDeserializable;
 import org.apache.geode.internal.cache.tier.sockets.CacheClientNotifier;
+import org.apache.geode.internal.cache.tier.sockets.CacheServerStats;
 import org.apache.geode.internal.cache.tier.sockets.ClientProxyMembershipID;
 import org.apache.geode.internal.cache.tier.sockets.ClientUpdateMessage;
 import org.apache.geode.internal.cache.tier.sockets.ClientUpdateMessageImpl;
+import org.apache.geode.internal.cache.tier.sockets.ConnectionListener;
 import org.apache.geode.internal.cache.tier.sockets.HAEventWrapper;
+import org.apache.geode.internal.concurrent.ConcurrentHashSet;
 import org.apache.geode.internal.util.BlobHelper;
 import org.apache.geode.internal.util.concurrent.StoppableReentrantReadWriteLock;
 
@@ -111,6 +130,34 @@ public class HARegionQueueIntegrationTest {
     return cache.createRegionFactory(RegionShortcut.REPLICATE).create("data");
   }
 
+  private InternalCache createMockInternalCache() {
+    InternalCache mockInternalCache = Mockito.mock(InternalCache.class);
+    doReturn(Mockito.mock(SystemTimer.class)).when(mockInternalCache).getCCPTimer();
+    doReturn(Mockito.mock(CancelCriterion.class)).when(mockInternalCache).getCancelCriterion();
+
+    InternalDistributedSystem mockInteralDistributedSystem = createMockInternalDistributedSystem();
+    doReturn(mockInteralDistributedSystem).when(mockInternalCache).getInternalDistributedSystem();
+    doReturn(mockInteralDistributedSystem).when(mockInternalCache).getDistributedSystem();
+
+    return mockInternalCache;
+  }
+
+  private InternalDistributedSystem createMockInternalDistributedSystem() {
+    InternalDistributedSystem mockInternalDistributedSystem =
+        Mockito.mock(InternalDistributedSystem.class);
+    DistributionManager mockDistributionManager = Mockito.mock(DistributionManager.class);
+
+    doReturn(Mockito.mock(InternalDistributedMember.class)).when(mockInternalDistributedSystem)
+        .getDistributedMember();
+    doReturn(Mockito.mock(Statistics.class)).when(mockInternalDistributedSystem)
+        .createAtomicStatistics(any(StatisticsType.class), any(String.class));
+    doReturn(Mockito.mock(DistributionConfig.class)).when(mockDistributionManager).getConfig();
+    doReturn(mockDistributionManager).when(mockInternalDistributedSystem).getDistributionManager();
+    doReturn(Mockito.mock(DSClock.class)).when(mockInternalDistributedSystem).getClock();
+
+    return mockInternalDistributedSystem;
+  }
+
   private CacheClientNotifier createCacheClientNotifier() {
     // Create a mock CacheClientNotifier
     CacheClientNotifier ccn = mock(CacheClientNotifier.class);
@@ -127,9 +174,18 @@ public class HARegionQueueIntegrationTest {
   }
 
   @Test
-  public void verifyEndGiiQueueingPutsHAEventWrapperNotClientUpdateMessage() throws Exception {
+  public void verifyEndGiiQueueingEmptiesQueueAndHAContainer() throws Exception {
+    // We need to use an actual cache client notifier for this test because we are making assertions
+    // based on the actual CacheClientNotifier.checkAndRemoveFromClientMsgsRegion() method.
+    InternalCache mockInternalCache = createMockInternalCache();
+    CacheClientNotifier cacheClientNotifier =
+        CacheClientNotifier.getInstance(mockInternalCache, Mockito.mock(CacheServerStats.class),
+            100000, 100000, Mockito.mock(ConnectionListener.class), null, false);
+    PowerMockito.when(CacheClientNotifier.getInstance()).thenReturn(cacheClientNotifier);
+
     // Create a HAContainerRegion
-    HAContainerWrapper haContainerWrapper = createHAContainerRegion();
+    HAContainerWrapper haContainerWrapper =
+        (HAContainerWrapper) cacheClientNotifier.getHaContainer();
 
     // create message and HAEventWrapper
     ClientUpdateMessage message = new ClientUpdateMessageImpl(EnumListenerEvent.AFTER_UPDATE,
@@ -137,6 +193,7 @@ public class HARegionQueueIntegrationTest {
         new ClientProxyMembershipID(), new EventID(cache.getDistributedSystem()));
     HAEventWrapper wrapper = new HAEventWrapper(message);
     wrapper.setHAContainer(haContainerWrapper);
+    wrapper.incrementPutInProgressCounter();
 
     // Create and update HARegionQueues forcing one queue to startGiiQueueing
     int numQueues = 10;
@@ -147,28 +204,33 @@ public class HARegionQueueIntegrationTest {
     assertEquals(1, haContainerWrapper.size());
 
     HAEventWrapper wrapperInContainer = (HAEventWrapper) haContainerWrapper.getKey(wrapper);
-    assertEquals(numQueues, wrapperInContainer.getReferenceCount());
+    assertEquals(numQueues - 1, wrapperInContainer.getReferenceCount());
+    assertTrue(wrapperInContainer.getPutInProgress());
 
-    // Verify that the HAEventWrapper in the giiQueue now has msg = null
-    // this gets set to null when wrapper is added to HAContainer (for non-gii queues)
+    // Verify that the HAEventWrapper in the giiQueue now has msg != null
+    // We don't null this out while putInProgress > 0 (true)
     Queue giiQueue = targetQueue.getGiiQueue();
     assertEquals(1, giiQueue.size());
 
+    // Simulate that we have iterated through all interested proxies
+    // and are now decrementing the PutInProgressCounter
+    wrapperInContainer.decrementPutInProgressCounter();
+
+    // Simulate that other queues have processed this event, then
+    // peek and process the event off the giiQueue
+    for (int i = 0; i < numQueues - 1; ++i) {
+      targetQueue.decAndRemoveFromHAContainer(wrapper);
+    }
+
     HAEventWrapper giiQueueEntry = (HAEventWrapper) giiQueue.peek();
     assertNotNull(giiQueueEntry);
-    assertNull(giiQueueEntry.getClientUpdateMessage());
+    assertNotNull(giiQueueEntry.getClientUpdateMessage());
 
-    // endGiiQueueing and verify queue empty and putEventInHARegion invoked with HAEventWrapper
-    // not ClientUpdateMessageImpl
-    HARegionQueue spyTargetQueue = spy(targetQueue);
-    spyTargetQueue.endGiiQueueing();
+    // endGiiQueueing and verify queue and HAContainer are empty
+    targetQueue.endGiiQueueing();
     assertEquals(0, giiQueue.size());
 
-    ArgumentCaptor<Conflatable> eventCaptor = ArgumentCaptor.forClass(Conflatable.class);
-    verify(spyTargetQueue).putEventInHARegion(eventCaptor.capture(), anyLong());
-    Conflatable capturedEvent = eventCaptor.getValue();
-    assertTrue(capturedEvent instanceof HAEventWrapper);
-    assertNotNull(((HAEventWrapper) capturedEvent).getClientUpdateMessage());
+    Assert.assertEquals("Expected HAContainer to be empty", 0, haContainerWrapper.size());
   }
 
   @Test
@@ -235,11 +297,221 @@ public class HARegionQueueIntegrationTest {
     verifyHAContainerWrapper(haContainerWrapper, cd, NUM_QUEUES);
   }
 
+  @Test
+  public void verifySimultaneousPutHAEventWrapperWithRegion() throws Exception {
+    HAContainerWrapper haContainerWrapper = createHAContainerRegion();
+
+    final int numQueues = 30;
+    final int numOperations = 1000;
+
+    Set<HAEventWrapper> haEventWrappersToValidate =
+        createAndPutHARegionQueuesSimulataneously(haContainerWrapper, numQueues, numOperations);
+
+    assertEquals(numOperations, haContainerWrapper.size());
+
+    for (HAEventWrapper haEventWrapperToValidate : haEventWrappersToValidate) {
+      HAEventWrapper wrapperInContainer =
+          (HAEventWrapper) haContainerWrapper.getKey(haEventWrapperToValidate);
+      assertEquals(numQueues, wrapperInContainer.getReferenceCount());
+    }
+  }
+
+  @Test
+  public void verifySequentialPutHAEventWrapperWithRegion() throws Exception {
+    HAContainerWrapper haContainerWrapper = createHAContainerRegion();
+
+    ClientUpdateMessage message = new ClientUpdateMessageImpl(EnumListenerEvent.AFTER_UPDATE,
+        (LocalRegion) dataRegion, "key", "value".getBytes(), (byte) 0x01, null,
+        new ClientProxyMembershipID(), new EventID(new byte[] {1}, 1, 2));
+    HAEventWrapper haEventWrapper = new HAEventWrapper(message);
+    haEventWrapper.setHAContainer(haContainerWrapper);
+
+    final int numQueues = 10;
+
+    createAndPutHARegionQueuesSequentially(haContainerWrapper, haEventWrapper, numQueues);
+
+    assertEquals(1, haContainerWrapper.size());
+
+    HAEventWrapper wrapperInContainer =
+        (HAEventWrapper) haContainerWrapper.getKey(haEventWrapper);
+    assertEquals(numQueues, wrapperInContainer.getReferenceCount());
+  }
+
+  @Test
+  public void verifySimultaneousPutHAEventWrapperWithMap() throws Exception {
+    HAContainerWrapper haContainerWrapper = new HAContainerMap(new ConcurrentHashMap());
+    when(ccn.getHaContainer()).thenReturn(haContainerWrapper);
+
+    final int numQueues = 30;
+    final int numOperations = 1000;
+
+    Set<HAEventWrapper> haEventWrappersToValidate =
+        createAndPutHARegionQueuesSimulataneously(haContainerWrapper, numQueues, numOperations);
+
+    assertEquals(numOperations, haContainerWrapper.size());
+
+    for (HAEventWrapper haEventWrapperToValidate : haEventWrappersToValidate) {
+      HAEventWrapper wrapperInContainer =
+          (HAEventWrapper) haContainerWrapper.getKey(haEventWrapperToValidate);
+      assertEquals(numQueues, wrapperInContainer.getReferenceCount());
+    }
+  }
+
+  @Test
+  public void verifySequentialPutHAEventWrapperWithMap() throws Exception {
+    HAContainerWrapper haContainerWrapper = new HAContainerMap(new ConcurrentHashMap());
+    when(ccn.getHaContainer()).thenReturn(haContainerWrapper);
+
+    ClientUpdateMessage message = new ClientUpdateMessageImpl(EnumListenerEvent.AFTER_UPDATE,
+        (LocalRegion) dataRegion, "key", "value".getBytes(), (byte) 0x01, null,
+        new ClientProxyMembershipID(), new EventID(new byte[] {1}, 1, 2));
+    HAEventWrapper haEventWrapper = new HAEventWrapper(message);
+    haEventWrapper.setHAContainer(haContainerWrapper);
+
+    final int numQueues = 10;
+    createAndPutHARegionQueuesSequentially(haContainerWrapper, haEventWrapper, numQueues);
+
+    assertEquals(1, haContainerWrapper.size());
+
+    HAEventWrapper wrapperInContainer =
+        (HAEventWrapper) haContainerWrapper.getKey(haEventWrapper);
+    assertEquals(numQueues, wrapperInContainer.getReferenceCount());
+  }
+
+  @Test
+  public void queueRemovalAndDispatchingConcurrently() throws Exception {
+    // Create a HAContainerMap to be used by the CacheClientNotifier
+    HAContainerWrapper haContainerWrapper = new HAContainerMap(new ConcurrentHashMap());
+    when(ccn.getHaContainer()).thenReturn(haContainerWrapper);
+
+    List<HARegionQueue> regionQueues = new ArrayList<>();
+
+    for (int i = 0; i < 2; ++i) {
+      HARegion haRegion = Mockito.mock(HARegion.class);
+      when(haRegion.getGemFireCache()).thenReturn((InternalCache) cache);
+
+      ConcurrentHashMap<Object, Object> mockRegion = new ConcurrentHashMap<>();
+
+      when(haRegion.put(Mockito.any(Object.class), Mockito.any(Object.class))).then(answer -> {
+        Object existingValue = mockRegion.put(answer.getArgument(0), answer.getArgument(1));
+        return existingValue;
+      });
+
+      when(haRegion.get(Mockito.any(Object.class))).then(answer -> {
+        return mockRegion.get(answer.getArgument(0));
+      });
+
+      doAnswer(answer -> {
+        mockRegion.remove(answer.getArgument(0));
+        return null;
+      }).when(haRegion).localDestroy(Mockito.any(Object.class));
+
+      regionQueues.add(createHARegionQueue(haContainerWrapper, i, haRegion, false));
+    }
+
+    ExecutorService service = Executors.newFixedThreadPool(2);
+
+    List<Callable<Object>> callables = new ArrayList<>();
+
+    for (int i = 0; i < 10000; ++i) {
+      callables.clear();
+
+      EventID eventID = new EventID(new byte[] {1}, 1, i);
+
+      ClientUpdateMessage message = new ClientUpdateMessageImpl(EnumListenerEvent.AFTER_UPDATE,
+          (LocalRegion) dataRegion, "key", "value".getBytes(), (byte) 0x01, null,
+          new ClientProxyMembershipID(), eventID);
+
+      HAEventWrapper wrapper = new HAEventWrapper(message);
+      wrapper.setHAContainer(haContainerWrapper);
+      wrapper.incrementPutInProgressCounter();
+
+      for (HARegionQueue queue : regionQueues) {
+        queue.put(wrapper);
+      }
+
+      wrapper.decrementPutInProgressCounter();
+
+      for (HARegionQueue queue : regionQueues) {
+        callables.add(Executors.callable(() -> {
+          try {
+            queue.peek();
+            queue.remove();
+          } catch (Exception ex) {
+            throw new RuntimeException(ex);
+          }
+        }));
+
+        callables.add(Executors.callable(() -> {
+          try {
+            queue.removeDispatchedEvents(eventID);
+          } catch (Exception ex) {
+            throw new RuntimeException(ex);
+          }
+        }));
+      }
+
+      // invokeAll() will wait until our two callables have completed
+      List<Future<Object>> futures = service.invokeAll(callables, 10, TimeUnit.SECONDS);
+
+      for (Future<Object> future : futures) {
+        try {
+          future.get();
+        } catch (Exception ex) {
+          throw new TestException(
+              "Exception thrown while executing regionQueue methods concurrently on iteration: "
+                  + i,
+              ex);
+        }
+      }
+    }
+  }
+
+  @Test
+  public void verifyPutEntryConditionallyInHAContainerNoOverwrite() throws Exception {
+    HAContainerWrapper haContainerWrapper = new HAContainerMap(new ConcurrentHashMap());
+
+    // create message and HAEventWrapper
+    EventID eventID = new EventID(cache.getDistributedSystem());
+    ClientUpdateMessage oldMessage = new ClientUpdateMessageImpl(EnumListenerEvent.AFTER_UPDATE,
+        (LocalRegion) dataRegion, "key", "value".getBytes(), (byte) 0x01, null,
+        new ClientProxyMembershipID(), eventID);
+    HAEventWrapper originalWrapperInstance = new HAEventWrapper(oldMessage);
+    originalWrapperInstance.incrementPutInProgressCounter();
+    originalWrapperInstance.setHAContainer(haContainerWrapper);
+
+    HARegionQueue haRegionQueue = createHARegionQueue(haContainerWrapper, 0);
+
+    haRegionQueue.putEventInHARegion(originalWrapperInstance, 1L);
+
+    // Simulate a QRM for this event
+    haRegionQueue.region.destroy(1L);
+    haRegionQueue.decAndRemoveFromHAContainer(originalWrapperInstance);
+
+    ClientUpdateMessage newMessage = new ClientUpdateMessageImpl(EnumListenerEvent.AFTER_UPDATE,
+        (LocalRegion) dataRegion, "key", "value".getBytes(), (byte) 0x01, null,
+        new ClientProxyMembershipID(), eventID);
+    HAEventWrapper newWrapperInstance = new HAEventWrapper(newMessage);
+    newWrapperInstance.incrementPutInProgressCounter();
+    newWrapperInstance.setHAContainer(haContainerWrapper);
+
+    haRegionQueue.putEventInHARegion(newWrapperInstance, 1L);
+
+    // Add the original wrapper back in, and verify that it does not overwrite the new one
+    // and that it increments the ref count on the container key.
+    haRegionQueue.putEventInHARegion(originalWrapperInstance, 1L);
+
+    Assert.assertEquals("Original message overwrote new message in container",
+        haContainerWrapper.get(originalWrapperInstance),
+        newWrapperInstance.getClientUpdateMessage());
+    Assert.assertEquals("Reference count was not the expected value", 2,
+        newWrapperInstance.getReferenceCount());
+    Assert.assertEquals("Container size was not the expected value", haContainerWrapper.size(), 1);
+  }
+
   private HAContainerRegion createHAContainerRegion() throws Exception {
-    // Create a Region to be used by the HAContainerRegion
     Region haContainerRegionRegion = createHAContainerRegionRegion();
 
-    // Create an HAContainerRegion
     HAContainerRegion haContainerRegion = new HAContainerRegion(haContainerRegionRegion);
 
     return haContainerRegion;
@@ -261,25 +533,27 @@ public class HARegionQueueIntegrationTest {
     return region;
   }
 
-  private HARegionQueue createHARegionQueue(Map haContainer, int index) throws Exception {
+  private HARegionQueue createHARegionQueue(Map haContainer, int index, HARegion haRegion,
+      boolean puttingGIIDataInQueue) throws Exception {
     StoppableReentrantReadWriteLock giiLock = Mockito.mock(StoppableReentrantReadWriteLock.class);
-    when(giiLock.writeLock())
-        .thenReturn(Mockito.mock(StoppableReentrantReadWriteLock.StoppableWriteLock.class));
-    when(giiLock.readLock())
-        .thenReturn(Mockito.mock(StoppableReentrantReadWriteLock.StoppableReadLock.class));
+    doReturn(Mockito.mock(StoppableReentrantReadWriteLock.StoppableWriteLock.class)).when(giiLock)
+        .writeLock();
+    doReturn(Mockito.mock(StoppableReentrantReadWriteLock.StoppableReadLock.class)).when(giiLock)
+        .readLock();
 
-    StoppableReentrantReadWriteLock rwLock = Mockito.mock(StoppableReentrantReadWriteLock.class);
-    when(rwLock.writeLock())
-        .thenReturn(Mockito.mock(StoppableReentrantReadWriteLock.StoppableWriteLock.class));
-    when(rwLock.readLock())
-        .thenReturn(Mockito.mock(StoppableReentrantReadWriteLock.StoppableReadLock.class));
-
-    HARegion haRegion = Mockito.mock(HARegion.class);
-    when(haRegion.getGemFireCache()).thenReturn((InternalCache) cache);
+    StoppableReentrantReadWriteLock rwLock =
+        new StoppableReentrantReadWriteLock(cache.getCancelCriterion());
 
     return new HARegionQueue("haRegion+" + index, haRegion, (InternalCache) cache, haContainer,
         null, (byte) 1, true, mock(HARegionQueueStats.class), giiLock, rwLock,
-        mock(CancelCriterion.class), false);
+        mock(CancelCriterion.class), puttingGIIDataInQueue);
+  }
+
+  private HARegionQueue createHARegionQueue(Map haContainer, int index) throws Exception {
+    HARegion haRegion = Mockito.mock(HARegion.class);
+    when(haRegion.getGemFireCache()).thenReturn((InternalCache) cache);
+
+    return createHARegionQueue(haContainer, index, haRegion, false);
   }
 
   private CachedDeserializable createCachedDeserializable(HAContainerWrapper haContainerWrapper)
@@ -319,17 +593,95 @@ public class HARegionQueueIntegrationTest {
 
     // create HARegionQueues and startGiiQueuing on a region about half way through
     for (int i = 0; i < numQueues; i++) {
-      HARegionQueue haRegionQueue = createHARegionQueue(haContainerWrapper, i);
+      HARegionQueue haRegionQueue = null;
 
       // start GII Queueing (targetRegionQueue)
       if (i == startGiiQueueingIndex) {
-        targetQueue = haRegionQueue;
-        targetQueue.startGiiQueueing();
+        HARegion haRegion = Mockito.mock(HARegion.class);
+
+        final HARegionQueue giiHaRegionQueue =
+            createHARegionQueue(haContainerWrapper, i, haRegion, false);;
+        giiHaRegionQueue.startGiiQueueing();
+        targetQueue = giiHaRegionQueue;
+
+        when(haRegion.put(Mockito.any(Object.class), Mockito.any(HAEventWrapper.class)))
+            .then(answer -> {
+              // Simulate that either a QRM or message dispatch has occurred immediately after the
+              // put.
+              // We want to ensure that the event is removed from the HAContainer if it is drained
+              // from the giiQueue
+              // and the ref count has dropped to 0.
+              HAEventWrapper haContainerKey = answer.getArgument(1);
+              giiHaRegionQueue.decAndRemoveFromHAContainer(haContainerKey);
+              return null;
+            });
+
+        when(haRegion.getGemFireCache()).thenReturn((InternalCache) cache);
+
+        haRegionQueue = giiHaRegionQueue;
+      } else {
+        haRegionQueue = createHARegionQueue(haContainerWrapper, i);
       }
 
       haRegionQueue.put(wrapper);
     }
+
     return targetQueue;
+  }
+
+  private Set<HAEventWrapper> createAndPutHARegionQueuesSimulataneously(
+      HAContainerWrapper haContainerWrapper, int numQueues, int numOperations) throws Exception {
+    ConcurrentLinkedQueue<HARegionQueue> queues = new ConcurrentLinkedQueue<>();
+    final ConcurrentHashSet<HAEventWrapper> testValidationWrapperSet = new ConcurrentHashSet<>();
+    final AtomicInteger count = new AtomicInteger();
+
+    // create HARegionQueuesv
+    for (int i = 0; i < numQueues; i++) {
+      queues.add(createHARegionQueue(haContainerWrapper, i));
+    }
+
+    for (int i = 0; i < numOperations; i++) {
+      count.set(i);
+
+      ClientUpdateMessage message = new ClientUpdateMessageImpl(EnumListenerEvent.AFTER_CREATE,
+          (LocalRegion) dataRegion, "key", "value".getBytes(), (byte) 0x01, null,
+          new ClientProxyMembershipID(), new EventID(new byte[] {1}, 1, count.get()));
+
+      queues.parallelStream().forEach(haRegionQueue -> {
+        try {
+          // In production (CacheClientNotifier.singletonRouteClientMessage), each queue has its
+          // own HAEventWrapper object even though they hold the same ClientUpdateMessage,
+          // so we create an object for each queue in here
+          HAEventWrapper haEventWrapper = new HAEventWrapper(message);
+
+          testValidationWrapperSet.add(haEventWrapper);
+
+          haRegionQueue.put(haEventWrapper);
+        } catch (InterruptedException iex) {
+          throw new RuntimeException(iex);
+        }
+      });
+    }
+
+    return testValidationWrapperSet;
+  }
+
+  private void createAndPutHARegionQueuesSequentially(HAContainerWrapper haContainerWrapper,
+      HAEventWrapper haEventWrapper, int numQueues) throws Exception {
+    ArrayList<HARegionQueue> queues = new ArrayList<>();
+
+    // create HARegionQueues
+    for (int i = 0; i < numQueues; i++) {
+      queues.add(createHARegionQueue(haContainerWrapper, i));
+    }
+
+    haEventWrapper.incrementPutInProgressCounter();
+
+    for (HARegionQueue queue : queues) {
+      queue.put(haEventWrapper);
+    }
+
+    haEventWrapper.decrementPutInProgressCounter();
   }
 
   private void createAndUpdateHARegionQueuesSimultaneously(HAContainerWrapper haContainerWrapper,

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/tier/sockets/CacheClientNotifierIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/tier/sockets/CacheClientNotifierIntegrationTest.java
@@ -1,0 +1,339 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.internal.cache.tier.sockets;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.shiro.subject.Subject;
+import org.awaitility.Awaitility;
+import org.awaitility.Duration;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import org.apache.geode.CancelCriterion;
+import org.apache.geode.DataSerializer;
+import org.apache.geode.Statistics;
+import org.apache.geode.StatisticsType;
+import org.apache.geode.cache.AttributesMutator;
+import org.apache.geode.cache.Operation;
+import org.apache.geode.cache.RegionAttributes;
+import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.distributed.internal.DSClock;
+import org.apache.geode.distributed.internal.DistributionConfig;
+import org.apache.geode.distributed.internal.DistributionManager;
+import org.apache.geode.distributed.internal.InternalDistributedSystem;
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
+import org.apache.geode.internal.InternalDataSerializer;
+import org.apache.geode.internal.SystemTimer;
+import org.apache.geode.internal.Version;
+import org.apache.geode.internal.cache.EntryEventImpl;
+import org.apache.geode.internal.cache.EnumListenerEvent;
+import org.apache.geode.internal.cache.EventID;
+import org.apache.geode.internal.cache.FilterProfile;
+import org.apache.geode.internal.cache.FilterRoutingInfo;
+import org.apache.geode.internal.cache.HARegion;
+import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.InternalRegionArguments;
+import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.security.SecurityService;
+import org.apache.geode.test.junit.categories.ClientSubscriptionTest;
+
+@Category({ClientSubscriptionTest.class})
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({CacheClientProxy.class, DataSerializer.class})
+public class CacheClientNotifierIntegrationTest {
+  @Test
+  public void testCacheClientNotifier_NotifyClients_QRMCausesPrematureRemovalFromHAContainer()
+      throws Exception {
+    final CountDownLatch messageDispatcherInitLatch = new CountDownLatch(1);
+    final CountDownLatch notifyClientLatch = new CountDownLatch(1);
+
+    setupMockMessageDispatcher(messageDispatcherInitLatch, notifyClientLatch);
+
+    InternalCache mockInternalCache = createMockInternalCache();
+
+    CacheClientNotifier cacheClientNotifier =
+        CacheClientNotifier.getInstance(mockInternalCache, mock(CacheServerStats.class),
+            100000, 100000, mock(ConnectionListener.class), null, false);
+
+    final String mockRegionNameProxyOne = "mockHARegionProxyOne";
+    final String mockRegionNameProxyTwo = "mockHARegionProxyTwo";
+
+    CacheClientProxy cacheClientProxyOne =
+        createMockCacheClientProxy(cacheClientNotifier, mockRegionNameProxyOne);
+    CacheClientProxy cacheClientProxyTwo =
+        createMockCacheClientProxy(cacheClientNotifier, mockRegionNameProxyTwo);
+
+    createMockHARegion(mockInternalCache, cacheClientProxyOne, mockRegionNameProxyOne, true);
+    createMockHARegion(mockInternalCache, cacheClientProxyTwo, mockRegionNameProxyTwo, false);
+
+    ExecutorService executorService = Executors.newFixedThreadPool(2);
+
+    Collection<Callable<Void>> initAndNotifyTasks = new ArrayList<>();
+
+    // On one thread, we are initializing the message dispatchers for the two CacheClientProxy
+    // objects. For the second client's initialization,
+    // we block until we can simulate a QRM message while the event sits in the CacheClientProxy's
+    // queuedEvents collection.
+    // This blocking logic can be found in setupMockMessageDispatcher().
+    ((ArrayList<Callable<Void>>) initAndNotifyTasks).add((Callable<Void>) () -> {
+      cacheClientProxyOne.initializeMessageDispatcher();
+      cacheClientProxyTwo.initializeMessageDispatcher();
+      return null;
+    });
+
+    EntryEventImpl mockEntryEventImpl = createMockEntryEvent(new ArrayList<CacheClientProxy>() {
+      {
+        add(cacheClientProxyOne);
+        add(cacheClientProxyTwo);
+      }
+    });
+
+    // On a second thread, we are notifying clients of our mocked events. For the first client, we
+    // wait for the message dispatcher to be
+    // initialized so the event is put/processed. For the second client, we ensure that the
+    // dispatcher is still initializing so we put the event
+    // in the CacheClientProxy's queuedEvents collection. When the event is handled by the first
+    // CacheClientProxy, we mocked a QRM in the HARegion
+    // put to simulate a QRM message being received at that time. The simulated QRM logic can be
+    // found in the createMockHARegion() method.
+    ((ArrayList<Callable<Void>>) initAndNotifyTasks).add((Callable<Void>) () -> {
+      messageDispatcherInitLatch.await();
+      CacheClientNotifier.notifyClients(mockEntryEventImpl);
+      notifyClientLatch.countDown();
+      return null;
+    });
+
+    List<Future<Void>> futures = executorService.invokeAll(initAndNotifyTasks);
+
+    for (Future<Void> future : futures) {
+      future.get();
+    }
+
+    // Verify that we do not hang in peek() for the second proxy due to the wrapper
+    Awaitility.waitAtMost(new Duration(30, TimeUnit.SECONDS)).until(() -> {
+      try {
+        Object eventPeeked = null;
+        while (eventPeeked == null) {
+          // Simulating message dispatching. We peek() and remove() but aren't testing
+          // the actual message delivery for this test.
+          eventPeeked = cacheClientProxyTwo.getHARegionQueue().peek();
+          if (eventPeeked != null) {
+            cacheClientProxyTwo.getHARegionQueue().remove();
+          }
+        }
+      } catch (InterruptedException e) {
+        e.printStackTrace();
+        throw (new RuntimeException(e));
+      }
+    });
+
+    Assert.assertEquals("Expected the HAContainer to be empty", 0,
+        cacheClientNotifier.getHaContainer().size());
+  }
+
+  private HARegion createMockHARegion(InternalCache internalCache,
+      CacheClientProxy cacheClientProxy,
+      String haRegionName,
+      boolean simulateQrm)
+      throws IOException, ClassNotFoundException {
+    HARegion mockHARegion = mock(HARegion.class);
+
+    doReturn(internalCache).when(mockHARegion).getCache();
+    doReturn(internalCache).when(mockHARegion).getGemFireCache();
+    doReturn(mock(CancelCriterion.class)).when(mockHARegion).getCancelCriterion();
+    doReturn(mock(AttributesMutator.class)).when(mockHARegion).getAttributesMutator();
+    doReturn(mockHARegion).when(internalCache).createVMRegion(eq(haRegionName),
+        any(RegionAttributes.class), any(InternalRegionArguments.class));
+
+    // We use a mock of the HARegion.put() method to simulate an queue removal message
+    // immediately after the event was successfully put. In production when a queue removal takes
+    // place at this time,
+    // it will decrement the ref count on the HAEventWrapper and potentially make it eligible for
+    // removal later on
+    // when CacheClientNotifier.checkAndRemoveFromClientMsgsRegion() is called.
+
+    Map<Object, Object> events = new HashMap<Object, Object>();
+
+    doAnswer(new Answer<Void>() {
+      @Override
+      public Void answer(InvocationOnMock invocation) throws Throwable {
+        long position = invocation.getArgument(0);
+        HAEventWrapper haEventWrapper = invocation.getArgument(1);
+
+        if (simulateQrm) {
+          // This call is ultimately what a QRM message will do when it is processed, so we simulate
+          // that here.
+          cacheClientProxy.getHARegionQueue().destroyFromAvailableIDs(position);
+          events.remove(position);
+          cacheClientProxy.getHARegionQueue()
+              .decAndRemoveFromHAContainer((HAEventWrapper) haEventWrapper);
+        } else {
+          events.put(position, haEventWrapper);
+        }
+
+        return null;
+      }
+    }).when(mockHARegion).put(any(long.class), any(HAEventWrapper.class));
+
+    // This is so that when peek() is called, the object is returned. Later we want to verify that
+    // it was successfully "delivered" to the client and subsequently removed from the HARegion.
+    doAnswer(new Answer<Object>() {
+      @Override
+      public Object answer(InvocationOnMock invocation) throws Throwable {
+        return events.get(invocation.getArgument(0));
+      }
+    }).when(mockHARegion).get(any(long.class));
+
+    return mockHARegion;
+  }
+
+  private InternalCache createMockInternalCache() {
+    InternalCache mockInternalCache = mock(InternalCache.class);
+    doReturn(mock(SystemTimer.class)).when(mockInternalCache).getCCPTimer();
+    doReturn(mock(CancelCriterion.class)).when(mockInternalCache).getCancelCriterion();
+
+    InternalDistributedSystem mockInteralDistributedSystem = createMockInternalDistributedSystem();
+    doReturn(mockInteralDistributedSystem).when(mockInternalCache).getInternalDistributedSystem();
+    doReturn(mockInteralDistributedSystem).when(mockInternalCache).getDistributedSystem();
+
+    return mockInternalCache;
+  }
+
+  private void setupMockMessageDispatcher(CountDownLatch messageDispatcherInitLatch,
+      CountDownLatch notifyClientLatch) throws Exception {
+    PowerMockito.whenNew(CacheClientProxy.MessageDispatcher.class).withAnyArguments()
+        .thenAnswer(new Answer<CacheClientProxy.MessageDispatcher>() {
+          private boolean secondClient = false;
+
+          @Override
+          public CacheClientProxy.MessageDispatcher answer(
+              org.mockito.invocation.InvocationOnMock invocation) throws Throwable {
+            if (secondClient) {
+              messageDispatcherInitLatch.countDown();
+              notifyClientLatch.await();
+            }
+
+            secondClient = true;
+
+            CacheClientProxy cacheClientProxy = invocation.getArgument(0);
+            String name = invocation.getArgument(1);
+
+            CacheClientProxy.MessageDispatcher messageDispatcher =
+                new CacheClientProxy.MessageDispatcher(cacheClientProxy,
+                    name);
+
+            return messageDispatcher;
+          }
+        });
+
+    PowerMockito.mockStatic(InternalDataSerializer.class);
+  }
+
+  private InternalDistributedSystem createMockInternalDistributedSystem() {
+    InternalDistributedSystem mockInternalDistributedSystem = mock(InternalDistributedSystem.class);
+    DistributionManager mockDistributionManager = mock(DistributionManager.class);
+
+    doReturn(mock(InternalDistributedMember.class)).when(mockInternalDistributedSystem)
+        .getDistributedMember();
+    doReturn(mock(Statistics.class)).when(mockInternalDistributedSystem)
+        .createAtomicStatistics(any(StatisticsType.class), any(String.class));
+    doReturn(mock(DistributionConfig.class)).when(mockDistributionManager).getConfig();
+    doReturn(mockDistributionManager).when(mockInternalDistributedSystem).getDistributionManager();
+    doReturn(mock(DSClock.class)).when(mockInternalDistributedSystem).getClock();
+
+    return mockInternalDistributedSystem;
+  }
+
+  private CacheClientProxy createMockCacheClientProxy(CacheClientNotifier cacheClientNotifier,
+      String haRegionName)
+      throws IOException {
+    Socket mockSocket = mock(Socket.class);
+    doReturn(mock(InetAddress.class)).when(mockSocket).getInetAddress();
+
+    ClientProxyMembershipID mockClientProxyMembershipID = mock(ClientProxyMembershipID.class);
+    doReturn(mock(DistributedMember.class)).when(mockClientProxyMembershipID)
+        .getDistributedMember();
+    doReturn(haRegionName).when(mockClientProxyMembershipID).getHARegionName();
+
+    CacheClientProxy cacheClientProxy =
+        new CacheClientProxy(cacheClientNotifier, mockSocket, mockClientProxyMembershipID, true,
+            (byte) 0, Version.GFE_58, 0, true, mock(SecurityService.class), mock(Subject.class));
+
+    cacheClientNotifier.addClientInitProxy(cacheClientProxy);
+
+    return cacheClientProxy;
+  }
+
+  private EntryEventImpl createMockEntryEvent(List<CacheClientProxy> proxies) {
+    FilterRoutingInfo.FilterInfo mockFilterInfo = mock(FilterRoutingInfo.FilterInfo.class);
+    Set mockInterestedClients = mock(Set.class);
+    doReturn(mockInterestedClients).when(mockFilterInfo).getInterestedClients();
+    doReturn(null).when(mockFilterInfo).getInterestedClientsInv();
+
+    EntryEventImpl mockEntryEventImpl = mock(EntryEventImpl.class);
+    doReturn(mockFilterInfo).when(mockEntryEventImpl).getLocalFilterInfo();
+
+    FilterProfile mockFilterProfile = mock(FilterProfile.class);
+    Set mockRealClientIDs = new HashSet<ClientProxyMembershipID>();
+
+    for (CacheClientProxy proxy : proxies) {
+      mockRealClientIDs.add(proxy.getProxyID());
+    }
+
+    doReturn(mockRealClientIDs).when(mockFilterProfile).getRealClientIDs(any(Collection.class));
+
+    LocalRegion mockLocalRegion = mock(LocalRegion.class);
+    doReturn(mockFilterProfile).when(mockLocalRegion).getFilterProfile();
+
+    doReturn(mockLocalRegion).when(mockEntryEventImpl).getRegion();
+    doReturn(EnumListenerEvent.AFTER_CREATE).when(mockEntryEventImpl).getEventType();
+    doReturn(Operation.CREATE).when(mockEntryEventImpl).getOperation();
+    EventID mockEventId = mock(EventID.class);
+    doReturn(new byte[] {1}).when(mockEventId).getMembershipID();
+    doReturn(mockEventId).when(mockEntryEventImpl).getEventId();
+
+    return mockEntryEventImpl;
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/HARegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/HARegion.java
@@ -192,7 +192,7 @@ public class HARegion extends DistributedRegion {
 
       // <HA overflow>
       if (conflatable instanceof HAEventWrapper) {
-        this.owningQueue.decAndRemoveFromHAContainer((HAEventWrapper) conflatable);
+        this.owningQueue.decAndRemoveFromHAContainer((HAEventWrapper) conflatable, "Invalidate");
       }
       // </HA overflow>
       // update the stats

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/ha/HAContainerMap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/ha/HAContainerMap.java
@@ -53,8 +53,6 @@ public class HAContainerMap implements HAContainerWrapper {
   }
 
   public Object putProxy(String haName, CacheClientProxy proxy) {
-    // InternalDistributedSystem.getLoggerI18n().info(LocalizedStrings.DEBUG, "adding proxy for " +
-    // haName + ": " + proxy, new Exception("stack trace"));
     return haRegionNameToProxy.put(haName, proxy);
   }
 
@@ -63,8 +61,6 @@ public class HAContainerMap implements HAContainerWrapper {
   }
 
   public Object removeProxy(String haName) {
-    // InternalDistributedSystem.getLoggerI18n().info(LocalizedStrings.DEBUG, "removing proxy for "
-    // + haName, new Exception("stack trace"));
     return haRegionNameToProxy.remove(haName);
   }
 
@@ -91,12 +87,10 @@ public class HAContainerMap implements HAContainerWrapper {
   }
 
   public boolean containsValue(Object value) {
-    // return map.containsValue(value);
     throw new UnsupportedOperationException("containsValue() not supported.");
   }
 
   public Set entrySet() {
-    // return map.entrySet();
     throw new UnsupportedOperationException("entrySet() not supported.");
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientNotifier.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientNotifier.java
@@ -892,9 +892,15 @@ public class CacheClientNotifier {
       }
     } else {
       HAEventWrapper wrapper = new HAEventWrapper(clientMessage);
-      // Set the putInProgress flag to true before starting the put on proxy's
-      // HA queues. Nowhere else, this flag is being set to true.
-      wrapper.setPutInProgress(true);
+      wrapper.incrementPutInProgressCounter();
+
+      if (logger.isDebugEnabled()) {
+        logger.debug(
+            "Initial increment PutInProgressCounter on HAEventWrapper with Event ID hash code: "
+                + wrapper.hashCode() + "; System ID hash code: "
+                + System.identityHashCode(wrapper) + "; Wrapper details: " + wrapper);
+      }
+
       conflatable = wrapper;
     }
 
@@ -990,7 +996,11 @@ public class CacheClientNotifier {
         this.blackListSlowReceiver(proxy);
       }
     }
-    checkAndRemoveFromClientMsgsRegion(conflatable);
+
+    if (conflatable instanceof HAEventWrapper) {
+      ((HAEventWrapper) conflatable).decrementPutInProgressCounter();
+    }
+
     // Remove any dead clients from the clients to notify
     if (deadProxies != null) {
       closeDeadProxies(deadProxies, false);
@@ -1298,47 +1308,6 @@ public class CacheClientNotifier {
     if (proxy != null) {
       proxy.setKeepAlive(keepalive);
       proxy.unregisterClientInterest(regionName, keysOfInterest, isClosing);
-    }
-  }
-
-  /**
-   * If the conflatable is an instance of HAEventWrapper, and if the corresponding entry is present
-   * in the haContainer, set the reference to the clientUpdateMessage to null and putInProgress flag
-   * to false. Also, if the ref count is zero, then remove the entry from the haContainer.
-   *
-   * @since GemFire 5.7
-   */
-  private void checkAndRemoveFromClientMsgsRegion(Conflatable conflatable) {
-    if (haContainer == null) {
-      return;
-    }
-    if (conflatable instanceof HAEventWrapper) {
-      HAEventWrapper wrapper = (HAEventWrapper) conflatable;
-      if (!wrapper.getIsRefFromHAContainer()) {
-        wrapper = (HAEventWrapper) haContainer.getKey(wrapper);
-        if (wrapper != null && !wrapper.getPutInProgress()) {
-          synchronized (wrapper) {
-            if (wrapper.getReferenceCount() == 0L) {
-              if (logger.isDebugEnabled()) {
-                logger.debug("Removing event from haContainer: {}", wrapper);
-              }
-              haContainer.remove(wrapper);
-            }
-          }
-        }
-      } else {
-        // This wrapper resides in haContainer.
-        wrapper.setClientUpdateMessage(null);
-        wrapper.setPutInProgress(false);
-        synchronized (wrapper) {
-          if (wrapper.getReferenceCount() == 0L) {
-            if (logger.isDebugEnabled()) {
-              logger.debug("Removing event from haContainer: {}", wrapper);
-            }
-            haContainer.remove(wrapper);
-          }
-        }
-      }
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/HAEventWrapper.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/HAEventWrapper.java
@@ -87,16 +87,13 @@ public class HAEventWrapper implements Conflatable, DataSerializableFixedID, Siz
       AtomicLongFieldUpdater.newUpdater(HAEventWrapper.class, "referenceCount");
 
   /**
-   * If true, the entry containing this HAEventWrapper instance will not be removed from the
-   * haContainer, even if the referenceCount value is zero.
+   * If greater than zero, the entry containing this HAEventWrapper instance will not be removed
+   * from the haContainer, even if the referenceCount value is zero.
    */
-  private transient boolean putInProgress = false;
-
-  /**
-   * A value true indicates that this instance is not used in the <code>haContainer</code>. So any
-   * changes in this instance will not be visible to the <code>haContainer</code>.
-   */
-  private transient boolean isRefFromHAContainer = false;
+  @SuppressWarnings("unused")
+  private transient volatile long putInProgressCount;
+  private static final AtomicLongFieldUpdater<HAEventWrapper> putInProgressCountUpdater =
+      AtomicLongFieldUpdater.newUpdater(HAEventWrapper.class, "putInProgressCount");
 
   /**
    * A reference to its <code>ClientUpdateMessage</code> instance.
@@ -119,6 +116,7 @@ public class HAEventWrapper implements Conflatable, DataSerializableFixedID, Siz
     this.shouldConflate = event.shouldBeConflated();
     this.eventIdentifier = event.getEventId();
     rcUpdater.set(this, 0);
+    putInProgressCountUpdater.set(this, 0);
     this.clientUpdateMessage = event;
     this.clientCqs = ((ClientUpdateMessageImpl) event).getClientCqs();
   }
@@ -128,6 +126,7 @@ public class HAEventWrapper implements Conflatable, DataSerializableFixedID, Siz
     this.clientUpdateMessage = new ClientUpdateMessageImpl(EnumListenerEvent.AFTER_CREATE,
         new ClientProxyMembershipID(), eventId);
     rcUpdater.set(this, 0);
+    putInProgressCountUpdater.set(this, 0);
   }
 
   /**
@@ -208,22 +207,6 @@ public class HAEventWrapper implements Conflatable, DataSerializableFixedID, Siz
     return this.clientCqs;
   }
 
-  public void setPutInProgress(boolean inProgress) {
-    this.putInProgress = inProgress;
-  }
-
-  public boolean getPutInProgress() {
-    return this.putInProgress;
-  }
-
-  public void setIsRefFromHAContainer(boolean bool) {
-    this.isRefFromHAContainer = bool;
-  }
-
-  public boolean getIsRefFromHAContainer() {
-    return this.isRefFromHAContainer;
-  }
-
   public void setHAContainer(Map container) {
     this.haContainer = container;
   }
@@ -258,12 +241,13 @@ public class HAEventWrapper implements Conflatable, DataSerializableFixedID, Siz
   @Override
   public String toString() {
     if (this.clientUpdateMessage != null) {
-      return "HAEventWrapper[refCount=" + getReferenceCount() + "; msg=" + this.clientUpdateMessage
-          + "]";
+      return "HAEventWrapper[refCount=" + getReferenceCount() + "; putInProgress="
+          + putInProgressCountUpdater.get(this) + "; msg=" + this.clientUpdateMessage + "]";
     } else {
       return "HAEventWrapper[region=" + this.regionName + "; key=" + this.keyOfInterest
-          + "; refCount=" + getReferenceCount() + "; inContainer=" + this.isRefFromHAContainer
-          + "; putInProgress=" + this.putInProgress + "; event=" + this.eventIdentifier
+          + "; refCount=" + getReferenceCount()
+          + "; putInProgress=" + putInProgressCountUpdater.get(this) + "; event="
+          + this.eventIdentifier
           + ((this.clientUpdateMessage == null) ? "; no message" : ";with message")
           + ((this.clientUpdateMessage == null) ? ""
               : ("; op=" + this.clientUpdateMessage.getOperation()))
@@ -411,4 +395,35 @@ public class HAEventWrapper implements Conflatable, DataSerializableFixedID, Siz
     return rcUpdater.decrementAndGet(this);
   }
 
+  public long incrementPutInProgressCounter() {
+    return putInProgressCountUpdater.incrementAndGet(this);
+  }
+
+  public long decrementPutInProgressCounter() {
+    synchronized (this) {
+      long putInProgressCounter = putInProgressCountUpdater.decrementAndGet(this);
+
+      if (logger.isDebugEnabled()) {
+        logger.debug("Decremented PutInProgressCounter on HAEventWrapper with Event ID hash code: "
+            + hashCode() + "; System ID hash code: "
+            + System.identityHashCode(this) + "; Wrapper details: " + toString());
+      }
+
+      if (putInProgressCounter == 0L) {
+        if (logger.isDebugEnabled()) {
+          logger.debug("Setting HAEventWrapper ClientUpdateMessage to null.  Event ID hash code: "
+              + hashCode()
+              + "; System ID hash code: " + System.identityHashCode(this) + "; Wrapper details: "
+              + toString());
+        }
+        setClientUpdateMessage(null);
+      }
+
+      return putInProgressCounter;
+    }
+  }
+
+  public boolean getPutInProgress() {
+    return putInProgressCountUpdater.get(this) > 0;
+  }
 }


### PR DESCRIPTION
- Updated putInProgress boolean in HAWrapper to a counter to prevent prematurely setting ClientUpdateMessage to null when events are temporarily queued during a GII or message dispatcher initialization
- decAndRemoveFromHAContainer only removes when putInProgress counter and ref count are 0
- Refactored putEventInHARegion/putConditionallyInHAContainer to prevent overwriting an existing entry in the HAContainer.  Also reduces simplifies the code and reduces duplicated logic.
- Wrote missing basic HARegionQueue unit/integration tests, and an integration test to capture setting the ClientUpdateMessage property on HAEventWrapper to null prematurely
- Added new event tracing messages at debug logging level to help track similar issues in the future

Co-authored-by: Ryan McMahon <rmcmahon@pivotal.io>
Co-authored-by: Lynn Hughes-Godfrey <lhughesgodfrey@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [X] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
