### PR TITLE
GEODE-5505 Cache listener not invoked on a retried destroy() operation

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
@@ -381,9 +381,7 @@ public class DistributedRegion extends LocalRegion implements InternalDistribute
         // if the listeners have already seen this event, then it has already
         // been successfully applied to the cache. Distributed messages and
         // return
-        if (isTraceEnabled) {
-          logger.trace("DR.virtualPut: this cache has already seen this event {}", event);
-        }
+        logger.debug("DR.virtualPut: this cache has already seen this event {}", event);
 
         // Fix 39014: when hasSeenEvent, put will still distribute
         // event, but putAll did not. We add the logic back here, not to put

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/map/RegionMapDestroy.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/map/RegionMapDestroy.java
@@ -551,6 +551,9 @@ public class RegionMapDestroy {
         if (regionEntry == null) {
           regionEntry = newRegionEntry;
         }
+        // invoke listeners and inform clients
+        internalRegion.basicDestroyPart2(regionEntry, event, inTokenMode,
+            false, duringRI, true);
         doPart3 = true;
       }
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Put61.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Put61.java
@@ -235,7 +235,7 @@ public class Put61 extends BaseCommand {
     } catch (InvalidDeltaException ide) {
       logger.info(LocalizedMessage.create(
           LocalizedStrings.UpdateOperation_ERROR_APPLYING_DELTA_FOR_KEY_0_OF_REGION_1,
-          new Object[] {key, regionName}));
+          new Object[] {key, regionName, ide.getMessage()}));
       writeException(clientMessage, MessageType.PUT_DELTA_ERROR, ide, false, serverConnection);
       serverConnection.setAsTrue(RESPONDED);
       region.getCachePerfStats().incDeltaFullValuesRequested();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Put65.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Put65.java
@@ -420,7 +420,7 @@ public class Put65 extends BaseCommand {
     } catch (InvalidDeltaException ide) {
       logger.info(LocalizedMessage.create(
           LocalizedStrings.UpdateOperation_ERROR_APPLYING_DELTA_FOR_KEY_0_OF_REGION_1,
-          new Object[] {key, regionName}));
+          new Object[] {key, regionName, ide.getMessage()}));
       writeException(clientMessage, MessageType.PUT_DELTA_ERROR, ide, false, serverConnection);
       serverConnection.setAsTrue(RESPONDED);
       region.getCachePerfStats().incDeltaFullValuesRequested();

--- a/geode-core/src/main/java/org/apache/geode/internal/i18n/LocalizedStrings.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/i18n/LocalizedStrings.java
@@ -6236,7 +6236,7 @@ public class LocalizedStrings {
   public static final StringId RegionAttributesCreation__CLONING_ENABLE_IS_NOT_THE_SAME_THIS_0_OTHER_1 =
       new StringId(4741, "Cloning enabled is not the same: this:  {0}  other:  {1}");
   public static final StringId UpdateOperation_ERROR_APPLYING_DELTA_FOR_KEY_0_OF_REGION_1 =
-      new StringId(4742, "Error applying delta for key {0} of region {1}");
+      new StringId(4742, "Error applying delta for key {0} of region {1}: {2}");
   public static final StringId RequestEventValue_0_THE_EVENT_ID_FOR_THE_GET_EVENT_VALUE_REQUEST_IS_NULL =
       new StringId(4744, "{0}: The event id for the get event value request is null.");
   public static final StringId RequestEventValue_UNABLE_TO_FIND_A_CLIENT_UPDATE_MESSAGE_FOR_0 =

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/map/RegionMapDestroyTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/map/RegionMapDestroyTest.java
@@ -20,6 +20,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -35,6 +36,7 @@ import org.apache.geode.cache.DataPolicy;
 import org.apache.geode.cache.EntryNotFoundException;
 import org.apache.geode.cache.EvictionAttributes;
 import org.apache.geode.cache.Operation;
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.AbstractRegionMap;
 import org.apache.geode.internal.cache.CachePerfStats;
 import org.apache.geode.internal.cache.EntryEventImpl;
@@ -49,7 +51,9 @@ import org.apache.geode.internal.cache.VMLRURegionMap;
 import org.apache.geode.internal.cache.eviction.EvictableEntry;
 import org.apache.geode.internal.cache.eviction.EvictionController;
 import org.apache.geode.internal.cache.eviction.EvictionCounters;
+import org.apache.geode.internal.cache.tier.sockets.ClientProxyMembershipID;
 import org.apache.geode.internal.cache.versions.RegionVersionVector;
+import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap;
 
@@ -172,6 +176,20 @@ public class RegionMapDestroyTest {
     arm.getEntryMap().put(KEY, entry);
   }
 
+  private void givenExistingEntryWithValueAndVersion(Object value, VersionTag version) {
+    RegionEntry entry = arm.getEntryFactory().createEntry(arm._getOwner(), KEY, value);
+    ((VersionStamp) entry).setVersions(version);
+    arm.getEntryMap().put(KEY, entry);
+  }
+
+  private void givenExistingEntryWithValueAndSameVersion(Object value, VersionTag version) {
+    givenExistingEntryWithValueAndVersion(value, version);
+
+    RegionVersionVector<?> versionVector = mock(RegionVersionVector.class);
+    when(arm._getOwner().getVersionVector()).thenReturn(versionVector);
+    event.setVersionTag(version);
+  }
+
   private void givenExistingEntry(Object value) {
     RegionEntry entry = arm.getEntryFactory().createEntry(arm._getOwner(), KEY, value);
     arm.getEntryMap().put(KEY, entry);
@@ -221,6 +239,23 @@ public class RegionMapDestroyTest {
 
   private void givenOriginIsRemote() {
     event.setOriginRemote(true);
+  }
+
+  @Test
+  public void destroWithDuplicateVersionInvokesListener() {
+    givenEmptyRegionMap();
+    givenConcurrencyChecks(true);
+    VersionTag version = VersionTag.create(new InternalDistributedMember("localhost", 123));
+    version.setEntryVersion(1);
+    version.setRegionVersion(1);
+    givenExistingEntryWithValueAndSameVersion(Token.TOMBSTONE, version);
+    // make this a client/server operation
+    event.setContext(new ClientProxyMembershipID());
+    assertThat(arm.destroy(event, inTokenMode, duringRI, cacheWrite, isEviction, expectedOldValue,
+        removeRecoveredEntry)).isTrue();
+    assertThat(event.getIsRedestroyedEntry()).isTrue();
+    verify(owner).basicDestroyPart2(isA(RegionEntry.class), isA(EntryEventImpl.class),
+        isA(Boolean.class), isA(Boolean.class), isA(Boolean.class), isA(Boolean.class));
   }
 
   @Test


### PR DESCRIPTION
This started happening when we moved listener/client notification to
LocalRegion.basicDestroyPart2.  The code to handle duplicate destroys
from a client was only invoking basicDestroyPart3.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
