### PR TITLE
GEODE-1882: Added foreground parameter

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/AbstractLauncher.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/AbstractLauncher.java
@@ -592,6 +592,14 @@ public abstract class AbstractLauncher<T extends Comparable<T>> implements Runna
       return Status.NOT_RESPONDING == getStatus() || Status.STARTING == getStatus();
     }
 
+    public boolean isOnline() {
+      return (isVmWithProcessIdRunning() && (getStatus() == Status.ONLINE));
+    }
+
+    public String getUpTimeInFormattedString() {
+      return toDaysHoursMinutesSeconds(getUptime());
+    }
+
     public boolean isVmWithProcessIdRunning() {
       // note: this will use JNA if available or return false
       return ProcessUtils.isProcessAlive(this.getPid());

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/i18n/CliStrings.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/i18n/CliStrings.java
@@ -94,6 +94,9 @@ public class CliStrings {
       "The name of the class implementing CustomExpiry for entry idle time. Append json string for initialization properties.";
   public static final String ENTRY_TTL_CUSTOM_EXPIRY_HELP =
       "The name of the class implementing CustomExpiry for entry time to live. Append json string for initialization properties.";
+  public static final String FOREGROUND = "foreground";
+  public static final String FOREGROUND__HELP =
+      "Starts the process in the foreground. GFSH command will not return as long as the process is running.";;
   private static final String LOG_LEVEL_VALUES =
       "Possible values for log-level include: ALL, TRACE, DEBUG, INFO, WARN, ERROR, FATAL, OFF.";
 


### PR DESCRIPTION
	* servers and locators can be started with a --foreground parameter
	* this will make the process to run in foreground and the gfsh command will not return till the process is alive.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
