### PR TITLE
GEODE-5479 - Fix usage of AvailablePortHelper

### DIFF
--- a/geode-assembly/src/distributedTest/java/org/apache/geode/rest/internal/web/controllers/RestAPIsWithSSLDUnitTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/rest/internal/web/controllers/RestAPIsWithSSLDUnitTest.java
@@ -404,8 +404,9 @@ public class RestAPIsWithSSLDUnitTest extends LocatorTestBase {
             ids.disconnect();
           }
           // try a different port
-          int httpServicePort = AvailablePortHelper.getRandomAvailableTCPPort();
-          int jmxManagerPort = AvailablePortHelper.getRandomAvailableTCPPort();
+          int[] randomPorts = AvailablePortHelper.getRandomAvailableTCPPorts(2);
+          int httpServicePort = randomPorts[0];
+          int jmxManagerPort = randomPorts[1];
           props.setProperty(HTTP_SERVICE_PORT, Integer.toString(httpServicePort));
           props.setProperty(JMX_MANAGER_PORT, Integer.toString(jmxManagerPort));
           System.out.println("Try a different http-service-port " + httpServicePort);

--- a/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/RegionChangesPersistThroughClusterConfigurationDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/RegionChangesPersistThroughClusterConfigurationDUnitTest.java
@@ -59,8 +59,9 @@ public class RegionChangesPersistThroughClusterConfigurationDUnitTest {
 
   @Before
   public void setup() throws Exception {
-    int jmxPort = AvailablePortHelper.getRandomAvailableTCPPort();
-    int httpPort = AvailablePortHelper.getRandomAvailableTCPPort();
+    int[] randomPorts = AvailablePortHelper.getRandomAvailableTCPPorts(2);
+    int jmxPort = randomPorts[0];
+    int httpPort = randomPorts[1];
     Properties props = new Properties();
     props.setProperty(MCAST_PORT, "0");
     props.setProperty(LOG_LEVEL, "fine");


### PR DESCRIPTION
We were getting two separate random ports and not validating that the
ports are actually distinct. This change gets both ports at the same time
and thus ensures uniqueness.