### PR TITLE
GEODE-5517: Have StatArchiveReader implement AutoCloseable

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/statistics/StatTypesAreRolledOverRegressionTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/statistics/StatTypesAreRolledOverRegressionTest.java
@@ -137,21 +137,22 @@ public class StatTypesAreRolledOverRegressionTest {
 
   private void verifyStatisticsTypeIsInArchiveFile(final File archiveFile,
       final int expectedResources) throws IOException {
-    StatArchiveReader reader = new StatArchiveReader(new File[] {archiveFile}, null, false);
+    try (StatArchiveReader reader = new StatArchiveReader(new File[] {archiveFile}, null, false)) {
 
-    // compare all resourceInst values against what was printed above
+      // compare all resourceInst values against what was printed above
 
-    List<ResourceInst> resources = reader.getResourceInstList();
-    if (expectedResources > 0) {
-      assertThat(resources).hasAtLeastOneElementOfType(ResourceInst.class);
-    }
+      List<ResourceInst> resources = reader.getResourceInstList();
+      if (expectedResources > 0) {
+        assertThat(resources).hasAtLeastOneElementOfType(ResourceInst.class);
+      }
 
-    for (ResourceInst resourceInstance : resources) {
-      if (resourceInstance == null)
-        continue;
-      assertThat(resourceInstance.getName()).isNotNull();
-      assertThat(resourceInstance.getType()).isNotNull();
-      assertThat(resourceInstance.getType().getName()).isEqualTo(this.statisticsType.getName());
+      for (ResourceInst resourceInstance : resources) {
+        if (resourceInstance == null)
+          continue;
+        assertThat(resourceInstance.getName()).isNotNull();
+        assertThat(resourceInstance.getType()).isNotNull();
+        assertThat(resourceInstance.getType().getName()).isEqualTo(this.statisticsType.getName());
+      }
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/statistics/StatArchiveReader.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/statistics/StatArchiveReader.java
@@ -50,7 +50,7 @@ import org.apache.geode.internal.logging.DateFormatter;
 /**
  * StatArchiveReader provides APIs to read statistic snapshots from an archive file.
  */
-public class StatArchiveReader implements StatArchiveFormat {
+public class StatArchiveReader implements StatArchiveFormat, AutoCloseable {
 
   protected static final NumberFormat nf = NumberFormat.getNumberInstance();
   static {


### PR DESCRIPTION
- This commit also fixes a resource leak in
  StatTypesAreRolledOverRegressionTest which was causing the test to fail on
  Windows.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
