### PR TITLE
GEODE-5520 Inconsistency created by delta interaction with concurrency control

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/cache/client/internal/PutOpJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/client/internal/PutOpJUnitTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache.client.internal;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import org.apache.geode.cache.Operation;
+import org.apache.geode.internal.cache.EntryEventImpl;
+import org.apache.geode.internal.cache.EventID;
+
+public class PutOpJUnitTest {
+
+  private EntryEventImpl getEntryEvent() {
+    EntryEventImpl entryEvent = Mockito.mock(EntryEventImpl.class);
+    Mockito.when(entryEvent.getEventId()).thenReturn(new EventID());
+    return entryEvent;
+  }
+
+  @Test
+  public void regularDeltaPutShouldNotRetryFlagInMessage() {
+    PutOp.PutOpImpl putOp = new PutOp.PutOpImpl("testRegion", "testKey", "testValue", new byte[10],
+        getEntryEvent(), Operation.UPDATE,
+        false, false, null, false, false);
+    assertFalse(putOp.getMessage().isRetry());
+  }
+
+  @Test
+  public void regularPutShouldNotRetryFlagInMessage() {
+
+    PutOp.PutOpImpl putOp = new PutOp.PutOpImpl("testRegion", "testKey", "testValue", null,
+        getEntryEvent(), Operation.UPDATE,
+        false, false, null, false, false);
+    assertFalse(putOp.getMessage().isRetry());
+  }
+
+  @Test
+  public void failedDeltaPutShouldSetRetryFlagInMessage() {
+    PutOp.PutOpImpl putOp = new PutOp.PutOpImpl("testRegion", "testKey", "testValue", new byte[10],
+        getEntryEvent(), Operation.UPDATE,
+        false, false, null, true, false);
+    assertTrue(putOp.getMessage().isRetry());
+  }
+
+}


### PR DESCRIPTION
When a new PutOp message is sent to the server with the full value instead
of a delta we now set the isRetry flag on the message so that the server
will know to check if a version has already been assigned to the operation.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
