### PR TITLE
GEODE-5508 Reverts change from GEODE-5492 that broke UTF-8 and manifests

### DIFF
--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -30,6 +30,41 @@ subprojects {
     throw new GradleException("Java version 1.8.0_121 or later required, but was " + javaVersion)
   }
 
+  // apply compiler options
+  gradle.taskGraph.whenReady({ graph ->
+    tasks.withType(JavaCompile).each { javac ->
+      javac.configure {
+        sourceCompatibility '1.8'
+        targetCompatibility '1.8'
+        options.encoding = 'UTF-8'
+      }
+      javac.options.incremental = true
+      javac.options.fork = true
+    }
+  })
+
+  // apply default manifest
+  gradle.taskGraph.whenReady({ graph ->
+    tasks.withType(Jar).each { jar ->
+      jar.doFirst {
+        manifest {
+          attributes(
+            "Manifest-Version": "1.0",
+            "Created-By": System.getProperty("user.name"),
+            "Title": rootProject.name,
+            "Version": version,
+            "Organization": productOrg
+          )
+        }
+      }
+      jar.metaInf {
+        from("$rootDir/LICENSE")
+        if (jar.source.filter({ it.name.contains('NOTICE') }).empty) {
+          from("$rootDir/NOTICE")
+        }
+      }
+    }
+  })
 
   configurations {
     testOutput {
@@ -62,41 +97,4 @@ subprojects {
     options.encoding = 'UTF-8'
     classpath += configurations.compileOnly
   }
-
-// apply compiler options
-  gradle.taskGraph.whenReady({ graph ->
-    tasks.withType(JavaCompile).each { javac ->
-      javac.configure {
-        sourceCompatibility '1.8'
-        targetCompatibility '1.8'
-        options.encoding = 'UTF-8'
-      }
-      javac.options.incremental = true
-      javac.options.fork = true
-    }
-  })
 }
-
-// apply default manifest
-gradle.taskGraph.whenReady({ graph ->
-  tasks.withType(Jar).each { jar ->
-    jar.doFirst {
-      manifest {
-        attributes(
-                "Manifest-Version": "1.0",
-                "Created-By": System.getProperty("user.name"),
-                "Title": rootProject.name,
-                "Version": version,
-                "Organization": productOrg
-        )
-      }
-    }
-    jar.metaInf {
-      from("$rootDir/LICENSE")
-      if (jar.source.filter({ it.name.contains('NOTICE') }).empty) {
-        from("$rootDir/NOTICE")
-      }
-    }
-  }
-})
-


### PR DESCRIPTION
Invoking 'tasks' within taskGraph.whenReady() does not get all tasks,
but only the tasks for the current project. Move the whenReady() back
within a subprojects closure to get correct behavior back

Signed-off-by: Finn Southerland <fsoutherland@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
