### PR TITLE
GEODE-5387: Adding job to the pr pipeline to stress new tests

### DIFF
--- a/ci/pipelines/pull-request/base.yml
+++ b/ci/pipelines/pull-request/base.yml
@@ -62,6 +62,7 @@ groups:
   - AcceptanceTest
   - IntegrationTest
   - UpgradeTest
+  - StressNewTests
 
 jobs:
 - name: Build

--- a/ci/pipelines/pull-request/deploy_pr_pipeline.sh
+++ b/ci/pipelines/pull-request/deploy_pr_pipeline.sh
@@ -69,7 +69,7 @@ for i in ${GEODEBUILDDIR}/test-stubs/*.yml; do
 done
 
 for i in ${SCRIPTDIR}/test-stubs/*.yml; do
-  X=$(basename $i)
+  X=pull-request-$(basename $i)
   echo "Merging ${i} into ${TMP_DIR}/${X}"
   ${SPRUCE} merge --prune metadata \
     <(echo "metadata:"; \

--- a/ci/pipelines/pull-request/deploy_pr_pipeline.sh
+++ b/ci/pipelines/pull-request/deploy_pr_pipeline.sh
@@ -68,6 +68,18 @@ for i in ${GEODEBUILDDIR}/test-stubs/*.yml; do
     ${i} > ${TMP_DIR}/${X}
 done
 
+for i in ${SCRIPTDIR}/test-stubs/*.yml; do
+  X=$(basename $i)
+  echo "Merging ${i} into ${TMP_DIR}/${X}"
+  ${SPRUCE} merge --prune metadata \
+    <(echo "metadata:"; \
+      echo "  geode-build-branch: ${GEODE_BRANCH}"; \
+      echo "  geode-fork: ${GEODE_FORK}"; \
+      echo "  ") \
+    ${SCRIPTDIR}/pr-template.yml \
+    ${i} > ${TMP_DIR}/${X}
+done
+
 echo "Spruce branch-name into resources"
 ${SPRUCE} merge --prune metadata \
   ${SCRIPTDIR}/base.yml \

--- a/ci/pipelines/pull-request/pr-template.yml
+++ b/ci/pipelines/pull-request/pr-template.yml
@@ -103,7 +103,7 @@ jobs:
           GRADLE_TASK_OPTIONS: (( grab metadata.job.gradle_task_options || "" ))
           ARTIFACT_SLUG: (( grab metadata.job.artifact_slug ))
         run:
-          path: geode/ci/scripts/execute_tests.sh
+          path: (( grab metadata.job.execute_command || "geode/ci/scripts/execute_tests.sh" ))
     on_success:
       do:
       - put: pull-request-job-success

--- a/ci/pipelines/pull-request/test-stubs/newtests.yml
+++ b/ci/pipelines/pull-request/test-stubs/newtests.yml
@@ -1,0 +1,33 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+metadata:
+  job:
+    name: StressNewTests
+    gradle_task: repeatTest
+    artifact_slug: stressnewtestfiles
+    execute_command: geode/ci/scripts/repeat-new-tests.sh
+    dunit:
+      parallel: true
+# max number of docker containers to run, generally cpus/2
+      forks: 48
+    cpus: 96
+# specified in Gigabytes.
+    ram: 210
+# specified in seconds
+    call_stack_timeout: 25200
+    timeout: 8h
+    size: []

--- a/ci/scripts/repeat-new-tests.sh
+++ b/ci/scripts/repeat-new-tests.sh
@@ -21,7 +21,7 @@ set -e
 
 SCRIPTDIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
-CHANGED_FILES=$(git diff --name-only HEAD $(git merge-base HEAD develop) | grep -e 'src/test/java\|src/integrationTest/java\|src/distributedTest/java')
+CHANGED_FILES=$(cd geode && git diff --name-only HEAD $(git merge-base HEAD develop) | grep -e 'src/test/java\|src/integrationTest/java\|src/distributedTest/java')
 
 TESTS_FLAG=""
 

--- a/ci/scripts/repeat-new-tests.sh
+++ b/ci/scripts/repeat-new-tests.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -e
+
+SCRIPTDIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+CHANGED_FILES=$(git diff --name-only HEAD $(git merge-base HEAD develop) | grep -e 'src/test/java\|src/integrationTest/java\|src/distributedTest/java')
+
+TESTS_FLAG=""
+
+if [ ${#CHANGED_FILES[@]} -gt 50 ] 
+  then
+    echo "Too many changed tests to stress test. Allowing this job to pass without stress testing."
+    exit 0
+fi
+
+for FILENAME in $CHANGED_FILES ; do
+  SHORT_NAME=$(basename $FILENAME)
+  SHORT_NAME="${SHORT_NAME%.java}"
+  TESTS_FLAG="$TESTS_FLAG --tests *$SHORT_NAME"
+done
+
+export GRADLE_TASK=repeatTest
+export GRADLE_TASK_OPTIONS="-Prepeat=200 -PfailOnNoMatchingTests=false $TESTS_FLAG"
+
+echo "GRADLE_TASK_OPTIONS=${GRADLE_TASK_OPTIONS}"
+
+${SCRIPTDIR}/execute_tests.sh
+

--- a/ci/scripts/repeat-new-tests.sh
+++ b/ci/scripts/repeat-new-tests.sh
@@ -19,6 +19,12 @@
 
 set -e
 
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  SCRIPTDIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
 SCRIPTDIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
 CHANGED_FILES=$(cd geode && git diff --name-only HEAD $(git merge-base HEAD develop) | grep -e 'src/test/java\|src/integrationTest/java\|src/distributedTest/java')

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -199,6 +199,12 @@ subprojects {
     testClassesDirs += project.sourceSets.distributedTest.output.classesDirs
     classpath += project.sourceSets.integrationTest.runtimeClasspath
     testClassesDirs += project.sourceSets.integrationTest.output.classesDirs
+
+    if(project.hasProperty("failOnNoMatchingTests")) {
+      filter {
+        setFailOnNoMatchingTests(Boolean.valueOf(project.failOnNoMatchingTests))
+      }
+    }
   }
 
   task flakyTest(type:Test) {


### PR DESCRIPTION
Adding a job to the PR pipeline that finds new or modified test files
and runs them many times. The goal is to fail PRs that create new flaky
tests.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
