### PR TITLE
GEODE-5492 Fix gradle dependencies to enable reliable parallel build

### DIFF
--- a/geode-assembly/build.gradle
+++ b/geode-assembly/build.gradle
@@ -46,6 +46,10 @@ gradle.taskGraph.whenReady( { graph ->
   tasks.srcDistTar {
     classifier 'src'
   }
+  tasks.withType(Jar).each { jarTasks ->
+    distTar.dependsOn(jarTasks)
+    distZip.dependsOn(jarTasks)
+  }
 })
 
 configurations {
@@ -280,6 +284,9 @@ task docs(type: Javadoc) {
     exclude 'org/apache/geode/test/**/'
     destinationDir = docsDir
 
+    parent.subprojects.each { project ->
+      dependsOn(project.tasks['javadoc'])
+    }
     doLast {
       parent.subprojects.each { project ->
         copy {
@@ -324,6 +331,7 @@ distributions {
         exclude '**/gradle/wrapper/gradle-wrapper.jar'
         exclude '**/.gradle'
         exclude '**/build/**'
+        exclude '**/out/**'
         exclude '**/.project'
         exclude '**/.classpath'
         exclude '**/.settings/**'

--- a/geode-core/build.gradle
+++ b/geode-core/build.gradle
@@ -204,8 +204,6 @@ task createVersionPropertiesFile {
   outputs.file propertiesFile
   inputs.dir "../.git/index"
 
-  mustRunAfter(compileJava)
-
   doLast {
     def props = [
       "Product-Name"      : productName,

--- a/geode-core/build.gradle
+++ b/geode-core/build.gradle
@@ -204,6 +204,8 @@ task createVersionPropertiesFile {
   outputs.file propertiesFile
   inputs.dir "../.git/index"
 
+  mustRunAfter(compileJava)
+
   doLast {
     def props = [
       "Product-Name"      : productName,
@@ -231,6 +233,8 @@ jar {
   exclude 'org/apache/geode/internal/i18n/StringIdResourceBundle_ja.txt'
   exclude 'org/apache/geode/admin/doc-files/ds4_0.dtd'
 }
+
+jar.dependsOn(createVersionPropertiesFile)
 
 task webJar (type: Jar, dependsOn: classes) {
   description 'Assembles the jar archive containing the gemfire management web classes.'

--- a/geode-old-versions/build.gradle
+++ b/geode-old-versions/build.gradle
@@ -56,6 +56,7 @@ task createGeodeClasspathsFile {
     }
   }
 }
+createGeodeClasspathsFile.mustRunAfter(clean)
 
 def addOldVersion(def source, def geodeVersion, def downloadInstall) {
   sourceSets.create("${source}", {})

--- a/geode-pulse/build.gradle
+++ b/geode-pulse/build.gradle
@@ -124,7 +124,7 @@ war {
   classpath configurations.runtime
   classpath project(':geode-core').webJar.archivePath
 }
-
+war.dependsOn(':geode-core:webJar')
 uiTest.dependsOn war
 uiTest.finalizedBy rootProject.combineReports
 rootProject.combineReports.mustRunAfter uiTest

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -30,40 +30,6 @@ subprojects {
     throw new GradleException("Java version 1.8.0_121 or later required, but was " + javaVersion)
   }
     
-  // apply compiler options
-  gradle.taskGraph.whenReady({ graph ->
-    tasks.withType(JavaCompile).each { javac ->
-      javac.configure {
-        sourceCompatibility '1.8'
-        targetCompatibility '1.8'
-        options.encoding = 'UTF-8'
-      }
-      javac.options.incremental = true
-    }
-  })
-
-  // apply default manifest
-  gradle.taskGraph.whenReady({ graph ->
-    tasks.withType(Jar).each { jar ->
-      jar.doFirst {
-        manifest {
-          attributes(
-            "Manifest-Version": "1.0",
-            "Created-By": System.getProperty("user.name"),
-            "Title": rootProject.name,
-            "Version": version,
-            "Organization": productOrg
-          )
-        }
-      }
-      jar.metaInf {
-          from("$rootDir/LICENSE")
-          if (jar.source.filter({ it.name.contains('NOTICE') }).empty) {
-            from("$rootDir/NOTICE")
-          }
-      }
-    }
-  })
 
   configurations {
     testOutput {
@@ -98,4 +64,39 @@ subprojects {
   }
 }
 
+// apply compiler options
+gradle.taskGraph.whenReady({ graph ->
+  tasks.withType(JavaCompile).each { javac ->
+    javac.configure {
+      sourceCompatibility '1.8'
+      targetCompatibility '1.8'
+      options.encoding = 'UTF-8'
+    }
+    javac.options.incremental = true
+    javac.options.fork = true
+  }
+})
+
+// apply default manifest
+gradle.taskGraph.whenReady({ graph ->
+  tasks.withType(Jar).each { jar ->
+    jar.doFirst {
+      manifest {
+        attributes(
+                "Manifest-Version": "1.0",
+                "Created-By": System.getProperty("user.name"),
+                "Title": rootProject.name,
+                "Version": version,
+                "Organization": productOrg
+        )
+      }
+    }
+    jar.metaInf {
+      from("$rootDir/LICENSE")
+      if (jar.source.filter({ it.name.contains('NOTICE') }).empty) {
+        from("$rootDir/NOTICE")
+      }
+    }
+  }
+})
 


### PR DESCRIPTION
- distZip and distTar tasks wait for all 'jar' tasks to finish
- geode-assembly:docs depends on all project's javadoc task
- geode-core 'jar' depends on the version properties file
- version properties file runs after compileJava
- geode-pulse 'war' depends on the webJar, instead of only including it
- fixed download of geode-old-versions to run after clean, even when
  specified backwards on the command line
- srcJar no longer includes the IntelliJ output directory

Co-authored-by: Patrick Rhomberg <prhomberg@pivotal.io>
Co-authored-by: Finn Southerland <fsoutherland@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
