### PR TITLE
GEODE-5495: Destroy available ID before decrement in updateHAContainer()

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/HARegionQueueDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/HARegionQueueDUnitTest.java
@@ -955,7 +955,7 @@ public class HARegionQueueDUnitTest extends JUnit4DistributedTestCase {
     WaitCriterion ev = new WaitCriterion() {
       @Override
       public boolean done() {
-        return hrq.getAvalaibleIds().size() == 0;
+        return hrq.getAvailableIds().size() == 0;
       }
 
       @Override
@@ -964,7 +964,7 @@ public class HARegionQueueDUnitTest extends JUnit4DistributedTestCase {
       }
     };
     Wait.waitForCriterion(ev, 60 * 1000, 200, true);
-    // assertIndexDetailsEquals(0, hrq.getAvalaibleIds().size());
+    // assertIndexDetailsEquals(0, hrq.getAvailableIds().size());
   }
 
   @Test

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/HARQAddOperationJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/HARQAddOperationJUnitTest.java
@@ -147,7 +147,7 @@ public class HARQAddOperationJUnitTest {
     Long cntr = (Long) conflationMap.get(KEY1);
     ConflatableObject retValue = (ConflatableObject) rq.getRegion().get(cntr);
     assertEquals(VALUE2, retValue.getValueToConflate());
-    assertEquals(1, rq.getAvalaibleIds().size());
+    assertEquals(1, rq.getAvailableIds().size());
 
     assertEquals(1, rq.getCurrentCounterSet(id1).size());
     this.logWriter.info("HARegionQueueJUnitTest : testQueueAddOperationWithConflation END");
@@ -171,13 +171,13 @@ public class HARQAddOperationJUnitTest {
     this.rq.put(c1);
 
     assertNull(rq.getConflationMapForTesting().get("region1"));
-    assertEquals(1, rq.getAvalaibleIds().size());
+    assertEquals(1, rq.getAvailableIds().size());
 
     assertEquals(1, rq.getCurrentCounterSet(id1).size());
 
     this.rq.put(c2);
     assertNull(rq.getConflationMapForTesting().get("region1"));
-    assertEquals(2, rq.getAvalaibleIds().size());
+    assertEquals(2, rq.getAvailableIds().size());
     assertEquals(2, rq.getCurrentCounterSet(id1).size());
 
     Iterator iter = rq.getCurrentCounterSet(id1).iterator();
@@ -212,7 +212,7 @@ public class HARQAddOperationJUnitTest {
     this.rq.put(obj);
     this.rq.take();
     assertNull(rq.getRegion().get(KEY1));
-    assertEquals(0, this.rq.getAvalaibleIds().size());
+    assertEquals(0, this.rq.getAvailableIds().size());
     Map eventsMap = this.rq.getEventsMapForTesting();
     assertEquals(1, eventsMap.size());
     assertEquals(0, rq.getCurrentCounterSet(id).size());
@@ -296,7 +296,7 @@ public class HARQAddOperationJUnitTest {
       // removed from Region, LastDispatchedWrapperSet should have size 0.
       Awaitility.await().atMost(60, TimeUnit.SECONDS)
           .until(() -> assertEquals(0, regionqueue.getRegion().entrySet(false).size()));
-      assertEquals(0, regionqueue.getAvalaibleIds().size());
+      assertEquals(0, regionqueue.getAvailableIds().size());
       assertNull(regionqueue.getCurrentCounterSet(id1));
 
     } catch (Exception e) {
@@ -323,11 +323,11 @@ public class HARQAddOperationJUnitTest {
     }
 
     // Available id size should be == 10 after puting ten entries
-    assertEquals(10, regionqueue.getAvalaibleIds().size());
+    assertEquals(10, regionqueue.getAvailableIds().size());
 
     // QRM message for therad id 1 and last sequence id 5
     regionqueue.removeDispatchedEvents(ids[4]);
-    assertEquals(5, regionqueue.getAvalaibleIds().size());
+    assertEquals(5, regionqueue.getAvailableIds().size());
     assertEquals(5, regionqueue.getCurrentCounterSet(ids[0]).size());
 
     Iterator iter = regionqueue.getCurrentCounterSet(ids[0]).iterator();
@@ -338,7 +338,7 @@ public class HARQAddOperationJUnitTest {
     }
 
     regionqueue.removeDispatchedEvents(ids[9]);
-    assertEquals(0, regionqueue.getAvalaibleIds().size());
+    assertEquals(0, regionqueue.getAvailableIds().size());
   }
 
   /**
@@ -388,7 +388,7 @@ public class HARQAddOperationJUnitTest {
     if (testFailed)
       fail("Test failed due to " + message);
 
-    assertEquals(0, regionqueue.getAvalaibleIds().size());
+    assertEquals(0, regionqueue.getAvailableIds().size());
     assertEquals(2, regionqueue.getLastDispatchedSequenceId(id2));
   }
 
@@ -438,7 +438,7 @@ public class HARQAddOperationJUnitTest {
     if (testFailed)
       fail("Test failed due to " + message);
 
-    assertEquals(0, regionqueue.getAvalaibleIds().size());
+    assertEquals(0, regionqueue.getAvailableIds().size());
     assertEquals(2, regionqueue.getLastDispatchedSequenceId(id2));
   }
 
@@ -531,8 +531,8 @@ public class HARQAddOperationJUnitTest {
             + regionqueue.getEventsMapForTesting().size(),
         numOfThreads, regionqueue.getEventsMapForTesting().size());
     assertEquals(
-        "size of availableids should 1 but actual size " + regionqueue.getAvalaibleIds().size(), 1,
-        regionqueue.getAvalaibleIds().size());
+        "size of availableids should 1 but actual size " + regionqueue.getAvailableIds().size(), 1,
+        regionqueue.getAvailableIds().size());
     int count = 0;
     for (int i = 0; i < numOfThreads; i++) {
       if ((regionqueue.getCurrentCounterSet(new EventID(new byte[] {(byte) i}, i, i))).size() > 0) {
@@ -543,8 +543,8 @@ public class HARQAddOperationJUnitTest {
     assertEquals("size of the counter set is  1 but the actual size is " + count, 1, count);
 
     Long position = null;
-    if (regionqueue.getAvalaibleIds().size() == 1) {
-      position = (Long) regionqueue.getAvalaibleIds().iterator().next();
+    if (regionqueue.getAvailableIds().size() == 1) {
+      position = (Long) regionqueue.getAvailableIds().iterator().next();
     }
     ConflatableObject id = (ConflatableObject) regionqueue.getRegion().get(position);
     assertEquals(regionqueue.getCurrentCounterSet(id.getEventId()).size(), 1);
@@ -605,7 +605,7 @@ public class HARQAddOperationJUnitTest {
           regionqueue.getCurrentCounterSet(new EventID(new byte[] {(byte) i}, i, 1)).size());
     }
 
-    assertEquals(0, regionqueue.getAvalaibleIds().size());
+    assertEquals(0, regionqueue.getAvailableIds().size());
 
     this.logWriter.info("testPeekAndRemoveWithoutConflation() completed successfully");
   }
@@ -666,7 +666,7 @@ public class HARQAddOperationJUnitTest {
           regionqueue.getCurrentCounterSet(new EventID(new byte[] {(byte) i}, i, 1)).size());
     }
 
-    assertEquals("size of availableIds map should be 0 ", 0, regionqueue.getAvalaibleIds().size());
+    assertEquals("size of availableIds map should be 0 ", 0, regionqueue.getAvailableIds().size());
     assertEquals("size of conflation map should be 0 ", 0,
         ((Map) regionqueue.getConflationMapForTesting().get("region1")).size());
 
@@ -770,7 +770,7 @@ public class HARQAddOperationJUnitTest {
           regionqueue.getCurrentCounterSet(new EventID(new byte[] {(byte) i}, i, 1)).size());
     }
 
-    assertEquals(0, regionqueue.getAvalaibleIds().size());
+    assertEquals(0, regionqueue.getAvailableIds().size());
 
     this.logWriter.info("testPeekForDiffBatchSizeAndRemoveAll() completed successfully");
   }
@@ -863,7 +863,7 @@ public class HARQAddOperationJUnitTest {
     if (testFailed)
       fail("Test failed due to " + message);
 
-    assertEquals(5, regionqueue.getAvalaibleIds().size());
+    assertEquals(5, regionqueue.getAvailableIds().size());
 
     this.logWriter.info("testPeekForDiffBatchSizeAndRemoveSome() completed successfully");
   }

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/HARegionQueueJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/HARegionQueueJUnitTest.java
@@ -284,7 +284,7 @@ public class HARegionQueueJUnitTest {
         !regionQueue.isEmpty(), is(true));
     assertThat(
         " Expected the available id's size not  to be zero since expiry time has not  been exceeded but it is not so ",
-        !regionQueue.getAvalaibleIds().isEmpty(), is(true));
+        !regionQueue.getAvailableIds().isEmpty(), is(true));
     assertThat(
         " Expected conflation map size not  to be zero since expiry time has not been exceeded but it is not so "
             + ((Map) regionQueue.getConflationMapForTesting().get(testName.getMethodName()))
@@ -297,7 +297,7 @@ public class HARegionQueueJUnitTest {
 
     waitAtLeast(1000, start, () -> {
       assertThat(regionQueue.getRegion().keys(), is(Collections.emptySet()));
-      assertThat(regionQueue.getAvalaibleIds(), is(Collections.emptySet()));
+      assertThat(regionQueue.getAvailableIds(), is(Collections.emptySet()));
       assertThat(regionQueue.getConflationMapForTesting().get(testName.getMethodName()),
           is(Collections.emptyMap()));
       assertThat(regionQueue.getEventsMapForTesting(), is(Collections.emptyMap()));
@@ -330,9 +330,9 @@ public class HARegionQueueJUnitTest {
         " Expected region size not to be zero since expiry time has not been exceeded but it is not so ",
         !regionQueue.isEmpty(), is(true));
     assertThat(" Expected the available id's size not  to have counter 1 but it has ",
-        !regionQueue.getAvalaibleIds().contains(1L), is(true));
+        !regionQueue.getAvailableIds().contains(1L), is(true));
     assertThat(" Expected the available id's size to have counter 2 but it does not have ",
-        regionQueue.getAvalaibleIds().contains(2L), is(true));
+        regionQueue.getAvailableIds().contains(2L), is(true));
     assertThat(" Expected eventID map not to have the first event, but it has",
         !regionQueue.getCurrentCounterSet(ev1).contains(1L), is(true));
     assertThat(" Expected eventID map to have the second event, but it does not",
@@ -393,7 +393,7 @@ public class HARegionQueueJUnitTest {
     assertThat(" Expected region peek to return cf but it is not so ", regionQueue.peek(), is(cf));
     assertThat(
         " Expected the available id's size not  to be zero since expiry time has not  been exceeded but it is not so ",
-        !regionQueue.getAvalaibleIds().isEmpty(), is(true));
+        !regionQueue.getAvailableIds().isEmpty(), is(true));
     assertThat(
         " Expected conflation map to have entry for this key since expiry time has not been exceeded but it is not so ",
         ((Map) regionQueue.getConflationMapForTesting().get(testName.getMethodName())).get("key"),
@@ -458,12 +458,12 @@ public class HARegionQueueJUnitTest {
 
     // verify 1-5 not in available Id's map
     for (int i = 1; i < 6; i++) {
-      assertThat(!regionQueue.getAvalaibleIds().contains((long) i), is(true));
+      assertThat(!regionQueue.getAvailableIds().contains((long) i), is(true));
     }
 
     // verify 6-10 in available id's map
     for (int i = 6; i < 11; i++) {
-      assertThat(regionQueue.getAvalaibleIds().contains((long) i), is(true));
+      assertThat(regionQueue.getAvailableIds().contains((long) i), is(true));
     }
   }
 
@@ -531,12 +531,12 @@ public class HARegionQueueJUnitTest {
 
     // verify 1-7 not in available Id's map
     for (int i = 4; i < 11; i++) {
-      assertThat(!regionQueue.getAvalaibleIds().contains((long) i), is(true));
+      assertThat(!regionQueue.getAvailableIds().contains((long) i), is(true));
     }
 
     // verify 8-10 in available id's map
     for (int i = 1; i < 4; i++) {
-      assertThat(regionQueue.getAvalaibleIds().contains((long) i), is(true));
+      assertThat(regionQueue.getAvailableIds().contains((long) i), is(true));
     }
   }
 
@@ -562,9 +562,9 @@ public class HARegionQueueJUnitTest {
     // the old key should not be present
     assertThat(!regionQueue.getRegion().containsKey(1L), is(true));
     // available ids should not contain the old id (the old position)
-    assertThat(!regionQueue.getAvalaibleIds().contains(1L), is(true));
+    assertThat(!regionQueue.getAvailableIds().contains(1L), is(true));
     // available id should have the new id (the new position)
-    assertThat(regionQueue.getAvalaibleIds().contains(2L), is(true));
+    assertThat(regionQueue.getAvailableIds().contains(2L), is(true));
     // events map should not contain the old position
     assertThat(regionQueue.getCurrentCounterSet(ev1).isEmpty(), is(true));
     // events map should contain the new position
@@ -589,7 +589,7 @@ public class HARegionQueueJUnitTest {
     Map conflationMap = ((HARegionQueue) regionqueue).getConflationMapForTesting();
     assertThat(((Map) conflationMap.get(testName.getMethodName())).size(), is(5));
 
-    Set availableIDs = ((HARegionQueue) regionqueue).getAvalaibleIds();
+    Set availableIDs = ((HARegionQueue) regionqueue).getAvailableIds();
     Set counters = ((HARegionQueue) regionqueue).getCurrentCounterSet(qrmID);
 
     assertThat(availableIDs.size(), is(5));


### PR DESCRIPTION
- Double decrementing of HAEventWrapper ref count could occur from simultaneously destroying the region while either processing a queue removal message or dispatching a message.  Fix is to remove the available ID before decrementing in the region destroy logic.
- Added tests for fix
- Fixed getAvalaibleIds() method name typo

Co-authored-by: Ryan McMahon <rmcmahon@pivotal.io>
Co-authored-by: Lynn Hughes-Godfrey <lhughesgodfrey@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [X] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
