### PR TITLE
GEODE-5528: client event listener invoked multiple times for the same…

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ClientServerTransactionDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ClientServerTransactionDUnitTest.java
@@ -38,6 +38,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.naming.Context;
 import javax.transaction.RollbackException;
@@ -111,6 +112,7 @@ import org.apache.geode.internal.jta.TransactionImpl;
 import org.apache.geode.internal.jta.TransactionManagerImpl;
 import org.apache.geode.internal.jta.UserTransactionImpl;
 import org.apache.geode.test.dunit.Assert;
+import org.apache.geode.test.dunit.DistributedTestUtils;
 import org.apache.geode.test.dunit.Host;
 import org.apache.geode.test.dunit.IgnoredException;
 import org.apache.geode.test.dunit.SerializableCallable;
@@ -2851,6 +2853,21 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
     });
   }
 
+  class CreateReplicateRegion extends SerializableCallable {
+    String regionName;
+
+    public CreateReplicateRegion(String replicateRegionName) {
+      this.regionName = replicateRegionName;
+    }
+
+    public Object call() throws Exception {
+      RegionFactory rf = getCache().createRegionFactory(RegionShortcut.REPLICATE);
+      rf.setConcurrencyChecksEnabled(getConcurrencyChecksEnabled());
+      rf.create(regionName);
+      return null;
+    }
+  }
+
   /**
    * start 3 servers, accessor has r1 and r2; ds1 has r1, ds2 has r2 stop server after distributing
    * commit but b4 replying to client
@@ -2869,21 +2886,6 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
         return AvailablePort.getRandomAvailablePort(AvailablePort.SOCKET);
       }
     });
-
-    class CreateReplicateRegion extends SerializableCallable {
-      String regionName;
-
-      public CreateReplicateRegion(String replicateRegionName) {
-        this.regionName = replicateRegionName;
-      }
-
-      public Object call() throws Exception {
-        RegionFactory rf = getCache().createRegionFactory(RegionShortcut.REPLICATE);
-        rf.setConcurrencyChecksEnabled(getConcurrencyChecksEnabled());
-        rf.create(regionName);
-        return null;
-      }
-    }
 
     accessor.invoke(new CreateReplicateRegion("r1"));
     accessor.invoke(new CreateReplicateRegion("r2"));
@@ -2969,6 +2971,105 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
         assertTrue(r2.containsKey("key2"));
         return null;
       }
+    });
+  }
+
+  /**
+   * start 3 servers with region r1. stop client's server after distributing
+   * commit but before replying to client. ensure that a listener in the
+   * client is only invoked once
+   */
+  @Test
+  public void testFailoverAfterCommitDistributionInvokesListenerInClientOnlyOnce() {
+    Host host = Host.getHost(0);
+    VM server = host.getVM(0);
+    VM datastore1 = host.getVM(1);
+    VM datastore2 = host.getVM(2);
+    VM client = host.getVM(3);
+
+    final int port1 = createRegionsAndStartServer(server, false);
+    final int port2 = AvailablePort.getRandomAvailablePort(AvailablePort.SOCKET);
+
+    server.invoke(new CreateReplicateRegion("r1"));
+
+
+    client.invoke("create client cache", () -> {
+      disconnectFromDS();
+      System.setProperty(DistributionConfig.GEMFIRE_PREFIX + "bridge.disableShufflingOfEndpoints",
+          "true");
+      ClientCacheFactory ccf = new ClientCacheFactory();
+      ccf.addPoolServer("localhost"/* getServerHostName(Host.getHost(0)) */, port1);
+      ccf.addPoolServer("localhost", port2);
+      ccf.setPoolMinConnections(5);
+      ccf.setPoolLoadConditioningInterval(-1);
+      ccf.setPoolSubscriptionEnabled(false);
+      ccf.set(LOG_LEVEL, getDUnitLogLevel());
+      ClientCache cCache = getClientCache(ccf);
+      Region r1 =
+          cCache.createClientRegionFactory(ClientRegionShortcut.CACHING_PROXY).create("r1");
+      Region r2 =
+          cCache.createClientRegionFactory(ClientRegionShortcut.CACHING_PROXY).create("r2");
+      return null;
+    });
+
+    datastore1.invoke("create backup server", () -> {
+      CacheServer s = getCache().addCacheServer();
+      getCache().getLogger().info("SWAP:ds1");
+      s.setPort(port2);
+      s.start();
+      return null;
+    });
+    datastore1.invoke(new CreateReplicateRegion("r1"));
+    datastore2.invoke(new CreateReplicateRegion("r1"));
+
+    final TransactionId txId = client.invoke("start transaction in client", () -> {
+      ClientCache cCache = (ClientCache) getCache();
+      Region r1 = cCache.getRegion("r1");
+      r1.put("key", "value");
+      cCache.getCacheTransactionManager().begin();
+      cCache.getLogger().info("beganTX");
+      r1.destroy("key");
+      return cCache.getCacheTransactionManager().getTransactionId();
+    });
+
+    server.invoke("close cache after sending tx message to other servers", () -> {
+      final TXManagerImpl mgr = (TXManagerImpl) getCache().getCacheTransactionManager();
+      assertTrue(mgr.isHostedTxInProgress((TXId) txId));
+      TXStateProxyImpl txProxy = (TXStateProxyImpl) mgr.getHostedTXState((TXId) txId);
+      final TXState txState = (TXState) txProxy.getRealDeal(null, null);
+      txState.setAfterSend(new Runnable() {
+        public void run() {
+          getCache().getLogger().info("server is now closing its cache");
+          System.setProperty(DistributionConfig.GEMFIRE_PREFIX + "no-flush-on-close", "true");
+          try {
+            mgr.removeHostedTXState((TXId) txState.getTransactionId());
+            DistributedTestUtils.crashDistributedSystem(getCache().getDistributedSystem());
+          } finally {
+            System.getProperties()
+                .remove(DistributionConfig.GEMFIRE_PREFIX + "no-flush-on-close");
+          }
+        }
+      });
+      return null;
+    });
+
+    client.invoke("committing transaction in client", () -> {
+      Region r1 = getCache().getRegion("r1");
+      final AtomicInteger afterDestroyInvocations = new AtomicInteger();
+      CacheListener listener = new CacheListenerAdapter() {
+        @Override
+        public void afterDestroy(EntryEvent event) {
+          System.err.println("afterDestroy invoked");
+          Thread.dumpStack();
+          afterDestroyInvocations.incrementAndGet();
+        }
+      };
+      r1.getAttributesMutator().addCacheListener(listener);
+
+      getCache().getCacheTransactionManager().commit();
+      assertFalse(r1.containsKey("key"));
+      assertEquals(1, afterDestroyInvocations.intValue());
+      return null;
     });
   }
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/RemoteTransactionDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/RemoteTransactionDUnitTest.java
@@ -47,7 +47,9 @@ import org.junit.Test;
 import org.apache.geode.ExpirationDetector;
 import org.apache.geode.cache.AttributesFactory;
 import org.apache.geode.cache.AttributesMutator;
