### PR TITLE
GEODE-1942: Limiting random strings to [A-Z] chars

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/redis/HashesJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/redis/HashesJUnitTest.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 
+import org.apache.commons.lang.RandomStringUtils;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -170,10 +171,7 @@ public class HashesJUnitTest {
 
   private String randString() {
     int length = rand.nextInt(8) + 5;
-    StringBuilder rString = new StringBuilder();
-    for (int i = 0; i < length; i++)
-      rString.append((char) (rand.nextInt(25) + 65));
-    return rString.toString();
+    return RandomStringUtils.randomAlphanumeric(length);
   }
 
   @After

--- a/geode-core/src/integrationTest/java/org/apache/geode/redis/HashesJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/redis/HashesJUnitTest.java
@@ -172,7 +172,7 @@ public class HashesJUnitTest {
     int length = rand.nextInt(8) + 5;
     StringBuilder rString = new StringBuilder();
     for (int i = 0; i < length; i++)
-      rString.append((char) (rand.nextInt(57) + 65));
+      rString.append((char) (rand.nextInt(25) + 65));
     return rString.toString();
   }
 


### PR DESCRIPTION
This test was generating random strings, but some strings were invalid
regions names, for example strings starting with __. Limiting the
strings the alphabet.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
