### PR TITLE
GEODE-5515: Only initTXMemberId in PartitionMessage if transaction is originated from client.

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/TransactionOnBehalfOfClientMemberDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/TransactionOnBehalfOfClientMemberDistributedTest.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.execute;
+
+import static org.apache.geode.test.dunit.VM.getHostName;
+import static org.apache.geode.test.dunit.VM.getVM;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.apache.geode.cache.PartitionAttributes;
+import org.apache.geode.cache.PartitionAttributesFactory;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.cache.TransactionId;
+import org.apache.geode.cache.client.ClientRegionFactory;
+import org.apache.geode.cache.client.ClientRegionShortcut;
+import org.apache.geode.cache.client.Pool;
+import org.apache.geode.cache.client.PoolManager;
+import org.apache.geode.cache.server.CacheServer;
+import org.apache.geode.internal.cache.TXId;
+import org.apache.geode.internal.cache.TXManagerImpl;
+import org.apache.geode.internal.cache.TXStateProxyImpl;
+import org.apache.geode.test.dunit.VM;
+import org.apache.geode.test.dunit.rules.CacheRule;
+import org.apache.geode.test.dunit.rules.ClientCacheRule;
+import org.apache.geode.test.dunit.rules.DistributedTestRule;
+import org.apache.geode.test.junit.rules.serializable.SerializableTestName;
+
+public class TransactionOnBehalfOfClientMemberDistributedTest implements Serializable {
+  private String hostName;
+  private String uniqueName;
+  private String regionName;
+  private VM server1;
+  private VM server2;
+
+  private int port1;
+
+  @Rule
+  public DistributedTestRule distributedTestRule = new DistributedTestRule();
+
+  @Rule
+  public CacheRule cacheRule = new CacheRule();
+
+  @Rule
+  public ClientCacheRule clientCacheRule = new ClientCacheRule();
+
+  @Rule
+  public SerializableTestName testName = new SerializableTestName();
+
+  @Before
+  public void setUp() {
+    server1 = getVM(0);
+    server2 = getVM(1);
+
+    hostName = getHostName();
+    uniqueName = getClass().getSimpleName() + "_" + testName.getMethodName();
+    regionName = uniqueName + "_region";
+  }
+
+  @Test
+  public void clientTransactionShouldSetOnBehalfOfClientMember() {
+    port1 = server1.invoke(() -> createServerRegion(1, true));
+    server2.invoke(() -> createServerRegion(1, false));
+    createClientRegion(port1);
+
+    TransactionId txId = beginAndSuspendTransaction(true);
+    server1.invoke(() -> verifyOnBehalfOfClientMember(true));
+    server2.invoke(() -> verifyOnBehalfOfClientMember(true));
+    resumeAndCommitTransaction(true, txId);
+  }
+
+  private int createServerRegion(int totalNumBuckets, boolean isAccessor) throws Exception {
+    PartitionAttributesFactory factory = new PartitionAttributesFactory();
+    factory.setTotalNumBuckets(totalNumBuckets);
+    if (isAccessor) {
+      factory.setLocalMaxMemory(0);
+    }
+    PartitionAttributes partitionAttributes = factory.create();
+    cacheRule.getOrCreateCache().createRegionFactory(RegionShortcut.PARTITION)
+        .setPartitionAttributes(partitionAttributes).create(regionName);
+
+    TXManagerImpl txManager = cacheRule.getCache().getTxManager();
+    txManager.setTransactionTimeToLiveForTest(4);
+
+    CacheServer server = cacheRule.getCache().addCacheServer();
+    server.setPort(0);
+    server.start();
+    return server.getPort();
+  }
+
+  private void createClientRegion(int port) {
+    clientCacheRule.createClientCache();
+    Pool pool = PoolManager.createFactory().addServer(hostName, port).create(uniqueName);
+
+    ClientRegionFactory crf =
+        clientCacheRule.getClientCache().createClientRegionFactory(ClientRegionShortcut.LOCAL);
+    crf.setPoolName(pool.getName());
+    crf.create(regionName);
+  }
+
+  private TransactionId beginAndSuspendTransaction(boolean isClient) {
+    Region region = getRegion(isClient);
+    TXManagerImpl txManager = getTXManager(isClient);
+    txManager.begin();
+    region.put(1, "value1");
+    return txManager.suspend();
+  }
+
+  private Region getRegion(boolean isClient) {
+    if (isClient) {
+      return clientCacheRule.getClientCache().getRegion(regionName);
+    }
+    return cacheRule.getCache().getRegion(regionName);
+  }
+
+  private TXManagerImpl getTXManager(boolean isClient) {
+    if (isClient) {
+      return (TXManagerImpl) clientCacheRule.getClientCache().getCacheTransactionManager();
+    }
+    return cacheRule.getCache().getTxManager();
+  }
+
+  private void verifyOnBehalfOfClientMember(boolean shouldSet) {
+    TXManagerImpl txManager = cacheRule.getCache().getTxManager();
+    ArrayList<TXId> txIds = txManager.getHostedTxIds();
+    for (TXId txId : txIds) {
+      TXStateProxyImpl txStateProxy = (TXStateProxyImpl) txManager.getHostedTXState(txId);
+      if (shouldSet) {
+        assertTrue(txStateProxy.isOnBehalfOfClient());
+      } else {
+        assertFalse(txStateProxy.isOnBehalfOfClient());
+      }
+    }
+  }
+
+  private void resumeAndCommitTransaction(boolean isClient, TransactionId txId) {
+    TXManagerImpl txManager = getTXManager(isClient);
+    txManager.resume(txId);
+    txManager.commit();
+  }
+
+  @Test
+  public void peerTransactionShouldNotSetOnBehalfOfClientMember() {
+    port1 = server1.invoke(() -> createServerRegion(1, true));
+    server2.invoke(() -> createServerRegion(1, false));
+    createClientRegion(port1);
+
+    TransactionId txId = server1.invoke(() -> beginAndSuspendTransaction(false));
+    server1.invoke(() -> verifyOnBehalfOfClientMember(false));
+    server2.invoke(() -> verifyOnBehalfOfClientMember(false));
+    server1.invoke(() -> resumeAndCommitTransaction(false, txId));
+  }
+
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PausedTXStateProxyImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PausedTXStateProxyImpl.java
@@ -410,4 +410,8 @@ public class PausedTXStateProxyImpl implements TXStateProxy {
   @Override
   public void updateProxyServer(InternalDistributedMember proxy) {}
 
+  @Override
+  public InternalDistributedMember getOnBehalfOfClientMember() {
+    return null;
+  }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXState.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXState.java
@@ -1936,10 +1936,10 @@ public class TXState implements TXStateInterface {
 
   @Override
   public InternalDistributedMember getOriginatingMember() {
-    /*
-     * State will never fwd on to other nodes so this is not relevant
-     */
-    return null;
+    // During set operations we need to forward it to other nodes to avoid
+    // wrong transaction is masqueraded if the transaction is on behalf of a client.
+    // This needs to be set to the clients member id if the client originated the tx.
+    return ((TXStateProxyImpl) proxy).onBehalfOfClientMember;
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXState.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXState.java
@@ -1939,7 +1939,7 @@ public class TXState implements TXStateInterface {
     // During set operations we need to forward it to other nodes to avoid
     // wrong transaction is masqueraded if the transaction is on behalf of a client.
     // This needs to be set to the clients member id if the client originated the tx.
-    return ((TXStateProxyImpl) proxy).onBehalfOfClientMember;
+    return proxy.getOnBehalfOfClientMember();
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXStateProxy.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXStateProxy.java
@@ -83,4 +83,6 @@ public interface TXStateProxy extends TXStateInterface {
   void setInProgress(boolean progress);
 
   void updateProxyServer(InternalDistributedMember proxy);
+
+  InternalDistributedMember getOnBehalfOfClientMember();
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXStateProxyImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXStateProxyImpl.java
@@ -979,4 +979,9 @@ public class TXStateProxyImpl implements TXStateProxy {
     this.lastOperationTimeFromClient = lastOperationTimeFromClient;
   }
 
+  @Override
+  public InternalDistributedMember getOnBehalfOfClientMember() {
+    return onBehalfOfClientMember;
+  }
+
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/PartitionMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/PartitionMessage.java
@@ -163,10 +163,7 @@ public abstract class PartitionMessage extends DistributionMessage
             "Sending remote txId even though transaction is local. This should never happen: txState="
                 + txState);
       }
-      // GEODE-3679. Even if TXStateProxy has a local transaction,
-      // we still need to forward original txMemberId to other nodes
-      // if the message does not start a new transaction.
-      this.txMemberId = txState.getTxId().getMemberId();
+      txMemberId = txState.getOriginatingMember();
     }
   }
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/TXStateTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/TXStateTest.java
@@ -35,6 +35,7 @@ import org.apache.geode.cache.CommitConflictException;
 import org.apache.geode.cache.SynchronizationCommitConflictException;
 import org.apache.geode.cache.TransactionDataNodeHasDepartedException;
 import org.apache.geode.cache.TransactionException;
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 
 public class TXStateTest {
   private TXStateProxyImpl txStateProxy;
@@ -146,5 +147,22 @@ public class TXStateTest {
     verify(txState, never()).cleanup();
     verify(regionState1, times(1)).close();
     verify(regionState2, times(1)).close();
+  }
+
+  @Test
+  public void getOriginatingMemberReturnsNullIfNotOriginatedFromClient() {
+    TXState txState = spy(new TXState(txStateProxy, false));
+
+    assertThat(txState.getOriginatingMember()).isNull();
+  }
+
+  @Test
+  public void getOriginatingMemberReturnsClientMemberIfOriginatedFromClient() {
+    InternalDistributedMember client = mock(InternalDistributedMember.class);
+    TXStateProxyImpl proxy = new TXStateProxyImpl(mock(InternalCache.class),
+        mock(TXManagerImpl.class), mock(TXId.class), client);
+    TXState txState = spy(new TXState(proxy, false));
+
+    assertThat(txState.getOriginatingMember()).isEqualTo(client);
   }
 }


### PR DESCRIPTION
  * Only initTXMemberId in PartitionMessage if transaction is originated from client.
  * Returns client member id in TXState.getOriginatingMember() if it is a client originated transaction
    so it can be correctly set in the PartitionMessage.
