### PR TITLE
GEODE-5212: reduce flakiness of ExportLogsOverHttpDistributedTest

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/ExportLogsDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/ExportLogsDUnitTest.java
@@ -188,6 +188,9 @@ public class ExportLogsDUnitTest {
     LogLine logLineAfterCutoffTime = new LogLine(messageAfterCutoffTime, "info", true);
     server1.invoke(() -> {
       Logger logger = LogService.getLogger();
+      DateTimeFormatter dateTimeFormatter1 = DateTimeFormatter.ofPattern(FORMAT);
+      ZonedDateTime currentTime = LocalDateTime.now().atZone(ZoneId.systemDefault());
+      System.out.println("On Server1: currentTime: " + dateTimeFormatter1.format(currentTime));
       logLineAfterCutoffTime.writeLog(logger);
     });
 
@@ -314,6 +317,10 @@ public class ExportLogsDUnitTest {
     for (LogLine logLine : expectedMessages.get(member)) {
       boolean shouldExpectLogLine =
           acceptedLogLevels.contains(logLine.level) && !logLine.shouldBeIgnoredDueToTimestamp;
+
+      System.out.println("LogLine (" + logLine.message + ") - logLine.level=" + logLine.level);
+      System.out.println("LogLine (" + logLine.message + ") - logLine.shouldBeIgnoredDueToTimeStamp=" + logLine.shouldBeIgnoredDueToTimestamp);
+      System.out.println("shouldExpectLogLine - " + shouldExpectLogLine);
 
       if (shouldExpectLogLine) {
         assertThat(logFileContents).contains(logLine.getMessage());


### PR DESCRIPTION
Added Awaitility to wait at least 1 millisecond to reduce flakiness on windows.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
