### PR TITLE
GEODE-5197: Synchronized update cache service profiles

### DIFF
--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneServiceImpl.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneServiceImpl.java
@@ -252,17 +252,10 @@ public class LuceneServiceImpl implements InternalLuceneService {
     LuceneIndexCreationProfile luceneIndexCreationProfile = new LuceneIndexCreationProfile(
         indexName, regionPath, fields, analyzer, fieldAnalyzers, serializer);
 
-    region.addCacheServiceProfile(luceneIndexCreationProfile);
+    Runnable validateIndexProfile =
+        getIndexValidationRunnable(region, indexName, luceneIndexCreationProfile);
+    region.executeSynchronizedOperationOnCacheProfiles(validateIndexProfile);
 
-    try {
-      validateLuceneIndexProfile(region);
-    } catch (IllegalStateException e) {
-      region.removeCacheServiceProfile(luceneIndexCreationProfile.getId());
-      throw new UnsupportedOperationException(
-          LocalizedStrings.LuceneIndexCreation_INDEX_CANNOT_BE_CREATED_DUE_TO_PROFILE_VIOLATION
-              .toString(indexName),
-          e);
-    }
     String aeqId = LuceneServiceImpl.getUniqueIndexName(indexName, regionPath);
     region.updatePRConfigWithNewGatewaySender(aeqId);
     LuceneIndexImpl luceneIndex = beforeDataRegionCreated(indexName, regionPath,
@@ -277,6 +270,22 @@ public class LuceneServiceImpl implements InternalLuceneService {
     }
 
     createLuceneIndexOnDataRegion(region, luceneIndex);
+  }
+
+  private Runnable getIndexValidationRunnable(PartitionedRegion region, String indexName,
+      LuceneIndexCreationProfile luceneIndexCreationProfile) {
+    return () -> {
+      region.addCacheServiceProfile(luceneIndexCreationProfile);
+      try {
+        validateLuceneIndexProfile(region);
+      } catch (IllegalStateException e) {
+        region.removeCacheServiceProfile(luceneIndexCreationProfile.getId());
+        throw new UnsupportedOperationException(
+            LocalizedStrings.LuceneIndexCreation_INDEX_CANNOT_BE_CREATED_DUE_TO_PROFILE_VIOLATION
+                .toString(indexName),
+            e);
+      }
+    };
   }
 
   protected void validateLuceneIndexProfile(PartitionedRegion region) {


### PR DESCRIPTION
	* new lock created for updating the region's cache service profile
 	* synchronized the addition / validation / removal of LuceneIndexCreationProfile in the data region.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
