### PR TITLE
GEODE-5549: Removing assertion about process exit status from kill test

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/process/BaseProcessStreamReaderIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/process/BaseProcessStreamReaderIntegrationTest.java
@@ -45,10 +45,24 @@ public abstract class BaseProcessStreamReaderIntegrationTest
     givenRunningProcessWithStreamReaders(ProcessSleeps.class);
 
     // act
-    process.destroy(); // results in SIGTERM which usually has an exit code of 143
+    process.destroyForcibly(); // results in SIGTERM which usually has an exit code of 143
 
     // assert
     waitUntilProcessStops(10, MINUTES);
     assertThatProcessAndReadersDied();
+  }
+
+  @Test
+  public void capturesStderrWhenProcessFailsDuringStart() throws Exception {
+    // arrange
+    givenStartedProcessWithStreamListeners(ProcessThrowsError.class);
+
+    // act
+    waitUntilProcessStops();
+
+    // assert
+    assertThatProcessAndReadersStoppedWithExitValue(1);
+    assertThatStdOutContainsExactly(ProcessThrowsError.STDOUT);
+    assertThatStdErrContains(ProcessThrowsError.ERROR_MSG);
   }
 }

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/process/BlockingProcessStreamReaderIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/process/BlockingProcessStreamReaderIntegrationTest.java
@@ -109,20 +109,6 @@ public class BlockingProcessStreamReaderIntegrationTest
     assertThatStdErrContainsExactly(ProcessPrintsToBoth.STDERR);
   }
 
-  @Test
-  public void capturesStderrWhenProcessFailsDuringStart() throws Exception {
-    // arrange
-    givenStartedProcessWithStreamListeners(ProcessThrowsError.class);
-
-    // act
-    waitUntilProcessStops();
-
-    // assert
-    assertThatProcessAndReadersStoppedWithExitValue(1);
-    assertThatStdOutContainsExactly(ProcessThrowsError.STDOUT);
-    assertThatStdErrContains(ProcessThrowsError.ERROR_MSG);
-  }
-
   @Override
   protected ReadingMode getReadingMode() {
     return BLOCKING;

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/process/NonBlockingProcessStreamReaderIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/process/NonBlockingProcessStreamReaderIntegrationTest.java
@@ -106,20 +106,6 @@ public class NonBlockingProcessStreamReaderIntegrationTest
     assertThatStdErrContainsExactly(ProcessPrintsToBoth.STDERR);
   }
 
-  @Test
-  public void capturesStderrWhenProcessFailsDuringStart() throws Exception {
-    // arrange
-    givenStartedProcessWithStreamListeners(ProcessThrowsError.class);
-
-    // act
-    waitUntilProcessStops();
-
-    // assert
-    assertThatProcessAndReadersStoppedWithExitValue(1);
-    assertThatStdOutContainsExactly(ProcessThrowsError.STDOUT);
-    assertThatStdErrContains(ProcessThrowsError.ERROR_MSG);
-  }
-
   @Override
   protected ReadingMode getReadingMode() {
     return NON_BLOCKING;

--- a/geode-core/src/test/java/org/apache/geode/internal/process/AbstractProcessStreamReaderIntegrationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/process/AbstractProcessStreamReaderIntegrationTest.java
@@ -96,7 +96,7 @@ public abstract class AbstractProcessStreamReaderIntegrationTest {
   }
 
   protected void assertThatProcessAndReadersDied() throws InterruptedException {
-    assertThat(process.exitValue()).isGreaterThan(0);
+    assertThat(process.isAlive()).isFalse();
     assertThat(stdout.join(READER_JOIN_TIMEOUT_MILLIS).isRunning()).isFalse();
     assertThat(stderr.join(READER_JOIN_TIMEOUT_MILLIS).isRunning()).isFalse();
   }


### PR DESCRIPTION
the processTerminatesWhenDestroyedTest was asserting the exit value was
greater than zero. It looks like in some cases it can be 0. Since the
point of the test is to assert what happens to the stream reader
threads, removing this extra assertion.

Co-authored-by: Kirk Lund <klund@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
