### PR TITLE
GEODE-5090: Added tests for accessor behavior

### DIFF
--- a/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneDUnitTest.java
+++ b/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneDUnitTest.java
@@ -50,6 +50,15 @@ public abstract class LuceneDUnitTest extends JUnit4CacheTestCase {
     dataStore2 = host.getVM(1);
   }
 
+  protected void createDataStore(RegionTestableType regionTestType) {
+    regionTestType.createDataStore(getCache(), REGION_NAME);
+  }
+
+
+  protected void createAccessor(RegionTestableType regionTestType) {
+    regionTestType.createAccessor(getCache(), REGION_NAME);
+  }
+
   protected void initDataStore(SerializableRunnableIF createIndex,
       RegionTestableType regionTestType) throws Exception {
     createIndex.run();

--- a/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneQueriesReindexDUnitTest.java
+++ b/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneQueriesReindexDUnitTest.java
@@ -19,8 +19,11 @@ import static org.apache.geode.cache.lucene.test.LuceneTestUtilities.REGION_NAME
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 
+import java.util.concurrent.TimeUnit;
+
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
+import org.awaitility.Awaitility;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -57,6 +60,49 @@ public class LuceneQueriesReindexDUnitTest extends LuceneQueriesAccessorBase {
         (LuceneIndexFactoryImpl) luceneService.createIndexFactory().addField(fieldName);
     indexFactory.create(indexName, REGION_NAME, true);
   };
+
+  @Test
+  @Parameters(method = "getListOfRegionTestTypes")
+  public void luceneQueryExecutedWithReindexWhenAllBucketsAreLostShouldNotCauseAHang(
+      RegionTestableType regionTestType) throws Exception {
+    dataStore1.invoke(() -> createDataStore(regionTestType));
+    dataStore2.invoke(() -> createDataStore(regionTestType));
+    accessor.invoke(() -> createAccessor(regionTestType));
+
+
+    putDataInRegion(accessor);
+    dataStore1.invoke(() -> Awaitility.await().atMost(1, TimeUnit.MINUTES)
+        .until(() -> assertTrue(getCache().getRegion(REGION_NAME).size() == 3)));
+
+    // re-index stored data
+    AsyncInvocation ai1 = dataStore1.invokeAsync(() -> {
+      createIndex("text");
+    });
+
+    AsyncInvocation ai2 = dataStore2.invokeAsync(() -> {
+      createIndex("text");
+    });
+    AsyncInvocation ai3 = accessor.invokeAsync(() -> {
+      createIndex("text");
+    });
+
+    ai1.join();
+    ai2.join();
+    ai3.join();
+
+    ai1.checkException();
+    ai2.checkException();
+    ai3.checkException();
+
+    waitForFlushBeforeExecuteTextSearch(accessor, 60000);
+    executeTextSearch(accessor);
+
+    dataStore1.invoke(() -> closeCache());
+    dataStore2.invoke(() -> closeCache());
+    executeQueryAndValidateNoHang(regionTestType);
+  }
+
+
 
   @Test
   @Parameters(method = "getListOfRegionTestTypes")


### PR DESCRIPTION
	* Accessors behavior tests for lucene index queries.
	* Accessors should not hang on lucene query execution, if all the servers holding the data are closed.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
