### PR TITLE
GEODE-3200: remove authzrequest

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/tier/sockets/ServerConnectionIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/tier/sockets/ServerConnectionIntegrationTest.java
@@ -165,7 +165,7 @@ public class ServerConnectionIntegrationTest {
 
     private void setFakeRequest() {
       testMessage = new TestMessage();
-      setRequestMsg(testMessage);
+      setRequestMessage(testMessage);
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/OriginalServerConnection.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/OriginalServerConnection.java
@@ -74,7 +74,7 @@ public class OriginalServerConnection extends ServerConnection {
       this.doHandshake = false;
     } else {
       this.resetTransientData();
-      doNormalMsg();
+      doNormalMessage();
     }
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/AddPdxEnum.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/AddPdxEnum.java
@@ -50,12 +50,6 @@ public class AddPdxEnum extends BaseCommand {
           serverConnection.getSocketString());
     }
 
-    if (!ServerConnection.allowInternalMessagesWithoutCredentials) {
-      serverConnection.getAuthzRequest();
-    }
-
-    int noOfParts = clientMessage.getNumberOfParts();
-
     EnumInfo enumInfo = (EnumInfo) clientMessage.getPart(0).getObject();
     int enumId = clientMessage.getPart(1).getInt();
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/AddPdxType.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/AddPdxType.java
@@ -50,12 +50,6 @@ public class AddPdxType extends BaseCommand {
           serverConnection.getSocketString());
     }
 
-    if (!ServerConnection.allowInternalMessagesWithoutCredentials) {
-      serverConnection.getAuthzRequest();
-    }
-
-    int noOfParts = clientMessage.getNumberOfParts();
-
     PdxType type = (PdxType) clientMessage.getPart(0).getObject();
     int typeId = clientMessage.getPart(1).getInt();
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/GetFunctionAttribute.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/GetFunctionAttribute.java
@@ -39,10 +39,6 @@ public class GetFunctionAttribute extends BaseCommand {
       final SecurityService securityService, long start) throws IOException {
     serverConnection.setAsTrue(REQUIRES_RESPONSE);
 
-    if (!ServerConnection.allowInternalMessagesWithoutCredentials) {
-      serverConnection.getAuthzRequest();
-    }
-
     String functionId = clientMessage.getPart(0).getString();
     if (functionId == null) {
       String message =

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/GetPDXEnumById.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/GetPDXEnumById.java
@@ -47,10 +47,6 @@ public class GetPDXEnumById extends BaseCommand {
           serverConnection.getSocketString());
     }
 
-    if (!ServerConnection.allowInternalMessagesWithoutCredentials) {
-      serverConnection.getAuthzRequest();
-    }
-
     int enumId = clientMessage.getPart(0).getInt();
 
     EnumInfo result;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/GetPDXIdForEnum.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/GetPDXIdForEnum.java
@@ -47,10 +47,6 @@ public class GetPDXIdForEnum extends BaseCommand {
           serverConnection.getSocketString());
     }
 
-    if (!ServerConnection.allowInternalMessagesWithoutCredentials) {
-      serverConnection.getAuthzRequest();
-    }
-
     EnumInfo enumInfo = (EnumInfo) clientMessage.getPart(0).getObject();
 
     int enumId;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/GetPDXIdForType.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/GetPDXIdForType.java
@@ -47,12 +47,6 @@ public class GetPDXIdForType extends BaseCommand {
           serverConnection.getSocketString());
     }
 
-    if (!ServerConnection.allowInternalMessagesWithoutCredentials) {
-      serverConnection.getAuthzRequest();
-    }
-
-    int noOfParts = clientMessage.getNumberOfParts();
-
     PdxType type = (PdxType) clientMessage.getPart(0).getObject();
 
     int pdxId;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/GetPDXTypeById.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/GetPDXTypeById.java
@@ -47,10 +47,6 @@ public class GetPDXTypeById extends BaseCommand {
           serverConnection.getSocketString());
     }
 
-    if (!ServerConnection.allowInternalMessagesWithoutCredentials) {
-      serverConnection.getAuthzRequest();
-    }
-
     int pdxId = clientMessage.getPart(0).getInt();
 
     PdxType type;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/GetPdxEnums70.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/GetPdxEnums70.java
@@ -46,10 +46,6 @@ public class GetPdxEnums70 extends BaseCommand {
           serverConnection.getSocketString());
     }
 
-    if (!ServerConnection.allowInternalMessagesWithoutCredentials) {
-      serverConnection.getAuthzRequest();
-    }
-
     Map<Integer, EnumInfo> enums;
     try {
       InternalCache cache = serverConnection.getCache();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/GetPdxTypes70.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/GetPdxTypes70.java
@@ -46,10 +46,6 @@ public class GetPdxTypes70 extends BaseCommand {
           serverConnection.getSocketString());
     }
 