+import org.apache.geode.cache.CacheClosedException;
 import org.apache.geode.cache.CacheEvent;
+import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.CacheListener;
 import org.apache.geode.cache.CacheLoader;
 import org.apache.geode.cache.CacheLoaderException;
@@ -133,6 +135,11 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
   private final SerializableCallable verifyNoTxState = new SerializableCallable() {
     @Override
     public Object call() throws Exception {
+      try {
+        CacheFactory.getAnyInstance();
+      } catch (CacheClosedException e) {
+        return null;
+      }
       // TXManagerImpl mgr = getGemfireCache().getTxManager();
       // assertIndexDetailsEquals(0, mgr.hostedTransactionsInProgressForTest());
       final TXManagerImpl mgr = getGemfireCache().getTxManager();


### PR DESCRIPTION
… transactional operation

TXCommitMessage.combine() was checking to see if a RegionCommit was already
in its collection by using Collection.contains() but RegionCommit doesn't
implement equals() so this check would return false even if the collection
had a RegionCommit for the same Region.

The fix is to check for the region's path instead.

You might notice that I changed some other things in the ClientServerTransactionDUnitTest.  It had a couple of problems that I noticed and addressed.  One was the orderly shutdown of a cache from a ServerConnection thread.  That thread is in an Executor and orderly shutdown terminates the Executor with a long timeout.  I changed the test to do a forced-disconnect.  The other problem was in teardown code that was creating a new cache if one didn't exist and then tearing it down.


Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
