### PR TITLE
GEODE-5257: remove unnecessary assertion that introduced the flakiness.

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/cache30/ShorteningExpirationTimeRegressionTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache30/ShorteningExpirationTimeRegressionTest.java
@@ -15,22 +15,16 @@
 package org.apache.geode.cache30;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
-import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
-import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
-import java.util.Properties;
-
-import org.junit.After;
-import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.junit.rules.TestName;
 
-import org.apache.geode.cache.Cache;
-import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.CustomExpiry;
 import org.apache.geode.cache.ExpirationAttributes;
 import org.apache.geode.cache.Region;
@@ -38,6 +32,7 @@ import org.apache.geode.cache.Region.Entry;
 import org.apache.geode.cache.RegionFactory;
 import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.test.junit.rules.ServerStarterRule;
 
 /**
  * If a new expiration time is specified that is shorter than an existing one, ensure the new
@@ -53,67 +48,52 @@ public class ShorteningExpirationTimeRegressionTest {
   private static final int LONG_WAIT_MS = 2 * 60 * 1000;
   private static final int SHORT_WAIT_MS = 1;
 
-  private static final String KEY = "key";
+  @ClassRule
+  public static ServerStarterRule server = new ServerStarterRule().withAutoStart();
 
-  private String uniqueName;
-  private String regionName;
-
-  private Cache cache;
-
-  @Rule
-  public RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
+  @ClassRule
+  public static RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
 
   @Rule
   public TestName testName = new TestName();
 
-  @Before
-  public void setUp() throws Exception {
-    Properties config = new Properties();
-    config.setProperty(MCAST_PORT, "0");
-    config.setProperty(LOCATORS, "");
-
-    uniqueName = getClass().getSimpleName() + "_" + testName.getMethodName();
-    regionName = uniqueName + "_region";
-
-    cache = new CacheFactory(config).create();
-
+  @BeforeClass
+  public static void setUp() {
     System.setProperty(LocalRegion.EXPIRY_MS_PROPERTY, "true");
-  }
-
-  @After
-  public void tearDown() throws Exception {
-    if (cache != null) {
-      cache.close();
-    }
   }
 
   @Test
   public void customEntryTimeToLiveCanBeShortened() throws Exception {
-    RegionFactory<String, String> rf = cache.createRegionFactory(RegionShortcut.LOCAL);
+    RegionFactory<String, String> rf = server.getCache().createRegionFactory(RegionShortcut.LOCAL);
     rf.setCustomEntryTimeToLive(new CustomExpiryTestClass<>());
     rf.setStatisticsEnabled(true);
 
-    Region<String, String> region = rf.create(regionName);
+    Region<String, String> region = rf.create(testName.getMethodName());
 
-    region.put(KEY, "longExpire");
-    region.put(KEY, "quickExpire");
-    assertThat(region.get(KEY)).isEqualTo("quickExpire");
+    // this sets the expiration timeout to 2 minutes
+    region.put("key", "longExpire");
+    // this sets the expiration timeout to 1 ms
+    region.put("key", "quickExpire");
 
-    await().atMost(1, MINUTES).until(() -> !region.containsValueForKey(KEY));
+    // make sure the entry is invalidated before 2 minutes (timeout shortened)
+    await().atMost(1, MINUTES).until(() -> !region.containsValueForKey("key"));
   }
 
   @Test
   public void customEntryIdleTimeoutCanBeShortened() throws Exception {
-    RegionFactory<String, String> rf = cache.createRegionFactory(RegionShortcut.LOCAL);
+    RegionFactory<String, String> rf = server.getCache().createRegionFactory(RegionShortcut.LOCAL);
     rf.setCustomEntryIdleTimeout(new CustomExpiryTestClass<>());
     rf.setStatisticsEnabled(true);
 
-    Region<String, String> region = rf.create(regionName);
+    Region<String, String> region = rf.create(testName.getMethodName());
 
-    region.put(KEY, "longExpire");
-    assertThat(region.get(KEY)).isEqualTo("longExpire");
+    // this sets the expiration timeout to 2 minutes
+    region.put("key", "longExpire");
+    // this sets the expiration timeout to 1 ms
+    assertThat(region.get("key")).isEqualTo("longExpire");
 
-    await().atMost(1, MINUTES).until(() -> !region.containsValueForKey(KEY));
+    // make sure the entry is invalidated before 2 minutes (timeout shortened)
+    await().atMost(1, MINUTES).until(() -> !region.containsValueForKey("key"));
   }
 
   private class CustomExpiryTestClass<K, V> implements CustomExpiry<K, V> {

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache30/ShorteningExpirationTimeRegressionTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache30/ShorteningExpirationTimeRegressionTest.java
@@ -49,7 +49,8 @@ public class ShorteningExpirationTimeRegressionTest {
   private static final String KEY = "key";
 
   @ClassRule
-  public static ServerStarterRule server = new ServerStarterRule().withAutoStart();
+  public static ServerStarterRule server =
+      new ServerStarterRule().withNoCacheServer().withAutoStart();
 
   @ClassRule
   public static RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();


### PR DESCRIPTION
* the timeout is changed to 1ms after the 2nd put. If the assertion call happens 1ms after the 2nd put, the test would fail
* remove boiler code using ServerStarterRule

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