-    if (!ServerConnection.allowInternalMessagesWithoutCredentials) {
-      serverConnection.getAuthzRequest();
-    }
-
     Map<Integer, PdxType> types;
     try {
       InternalCache cache = serverConnection.getCache();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/RegisterDataSerializers.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/RegisterDataSerializers.java
@@ -47,10 +47,6 @@ public class RegisterDataSerializers extends BaseCommand {
           serverConnection.getSocketString());
     }
 
-    if (!ServerConnection.allowInternalMessagesWithoutCredentials) {
-      serverConnection.getAuthzRequest();
-    }
-
     int noOfParts = clientMessage.getNumberOfParts();
 
     // 2 parts per instantiator and one eventId part

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/RegisterInstantiators.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/RegisterInstantiators.java
@@ -56,10 +56,6 @@ public class RegisterInstantiators extends BaseCommand {
           serverConnection.getSocketString());
     }
 
-    if (!ServerConnection.allowInternalMessagesWithoutCredentials) {
-      serverConnection.getAuthzRequest();
-    }
-
     int noOfParts = clientMessage.getNumberOfParts();
     // Assert parts
     Assert.assertTrue((noOfParts - 1) % 3 == 0);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ServerConnectionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ServerConnectionTest.java
@@ -20,8 +20,8 @@ package org.apache.geode.internal.cache.tier.sockets;
 import static org.apache.geode.internal.i18n.LocalizedStrings.HandShake_NO_SECURITY_CREDENTIALS_ARE_PROVIDED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyLong;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -58,7 +58,7 @@ public class ServerConnectionTest {
    */
   @Rule
   public final RestoreLocaleRule restoreLocale =
-      new RestoreLocaleRule(Locale.ENGLISH, l -> StringId.setLocale(l));
+      new RestoreLocaleRule(Locale.ENGLISH, StringId::setLocale);
 
   @Mock
   private Message requestMsg;
@@ -69,27 +69,22 @@ public class ServerConnectionTest {
   @InjectMocks
   private ServerConnection serverConnection;
 
-  private AcceptorImpl acceptor;
-  private Socket socket;
   private ServerSideHandshake handshake;
-  private InternalCache cache;
-  private SecurityService securityService;
-  private CacheServerStats stats;
 
   @Before
   public void setUp() throws IOException {
-    acceptor = mock(AcceptorImpl.class);
+    AcceptorImpl acceptor = mock(AcceptorImpl.class);
 
     InetAddress inetAddress = mock(InetAddress.class);
     when(inetAddress.getHostAddress()).thenReturn("localhost");
 
-    socket = mock(Socket.class);
+    Socket socket = mock(Socket.class);
     when(socket.getInetAddress()).thenReturn(inetAddress);
 
-    cache = mock(InternalCache.class);
-    securityService = mock(SecurityService.class);
+    InternalCache cache = mock(InternalCache.class);
+    SecurityService securityService = mock(SecurityService.class);
 
-    stats = mock(CacheServerStats.class);
+    CacheServerStats stats = mock(CacheServerStats.class);
 
     handshake = mock(ServerSideHandshake.class);
     when(handshake.getEncryptor()).thenReturn(mock(Encryptor.class));
@@ -128,7 +123,7 @@ public class ServerConnectionTest {
   public void post65SecureShouldUseUniqueIdFromMessage() {
     long uniqueIdFromMessage = 23456L;
     when(handshake.getVersion()).thenReturn(Version.GFE_82);
-    serverConnection.setRequestMsg(requestMsg);
+    serverConnection.setRequestMessage(requestMsg);
 
     assertThat(serverConnection.getRequestMessage()).isSameAs(requestMsg);
     when(requestMsg.isSecureMode()).thenReturn(true);

--- a/geode-cq/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/MonitorCQ.java
+++ b/geode-cq/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/MonitorCQ.java
@@ -47,10 +47,6 @@ public class MonitorCQ extends BaseCQCommand {
     serverConnection.setAsTrue(REQUIRES_RESPONSE);
     serverConnection.setAsTrue(REQUIRES_CHUNKED_RESPONSE);
 
-    if (!ServerConnection.allowInternalMessagesWithoutCredentials) {
-      serverConnection.getAuthzRequest();
-    }
-
     int op = clientMessage.getPart(0).getInt();
 
     if (op < 1) {


### PR DESCRIPTION
- also cleaned up naming and modernized sections that were able to be more modern

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?
The original ticket calls out two things
1. Removing `authzrequest` private variable which is no longer used in any meaningful way
1. Checking if `getAuthzRequest` is used
`getAuthzRequest` is used in quite a lot of spots, but the second commit removes calls that do not care about the result.  If the maintainers end up not liking that but like the remove of private variable, then it is easier to revert (otherwise one can use the squash in GitHub or I'll squash if politely asked)

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
