### PR TITLE
GEODE-5314: MBeanStatsMonitor child classes should use atomics instead of volatiles to avoid data race

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/stats/AggregateRegionStatsMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/stats/AggregateRegionStatsMonitor.java
@@ -19,6 +19,7 @@ import java.util.Map;
 
 import org.apache.geode.StatisticDescriptor;
 import org.apache.geode.Statistics;
+import org.apache.geode.distributed.ConfigurationProperties;
 import org.apache.geode.internal.statistics.StatisticId;
 import org.apache.geode.internal.statistics.StatisticNotFoundException;
 import org.apache.geode.internal.statistics.StatisticsListener;
@@ -28,13 +29,17 @@ import org.apache.geode.internal.statistics.ValueMonitor;
 /**
  * This class acts as a monitor and listen for Region statistics updates on behalf of MemberMBean.
  * <p>
- * There's only one dedicated sampler thread that mutates the fields and writes the statistics to a
- * file. The mutable fields are declared as {@code volatile} to make sure readers of the statistics
- * get the latest value recorded.
+ * There's only one dedicated thread that wakes up at the
+ * {@link ConfigurationProperties#STATISTIC_SAMPLE_RATE} configured, samples all the statistics,
+ * writes them to the {@link ConfigurationProperties#STATISTIC_ARCHIVE_FILE} configured (if any) and
+ * notifies listeners of changes. The mutable fields are declared as {@code volatile} to make sure
+ * readers of the statistics get the latest recorded value.
  * <p>
- * The class is not thread-safe. If multiple threads access an instance concurrently, it must be
- * synchronized externally.
+ * This class is conditionally thread-safe, there can be multiple concurrent readers accessing a
+ * instance, but concurrent writers need to be synchronized externally.
  *
+ * @see org.apache.geode.internal.statistics.HostStatSampler
+ * @see org.apache.geode.distributed.ConfigurationProperties
  * @see org.apache.geode.management.internal.beans.stats.MBeanStatsMonitor
  */
 public class AggregateRegionStatsMonitor extends MBeanStatsMonitor {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/stats/GCStatsMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/stats/GCStatsMonitor.java
@@ -15,6 +15,7 @@
 package org.apache.geode.management.internal.beans.stats;
 
 import org.apache.geode.StatisticDescriptor;
+import org.apache.geode.distributed.ConfigurationProperties;
 import org.apache.geode.internal.statistics.StatisticId;
 import org.apache.geode.internal.statistics.StatisticNotFoundException;
 import org.apache.geode.internal.statistics.StatisticsNotification;
@@ -22,13 +23,17 @@ import org.apache.geode.internal.statistics.StatisticsNotification;
 /**
  * This class acts as a monitor and listen for GC statistics updates on behalf of MemberMBean.
  * <p>
- * There's only one dedicated sampler thread that mutates the fields and writes the statistics to a
- * file. The mutable fields are declared as {@code volatile} to make sure readers of the statistics
- * get the latest value recorded.
+ * There's only one dedicated thread that wakes up at the
+ * {@link ConfigurationProperties#STATISTIC_SAMPLE_RATE} configured, samples all the statistics,
+ * writes them to the {@link ConfigurationProperties#STATISTIC_ARCHIVE_FILE} configured (if any) and
+ * notifies listeners of changes. The mutable fields are declared as {@code volatile} to make sure
+ * readers of the statistics get the latest recorded value.
  * <p>
- * The class is not thread-safe. If multiple threads access an instance concurrently, it must be
- * synchronized externally.
+ * This class is conditionally thread-safe, there can be multiple concurrent readers accessing a
+ * instance, but concurrent writers need to be synchronized externally.
  *
+ * @see org.apache.geode.internal.statistics.HostStatSampler
+ * @see org.apache.geode.distributed.ConfigurationProperties
  * @see org.apache.geode.management.internal.beans.stats.MBeanStatsMonitor
  */
 public class GCStatsMonitor extends MBeanStatsMonitor {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/stats/GCStatsMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/stats/GCStatsMonitor.java
@@ -38,18 +38,17 @@ public class GCStatsMonitor extends MBeanStatsMonitor {
   }
 
   void decreasePrevValues(DefaultHashMap statsMap) {
-    collections.set(collections.get() - statsMap.get(StatsKey.VM_GC_STATS_COLLECTIONS).intValue());
-    collectionTime
-        .set(collectionTime.get() - statsMap.get(StatsKey.VM_GC_STATS_COLLECTION_TIME).intValue());
+    collections.getAndAdd(-statsMap.get(StatsKey.VM_GC_STATS_COLLECTIONS).intValue());
+    collectionTime.getAndAdd(-statsMap.get(StatsKey.VM_GC_STATS_COLLECTION_TIME).intValue());
   }
 
   void increaseStats(String name, Number value) {
     if (name.equals(StatsKey.VM_GC_STATS_COLLECTIONS)) {
-      collections.set(collections.get() + value.longValue());
+      collections.getAndAdd(value.longValue());
     }
 
     if (name.equals(StatsKey.VM_GC_STATS_COLLECTION_TIME)) {
-      collectionTime.set(collectionTime.get() + value.longValue());
+      collectionTime.getAndAdd(value.longValue());
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/stats/GatewaySenderOverflowMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/stats/GatewaySenderOverflowMonitor.java
@@ -19,6 +19,7 @@ import java.util.Map;
 
 import org.apache.geode.StatisticDescriptor;
 import org.apache.geode.Statistics;
+import org.apache.geode.distributed.ConfigurationProperties;
 import org.apache.geode.internal.statistics.StatisticId;
 import org.apache.geode.internal.statistics.StatisticNotFoundException;
 import org.apache.geode.internal.statistics.StatisticsListener;
@@ -29,13 +30,17 @@ import org.apache.geode.internal.statistics.ValueMonitor;
  * This class acts as a monitor and listen for Gateway Sender Overflow statistics updates on
  * behalf of MemberMBean.
  * <p>
- * There's only one dedicated sampler thread that mutates the fields and writes the statistics to a
- * file. The mutable fields are declared as {@code volatile} to make sure readers of the statistics
- * get the latest value recorded.
+ * There's only one dedicated thread that wakes up at the
+ * {@link ConfigurationProperties#STATISTIC_SAMPLE_RATE} configured, samples all the statistics,
+ * writes them to the {@link ConfigurationProperties#STATISTIC_ARCHIVE_FILE} configured (if any) and
+ * notifies listeners of changes. The mutable fields are declared as {@code volatile} to make sure
+ * readers of the statistics get the latest recorded value.
  * <p>
- * The class is not thread-safe. If multiple threads access an instance concurrently, it must be
- * synchronized externally.
+ * This class is conditionally thread-safe, there can be multiple concurrent readers accessing a
+ * instance, but concurrent writers need to be synchronized externally.
  *
+ * @see org.apache.geode.internal.statistics.HostStatSampler
+ * @see org.apache.geode.distributed.ConfigurationProperties
  * @see org.apache.geode.management.internal.beans.stats.MBeanStatsMonitor
  */
 public class GatewaySenderOverflowMonitor extends MBeanStatsMonitor {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/stats/GatewaySenderOverflowMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/stats/GatewaySenderOverflowMonitor.java
@@ -81,17 +81,17 @@ public class GatewaySenderOverflowMonitor extends MBeanStatsMonitor {
 
   void increaseStats(String name, Number value) {
     if (name.equals(StatsKey.GATEWAYSENDER_LRU_EVICTIONS)) {
-      lruEvictions.set(lruEvictions.get() + value.longValue());
+      lruEvictions.getAndAdd(value.longValue());
       return;
     }
 
     if (name.equals(StatsKey.GATEWAYSENDER_ENTRIES_OVERFLOWED_TO_DISK)) {
-      entriesOverflowedToDisk.set(entriesOverflowedToDisk.get() + value.longValue());
+      entriesOverflowedToDisk.getAndAdd(value.longValue());
       return;
     }
 
     if (name.equals(StatsKey.GATEWAYSENDER_BYTES_OVERFLOWED_TO_DISK)) {
-      bytesOverflowedToDisk.set(bytesOverflowedToDisk.get() + value.longValue());
+      bytesOverflowedToDisk.getAndAdd(value.longValue());
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/stats/MemberLevelDiskMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/stats/MemberLevelDiskMonitor.java
@@ -19,6 +19,7 @@ import java.util.Map;
 
 import org.apache.geode.StatisticDescriptor;
 import org.apache.geode.Statistics;
+import org.apache.geode.distributed.ConfigurationProperties;
 import org.apache.geode.internal.statistics.StatisticId;
 import org.apache.geode.internal.statistics.StatisticNotFoundException;
 import org.apache.geode.internal.statistics.StatisticsListener;
@@ -28,13 +29,17 @@ import org.apache.geode.internal.statistics.ValueMonitor;
 /**
  * This class acts as a monitor and listen for Disk statistics updates on behalf of MemberMBean.
  * <p>
- * There's only one dedicated sampler thread that mutates the fields and writes the statistics to a
- * file. The mutable fields are declared as {@code volatile} to make sure readers of the statistics
- * get the latest value recorded.
+ * There's only one dedicated thread that wakes up at the
+ * {@link ConfigurationProperties#STATISTIC_SAMPLE_RATE} configured, samples all the statistics,
+ * writes them to the {@link ConfigurationProperties#STATISTIC_ARCHIVE_FILE} configured (if any) and
+ * notifies listeners of changes. The mutable fields are declared as {@code volatile} to make sure
+ * readers of the statistics get the latest recorded value.
  * <p>
- * The class is not thread-safe. If multiple threads access an instance concurrently, it must be
- * synchronized externally.
+ * This class is conditionally thread-safe, there can be multiple concurrent readers accessing a
+ * instance, but concurrent writers need to be synchronized externally.
  *
+ * @see org.apache.geode.internal.statistics.HostStatSampler
+ * @see org.apache.geode.distributed.ConfigurationProperties
  * @see org.apache.geode.management.internal.beans.stats.MBeanStatsMonitor
  */
 public class MemberLevelDiskMonitor extends MBeanStatsMonitor {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/stats/MemberLevelDiskMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/stats/MemberLevelDiskMonitor.java
@@ -16,6 +16,8 @@ package org.apache.geode.management.internal.beans.stats;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.geode.StatisticDescriptor;
 import org.apache.geode.Statistics;
@@ -24,36 +26,192 @@ import org.apache.geode.internal.statistics.StatisticNotFoundException;
 import org.apache.geode.internal.statistics.StatisticsListener;
 import org.apache.geode.internal.statistics.StatisticsNotification;
 import org.apache.geode.internal.statistics.ValueMonitor;
-import org.apache.geode.management.internal.beans.stats.MBeanStatsMonitor.DefaultHashMap;
 
 public class MemberLevelDiskMonitor extends MBeanStatsMonitor {
-
-
-  private volatile long diskReadBytes = 0;
-
-  private volatile long diskWrittenBytes = 0;
-
-  private volatile int backupsInProgress = 0;
-
-  private volatile int backupsCompleted = 0;
-
-  private volatile long flushedBytes = 0;
-
-  private volatile long flushes = 0;
-
-  private volatile long flushTime = 0;
-
-  private volatile int queueSize = 0;
-
-
   private Map<Statistics, ValueMonitor> monitors;
-
   private Map<Statistics, MemberLevelDiskStatisticsListener> listeners;
+  private AtomicLong flushes = new AtomicLong(0);
+  private AtomicInteger queueSize = new AtomicInteger(0);
+  private AtomicLong flushTime = new AtomicLong(0);
+  private AtomicLong flushedBytes = new AtomicLong(0);
+  private AtomicLong diskReadBytes = new AtomicLong(0);
+  private AtomicInteger backupsCompleted = new AtomicInteger(0);
+  private AtomicLong diskWrittenBytes = new AtomicLong(0);
+  private AtomicInteger backupsInProgress = new AtomicInteger(0);
+
+  public long getFlushes() {
+    return flushes.get();
+  }
+
+  public int getQueueSize() {
+    return queueSize.get();
+  }
+
+  public long getFlushTime() {
+    return flushTime.get();
+  }
+
+  public long getFlushedBytes() {
+    return flushedBytes.get();
+  }
+
+  public long getDiskReadBytes() {
+    return diskReadBytes.get();
+  }
+
+  public int getBackupsCompleted() {
+    return backupsCompleted.get();
+  }
+
+  public long getDiskWrittenBytes() {
+    return diskWrittenBytes.get();
+  }
+
+  public int getBackupsInProgress() {
+    return backupsInProgress.get();
+  }
+
+  Map<Statistics, ValueMonitor> getMonitors() {
+    return monitors;
+  }
+
+  Map<Statistics, MemberLevelDiskStatisticsListener> getListeners() {
+    return listeners;
+  }
 
   public MemberLevelDiskMonitor(String name) {
     super(name);
-    monitors = new HashMap<Statistics, ValueMonitor>();
-    listeners = new HashMap<Statistics, MemberLevelDiskStatisticsListener>();
+    monitors = new HashMap<>();
+    listeners = new HashMap<>();
+  }
+
+  Number computeDelta(DefaultHashMap statsMap, String name, Number currentValue) {
+    if (name.equals(StatsKey.DISK_READ_BYTES)) {
+      Number prevValue = statsMap.get(StatsKey.DISK_READ_BYTES).longValue();
+      return currentValue.longValue() - prevValue.longValue();
+    }
+
+    if (name.equals(StatsKey.DISK_RECOVERED_BYTES)) {
+      Number prevValue = statsMap.get(StatsKey.DISK_RECOVERED_BYTES).longValue();
+      return currentValue.longValue() - prevValue.longValue();
+    }
+
+    if (name.equals(StatsKey.DISK_WRITEN_BYTES)) {
+      Number prevValue = statsMap.get(StatsKey.DISK_WRITEN_BYTES).longValue();
+      return currentValue.longValue() - prevValue.longValue();
+    }
+
+    if (name.equals(StatsKey.BACKUPS_IN_PROGRESS)) {
+      // A negative value is also OK. previous backup_in_progress = 5 curr_backup_in_progress = 2
+      // delta = -3 delta should be added to aggregate backup in progress
+      Number prevValue = statsMap.get(StatsKey.BACKUPS_IN_PROGRESS).longValue();
+      return currentValue.longValue() - prevValue.longValue();
+    }
+
+    if (name.equals(StatsKey.BACKUPS_COMPLETED)) {
+      Number prevValue = statsMap.get(StatsKey.BACKUPS_COMPLETED).longValue();
+      return currentValue.longValue() - prevValue.longValue();
+    }
+
+    if (name.equals(StatsKey.FLUSHED_BYTES)) {
+      Number prevValue = statsMap.get(StatsKey.FLUSHED_BYTES).longValue();
+      return currentValue.longValue() - prevValue.longValue();
+    }
+
+    if (name.equals(StatsKey.NUM_FLUSHES)) {
+      Number prevValue = statsMap.get(StatsKey.NUM_FLUSHES).longValue();
+      return currentValue.longValue() - prevValue.longValue();
+    }
+
+    if (name.equals(StatsKey.TOTAL_FLUSH_TIME)) {
+      Number prevValue = statsMap.get(StatsKey.TOTAL_FLUSH_TIME).longValue();
+      return currentValue.longValue() - prevValue.longValue();
+    }
+
+    if (name.equals(StatsKey.DISK_QUEUE_SIZE)) {
+      Number prevValue = statsMap.get(StatsKey.DISK_QUEUE_SIZE).longValue();
+      return currentValue.longValue() - prevValue.longValue();
+    }
+
+    return 0;
+  }
+
+  void increaseStats(String name, Number value) {
+    if ((name.equals(StatsKey.DISK_READ_BYTES) || name.equals(StatsKey.DISK_RECOVERED_BYTES))) {
+      diskReadBytes.set(diskReadBytes.get() + value.longValue());
+      return;
+    }
+
+    if (name.equals(StatsKey.DISK_WRITEN_BYTES)) {
+      diskWrittenBytes.set(diskWrittenBytes.get() + value.longValue());
+      return;
+    }
+
+    if (name.equals(StatsKey.BACKUPS_IN_PROGRESS)) {
+      backupsInProgress.set(backupsInProgress.get() + value.intValue());
+      return;
+    }
+
+    if (name.equals(StatsKey.BACKUPS_COMPLETED)) {
+      backupsCompleted.set(backupsCompleted.get() + value.intValue());
+      return;
+    }
+
+    if (name.equals(StatsKey.FLUSHED_BYTES)) {
+      flushedBytes.set(flushedBytes.get() + value.longValue());
+      return;
+    }
+
+    if (name.equals(StatsKey.NUM_FLUSHES)) {
+      flushes.set(flushes.get() + value.longValue());
+      return;
+    }
+
+    if (name.equals(StatsKey.TOTAL_FLUSH_TIME)) {
+      flushTime.set(flushTime.get() + value.longValue());
+      return;
+    }
+
+    if (name.equals(StatsKey.DISK_QUEUE_SIZE)) {
+      queueSize.set(queueSize.get() + value.intValue());
+    }
+  }
+
+  @Override
+  public Number getStatistic(String name) {
+    if (name.equals(StatsKey.DISK_READ_BYTES)) {
+      return getDiskReadBytes();
+    }
+
+    if (name.equals(StatsKey.DISK_WRITEN_BYTES)) {
+      return getDiskWrittenBytes();
+    }
+
+    if (name.equals(StatsKey.BACKUPS_IN_PROGRESS)) {
+      return getBackupsInProgress();
+    }
+
+    if (name.equals(StatsKey.BACKUPS_COMPLETED)) {
+      return getBackupsCompleted();
+    }
+
+    if (name.equals(StatsKey.FLUSHED_BYTES)) {
+      return getFlushedBytes();
+    }
+
+    if (name.equals(StatsKey.NUM_FLUSHES)) {
+      return getFlushes();
+    }
+
+    if (name.equals(StatsKey.TOTAL_FLUSH_TIME)) {
+      return getFlushTime();
+    }
+
+    if (name.equals(StatsKey.DISK_QUEUE_SIZE)) {
+      return getQueueSize();
+    }
+
+    return 0;
   }
 
   @Override
@@ -62,21 +220,9 @@ public class MemberLevelDiskMonitor extends MBeanStatsMonitor {
     MemberLevelDiskStatisticsListener listener = new MemberLevelDiskStatisticsListener();
     diskMonitor.addListener(listener);
     diskMonitor.addStatistics(stats);
+
     monitors.put(stats, diskMonitor);
     listeners.put(stats, listener);
-  }
-
-  @Override
-  public void removeStatisticsFromMonitor(Statistics stats) {
-    ValueMonitor monitor = monitors.remove(stats);
-    if (monitor != null) {
-      monitor.removeStatistics(stats);
-    }
-    MemberLevelDiskStatisticsListener listener = listeners.remove(stats);
-    if (listener != null) {
-      monitor.removeListener(listener);
-    }
-    listener.decreaseDiskStoreStats(stats);
   }
 
   @Override
@@ -86,43 +232,30 @@ public class MemberLevelDiskMonitor extends MBeanStatsMonitor {
       monitor.removeListener(listeners.get(stat));
       monitor.removeStatistics(stat);
     }
-    listeners.clear();
+
     monitors.clear();
+    listeners.clear();
   }
 
   @Override
-  public Number getStatistic(String name) {
-    if (name.equals(StatsKey.DISK_READ_BYTES)) {
-      return getDiskReads();
+  public void removeStatisticsFromMonitor(Statistics stats) {
+    ValueMonitor monitor = monitors.remove(stats);
+    if (monitor != null) {
+      monitor.removeStatistics(stats);
     }
-    if (name.equals(StatsKey.DISK_WRITEN_BYTES)) {
-      return getDiskWrites();
+
+    MemberLevelDiskStatisticsListener listener = listeners.remove(stats);
+    if (listener != null) {
+      if (monitor != null) {
+        monitor.removeListener(listener);
+      }
+
+      listener.decreaseDiskStoreStats();
     }
-    if (name.equals(StatsKey.BACKUPS_IN_PROGRESS)) {
-      return getBackupsInProgress();
-    }
-    if (name.equals(StatsKey.BACKUPS_COMPLETED)) {
-      return getBackupsCompleted();
-    }
-    if (name.equals(StatsKey.FLUSHED_BYTES)) {
-      return getFlushedBytes();
-    }
-    if (name.equals(StatsKey.NUM_FLUSHES)) {
-      return getFlushes();
-    }
-    if (name.equals(StatsKey.TOTAL_FLUSH_TIME)) {
-      return getFlushTime();
-    }
-    if (name.equals(StatsKey.DISK_QUEUE_SIZE)) {
-      return getQueueSize();
-    }
-    return 0;
   }
 
-  private class MemberLevelDiskStatisticsListener implements StatisticsListener {
-
+  class MemberLevelDiskStatisticsListener implements StatisticsListener {
     DefaultHashMap statsMap = new DefaultHashMap();
-
     private boolean removed = false;
 
     @Override
@@ -131,23 +264,23 @@ public class MemberLevelDiskMonitor extends MBeanStatsMonitor {
         if (removed) {
           return;
         }
+
         for (StatisticId statId : notification) {
           StatisticDescriptor descriptor = statId.getStatisticDescriptor();
           String name = descriptor.getName();
           Number value;
+
           try {
             value = notification.getValue(statId);
           } catch (StatisticNotFoundException e) {
             value = 0;
           }
-          log(name, value);
 
+          log(name, value);
           Number deltaValue = computeDelta(statsMap, name, value);
           statsMap.put(name, value);
           increaseStats(name, deltaValue);
-
         }
-
       }
     }
 
@@ -159,138 +292,13 @@ public class MemberLevelDiskMonitor extends MBeanStatsMonitor {
      * DefaultHashMap for the disk
      *
      */
-
-    public void decreaseDiskStoreStats(Statistics stats) {
+    void decreaseDiskStoreStats() {
       synchronized (statsMap) {
-        queueSize -= statsMap.get(StatsKey.DISK_QUEUE_SIZE).intValue();
-        backupsInProgress -= statsMap.get(StatsKey.BACKUPS_IN_PROGRESS).intValue();;
+        queueSize.set(queueSize.get() - statsMap.get(StatsKey.DISK_QUEUE_SIZE).intValue());
+        backupsInProgress
+            .set(backupsInProgress.get() - statsMap.get(StatsKey.BACKUPS_IN_PROGRESS).intValue());
         removed = true;
-
       }
-
     }
-
-  };
-
-  private Number computeDelta(DefaultHashMap statsMap, String name, Number currentValue) {
-    if (name.equals(StatsKey.DISK_READ_BYTES)) {
-      Number prevValue = statsMap.get(StatsKey.DISK_READ_BYTES).longValue();
-      Number deltaValue = currentValue.longValue() - prevValue.longValue();
-      return deltaValue;
-    }
-    if (name.equals(StatsKey.DISK_RECOVERED_BYTES)) {
-      Number prevValue = statsMap.get(StatsKey.DISK_RECOVERED_BYTES).longValue();
-      Number deltaValue = currentValue.longValue() - prevValue.longValue();
-      return deltaValue;
-    }
-
-    if (name.equals(StatsKey.DISK_WRITEN_BYTES)) {
-      Number prevValue = statsMap.get(StatsKey.DISK_WRITEN_BYTES).longValue();
-      Number deltaValue = currentValue.longValue() - prevValue.longValue();
-      return deltaValue;
-    }
-    if (name.equals(StatsKey.BACKUPS_IN_PROGRESS)) {
-      /**
-       * A negative value is also OK. previous backup_in_progress = 5 curr_backup_in_progress = 2
-       * delta = -3 delta should be added to aggregate backup in progress
-       */
-      Number prevValue = statsMap.get(StatsKey.BACKUPS_IN_PROGRESS).longValue();
-      Number deltaValue = currentValue.longValue() - prevValue.longValue();
-      return deltaValue;
-    }
-    if (name.equals(StatsKey.BACKUPS_COMPLETED)) {
-      Number prevValue = statsMap.get(StatsKey.BACKUPS_COMPLETED).longValue();
-      Number deltaValue = currentValue.longValue() - prevValue.longValue();
-      return deltaValue;
-    }
-    if (name.equals(StatsKey.FLUSHED_BYTES)) {
-      Number prevValue = statsMap.get(StatsKey.FLUSHED_BYTES).longValue();
-      Number deltaValue = currentValue.longValue() - prevValue.longValue();
-      return deltaValue;
-    }
-    if (name.equals(StatsKey.NUM_FLUSHES)) {
-      Number prevValue = statsMap.get(StatsKey.NUM_FLUSHES).longValue();
-      Number deltaValue = currentValue.longValue() - prevValue.longValue();
-      return deltaValue;
-    }
-    if (name.equals(StatsKey.TOTAL_FLUSH_TIME)) {
-      Number prevValue = statsMap.get(StatsKey.TOTAL_FLUSH_TIME).longValue();
-      Number deltaValue = currentValue.longValue() - prevValue.longValue();
-      return deltaValue;
-    }
-    if (name.equals(StatsKey.DISK_QUEUE_SIZE)) {
-      Number prevValue = statsMap.get(StatsKey.DISK_QUEUE_SIZE).longValue();
-      Number deltaValue = currentValue.longValue() - prevValue.longValue();
-      return deltaValue;
-    }
-    return 0;
-  }
-
-  private void increaseStats(String name, Number value) {
-    if ((name.equals(StatsKey.DISK_READ_BYTES) || name.equals(StatsKey.DISK_RECOVERED_BYTES))) {
-      diskReadBytes = diskReadBytes + value.longValue();
-      return;
-    }
-    if (name.equals(StatsKey.DISK_WRITEN_BYTES)) {
-      diskWrittenBytes = diskWrittenBytes + value.longValue();
-      return;
-    }
-    if (name.equals(StatsKey.BACKUPS_IN_PROGRESS)) {
-      backupsInProgress = backupsInProgress + value.intValue();
-      return;
-    }
-    if (name.equals(StatsKey.BACKUPS_COMPLETED)) {
-      backupsCompleted = backupsCompleted + value.intValue();
-      return;
-    }
-    if (name.equals(StatsKey.FLUSHED_BYTES)) {
-      flushedBytes = flushedBytes + value.longValue();
-      return;
-    }
-    if (name.equals(StatsKey.NUM_FLUSHES)) {
-      flushes = flushes + value.longValue();
-      return;
-    }
-    if (name.equals(StatsKey.TOTAL_FLUSH_TIME)) {
-      flushTime = flushTime + value.longValue();
-      return;
-    }
-    if (name.equals(StatsKey.DISK_QUEUE_SIZE)) {
-      queueSize = queueSize + value.intValue();
-      return;
-    }
-  }
-
-
-  public long getDiskReads() {
-    return diskReadBytes;
-  }
-
-  public long getDiskWrites() {
-    return diskWrittenBytes;
-  }
-
-  public int getBackupsInProgress() {
-    return backupsInProgress;
-  }
-
-  public int getBackupsCompleted() {
-    return backupsCompleted;
-  }
-
-  public long getFlushedBytes() {
-    return flushedBytes;
-  }
-
-  public long getFlushes() {
-    return flushes;
-  }
-
-  public long getFlushTime() {
-    return flushTime;
-  }
-
-  public int getQueueSize() {
-    return queueSize;
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/stats/VMStatsMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/stats/VMStatsMonitor.java
@@ -15,6 +15,7 @@
 package org.apache.geode.management.internal.beans.stats;
 
 import java.lang.management.ManagementFactory;
+import java.time.Instant;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.geode.StatisticDescriptor;
@@ -33,7 +34,7 @@ public class VMStatsMonitor extends MBeanStatsMonitor {
   private long lastSystemTime = 0;
   private long lastProcessCpuTime = 0;
   private final boolean processCPUTimeAvailable;
-  private AtomicInteger cpuUsageBits = new AtomicInteger(Float.floatToIntBits(0f));
+  private final AtomicInteger cpuUsageBits = new AtomicInteger(Float.floatToIntBits(0f));
 
   public float getCpuUsage() {
     return Float.intBitsToFloat(cpuUsageBits.get());
@@ -49,7 +50,7 @@ public class VMStatsMonitor extends MBeanStatsMonitor {
   }
 
   long currentTimeMillis() {
-    return System.currentTimeMillis();
+    return Instant.now().toEpochMilli();
   }
 
   /**
@@ -70,7 +71,7 @@ public class VMStatsMonitor extends MBeanStatsMonitor {
    * Right now it only refreshes CPU usage in terms of percentage. This method can be used for any
    * other computation based on Stats in future.
    */
-  void refreshStats() {
+  synchronized void refreshStats() {
     if (processCPUTimeAvailable) {
       Number processCpuTime = statsMap.get(StatsKey.VM_PROCESS_CPU_TIME);
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/stats/VMStatsMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/stats/VMStatsMonitor.java
@@ -52,6 +52,14 @@ public class VMStatsMonitor extends MBeanStatsMonitor {
     return cpuUsage;
   }
 
+  long getLastSystemTime() {
+    return lastSystemTime;
+  }
+
+  long getLastProcessCpuTime() {
+    return lastProcessCpuTime;
+  }
+
   public VMStatsMonitor(String name) {
     super(name);
     processCPUTimeAvailable = MBeanJMXAdapter.isAttributeAvailable(PROCESS_CPU_TIME_ATTRIBUTE,
@@ -75,8 +83,8 @@ public class VMStatsMonitor extends MBeanStatsMonitor {
    */
   float calculateCpuUsage(long systemTime, long cpuTime) {
     // 10000 = (Nano conversion factor / 100 for percentage)
-    long denom = (systemTime - lastSystemTime) * 10000;
-    return (float) (cpuTime - lastProcessCpuTime) / denom;
+    long denom = (systemTime - getLastSystemTime()) * 10000;
+    return (float) (cpuTime - getLastProcessCpuTime()) / denom;
   }
 
   /**
@@ -106,9 +114,9 @@ public class VMStatsMonitor extends MBeanStatsMonitor {
       }
 
       long systemTime = currentTimeMillis();
+      cpuUsage = calculateCpuUsage(systemTime, cpuTime);
       lastSystemTime = systemTime;
       lastProcessCpuTime = cpuTime;
-      cpuUsage = calculateCpuUsage(systemTime, cpuTime);
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/stats/VMStatsMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/stats/VMStatsMonitor.java
@@ -18,6 +18,7 @@ import java.lang.management.ManagementFactory;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.geode.StatisticDescriptor;
+import org.apache.geode.distributed.ConfigurationProperties;
 import org.apache.geode.internal.statistics.StatisticId;
 import org.apache.geode.internal.statistics.StatisticNotFoundException;
 import org.apache.geode.internal.statistics.StatisticsNotification;
@@ -26,13 +27,17 @@ import org.apache.geode.management.internal.MBeanJMXAdapter;
 /**
  * This class acts as a monitor and listen for VM stats update on behalf of MemberMBean.
  * <p>
- * There's only one dedicated sampler thread that mutates the fields and writes the statistics to a
- * file. The mutable fields are declared as {@code volatile} to make sure readers of the statistics
- * get the latest value recorded.
+ * There's only one dedicated thread that wakes up at the
+ * {@link ConfigurationProperties#STATISTIC_SAMPLE_RATE} configured, samples all the statistics,
+ * writes them to the {@link ConfigurationProperties#STATISTIC_ARCHIVE_FILE} configured (if any) and
+ * notifies listeners of changes. The mutable fields are declared as {@code volatile} to make sure
+ * readers of the statistics get the latest recorded value.
  * <p>
- * The class is not thread-safe. If multiple threads access an instance concurrently, it must be
- * synchronized externally.
+ * This class is conditionally thread-safe, there can be multiple concurrent readers accessing a
+ * instance, but concurrent writers need to be synchronized externally.
  *
+ * @see org.apache.geode.internal.statistics.HostStatSampler
+ * @see org.apache.geode.distributed.ConfigurationProperties
  * @see org.apache.geode.management.internal.beans.stats.MBeanStatsMonitor
  */
 public class VMStatsMonitor extends MBeanStatsMonitor {

--- a/geode-core/src/test/java/org/apache/geode/management/internal/beans/stats/AggregateRegionStatsMonitorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/beans/stats/AggregateRegionStatsMonitorTest.java
@@ -84,7 +84,7 @@ public class AggregateRegionStatsMonitorTest {
   @Test
   public void computeDeltaShouldReturnZeroForUnknownStatistics() {
     assertThat(aggregateRegionStatsMonitor.computeDelta(new MBeanStatsMonitor.DefaultHashMap(),
-        "UnknownStatistic", 6)).isEqualTo(0);
+        "unknownStatistic", 6)).isEqualTo(0);
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/management/internal/beans/stats/AggregateRegionStatsMonitorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/beans/stats/AggregateRegionStatsMonitorTest.java
@@ -1,0 +1,244 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.management.internal.beans.stats;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TestName;
+
+import org.apache.geode.Statistics;
+import org.apache.geode.internal.NanoTimer;
+import org.apache.geode.internal.io.MainWithChildrenRollingFileHandler;
+import org.apache.geode.internal.statistics.SampleCollector;
+import org.apache.geode.internal.statistics.StatArchiveHandlerConfig;
+import org.apache.geode.internal.statistics.StatisticsSampler;
+import org.apache.geode.internal.statistics.TestStatisticsManager;
+import org.apache.geode.internal.statistics.TestStatisticsSampler;
+import org.apache.geode.internal.statistics.ValueMonitor;
+import org.apache.geode.test.junit.categories.StatisticsTest;
+
+@Category(StatisticsTest.class)
+public class AggregateRegionStatsMonitorTest {
+  @Rule
+  public TestName testName = new TestName();
+
+  private AggregateRegionStatsMonitor aggregateRegionStatsMonitor;
+
+  @Before
+  public void setUp() {
+    final long startTime = System.currentTimeMillis();
+    TestStatisticsManager manager =
+        new TestStatisticsManager(1, getClass().getSimpleName(), startTime);
+    StatArchiveHandlerConfig mockStatArchiveHandlerConfig = mock(StatArchiveHandlerConfig.class,
+        getClass().getSimpleName() + "$" + StatArchiveHandlerConfig.class.getSimpleName());
+    when(mockStatArchiveHandlerConfig.getArchiveFileName()).thenReturn(new File(""));
+    when(mockStatArchiveHandlerConfig.getArchiveFileSizeLimit()).thenReturn(0L);
+    when(mockStatArchiveHandlerConfig.getArchiveDiskSpaceLimit()).thenReturn(0L);
+    when(mockStatArchiveHandlerConfig.getSystemId()).thenReturn(0L);
+    when(mockStatArchiveHandlerConfig.getSystemStartTime()).thenReturn(startTime);
+    when(mockStatArchiveHandlerConfig.getSystemDirectoryPath()).thenReturn("");
+    when(mockStatArchiveHandlerConfig.getProductDescription())
+        .thenReturn(getClass().getSimpleName());
+
+    StatisticsSampler sampler = new TestStatisticsSampler(manager);
+    SampleCollector sampleCollector = new SampleCollector(sampler);
+    sampleCollector.initialize(mockStatArchiveHandlerConfig, NanoTimer.getTime(),
+        new MainWithChildrenRollingFileHandler());
+    aggregateRegionStatsMonitor =
+        spy(new AggregateRegionStatsMonitor(this.testName.getMethodName()));
+
+    assertThat(aggregateRegionStatsMonitor).isNotNull();
+    assertThat(aggregateRegionStatsMonitor.getMonitors()).isEmpty();
+    assertThat(aggregateRegionStatsMonitor.getListeners()).isEmpty();
+    assertThat(aggregateRegionStatsMonitor.getDiskSpace()).isEqualTo(0);
+    assertThat(aggregateRegionStatsMonitor.getTotalBucketCount()).isEqualTo(0);
+    assertThat(aggregateRegionStatsMonitor.getLruDestroys()).isEqualTo(0);
+    assertThat(aggregateRegionStatsMonitor.getLruEvictions()).isEqualTo(0);
+    assertThat(aggregateRegionStatsMonitor.getTotalBucketSize()).isEqualTo(0);
+    assertThat(aggregateRegionStatsMonitor.getTotalPrimaryBucketCount()).isEqualTo(0);
+  }
+
+  @Test
+  public void computeDeltaShouldReturnZeroForUnknownStatistics() {
+    assertThat(aggregateRegionStatsMonitor.computeDelta(new MBeanStatsMonitor.DefaultHashMap(),
+        "UnknownStatistic", 6)).isEqualTo(0);
+  }
+
+  @Test
+  public void computeDeltaShouldOperateForHandledStatistics() {
+    MBeanStatsMonitor.DefaultHashMap statsMap = new MBeanStatsMonitor.DefaultHashMap();
+    statsMap.put(StatsKey.PRIMARY_BUCKET_COUNT, 5);
+    statsMap.put(StatsKey.BUCKET_COUNT, 13);
+    statsMap.put(StatsKey.TOTAL_BUCKET_SIZE, 1024);
+    statsMap.put(StatsKey.LRU_EVICTIONS, 12);
+    statsMap.put(StatsKey.LRU_DESTROYS, 5);
+    statsMap.put(StatsKey.DISK_SPACE, 2048);
+
+    assertThat(aggregateRegionStatsMonitor.computeDelta(statsMap, StatsKey.PRIMARY_BUCKET_COUNT, 6))
+        .isEqualTo(1);
+    assertThat(aggregateRegionStatsMonitor.computeDelta(statsMap, StatsKey.BUCKET_COUNT, 15))
+        .isEqualTo(2);
+    assertThat(aggregateRegionStatsMonitor.computeDelta(statsMap, StatsKey.TOTAL_BUCKET_SIZE, 1030))
+        .isEqualTo(6);
+    assertThat(aggregateRegionStatsMonitor.computeDelta(statsMap, StatsKey.LRU_EVICTIONS, 20))
+        .isEqualTo(8L);
+    assertThat(aggregateRegionStatsMonitor.computeDelta(statsMap, StatsKey.LRU_DESTROYS, 6))
+        .isEqualTo(1L);
+    assertThat(aggregateRegionStatsMonitor.computeDelta(statsMap, StatsKey.DISK_SPACE, 2050))
+        .isEqualTo(2L);
+  }
+
+  @Test
+  public void increaseStatsShouldIncrementStatisticsUsingTheSelectedValue() {
+    aggregateRegionStatsMonitor.increaseStats(StatsKey.PRIMARY_BUCKET_COUNT, 5);
+    aggregateRegionStatsMonitor.increaseStats(StatsKey.BUCKET_COUNT, 13);
+    aggregateRegionStatsMonitor.increaseStats(StatsKey.TOTAL_BUCKET_SIZE, 1024);
+    aggregateRegionStatsMonitor.increaseStats(StatsKey.LRU_EVICTIONS, 12);
+    aggregateRegionStatsMonitor.increaseStats(StatsKey.LRU_DESTROYS, 5);
+    aggregateRegionStatsMonitor.increaseStats(StatsKey.DISK_SPACE, 2048);
+    assertThat(aggregateRegionStatsMonitor.getStatistic(StatsKey.PRIMARY_BUCKET_COUNT))
+        .isEqualTo(5);
+    assertThat(aggregateRegionStatsMonitor.getStatistic(StatsKey.BUCKET_COUNT)).isEqualTo(13);
+    assertThat(aggregateRegionStatsMonitor.getStatistic(StatsKey.TOTAL_BUCKET_SIZE))
+        .isEqualTo(1024);
+    assertThat(aggregateRegionStatsMonitor.getStatistic(StatsKey.LRU_EVICTIONS)).isEqualTo(12L);
+    assertThat(aggregateRegionStatsMonitor.getStatistic(StatsKey.LRU_DESTROYS)).isEqualTo(5L);
+    assertThat(aggregateRegionStatsMonitor.getStatistic(StatsKey.DISK_SPACE)).isEqualTo(2048L);
+
+    aggregateRegionStatsMonitor.increaseStats(StatsKey.PRIMARY_BUCKET_COUNT, 2);
+    aggregateRegionStatsMonitor.increaseStats(StatsKey.BUCKET_COUNT, 2);
+    aggregateRegionStatsMonitor.increaseStats(StatsKey.TOTAL_BUCKET_SIZE, 1);
+    aggregateRegionStatsMonitor.increaseStats(StatsKey.LRU_EVICTIONS, 8);
+    aggregateRegionStatsMonitor.increaseStats(StatsKey.LRU_DESTROYS, 5);
+    aggregateRegionStatsMonitor.increaseStats(StatsKey.DISK_SPACE, 2);
+    assertThat(aggregateRegionStatsMonitor.getStatistic(StatsKey.PRIMARY_BUCKET_COUNT))
+        .isEqualTo(7);
+    assertThat(aggregateRegionStatsMonitor.getStatistic(StatsKey.BUCKET_COUNT)).isEqualTo(15);
+    assertThat(aggregateRegionStatsMonitor.getStatistic(StatsKey.TOTAL_BUCKET_SIZE))
+        .isEqualTo(1025);
+    assertThat(aggregateRegionStatsMonitor.getStatistic(StatsKey.LRU_EVICTIONS)).isEqualTo(20L);
+    assertThat(aggregateRegionStatsMonitor.getStatistic(StatsKey.LRU_DESTROYS)).isEqualTo(10L);
+    assertThat(aggregateRegionStatsMonitor.getStatistic(StatsKey.DISK_SPACE)).isEqualTo(2050L);
+  }
+
+  @Test
+  public void removeLRUStatisticsShouldRemoveListenerAndMonitor() {
+    Statistics statistics = mock(Statistics.class);
+    ValueMonitor regionMonitor = mock(ValueMonitor.class);
+    AggregateRegionStatsMonitor.MemberLevelRegionStatisticsListener listener =
+        mock(AggregateRegionStatsMonitor.MemberLevelRegionStatisticsListener.class);
+    aggregateRegionStatsMonitor.getListeners().put(statistics, listener);
+    aggregateRegionStatsMonitor.getMonitors().put(statistics, regionMonitor);
+
+    aggregateRegionStatsMonitor.removeLRUStatistics(statistics);
+    assertThat(aggregateRegionStatsMonitor.getListeners()).isEmpty();
+    assertThat(aggregateRegionStatsMonitor.getMonitors()).isEmpty();
+    verify(regionMonitor, times(1)).removeListener(listener);
+    verify(regionMonitor, times(1)).removeStatistics(statistics);
+  }
+
+  @Test
+  public void removeDirectoryStatisticsShouldRemoveListenerAndMonitor() {
+    Statistics statistics = mock(Statistics.class);
+    ValueMonitor regionMonitor = mock(ValueMonitor.class);
+    AggregateRegionStatsMonitor.MemberLevelRegionStatisticsListener listener =
+        mock(AggregateRegionStatsMonitor.MemberLevelRegionStatisticsListener.class);
+    aggregateRegionStatsMonitor.getListeners().put(statistics, listener);
+    aggregateRegionStatsMonitor.getMonitors().put(statistics, regionMonitor);
+
+    aggregateRegionStatsMonitor.removeDirectoryStatistics(statistics);
+    assertThat(aggregateRegionStatsMonitor.getListeners()).isEmpty();
+    assertThat(aggregateRegionStatsMonitor.getMonitors()).isEmpty();
+    verify(regionMonitor, times(1)).removeListener(listener);
+    verify(regionMonitor, times(1)).removeStatistics(statistics);
+  }
+
+  @Test
+  public void removePartitionStatisticsShouldDecreaseStatsAndRemoveBothListenerAndMonitor() {
+    Statistics statistics = mock(Statistics.class);
+    ValueMonitor regionMonitor = mock(ValueMonitor.class);
+    AggregateRegionStatsMonitor.MemberLevelRegionStatisticsListener listener =
+        mock(AggregateRegionStatsMonitor.MemberLevelRegionStatisticsListener.class);
+    aggregateRegionStatsMonitor.getListeners().put(statistics, listener);
+    aggregateRegionStatsMonitor.getMonitors().put(statistics, regionMonitor);
+
+    aggregateRegionStatsMonitor.removePartitionStatistics(statistics);
+    assertThat(aggregateRegionStatsMonitor.getListeners()).isEmpty();
+    assertThat(aggregateRegionStatsMonitor.getMonitors()).isEmpty();
+    verify(listener, times(1)).decreaseParStats();
+    verify(regionMonitor, times(1)).removeListener(listener);
+    verify(regionMonitor, times(1)).removeStatistics(statistics);
+  }
+
+  @Test
+  public void getStatisticShouldReturnZeroForUnknownStatistics() {
+    assertThat(aggregateRegionStatsMonitor.getStatistic("unhandledStatistic")).isEqualTo(0);
+  }
+
+  @Test
+  public void getStatisticShouldReturnTheRecordedValueForHandledStatistics() {
+    aggregateRegionStatsMonitor.increaseStats(StatsKey.PRIMARY_BUCKET_COUNT, 5);
+    aggregateRegionStatsMonitor.increaseStats(StatsKey.BUCKET_COUNT, 13);
+    aggregateRegionStatsMonitor.increaseStats(StatsKey.TOTAL_BUCKET_SIZE, 1024);
+    aggregateRegionStatsMonitor.increaseStats(StatsKey.LRU_EVICTIONS, 12);
+    aggregateRegionStatsMonitor.increaseStats(StatsKey.LRU_DESTROYS, 5);
+    aggregateRegionStatsMonitor.increaseStats(StatsKey.DISK_SPACE, 2048);
+
+    assertThat(aggregateRegionStatsMonitor.getStatistic(StatsKey.PRIMARY_BUCKET_COUNT))
+        .isEqualTo(5);
+    assertThat(aggregateRegionStatsMonitor.getStatistic(StatsKey.BUCKET_COUNT)).isEqualTo(13);
+    assertThat(aggregateRegionStatsMonitor.getStatistic(StatsKey.TOTAL_BUCKET_SIZE))
+        .isEqualTo(1024);
+    assertThat(aggregateRegionStatsMonitor.getStatistic(StatsKey.LRU_EVICTIONS)).isEqualTo(12L);
+    assertThat(aggregateRegionStatsMonitor.getStatistic(StatsKey.LRU_DESTROYS)).isEqualTo(5L);
+    assertThat(aggregateRegionStatsMonitor.getStatistic(StatsKey.DISK_SPACE)).isEqualTo(2048L);
+  }
+
+  @Test
+  public void addStatisticsToMonitorShouldAddListenerAndMonitor() {
+    Statistics statistics = mock(Statistics.class);
+    aggregateRegionStatsMonitor.addStatisticsToMonitor(statistics);
+
+    assertThat(aggregateRegionStatsMonitor.getMonitors().size()).isEqualTo(1);
+    assertThat(aggregateRegionStatsMonitor.getListeners().size()).isEqualTo(1);
+  }
+
+  @Test
+  public void stopListenerShouldRemoveListenerAndMonitor() {
+    Statistics statistics = mock(Statistics.class);
+    ValueMonitor regionMonitor = mock(ValueMonitor.class);
+    AggregateRegionStatsMonitor.MemberLevelRegionStatisticsListener listener =
+        mock(AggregateRegionStatsMonitor.MemberLevelRegionStatisticsListener.class);
+    aggregateRegionStatsMonitor.getListeners().put(statistics, listener);
+    aggregateRegionStatsMonitor.getMonitors().put(statistics, regionMonitor);
+
+    aggregateRegionStatsMonitor.stopListener();
+    verify(regionMonitor, times(1)).removeListener(listener);
+    verify(regionMonitor, times(1)).removeStatistics(statistics);
+    assertThat(aggregateRegionStatsMonitor.getMonitors()).isEmpty();
+    assertThat(aggregateRegionStatsMonitor.getListeners()).isEmpty();
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/management/internal/beans/stats/GCStatsMonitorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/beans/stats/GCStatsMonitorTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.management.internal.beans.stats;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TestName;
+
+import org.apache.geode.test.junit.categories.StatisticsTest;
+
+@Category(StatisticsTest.class)
+public class GCStatsMonitorTest {
+  @Rule
+  public TestName testName = new TestName();
+
+  private GCStatsMonitor gcStatsMonitor;
+
+  @Before
+  public void setUp() {
+    gcStatsMonitor = new GCStatsMonitor(testName.getMethodName());
+
+    assertThat(gcStatsMonitor).isNotNull();
+    assertThat(gcStatsMonitor.getCollections()).isEqualTo(0);
+    assertThat(gcStatsMonitor.getCollectionTime()).isEqualTo(0);
+  }
+
+  @Test
+  public void getStatisticShouldReturnZeroForUnknownStatistics() {
+    assertThat(gcStatsMonitor.getStatistic("unhandledStatistic")).isEqualTo(0);
+  }
+
+  @Test
+  public void getStatisticShouldReturnTheRecordedValueForHandledStatistics() {
+    gcStatsMonitor.increaseStats(StatsKey.VM_GC_STATS_COLLECTIONS, 10);
+    gcStatsMonitor.increaseStats(StatsKey.VM_GC_STATS_COLLECTION_TIME, 10000);
+
+    assertThat(gcStatsMonitor.getStatistic(StatsKey.VM_GC_STATS_COLLECTIONS)).isEqualTo(10L);
+    assertThat(gcStatsMonitor.getStatistic(StatsKey.VM_GC_STATS_COLLECTION_TIME)).isEqualTo(10000L);
+  }
+
+  @Test
+  public void increaseStatsShouldIncrementStatisticsUsingTheSelectedValue() {
+    gcStatsMonitor.increaseStats(StatsKey.VM_GC_STATS_COLLECTIONS, 10);
+    gcStatsMonitor.increaseStats(StatsKey.VM_GC_STATS_COLLECTION_TIME, 10000);
+    assertThat(gcStatsMonitor.getStatistic(StatsKey.VM_GC_STATS_COLLECTIONS)).isEqualTo(10L);
+    assertThat(gcStatsMonitor.getStatistic(StatsKey.VM_GC_STATS_COLLECTION_TIME)).isEqualTo(10000L);
+
+    gcStatsMonitor.increaseStats(StatsKey.VM_GC_STATS_COLLECTIONS, 15);
+    gcStatsMonitor.increaseStats(StatsKey.VM_GC_STATS_COLLECTION_TIME, 20000);
+    assertThat(gcStatsMonitor.getStatistic(StatsKey.VM_GC_STATS_COLLECTIONS)).isEqualTo(25L);
+    assertThat(gcStatsMonitor.getStatistic(StatsKey.VM_GC_STATS_COLLECTION_TIME)).isEqualTo(30000L);
+  }
+
+  @Test
+  public void decreasePrevValuesShouldDecrementStatisticsUsingTheSelectedValue() {
+    gcStatsMonitor.increaseStats(StatsKey.VM_GC_STATS_COLLECTIONS, 10);
+    gcStatsMonitor.increaseStats(StatsKey.VM_GC_STATS_COLLECTION_TIME, 10000);
+    assertThat(gcStatsMonitor.getStatistic(StatsKey.VM_GC_STATS_COLLECTIONS)).isEqualTo(10L);
+    assertThat(gcStatsMonitor.getStatistic(StatsKey.VM_GC_STATS_COLLECTION_TIME)).isEqualTo(10000L);
+    MBeanStatsMonitor.DefaultHashMap statsMap = new MBeanStatsMonitor.DefaultHashMap();
+    statsMap.put(StatsKey.VM_GC_STATS_COLLECTIONS, 5);
+    statsMap.put(StatsKey.VM_GC_STATS_COLLECTION_TIME, 5000);
+
+    gcStatsMonitor.decreasePrevValues(statsMap);
+    assertThat(gcStatsMonitor.getStatistic(StatsKey.VM_GC_STATS_COLLECTIONS)).isEqualTo(5L);
+    assertThat(gcStatsMonitor.getStatistic(StatsKey.VM_GC_STATS_COLLECTION_TIME)).isEqualTo(5000L);
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/management/internal/beans/stats/GCStatsMonitorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/beans/stats/GCStatsMonitorTest.java
@@ -42,7 +42,7 @@ public class GCStatsMonitorTest {
 
   @Test
   public void getStatisticShouldReturnZeroForUnknownStatistics() {
-    assertThat(gcStatsMonitor.getStatistic("unhandledStatistic")).isEqualTo(0);
+    assertThat(gcStatsMonitor.getStatistic("unknownStatistic")).isEqualTo(0);
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/management/internal/beans/stats/GatewaySenderOverflowMonitorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/beans/stats/GatewaySenderOverflowMonitorTest.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.management.internal.beans.stats;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TestName;
+
+import org.apache.geode.Statistics;
+import org.apache.geode.internal.NanoTimer;
+import org.apache.geode.internal.io.MainWithChildrenRollingFileHandler;
+import org.apache.geode.internal.statistics.SampleCollector;
+import org.apache.geode.internal.statistics.StatArchiveHandlerConfig;
+import org.apache.geode.internal.statistics.StatisticsSampler;
+import org.apache.geode.internal.statistics.TestStatisticsManager;
+import org.apache.geode.internal.statistics.TestStatisticsSampler;
+import org.apache.geode.internal.statistics.ValueMonitor;
+import org.apache.geode.test.junit.categories.StatisticsTest;
+
+@Category(StatisticsTest.class)
+public class GatewaySenderOverflowMonitorTest {
+  @Rule
+  public TestName testName = new TestName();
+
+  private GatewaySenderOverflowMonitor gatewaySenderOverflowMonitor;
+
+  @Before
+  public void setUp() {
+    final long startTime = System.currentTimeMillis();
+    TestStatisticsManager manager =
+        new TestStatisticsManager(1, getClass().getSimpleName(), startTime);
+    StatArchiveHandlerConfig mockStatArchiveHandlerConfig = mock(StatArchiveHandlerConfig.class,
+        getClass().getSimpleName() + "$" + StatArchiveHandlerConfig.class.getSimpleName());
+    when(mockStatArchiveHandlerConfig.getArchiveFileName()).thenReturn(new File(""));
+    when(mockStatArchiveHandlerConfig.getArchiveFileSizeLimit()).thenReturn(0L);
+    when(mockStatArchiveHandlerConfig.getArchiveDiskSpaceLimit()).thenReturn(0L);
+    when(mockStatArchiveHandlerConfig.getSystemId()).thenReturn(0L);
+    when(mockStatArchiveHandlerConfig.getSystemStartTime()).thenReturn(startTime);
+    when(mockStatArchiveHandlerConfig.getSystemDirectoryPath()).thenReturn("");
+    when(mockStatArchiveHandlerConfig.getProductDescription())
+        .thenReturn(getClass().getSimpleName());
+
+    StatisticsSampler sampler = new TestStatisticsSampler(manager);
+    SampleCollector sampleCollector = new SampleCollector(sampler);
+    sampleCollector.initialize(mockStatArchiveHandlerConfig, NanoTimer.getTime(),
+        new MainWithChildrenRollingFileHandler());
+    gatewaySenderOverflowMonitor =
+        spy(new GatewaySenderOverflowMonitor(this.testName.getMethodName()));
+
+    assertThat(gatewaySenderOverflowMonitor).isNotNull();
+    assertThat(gatewaySenderOverflowMonitor.getMonitors()).isEmpty();
+    assertThat(gatewaySenderOverflowMonitor.getListeners()).isEmpty();
+    assertThat(gatewaySenderOverflowMonitor.getLruEvictions()).isEqualTo(0);
+    assertThat(gatewaySenderOverflowMonitor.getBytesOverflowedToDisk()).isEqualTo(0);
+    assertThat(gatewaySenderOverflowMonitor.getEntriesOverflowedToDisk()).isEqualTo(0);
+  }
+
+  @Test
+  public void computeDeltaShouldReturnZeroForUnknownStatistics() {
+    assertThat(gatewaySenderOverflowMonitor.computeDelta(new MBeanStatsMonitor.DefaultHashMap(),
+        "UnknownStatistic", 6)).isEqualTo(0);
+  }
+
+  @Test
+  public void computeDeltaShouldOperateForHandledStatistics() {
+    MBeanStatsMonitor.DefaultHashMap statsMap = new MBeanStatsMonitor.DefaultHashMap();
+    statsMap.put(StatsKey.GATEWAYSENDER_LRU_EVICTIONS, 50);
+    statsMap.put(StatsKey.GATEWAYSENDER_BYTES_OVERFLOWED_TO_DISK, 2048);
+    statsMap.put(StatsKey.GATEWAYSENDER_ENTRIES_OVERFLOWED_TO_DISK, 100);
+
+    assertThat(gatewaySenderOverflowMonitor.computeDelta(statsMap,
+        StatsKey.GATEWAYSENDER_LRU_EVICTIONS, 60)).isEqualTo(10L);
+    assertThat(gatewaySenderOverflowMonitor.computeDelta(statsMap,
+        StatsKey.GATEWAYSENDER_BYTES_OVERFLOWED_TO_DISK, 2100)).isEqualTo(52L);
+    assertThat(gatewaySenderOverflowMonitor.computeDelta(statsMap,
+        StatsKey.GATEWAYSENDER_ENTRIES_OVERFLOWED_TO_DISK, 150)).isEqualTo(50L);
+  }
+
+  @Test
+  public void increaseStatsShouldIncrementStatisticsUsingTheSelectedValue() {
+    gatewaySenderOverflowMonitor.increaseStats(StatsKey.GATEWAYSENDER_LRU_EVICTIONS, 5L);
+    gatewaySenderOverflowMonitor.increaseStats(StatsKey.GATEWAYSENDER_BYTES_OVERFLOWED_TO_DISK,
+        1024L);
+    gatewaySenderOverflowMonitor.increaseStats(StatsKey.GATEWAYSENDER_ENTRIES_OVERFLOWED_TO_DISK,
+        10000L);
+    assertThat(gatewaySenderOverflowMonitor.getStatistic(StatsKey.GATEWAYSENDER_LRU_EVICTIONS))
+        .isEqualTo(5L);
+    assertThat(
+        gatewaySenderOverflowMonitor.getStatistic(StatsKey.GATEWAYSENDER_BYTES_OVERFLOWED_TO_DISK))
+            .isEqualTo(1024L);
+    assertThat(gatewaySenderOverflowMonitor
+        .getStatistic(StatsKey.GATEWAYSENDER_ENTRIES_OVERFLOWED_TO_DISK)).isEqualTo(10000L);
+
+    gatewaySenderOverflowMonitor.increaseStats(StatsKey.GATEWAYSENDER_LRU_EVICTIONS, 5L);
+    gatewaySenderOverflowMonitor.increaseStats(StatsKey.GATEWAYSENDER_BYTES_OVERFLOWED_TO_DISK,
+        1024L);
+    gatewaySenderOverflowMonitor.increaseStats(StatsKey.GATEWAYSENDER_ENTRIES_OVERFLOWED_TO_DISK,
+        10000L);
+    assertThat(gatewaySenderOverflowMonitor.getStatistic(StatsKey.GATEWAYSENDER_LRU_EVICTIONS))
+        .isEqualTo(10L);
+    assertThat(
+        gatewaySenderOverflowMonitor.getStatistic(StatsKey.GATEWAYSENDER_BYTES_OVERFLOWED_TO_DISK))
+            .isEqualTo(2048L);
+    assertThat(gatewaySenderOverflowMonitor
+        .getStatistic(StatsKey.GATEWAYSENDER_ENTRIES_OVERFLOWED_TO_DISK)).isEqualTo(20000L);
+  }
+
+  @Test
+  public void getStatisticShouldReturnZeroForUnknownStatistics() {
+    assertThat(gatewaySenderOverflowMonitor.getStatistic("unhandledStatistic")).isEqualTo(0);
+  }
+
+  @Test
+  public void getStatisticShouldReturnTheRecordedValueForHandledStatistics() {
+    gatewaySenderOverflowMonitor.increaseStats(StatsKey.GATEWAYSENDER_LRU_EVICTIONS, 5);
+    gatewaySenderOverflowMonitor.increaseStats(StatsKey.GATEWAYSENDER_BYTES_OVERFLOWED_TO_DISK,
+        2048);
+    gatewaySenderOverflowMonitor.increaseStats(StatsKey.GATEWAYSENDER_ENTRIES_OVERFLOWED_TO_DISK,
+        10000);
+
+    assertThat(gatewaySenderOverflowMonitor.getStatistic(StatsKey.GATEWAYSENDER_LRU_EVICTIONS))
+        .isEqualTo(5L);
+    assertThat(
+        gatewaySenderOverflowMonitor.getStatistic(StatsKey.GATEWAYSENDER_BYTES_OVERFLOWED_TO_DISK))
+            .isEqualTo(2048L);
+    assertThat(gatewaySenderOverflowMonitor
+        .getStatistic(StatsKey.GATEWAYSENDER_ENTRIES_OVERFLOWED_TO_DISK)).isEqualTo(10000L);
+  }
+
+  @Test
+  public void addStatisticsToMonitorShouldAddListenerAndMonitor() {
+    Statistics statistics = mock(Statistics.class);
+    gatewaySenderOverflowMonitor.addStatisticsToMonitor(statistics);
+
+    assertThat(gatewaySenderOverflowMonitor.getMonitors().size()).isEqualTo(1);
+    assertThat(gatewaySenderOverflowMonitor.getListeners().size()).isEqualTo(1);
+  }
+
+  @Test
+  public void stopListenerShouldRemoveListenerAndMonitor() {
+    Statistics statistics = mock(Statistics.class);
+    ValueMonitor regionMonitor = mock(ValueMonitor.class);
+    GatewaySenderOverflowMonitor.GatewaySenderOverflowStatisticsListener listener =
+        mock(GatewaySenderOverflowMonitor.GatewaySenderOverflowStatisticsListener.class);
+    gatewaySenderOverflowMonitor.getListeners().put(statistics, listener);
+    gatewaySenderOverflowMonitor.getMonitors().put(statistics, regionMonitor);
+
+    gatewaySenderOverflowMonitor.stopListener();
+    verify(regionMonitor, times(1)).removeListener(listener);
+    verify(regionMonitor, times(1)).removeStatistics(statistics);
+    assertThat(gatewaySenderOverflowMonitor.getMonitors()).isEmpty();
+    assertThat(gatewaySenderOverflowMonitor.getListeners()).isEmpty();
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/management/internal/beans/stats/GatewaySenderOverflowMonitorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/beans/stats/GatewaySenderOverflowMonitorTest.java
@@ -81,7 +81,7 @@ public class GatewaySenderOverflowMonitorTest {
   @Test
   public void computeDeltaShouldReturnZeroForUnknownStatistics() {
     assertThat(gatewaySenderOverflowMonitor.computeDelta(new MBeanStatsMonitor.DefaultHashMap(),
-        "UnknownStatistic", 6)).isEqualTo(0);
+        "unknownStatistic", 6)).isEqualTo(0);
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/management/internal/beans/stats/MemberLevelDiskMonitorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/beans/stats/MemberLevelDiskMonitorTest.java
@@ -1,0 +1,230 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.management.internal.beans.stats;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TestName;
+
+import org.apache.geode.Statistics;
+import org.apache.geode.internal.NanoTimer;
+import org.apache.geode.internal.io.MainWithChildrenRollingFileHandler;
+import org.apache.geode.internal.statistics.SampleCollector;
+import org.apache.geode.internal.statistics.StatArchiveHandlerConfig;
+import org.apache.geode.internal.statistics.StatisticsSampler;
+import org.apache.geode.internal.statistics.TestStatisticsManager;
+import org.apache.geode.internal.statistics.TestStatisticsSampler;
+import org.apache.geode.internal.statistics.ValueMonitor;
+import org.apache.geode.test.junit.categories.StatisticsTest;
+
+@Category(StatisticsTest.class)
+public class MemberLevelDiskMonitorTest {
+  @Rule
+  public TestName testName = new TestName();
+
+  private MemberLevelDiskMonitor memberLevelDiskMonitor;
+
+  @Before
+  public void setUp() {
+    final long startTime = System.currentTimeMillis();
+    TestStatisticsManager manager =
+        new TestStatisticsManager(1, getClass().getSimpleName(), startTime);
+    StatArchiveHandlerConfig mockStatArchiveHandlerConfig = mock(StatArchiveHandlerConfig.class,
+        getClass().getSimpleName() + "$" + StatArchiveHandlerConfig.class.getSimpleName());
+    when(mockStatArchiveHandlerConfig.getArchiveFileName()).thenReturn(new File(""));
+    when(mockStatArchiveHandlerConfig.getArchiveFileSizeLimit()).thenReturn(0L);
+    when(mockStatArchiveHandlerConfig.getArchiveDiskSpaceLimit()).thenReturn(0L);
+    when(mockStatArchiveHandlerConfig.getSystemId()).thenReturn(0L);
+    when(mockStatArchiveHandlerConfig.getSystemStartTime()).thenReturn(startTime);
+    when(mockStatArchiveHandlerConfig.getSystemDirectoryPath()).thenReturn("");
+    when(mockStatArchiveHandlerConfig.getProductDescription())
+        .thenReturn(getClass().getSimpleName());
+
+    StatisticsSampler sampler = new TestStatisticsSampler(manager);
+    SampleCollector sampleCollector = new SampleCollector(sampler);
+    sampleCollector.initialize(mockStatArchiveHandlerConfig, NanoTimer.getTime(),
+        new MainWithChildrenRollingFileHandler());
+    memberLevelDiskMonitor = spy(new MemberLevelDiskMonitor(this.testName.getMethodName()));
+
+    assertThat(memberLevelDiskMonitor).isNotNull();
+    assertThat(memberLevelDiskMonitor.getMonitors()).isEmpty();
+    assertThat(memberLevelDiskMonitor.getListeners()).isEmpty();
+    assertThat(memberLevelDiskMonitor.getFlushes()).isEqualTo(0);
+    assertThat(memberLevelDiskMonitor.getQueueSize()).isEqualTo(0);
+    assertThat(memberLevelDiskMonitor.getFlushTime()).isEqualTo(0);
+    assertThat(memberLevelDiskMonitor.getFlushedBytes()).isEqualTo(0);
+    assertThat(memberLevelDiskMonitor.getDiskReadBytes()).isEqualTo(0);
+    assertThat(memberLevelDiskMonitor.getBackupsCompleted()).isEqualTo(0);
+    assertThat(memberLevelDiskMonitor.getDiskWrittenBytes()).isEqualTo(0);
+    assertThat(memberLevelDiskMonitor.getBackupsInProgress()).isEqualTo(0);
+  }
+
+  @Test
+  public void computeDeltaShouldReturnZeroForUnknownStatistics() {
+    assertThat(memberLevelDiskMonitor.computeDelta(new MBeanStatsMonitor.DefaultHashMap(),
+        "UnknownStatistic", 6)).isEqualTo(0);
+  }
+
+  @Test
+  public void computeDeltaShouldOperateForHandledStatistics() {
+    MBeanStatsMonitor.DefaultHashMap statsMap = new MBeanStatsMonitor.DefaultHashMap();
+    statsMap.put(StatsKey.NUM_FLUSHES, 10);
+    statsMap.put(StatsKey.DISK_QUEUE_SIZE, 148);
+    statsMap.put(StatsKey.TOTAL_FLUSH_TIME, 10000);
+    statsMap.put(StatsKey.FLUSHED_BYTES, 2048);
+    statsMap.put(StatsKey.DISK_READ_BYTES, 1024);
+    statsMap.put(StatsKey.DISK_RECOVERED_BYTES, 512);
+    statsMap.put(StatsKey.BACKUPS_COMPLETED, 5);
+    statsMap.put(StatsKey.DISK_WRITEN_BYTES, 8192);
+    statsMap.put(StatsKey.BACKUPS_IN_PROGRESS, 2);
+
+    assertThat(memberLevelDiskMonitor.computeDelta(statsMap, StatsKey.NUM_FLUSHES, 16))
+        .isEqualTo(6L);
+    assertThat(memberLevelDiskMonitor.computeDelta(statsMap, StatsKey.DISK_QUEUE_SIZE, 150))
+        .isEqualTo(2L);
+    assertThat(memberLevelDiskMonitor.computeDelta(statsMap, StatsKey.TOTAL_FLUSH_TIME, 10000))
+        .isEqualTo(0L);
+    assertThat(memberLevelDiskMonitor.computeDelta(statsMap, StatsKey.FLUSHED_BYTES, 3000))
+        .isEqualTo(952L);
+    assertThat(memberLevelDiskMonitor.computeDelta(statsMap, StatsKey.DISK_READ_BYTES, 2048))
+        .isEqualTo(1024L);
+    assertThat(memberLevelDiskMonitor.computeDelta(statsMap, StatsKey.DISK_RECOVERED_BYTES, 1024))
+        .isEqualTo(512L);
+    assertThat(memberLevelDiskMonitor.computeDelta(statsMap, StatsKey.BACKUPS_COMPLETED, 6))
+        .isEqualTo(1L);
+    assertThat(memberLevelDiskMonitor.computeDelta(statsMap, StatsKey.DISK_WRITEN_BYTES, 8193))
+        .isEqualTo(1L);
+    assertThat(memberLevelDiskMonitor.computeDelta(statsMap, StatsKey.BACKUPS_IN_PROGRESS, 1))
+        .isEqualTo(-1L);
+  }
+
+  @Test
+  public void increaseStatsShouldIncrementStatisticsUsingTheSelectedValue() {
+    memberLevelDiskMonitor.increaseStats(StatsKey.NUM_FLUSHES, 5);
+    memberLevelDiskMonitor.increaseStats(StatsKey.DISK_QUEUE_SIZE, 13);
+    memberLevelDiskMonitor.increaseStats(StatsKey.TOTAL_FLUSH_TIME, 1024);
+    memberLevelDiskMonitor.increaseStats(StatsKey.FLUSHED_BYTES, 12);
+    memberLevelDiskMonitor.increaseStats(StatsKey.DISK_READ_BYTES, 5);
+    memberLevelDiskMonitor.increaseStats(StatsKey.DISK_RECOVERED_BYTES, 2048);
+    memberLevelDiskMonitor.increaseStats(StatsKey.BACKUPS_COMPLETED, 20);
+    memberLevelDiskMonitor.increaseStats(StatsKey.DISK_WRITEN_BYTES, 51);
+    memberLevelDiskMonitor.increaseStats(StatsKey.BACKUPS_IN_PROGRESS, 60);
+    assertThat(memberLevelDiskMonitor.getStatistic(StatsKey.NUM_FLUSHES)).isEqualTo(5L);
+    assertThat(memberLevelDiskMonitor.getStatistic(StatsKey.DISK_QUEUE_SIZE)).isEqualTo(13);
+    assertThat(memberLevelDiskMonitor.getStatistic(StatsKey.TOTAL_FLUSH_TIME)).isEqualTo(1024L);
+    assertThat(memberLevelDiskMonitor.getStatistic(StatsKey.FLUSHED_BYTES)).isEqualTo(12L);
+    assertThat(memberLevelDiskMonitor.getStatistic(StatsKey.DISK_READ_BYTES)).isEqualTo(2053L);
+    assertThat(memberLevelDiskMonitor.getStatistic(StatsKey.BACKUPS_COMPLETED)).isEqualTo(20);
+    assertThat(memberLevelDiskMonitor.getStatistic(StatsKey.DISK_WRITEN_BYTES)).isEqualTo(51L);
+    assertThat(memberLevelDiskMonitor.getStatistic(StatsKey.BACKUPS_IN_PROGRESS)).isEqualTo(60);
+
+    memberLevelDiskMonitor.increaseStats(StatsKey.NUM_FLUSHES, 2);
+    memberLevelDiskMonitor.increaseStats(StatsKey.DISK_QUEUE_SIZE, 2);
+    memberLevelDiskMonitor.increaseStats(StatsKey.TOTAL_FLUSH_TIME, 1);
+    memberLevelDiskMonitor.increaseStats(StatsKey.FLUSHED_BYTES, 8);
+    memberLevelDiskMonitor.increaseStats(StatsKey.DISK_READ_BYTES, 5);
+    memberLevelDiskMonitor.increaseStats(StatsKey.DISK_RECOVERED_BYTES, 2);
+    memberLevelDiskMonitor.increaseStats(StatsKey.BACKUPS_COMPLETED, 1);
+    memberLevelDiskMonitor.increaseStats(StatsKey.DISK_WRITEN_BYTES, 11);
+    memberLevelDiskMonitor.increaseStats(StatsKey.BACKUPS_IN_PROGRESS, 6);
+    assertThat(memberLevelDiskMonitor.getStatistic(StatsKey.NUM_FLUSHES)).isEqualTo(7L);
+    assertThat(memberLevelDiskMonitor.getStatistic(StatsKey.DISK_QUEUE_SIZE)).isEqualTo(15);
+    assertThat(memberLevelDiskMonitor.getStatistic(StatsKey.TOTAL_FLUSH_TIME)).isEqualTo(1025L);
+    assertThat(memberLevelDiskMonitor.getStatistic(StatsKey.FLUSHED_BYTES)).isEqualTo(20L);
+    assertThat(memberLevelDiskMonitor.getStatistic(StatsKey.DISK_READ_BYTES)).isEqualTo(2060L);
+    assertThat(memberLevelDiskMonitor.getStatistic(StatsKey.BACKUPS_COMPLETED)).isEqualTo(21);
+    assertThat(memberLevelDiskMonitor.getStatistic(StatsKey.DISK_WRITEN_BYTES)).isEqualTo(62L);
+    assertThat(memberLevelDiskMonitor.getStatistic(StatsKey.BACKUPS_IN_PROGRESS)).isEqualTo(66);
+  }
+
+  @Test
+  public void addStatisticsToMonitorShouldAddListenerAndMonitor() {
+    Statistics statistics = mock(Statistics.class);
+    memberLevelDiskMonitor.addStatisticsToMonitor(statistics);
+
+    assertThat(memberLevelDiskMonitor.getMonitors().size()).isEqualTo(1);
+    assertThat(memberLevelDiskMonitor.getListeners().size()).isEqualTo(1);
+  }
+
+  @Test
+  public void stopListenerShouldRemoveListenerAndMonitor() {
+    Statistics statistics = mock(Statistics.class);
+    ValueMonitor regionMonitor = mock(ValueMonitor.class);
+    MemberLevelDiskMonitor.MemberLevelDiskStatisticsListener listener =
+        mock(MemberLevelDiskMonitor.MemberLevelDiskStatisticsListener.class);
+    memberLevelDiskMonitor.getListeners().put(statistics, listener);
+    memberLevelDiskMonitor.getMonitors().put(statistics, regionMonitor);
+
+    memberLevelDiskMonitor.stopListener();
+    verify(regionMonitor, times(1)).removeListener(listener);
+    verify(regionMonitor, times(1)).removeStatistics(statistics);
+    assertThat(memberLevelDiskMonitor.getMonitors()).isEmpty();
+    assertThat(memberLevelDiskMonitor.getListeners()).isEmpty();
+  }
+
+  @Test
+  public void getStatisticShouldReturnZeroForUnknownStatistics() {
+    assertThat(memberLevelDiskMonitor.getStatistic("unhandledStatistic")).isEqualTo(0);
+  }
+
+  @Test
+  public void getStatisticShouldReturnTheRecordedValueForHandledStatistics() {
+    memberLevelDiskMonitor.increaseStats(StatsKey.NUM_FLUSHES, 5);
+    memberLevelDiskMonitor.increaseStats(StatsKey.DISK_QUEUE_SIZE, 13);
+    memberLevelDiskMonitor.increaseStats(StatsKey.TOTAL_FLUSH_TIME, 1024);
+    memberLevelDiskMonitor.increaseStats(StatsKey.FLUSHED_BYTES, 12);
+    memberLevelDiskMonitor.increaseStats(StatsKey.DISK_READ_BYTES, 5);
+    memberLevelDiskMonitor.increaseStats(StatsKey.DISK_RECOVERED_BYTES, 2048);
+    memberLevelDiskMonitor.increaseStats(StatsKey.BACKUPS_COMPLETED, 20);
+    memberLevelDiskMonitor.increaseStats(StatsKey.DISK_WRITEN_BYTES, 51);
+    memberLevelDiskMonitor.increaseStats(StatsKey.BACKUPS_IN_PROGRESS, 60);
+    assertThat(memberLevelDiskMonitor.getStatistic(StatsKey.NUM_FLUSHES)).isEqualTo(5L);
+    assertThat(memberLevelDiskMonitor.getStatistic(StatsKey.DISK_QUEUE_SIZE)).isEqualTo(13);
+    assertThat(memberLevelDiskMonitor.getStatistic(StatsKey.TOTAL_FLUSH_TIME)).isEqualTo(1024L);
+    assertThat(memberLevelDiskMonitor.getStatistic(StatsKey.FLUSHED_BYTES)).isEqualTo(12L);
+    assertThat(memberLevelDiskMonitor.getStatistic(StatsKey.DISK_READ_BYTES)).isEqualTo(2053L);
+    assertThat(memberLevelDiskMonitor.getStatistic(StatsKey.BACKUPS_COMPLETED)).isEqualTo(20);
+    assertThat(memberLevelDiskMonitor.getStatistic(StatsKey.DISK_WRITEN_BYTES)).isEqualTo(51L);
+    assertThat(memberLevelDiskMonitor.getStatistic(StatsKey.BACKUPS_IN_PROGRESS)).isEqualTo(60);
+  }
+
+  @Test
+  public void removeStatisticsFromMonitorShouldRemoveListenerAndMonitor() {
+    Statistics statistics = mock(Statistics.class);
+    ValueMonitor regionMonitor = mock(ValueMonitor.class);
+    MemberLevelDiskMonitor.MemberLevelDiskStatisticsListener listener =
+        mock(MemberLevelDiskMonitor.MemberLevelDiskStatisticsListener.class);
+    memberLevelDiskMonitor.getListeners().put(statistics, listener);
+    memberLevelDiskMonitor.getMonitors().put(statistics, regionMonitor);
+
+    memberLevelDiskMonitor.removeStatisticsFromMonitor(statistics);
+    assertThat(memberLevelDiskMonitor.getListeners()).isEmpty();
+    assertThat(memberLevelDiskMonitor.getMonitors()).isEmpty();
+    verify(listener, times(1)).decreaseDiskStoreStats();
+    verify(regionMonitor, times(1)).removeListener(listener);
+    verify(regionMonitor, times(1)).removeStatistics(statistics);
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/management/internal/beans/stats/MemberLevelDiskMonitorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/beans/stats/MemberLevelDiskMonitorTest.java
@@ -85,7 +85,7 @@ public class MemberLevelDiskMonitorTest {
   @Test
   public void computeDeltaShouldReturnZeroForUnknownStatistics() {
     assertThat(memberLevelDiskMonitor.computeDelta(new MBeanStatsMonitor.DefaultHashMap(),
-        "UnknownStatistic", 6)).isEqualTo(0);
+        "unknownStatistic", 6)).isEqualTo(0);
   }
 
   @Test
@@ -104,7 +104,7 @@ public class MemberLevelDiskMonitorTest {
     assertThat(memberLevelDiskMonitor.computeDelta(statsMap, StatsKey.NUM_FLUSHES, 16))
         .isEqualTo(6L);
     assertThat(memberLevelDiskMonitor.computeDelta(statsMap, StatsKey.DISK_QUEUE_SIZE, 150))
-        .isEqualTo(2L);
+        .isEqualTo(2);
     assertThat(memberLevelDiskMonitor.computeDelta(statsMap, StatsKey.TOTAL_FLUSH_TIME, 10000))
         .isEqualTo(0L);
     assertThat(memberLevelDiskMonitor.computeDelta(statsMap, StatsKey.FLUSHED_BYTES, 3000))
@@ -114,11 +114,11 @@ public class MemberLevelDiskMonitorTest {
     assertThat(memberLevelDiskMonitor.computeDelta(statsMap, StatsKey.DISK_RECOVERED_BYTES, 1024))
         .isEqualTo(512L);
     assertThat(memberLevelDiskMonitor.computeDelta(statsMap, StatsKey.BACKUPS_COMPLETED, 6))
-        .isEqualTo(1L);
+        .isEqualTo(1);
     assertThat(memberLevelDiskMonitor.computeDelta(statsMap, StatsKey.DISK_WRITEN_BYTES, 8193))
         .isEqualTo(1L);
     assertThat(memberLevelDiskMonitor.computeDelta(statsMap, StatsKey.BACKUPS_IN_PROGRESS, 1))
-        .isEqualTo(-1L);
+        .isEqualTo(-1);
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/management/internal/beans/stats/VMStatsMonitorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/beans/stats/VMStatsMonitorTest.java
@@ -79,19 +79,19 @@ public class VMStatsMonitorTest {
     Number processCpuTime = spy(Number.class);
     vmStatsMonitor.statsMap.put(StatsKey.VM_PROCESS_CPU_TIME, processCpuTime);
 
-    // First Run: updates lastSystemTime.
+    // First Run: updates lastSystemTime
     when(vmStatsMonitor.currentTimeMillis()).thenReturn(now.toInstant().toEpochMilli());
     vmStatsMonitor.refreshStats();
     assertThat(vmStatsMonitor.getCpuUsage()).isEqualTo(0);
     verify(processCpuTime, times(0)).longValue();
 
-    // Second Run: updates lastProcessCpuTime.
+    // Second Run: updates lastProcessCpuTime
     when(processCpuTime.longValue()).thenReturn(500L);
     vmStatsMonitor.refreshStats();
     assertThat(vmStatsMonitor.getCpuUsage()).isEqualTo(0);
     verify(processCpuTime, times(1)).longValue();
 
-    // Next runs will update the actual cpuUsage.
+    // Next runs will update the actual cpuUsage
     for (int i = 2; i < 6; i++) {
       long mockProcessCpuTime = i * 500;
       long mockSystemTime = now.plus(i, ChronoUnit.SECONDS).toInstant().toEpochMilli();

--- a/geode-core/src/test/java/org/apache/geode/management/internal/beans/stats/VMStatsMonitorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/beans/stats/VMStatsMonitorTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.management.internal.beans.stats;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import org.apache.geode.management.internal.MBeanJMXAdapter;
+import org.apache.geode.test.junit.categories.StatisticsTest;
+
+@Category(StatisticsTest.class)
+@RunWith(PowerMockRunner.class)
+@PowerMockIgnore("*.UnitTest")
+@PrepareForTest(MBeanJMXAdapter.class)
+public class VMStatsMonitorTest {
+  @Rule
+  public TestName testName = new TestName();
+
+  private VMStatsMonitor vmStatsMonitor;
+
+  @Before
+  public void setUp() {
+    PowerMockito.mockStatic(MBeanJMXAdapter.class);
+  }
+
+  @Test
+  public void statisticInitialValueShouldBeZeroWhenTheProcessCpuTimeJmxAttributeIsAvailable() {
+    when(MBeanJMXAdapter.isAttributeAvailable(anyString(), anyString())).thenReturn(true);
+    vmStatsMonitor = new VMStatsMonitor(testName.getMethodName());
+    assertThat(vmStatsMonitor).isNotNull();
+    assertThat(vmStatsMonitor.getCpuUsage()).isEqualTo(0);
+  }
+
+  @Test
+  public void statisticInitialValueShouldBeUndefinedWhenTheProcessCpuTimeJmxAttributeIsNotAvailable() {
+    when(MBeanJMXAdapter.isAttributeAvailable(anyString(), anyString())).thenReturn(false);
+    vmStatsMonitor = new VMStatsMonitor(testName.getMethodName());
+    assertThat(vmStatsMonitor).isNotNull();
+    assertThat(vmStatsMonitor.getCpuUsage()).isEqualTo(VMStatsMonitor.VALUE_NOT_AVAILABLE);
+  }
+
+  @Test
+  public void refreshStatsShouldUpdateCpuUsage() {
+    ZonedDateTime now = ZonedDateTime.now();
+    when(MBeanJMXAdapter.isAttributeAvailable(anyString(), anyString())).thenReturn(true);
+    vmStatsMonitor = spy(new VMStatsMonitor(testName.getMethodName()));
+    assertThat(vmStatsMonitor).isNotNull();
+    assertThat(vmStatsMonitor.getCpuUsage()).isEqualTo(0);
+    Number processCpuTime = spy(Number.class);
+    vmStatsMonitor.statsMap.put(StatsKey.VM_PROCESS_CPU_TIME, processCpuTime);
+
+    // First Run: updates lastSystemTime.
+    when(vmStatsMonitor.currentTimeMillis()).thenReturn(now.toInstant().toEpochMilli());
+    vmStatsMonitor.refreshStats();
+    assertThat(vmStatsMonitor.getCpuUsage()).isEqualTo(0);
+    verify(processCpuTime, times(0)).longValue();
+
+    // Second Run: updates lastProcessCpuTime.
+    when(processCpuTime.longValue()).thenReturn(500L);
+    vmStatsMonitor.refreshStats();
+    assertThat(vmStatsMonitor.getCpuUsage()).isEqualTo(0);
+    verify(processCpuTime, times(1)).longValue();
+
+    // Next runs will update the actual cpuUsage.
+    for (int i = 2; i < 6; i++) {
+      long mockProcessCpuTime = i * 500;
+      long mockSystemTime = now.plus(i, ChronoUnit.SECONDS).toInstant().toEpochMilli();
+      when(processCpuTime.longValue()).thenReturn(mockProcessCpuTime);
+      when(vmStatsMonitor.currentTimeMillis()).thenReturn(mockSystemTime);
+
+      vmStatsMonitor.refreshStats();
+      verify(vmStatsMonitor, times(1)).calculateCpuUsage(mockSystemTime, mockProcessCpuTime);
+      assertThat(vmStatsMonitor.getCpuUsage()).isNotEqualTo(0);
+    }
+  }
+}


### PR DESCRIPTION
GEODE-5314: Use Atomics instead of Volatile

- Fixed minor warnings.
- Added JUnit Tests for all modified classes.
- Replaced `volatile` by `AtomicIntenger` / `AtomicLong` in
  `GcStatsMonitor`, `AggregateRegionStatsMonitor`, `VMStatsMonitor`,
  `GatewaySenderOverflowMonitor` and `MemberLevelDiskMonitor`.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
