### PR TITLE
GEODE-5555: Add 'devBuild' task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ allprojects {
   version = versionNumber + releaseQualifier + releaseType
   ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
-  // We want to see all test results.  This is equivalatent to setting --continue
+  // We want to see all test results.  This is equivalent to setting --continue
   // on the command line.
   gradle.startParameter.continueOnFailure = true
 
@@ -101,4 +101,14 @@ subprojects {
   clean.finalizedBy rootProject.cleanAll
 
   apply plugin: 'com.github.ben-manes.versions'
+}
+
+task devBuild(dependsOn: [":assemble"]) {
+  description "A convenience target for a typical developer workflow: apply spotless and assemble all classes."
+  // spotless targets are not available until after evaluation.
+  subprojects {
+    afterEvaluate {
+      this.devBuild.dependsOn(project.spotlessApply)
+    }
+  }
 }

--- a/geode-web/build.gradle
+++ b/geode-web/build.gradle
@@ -18,28 +18,28 @@
 apply plugin: 'war'
 
 dependencies {
-  runtime ('org.springframework:spring-aspects:' + project.'springframework.version') {
+  runtime('org.springframework:spring-aspects:' + project.'springframework.version') {
     exclude module: 'aspectjweaver'
     exclude module: 'aopalliance'
     exclude module: 'spring-core'
   }
-  runtime ('org.springframework:spring-oxm:' + project.'springframework.version') {
+  runtime('org.springframework:spring-oxm:' + project.'springframework.version') {
     exclude module: 'commons-logging'
     exclude module: 'spring-beans'
     exclude module: 'spring-core'
   }
-  runtime ('org.springframework:spring-webmvc:' + project.'springframework.version') {
+  runtime('org.springframework:spring-webmvc:' + project.'springframework.version') {
     exclude module: 'aopalliance'
     exclude module: 'aspectjweaver'
     exclude module: 'spring-core'
   }
-  runtime ('commons-fileupload:commons-fileupload:' + project.'commons-fileupload.version') {
+  runtime('commons-fileupload:commons-fileupload:' + project.'commons-fileupload.version') {
     exclude module: 'commons-io'
   }
 
   testCompile 'org.springframework:spring-test:' + project.'springframework.version'
 
-  testCompile ('org.springframework:spring-webmvc:' + project.'springframework.version') {
+  testCompile('org.springframework:spring-webmvc:' + project.'springframework.version') {
     exclude module: 'aopalliance'
     exclude module: 'spring-aop'
   }
@@ -63,11 +63,9 @@ dependencies {
   testCompile files(project(':geode-old-versions').sourceSets.main.output)
 
   integrationTestCompile project(":geode-dunit")
-  // TODO remove dependency on sources from other test modules
   integrationTestCompile files(project(':geode-core').sourceSets.integrationTest.output)
 
   distributedTestCompile project(":geode-dunit")
-  // TODO remove dependency on sources from other test modules
   distributedTestCompile files(project(':geode-core').sourceSets.distributedTest.output)
 
   upgradeTestCompile project(":geode-dunit")
@@ -78,18 +76,13 @@ dependencies {
 //minusConfigurations does not work here, because it removes the entire
 //geode-core project
 eclipse.classpath.file {
-    whenMerged { classpath ->
-        classpath.entries.removeAll { entry -> entry.path.contains('geode-core/build')}
-    }
+  whenMerged { classpath ->
+    classpath.entries.removeAll { entry -> entry.path.contains('geode-core/build') }
+  }
 }
 
-distributedTest {
-  dependsOn war
-}
-
-integrationTest {
-  dependsOn war
-}
+distributedTest.dependsOn(war)
+integrationTest.dependsOn(war)
 
 war {
   dependsOn ':geode-core:webJar'

--- a/gradle/spotless.gradle
+++ b/gradle/spotless.gradle
@@ -23,6 +23,7 @@ subprojects {
       target project.fileTree(project.projectDir) {
         include '**/*.java'
         exclude '**/generated-src/**'
+        exclude '**/build/**'
       }
 
       // As the method name suggests, bump this number if any of the below "custom" rules change.

--- a/gradle/spotless.gradle
+++ b/gradle/spotless.gradle
@@ -100,4 +100,10 @@ subprojects {
       endWithNewline()
     }
   }
+
+  // If we add more languages to Spotless, add them to 'compileXYZ' trigger below
+  afterEvaluate {
+    project.tasks['compileJava'].mustRunAfter(spotlessCheck)
+    project.tasks['compileJava'].mustRunAfter(spotlessApply)
+  }
 }

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -311,7 +311,7 @@ subprojects {
   })
 
   // Make precheckin task run all validation tests for checking in code.
-  task precheckin (dependsOn: [ build, ":geode-assembly:acceptanceTest", integrationTest, distributedTest, flakyTest ]) {
+  task precheckin (dependsOn: [ build, acceptanceTest, integrationTest, distributedTest, flakyTest, uiTest, upgradeTest ]) {
     description 'Run this task before checking in code to validate changes. This task combines the following tasks: build, integrationTest, distributedTest, and flakyTest'
   }
 

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -311,8 +311,8 @@ subprojects {
   })
 
   // Make precheckin task run all validation tests for checking in code.
-  task precheckin (dependsOn: [ build, acceptanceTest, integrationTest, distributedTest, flakyTest, uiTest, upgradeTest ]) {
-    description 'Run this task before checking in code to validate changes. This task combines the following tasks: build, integrationTest, distributedTest, and flakyTest'
+  task precheckin (dependsOn: [ build, acceptanceTest, integrationTest, distributedTest, upgradeTest ]) {
+    description 'Run this task before checking in code to validate changes. It runs tests beyond unitTest'
   }
 
   combineReports.mustRunAfter check, test, integrationTest, distributedTest, flakyTest, acceptanceTest, repeatTest, upgradeTest


### PR DESCRIPTION
* devBuild depends on :assembly and :spotlessApply
* Ensure that spotlessApply and spotlessCheck run before compilation
*** This ordering dependency is project wide, not only with respect to
devBuild
* Correct apparent error in precheckin task only running
acceptanceTest task in geode-assembly module
*** Historically, this was the only module that contained
acceptanceTests.  This was changed with the introduction of nebula
facets.
* Minor readability improvements in touched files.

Signed-off-by: Patrick Rhomberg <prhomberg@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [n/a] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
