### PR TITLE
GEODE-5531/GEODE-1507: Variable Substitution in GFSH

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/shell/Gfsh.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/shell/Gfsh.java
@@ -562,6 +562,19 @@ public class Gfsh extends JLineShell {
   }
 
   /**
+   * Executes a single command string.
+   * It substitutes the variables defined within the command, if any, and then delegates to the
+   * default execution.
+   *
+   * @param line command string to be executed
+   * @return command execution result.
+   */
+  @Override
+  public org.springframework.shell.core.CommandResult executeCommand(String line) {
+    return super.executeCommand(!line.contains("$") ? line : expandProperties(line));
+  }
+
+  /**
    * Executes the given command string. We have over-ridden the behavior to extend the original
    * implementation to store the 'last command execution status'.
    *
@@ -1125,7 +1138,7 @@ public class Gfsh extends JLineShell {
     return gfshHistory;
   }
 
-  private String expandProperties(final String input) {
+  protected String expandProperties(final String input) {
     String output = input;
     Scanner s = new Scanner(output);
     String foundInLine;

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/shell/GfshAbstractUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/shell/GfshAbstractUnitTest.java
@@ -20,10 +20,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import java.util.Enumeration;
-import java.util.logging.LogManager;
-import java.util.logging.Logger;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.shell.core.CommandResult;
@@ -31,9 +27,9 @@ import org.springframework.shell.core.CommandResult;
 import org.apache.geode.management.internal.cli.result.LegacyCommandResult;
 
 
-public class GfshJunitTest {
-  private String testString;
-  private Gfsh gfsh;
+public class GfshAbstractUnitTest {
+  protected Gfsh gfsh;
+  protected String testString;
 
   @Before
   public void before() {
@@ -68,55 +64,6 @@ public class GfshJunitTest {
     assertThat(gfsh.getEnvAppContextPath()).isEqualTo("");
     gfsh.setEnvProperty(Gfsh.ENV_APP_CONTEXT_PATH, "test");
     assertThat(gfsh.getEnvAppContextPath()).isEqualTo("test");
-  }
-
-  @Test
-  public void loggerParentInHeadlessMode() {
-    gfsh = new Gfsh(false, null, new GfshConfig());
-    LogManager logManager = LogManager.getLogManager();
-    Enumeration<String> loggerNames = logManager.getLoggerNames();
-    while (loggerNames.hasMoreElements()) {
-      String loggerName = loggerNames.nextElement();
-      Logger logger = logManager.getLogger(loggerName);
-      // make sure jdk's logging goes to the gfsh log file
-      if (loggerName.startsWith("java")) {
-        assertThat(logger.getParent().getName()).endsWith("LogWrapper");
-      }
-      // make sure Gfsh's logging goes to the gfsh log file
-      else if (loggerName.endsWith(".Gfsh")) {
-        assertThat(logger.getParent().getName()).endsWith("LogWrapper");
-      }
-      // make sure SimpleParser's logging will still show up in the console
-      else if (loggerName.endsWith(".SimpleParser")) {
-        assertThat(logger.getParent().getName()).doesNotEndWith("LogWrapper");
-      }
-    }
-  }
-
-  @Test
-  public void loggerParentInConsoleMode() {
-    gfsh = new Gfsh(true, null, new GfshConfig());
-    LogManager logManager = LogManager.getLogManager();
-    Enumeration<String> loggerNames = logManager.getLoggerNames();
-    // when initialized in console mode, all log messages will show up in console
-    // initially. so that we see messages when "start locator", "start server" command
-    // are executed. Only after connection, JDK's logging is turned off
-    while (loggerNames.hasMoreElements()) {
-      String loggerName = loggerNames.nextElement();
-      Logger logger = logManager.getLogger(loggerName);
-      // make sure jdk's logging goes to the gfsh log file
-      if (loggerName.startsWith("java")) {
-        assertThat(logger.getParent().getName()).endsWith("LogWrapper");
-      }
-      // make sure Gfsh's logging goes to the gfsh log file
-      else if (loggerName.endsWith(".Gfsh")) {
-        assertThat(logger.getParent().getName()).doesNotEndWith("LogWrapper");
-      }
-      // make sure SimpleParser's logging will still show up in the console
-      else if (loggerName.endsWith(".SimpleParser")) {
-        assertThat(logger.getParent().getName()).doesNotEndWith("LogWrapper");
-      }
-    }
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/shell/GfshConsoleModeUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/shell/GfshConsoleModeUnitTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.management.internal.cli.shell;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Enumeration;
+import java.util.logging.LogManager;
+import java.util.logging.Logger;
+
+import org.junit.Before;
+import org.junit.Test;
+
+
+public class GfshConsoleModeUnitTest extends GfshAbstractUnitTest {
+
+  @Before
+  public void before() {
+    super.before();
+    gfsh = new Gfsh(true, null, new GfshConfig());
+  }
+
+  @Test
+  public void consoleModeShouldRedirectOnlyJDKLoggers() {
+    gfsh = new Gfsh(true, null, new GfshConfig());
+    LogManager logManager = LogManager.getLogManager();
+    Enumeration<String> loggerNames = logManager.getLoggerNames();
+    // when initialized in console mode, all log messages will show up in console
+    // initially. so that we see messages when "start locator", "start server" command
+    // are executed. Only after connection, JDK's logging is turned off
+    while (loggerNames.hasMoreElements()) {
+      String loggerName = loggerNames.nextElement();
+      Logger logger = logManager.getLogger(loggerName);
+      // make sure jdk's logging goes to the gfsh log file
+      if (loggerName.startsWith("java")) {
+        assertThat(logger.getParent().getName()).endsWith("LogWrapper");
+      }
+      // make sure Gfsh's logging goes to the gfsh log file
+      else if (loggerName.endsWith(".Gfsh")) {
+        assertThat(logger.getParent().getName()).doesNotEndWith("LogWrapper");
+      }
+      // make sure SimpleParser's logging will still show up in the console
+      else if (loggerName.endsWith(".SimpleParser")) {
+        assertThat(logger.getParent().getName()).doesNotEndWith("LogWrapper");
+      }
+    }
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/shell/GfshHeadlessModeUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/shell/GfshHeadlessModeUnitTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.management.internal.cli.shell;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Enumeration;
+import java.util.logging.LogManager;
+import java.util.logging.Logger;
+
+import org.junit.Before;
+import org.junit.Test;
+
+
+public class GfshHeadlessModeUnitTest extends GfshAbstractUnitTest {
+
+  @Before
+  public void before() {
+    super.before();
+    gfsh = new Gfsh(false, null, new GfshConfig());
+  }
+
+  @Test
+  public void headlessModeShouldRedirectBothJDKAndGFSHLoggers() {
+    gfsh = new Gfsh(false, null, new GfshConfig());
+    LogManager logManager = LogManager.getLogManager();
+    Enumeration<String> loggerNames = logManager.getLoggerNames();
+    while (loggerNames.hasMoreElements()) {
+      String loggerName = loggerNames.nextElement();
+      Logger logger = logManager.getLogger(loggerName);
+      // make sure jdk's logging goes to the gfsh log file
+      if (loggerName.startsWith("java")) {
+        assertThat(logger.getParent().getName()).endsWith("LogWrapper");
+      }
+      // make sure Gfsh's logging goes to the gfsh log file
+      else if (loggerName.endsWith(".Gfsh")) {
+        assertThat(logger.getParent().getName()).endsWith("LogWrapper");
+      }
+      // make sure SimpleParser's logging will still show up in the console
+      else if (loggerName.endsWith(".SimpleParser")) {
+        assertThat(logger.getParent().getName()).doesNotEndWith("LogWrapper");
+      }
+    }
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/shell/GfshJunitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/shell/GfshJunitTest.java
@@ -137,5 +137,13 @@ public class GfshJunitTest {
     verify(gfsh, times(1)).expandProperties("echo --string=SYS_USER:${SYS_USER}");
     assertThat(((LegacyCommandResult) commandResult.getResult()).getMessageFromContent())
         .isEqualTo("SYS_USER:" + System.getProperty("user.name"));
+
+    // '$' character present but not variable referenced, should try to expand, find nothing (no
+    // replacement) and delegate to default implementation.
+    commandResult = gfsh.executeCommand("echo --string=MyNameIs:$USER_NAME");
+    assertThat(commandResult.isSuccess()).isTrue();
+    verify(gfsh, times(1)).expandProperties("echo --string=MyNameIs:$USER_NAME");
+    assertThat(((LegacyCommandResult) commandResult.getResult()).getMessageFromContent())
+        .isEqualTo("MyNameIs:$USER_NAME");
   }
 }


### PR DESCRIPTION
GEODE-5531/GEODE-1507: Variable Substitution in GFSH

The problem was introduced when `spring-shell` and `jline` libraries
were upgraded. The method `Gfsh.executeCommand` now substitutes all
variables (overriding `AbstractShell.executeCommand`) before delegating
the execution to the parent class (as `Gfsh.executeScriptLine` does).

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
