### PR TITLE
GEODE-3839: Warning when cache xml is used

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartServerCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartServerCommand.java
@@ -202,9 +202,14 @@ public class StartServerCommand extends InternalGfshCommand {
 
     cacheXmlPathname = CliUtil.resolvePathname(cacheXmlPathname);
 
-    if (StringUtils.isNotBlank(cacheXmlPathname) && !IOUtils.isExistingPathname(cacheXmlPathname)) {
-      return ResultBuilder.createUserErrorResult(
-          CliStrings.format(CliStrings.CACHE_XML_NOT_FOUND_MESSAGE, cacheXmlPathname));
+    if (StringUtils.isNotBlank(cacheXmlPathname)) {
+      if (!IOUtils.isExistingPathname(cacheXmlPathname)) {
+        return ResultBuilder.createUserErrorResult(
+            CliStrings.format(CliStrings.CACHE_XML_NOT_FOUND_MESSAGE, cacheXmlPathname));
+      } else {
+        getGfsh().logWarning(
+            CliStrings.CLUSTER_CONFIG_PRECEDENCE_OVER_CACHE_XML_WARN + cacheXmlPathname, null);
+      }
     }
 
     if (gemfirePropertiesFile != null && !gemfirePropertiesFile.exists()) {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/i18n/CliStrings.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/i18n/CliStrings.java
@@ -170,6 +170,8 @@ public class CliStrings {
       "Unable to locate the Java executables and dependencies.  Please set the JAVA_HOME environment variable.";
   public static final String CACHE_XML_NOT_FOUND_MESSAGE =
       "Warning: The Geode cache XML file {0} could not be found.";
+  public static final String CLUSTER_CONFIG_PRECEDENCE_OVER_CACHE_XML_WARN =
+      "NOTE: If cluster configuration is enabled, then those settings will take precedence over: ";
   public static final String GEODE_0_PROPERTIES_1_NOT_FOUND_MESSAGE =
       "Warning: The Geode {0}properties file {1} could not be found.";
   public static final String MEMBER_NOT_FOUND_ERROR_MESSAGE =
@@ -2473,7 +2475,7 @@ public class CliStrings {
       "The IP address on which the Server will be bound.  By default, the Server is bound to all local addresses.";
   public static final String START_SERVER__CACHE_XML_FILE = CACHE_XML_FILE;
   public static final String START_SERVER__CACHE_XML_FILE__HELP =
-      "Specifies the name of the XML file or resource to initialize the cache with when it is created.";
+      "Specifies the name of the cache XML file or resource to initialize the cache with when it is created. NOTE: If cluster configuration is enabled, then it will take precedence over this option";
   public static final String START_SERVER__CLASSPATH = "classpath";
   public static final String START_SERVER__CLASSPATH__HELP =
       "Location of user application classes required by the Server. The user classpath is prepended to the Server's classpath.";


### PR DESCRIPTION
	* Additional logs added when cache-xml file is used in start server gfsh command.
	* A warning is logged mentioning that cluster config will take precedence over the cache-xml file provided in the command.
	* start server command help updated with the above information.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
