### PR TITLE
GEODE-5212: Fix TestUtil to return path

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/client/internal/LocatorSSLJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/client/internal/LocatorSSLJUnitTest.java
@@ -48,6 +48,9 @@ public class LocatorSSLJUnitTest {
 
   @Test
   public void canStopLocatorWithSSL() throws IOException {
+    System.out.println("############### SERVER_KEY_STORE=" + SERVER_KEY_STORE);
+    System.out.println("############### SERVER_TRUST_STORE=" + SERVER_TRUST_STORE);
+
     Properties properties = new Properties();
     properties.setProperty(MCAST_PORT, "0");
     properties.put(SSL_ENABLED_COMPONENTS, "all");

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/client/internal/LocatorSSLJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/client/internal/LocatorSSLJUnitTest.java
@@ -48,9 +48,6 @@ public class LocatorSSLJUnitTest {
 
   @Test
   public void canStopLocatorWithSSL() throws IOException {
-    System.out.println("############### SERVER_KEY_STORE=" + SERVER_KEY_STORE);
-    System.out.println("############### SERVER_TRUST_STORE=" + SERVER_TRUST_STORE);
-
     Properties properties = new Properties();
     properties.setProperty(MCAST_PORT, "0");
     properties.put(SSL_ENABLED_COMPONENTS, "all");

--- a/geode-junit/src/main/java/org/apache/geode/util/test/TestUtil.java
+++ b/geode-junit/src/main/java/org/apache/geode/util/test/TestUtil.java
@@ -58,14 +58,17 @@ public class TestUtil {
     }
     try {
       String path = resource.toURI().getPath();
-      System.out.println("############### TestUtil::getResourcePath before if -" + path);
+      System.out.println("############### TestUtil::getResourcePath before if resource.toURI() - "
+          + resource.toURI());
+      System.out.println("############### TestUtil::getResourcePath before if path - " + path);
       if (path == null) {
         String filename = name.replaceFirst(".*/", "");
         File tmpFile = File.createTempFile(filename, null);
         tmpFile.deleteOnExit();
-        System.out.println("############### TestUtil::getResourcePath inside if -" + tmpFile.getAbsolutePath());
+        System.out.println(
+            "############### TestUtil::getResourcePath inside if -" + tmpFile.getAbsolutePath());
         FileUtils.copyURLToFile(resource, tmpFile);
-        return compatibleWithWindows(tmpFile.getAbsolutePath());
+        return tmpFile.getAbsolutePath();
       }
       return compatibleWithWindows(path);
     } catch (URISyntaxException | IOException e) {

--- a/geode-junit/src/main/java/org/apache/geode/util/test/TestUtil.java
+++ b/geode-junit/src/main/java/org/apache/geode/util/test/TestUtil.java
@@ -58,10 +58,12 @@ public class TestUtil {
     }
     try {
       String path = resource.toURI().getPath();
+      System.out.println("############### TestUtil::getResourcePath before if -" + path);
       if (path == null) {
         String filename = name.replaceFirst(".*/", "");
         File tmpFile = File.createTempFile(filename, null);
         tmpFile.deleteOnExit();
+        System.out.println("############### TestUtil::getResourcePath inside if -" + tmpFile.getAbsolutePath());
         FileUtils.copyURLToFile(resource, tmpFile);
         return compatibleWithWindows(tmpFile.getAbsolutePath());
       }
@@ -72,6 +74,7 @@ public class TestUtil {
   }
 
   private static String compatibleWithWindows(String path) {
+    System.out.println("############### TestUtil::compatibleWithWindows -" + path);
     return SystemUtils.IS_OS_WINDOWS ? path.substring(1) : path;
   }
 }

--- a/geode-junit/src/main/java/org/apache/geode/util/test/TestUtil.java
+++ b/geode-junit/src/main/java/org/apache/geode/util/test/TestUtil.java
@@ -58,15 +58,10 @@ public class TestUtil {
     }
     try {
       String path = resource.toURI().getPath();
-      System.out.println("############### TestUtil::getResourcePath before if resource.toURI() - "
-          + resource.toURI());
-      System.out.println("############### TestUtil::getResourcePath before if path - " + path);
       if (path == null) {
         String filename = name.replaceFirst(".*/", "");
         File tmpFile = File.createTempFile(filename, null);
         tmpFile.deleteOnExit();
-        System.out.println(
-            "############### TestUtil::getResourcePath inside if -" + tmpFile.getAbsolutePath());
         FileUtils.copyURLToFile(resource, tmpFile);
         return tmpFile.getAbsolutePath();
       }
@@ -77,7 +72,6 @@ public class TestUtil {
   }
 
   private static String compatibleWithWindows(String path) {
-    System.out.println("############### TestUtil::compatibleWithWindows -" + path);
     return SystemUtils.IS_OS_WINDOWS ? path.substring(1) : path;
   }
 }


### PR DESCRIPTION
   When a classpath resource is looked up the path
   retrieved from the resource URI can be null in which 
   case it creates a file from copying the resource. This
   temp file path is already a good one to be returned.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
