### PR TITLE
GEODE-5248: Fixes in GatewayReceiverMBeanBridge

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/management/bean/stats/GatewayReceiverStatsJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/bean/stats/GatewayReceiverStatsJUnitTest.java
@@ -65,7 +65,6 @@ public class GatewayReceiverStatsJUnitTest extends MBeanStatsTestCase {
     assertEquals(1, getCurrentClients());
     assertEquals(1, getConnectionThreads());
     assertEquals(1, getThreadQueueSize());
-    assertEquals(1, getClientConnectionCount());
     assertEquals(1, getTotalFailedConnectionAttempts());
     assertEquals(1, getTotalConnectionsTimedOut());
     assertEquals(20, getTotalSentBytes());
@@ -189,10 +188,6 @@ public class GatewayReceiverStatsJUnitTest extends MBeanStatsTestCase {
 
   private long getTotalReceivedBytes() {
     return bridge.getTotalReceivedBytes();
-  }
-
-  private int getClientConnectionCount() {
-    return bridge.getClientConnectionCount();
   }
 
   private int getCurrentClients() {

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/wancommand/StatusGatewayReceiverCommandDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/wancommand/StatusGatewayReceiverCommandDUnitTest.java
@@ -19,7 +19,6 @@ import static org.apache.geode.distributed.ConfigurationProperties.GROUPS;
 import static org.apache.geode.distributed.ConfigurationProperties.REMOTE_LOCATORS;
 import static org.apache.geode.internal.cache.wan.wancommand.WANCommandUtils.createAndStartReceiver;
 import static org.apache.geode.internal.cache.wan.wancommand.WANCommandUtils.getMember;
-import static org.apache.geode.internal.cache.wan.wancommand.WANCommandUtils.stopReceiver;
 import static org.apache.geode.internal.cache.wan.wancommand.WANCommandUtils.validateGatewayReceiverMXBeanProxy;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -76,9 +75,9 @@ public class StatusGatewayReceiverCommandDUnitTest implements Serializable {
   }
 
   @Test
-  public void testGatewayReceiverStatus() throws Exception {
-    Integer lnPort = locatorSite1.getPort();
-    Integer nyPort = locatorSite2.getPort();
+  public void testGatewayReceiverStatus() {
+    int lnPort = locatorSite1.getPort();
+    int nyPort = locatorSite2.getPort();
 
     // setup servers in Site #1 (London)
     server1 = clusterStartupRule.startServerVM(3, lnPort);
@@ -112,9 +111,9 @@ public class StatusGatewayReceiverCommandDUnitTest implements Serializable {
     assertThat(result_Status).hasSize(3);
     assertThat(result_Status).doesNotContain(CliStrings.GATEWAY_NOT_RUNNING);
 
-    server1.invoke(() -> stopReceiver());
-    server2.invoke(() -> stopReceiver());
-    server3.invoke(() -> stopReceiver());
+    server1.invoke(WANCommandUtils::stopReceivers);
+    server2.invoke(WANCommandUtils::stopReceivers);
+    server3.invoke(WANCommandUtils::stopReceivers);
 
     locatorSite1
         .invoke(() -> validateGatewayReceiverMXBeanProxy(getMember(server1.getVM()), false));
@@ -137,9 +136,9 @@ public class StatusGatewayReceiverCommandDUnitTest implements Serializable {
   }
 
   @Test
-  public void testGatewayReceiverStatus_OnMember() throws Exception {
-    Integer lnPort = locatorSite1.getPort();
-    Integer nyPort = locatorSite2.getPort();
+  public void testGatewayReceiverStatus_OnMember() {
+    int lnPort = locatorSite1.getPort();
+    int nyPort = locatorSite2.getPort();
 
     // setup servers in Site #1 (London)
     server1 = clusterStartupRule.startServerVM(3, lnPort);
@@ -175,9 +174,9 @@ public class StatusGatewayReceiverCommandDUnitTest implements Serializable {
     assertThat(result_Status).hasSize(1);
     assertThat(result_Status).doesNotContain(CliStrings.GATEWAY_NOT_RUNNING);
 
-    server1.invoke(() -> stopReceiver());
-    server2.invoke(() -> stopReceiver());
-    server3.invoke(() -> stopReceiver());
+    server1.invoke(WANCommandUtils::stopReceivers);
+    server2.invoke(WANCommandUtils::stopReceivers);
+    server3.invoke(WANCommandUtils::stopReceivers);
 
     locatorSite1
         .invoke(() -> validateGatewayReceiverMXBeanProxy(getMember(server1.getVM()), false));
@@ -200,9 +199,9 @@ public class StatusGatewayReceiverCommandDUnitTest implements Serializable {
   }
 
   @Test
-  public void testGatewayReceiverStatus_OnGroups() throws Exception {
-    Integer lnPort = locatorSite1.getPort();
-    Integer nyPort = locatorSite2.getPort();
+  public void testGatewayReceiverStatus_OnGroups() {
+    int lnPort = locatorSite1.getPort();
+    int nyPort = locatorSite2.getPort();
 
     // setup servers in Site #1 (London)
     server1 = startServerWithGroups(3, "RG1, RG2", lnPort);
@@ -239,9 +238,9 @@ public class StatusGatewayReceiverCommandDUnitTest implements Serializable {
     assertThat(result_Status).hasSize(3);
     assertThat(result_Status).doesNotContain(CliStrings.GATEWAY_NOT_RUNNING);
 
-    server1.invoke(() -> stopReceiver());
-    server2.invoke(() -> stopReceiver());
-    server3.invoke(() -> stopReceiver());
+    server1.invoke(WANCommandUtils::stopReceivers);
+    server2.invoke(WANCommandUtils::stopReceivers);
+    server3.invoke(WANCommandUtils::stopReceivers);
 
     locatorSite1
         .invoke(() -> validateGatewayReceiverMXBeanProxy(getMember(server1.getVM()), false));
@@ -263,7 +262,7 @@ public class StatusGatewayReceiverCommandDUnitTest implements Serializable {
     assertThat(result_Status).doesNotContain(CliStrings.GATEWAY_RUNNING);
   }
 
-  private MemberVM startServerWithGroups(int index, String groups, int locPort) throws Exception {
+  private MemberVM startServerWithGroups(int index, String groups, int locPort) {
     Properties props = new Properties();
     props.setProperty(GROUPS, groups);
     return clusterStartupRule.startServerVM(index, props, locPort);

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/wancommand/WANCommandUtils.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/wancommand/WANCommandUtils.java
@@ -243,7 +243,7 @@ public class WANCommandUtils implements Serializable {
     }
   }
 
-  public static void stopReceiver() {
+  public static void stopReceivers() {
     Cache cache = ClusterStartupRule.getCache();
     Set<GatewayReceiver> receivers = cache.getGatewayReceivers();
     for (GatewayReceiver receiver : receivers) {


### PR DESCRIPTION
The class `GatewayReceiverMBeanBridge` uses the `MBeanStatsMonitor` to
retrieve the amount of senders currently connected. This statistic
tends to be out of date and heavily depends on the `HostStatSampler`
class to run periodically and update the data. Whenever a receiver is
stopped its stats are also closed and, as such, the
`clientConnectionCount` is not updated anymore, resulting in a wrong
gateway-sender connected count reported.

- Fixed some minor warnings.
- Added tests to verify the accuracy of the current gateway-senders
  connected.
- Renamed `WanCommandListDUnitTest` to `ListGatewaysCommandDUnitTest`.
- Modified the `GatewayReceiverMBeanBridge` to retrieve the current
  client connection count from the underlying acceptor instead of
  the `MBeanStatsMonitor` class.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
