### PR TITLE
[GEODE-5548] Reduce RAM usage in various jobs due to unused resources.

### DIFF
--- a/ci/pipelines/geode-build/test-stubs/acceptance.yml
+++ b/ci/pipelines/geode-build/test-stubs/acceptance.yml
@@ -24,7 +24,7 @@ metadata:
       forks: 7
     cpus: 8
 # specified in Gigabytes.
-    ram: 30
+    ram: 12
 # specified in seconds
     call_stack_timeout: 1800
     timeout: 45m

--- a/ci/pipelines/geode-build/test-stubs/distributed.yml
+++ b/ci/pipelines/geode-build/test-stubs/distributed.yml
@@ -25,7 +25,7 @@ metadata:
       forks: 48
     cpus: 96
 # specified in Gigabytes.
-    ram: 210
+    ram: 180
 # specified in seconds
     call_stack_timeout: 3600
     timeout: 1h15m

--- a/ci/pipelines/geode-build/test-stubs/integration.yml
+++ b/ci/pipelines/geode-build/test-stubs/integration.yml
@@ -24,7 +24,7 @@ metadata:
       forks: 48
     cpus: 96
 # specified in Gigabytes.
-    ram: 210
+    ram: 48
 # specified in seconds
     call_stack_timeout: 1500
     timeout: 40m

--- a/ci/pipelines/geode-build/test-stubs/upgrade.yml
+++ b/ci/pipelines/geode-build/test-stubs/upgrade.yml
@@ -25,7 +25,7 @@ metadata:
       forks: 48
     cpus: 96
 # specified in Gigabytes.
-    ram: 210
+    ram: 120
 # specified in seconds
     call_stack_timeout: 3000
     timeout: 1h


### PR DESCRIPTION
* Reduce acceptancetest from 30GB to 12GB
* Reduce distributedtest from 210GB to 180GB
* Reduce integrationtest from 210GB to 48GB
* Reduce upgradetest from 210GB to 120GB

Signed-off-by: Finn Southerland <fsoutherland@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
