### PR TITLE
GEODE-5559: Improve runtime of RegionVersionHolder.canonicalExceptions

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/versions/RVVException.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/versions/RVVException.java
@@ -176,12 +176,11 @@ abstract class RVVException
 
   protected abstract void writeReceived(DataOutput out) throws IOException;
 
-  public abstract ReceivedVersionsIterator receivedVersionsIterator();
+  public abstract ReceivedVersionsReverseIterator receivedVersionsReverseIterator();
 
   public abstract long getHighestReceivedVersion();
 
-  /** it's a shame that BitSet has no iterator */
-  public abstract class ReceivedVersionsIterator {
+  public abstract class ReceivedVersionsReverseIterator {
 
     abstract boolean hasNext();
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/versions/RVVExceptionB.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/versions/RVVExceptionB.java
@@ -126,32 +126,26 @@ public class RVVExceptionB extends RVVException {
   }
 
   protected void writeReceived(DataOutput out) throws IOException {
-    int size = 0;
-    long[] deltas = null;
-    long last = this.previousVersion;
+    final int size = received == null ? 1 : received.length() + 1;
+
+    int deltaIndex = size - 1;
+    long[] deltas = new long[size];
+    long last = this.nextVersion;
 
     // TODO - it would be better just to serialize the longs[] in the BitSet
     // as is, rather than go through this delta encoding.
-    for (ReceivedVersionsIterator it = receivedVersionsIterator(); it.hasNext();) {
+    for (ReceivedVersionsReverseIterator it = receivedVersionsReverseIterator(); it.hasNext();) {
       Long version = it.next();
-      long delta = version.longValue() - last;
-      if (deltas == null) {
-        deltas = new long[this.received.length()];
-      }
-      deltas[size++] = delta;
+      long delta = last - version.longValue();
+      deltas[--deltaIndex] = delta;
       last = version.longValue();
     }
-    InternalDataSerializer.writeUnsignedVL(size, out);
+    deltas[0] = last - this.previousVersion;
+    InternalDataSerializer.writeUnsignedVL(size - 1, out);
 
-    for (int i = 0; i < size; i++) {
-      InternalDataSerializer.writeUnsignedVL(deltas[i], out);
+    for (long value : deltas) {
+      InternalDataSerializer.writeUnsignedVL(value, out);
     }
-
-    // Write each version in the exception as a delta from the previous version
-    // this will likely be smaller than the absolute value, so it will
-    // be more likely to fit into a byte or a short.
-    long delta = this.nextVersion - last;
-    InternalDataSerializer.writeUnsignedVL(delta, out);
   }
 
   @Override
@@ -177,17 +171,6 @@ public class RVVExceptionB extends RVVException {
     }
     return "e(n=" + this.nextVersion + " p=" + this.previousVersion + "; rb=[])";
   }
-
-  // @Override
-  // public int hashCode() {
-  // final int prime = 31;
-  // int result = 1;
-  // result = prime * result + (int) (nextVersion ^ (nextVersion >>> 32));
-  // result = prime * result
-  // + (int) (previousVersion ^ (previousVersion >>> 32));
-  // result = prime * result + ((this.received == null) ? 0 : this.received.hashCode());
-  // return result;
-  // }
 
   /**
    * For test purposes only. This isn't quite accurate, because I think two RVVs that have
@@ -225,10 +208,8 @@ public class RVVExceptionB extends RVVException {
     return (this.received == null) || (this.received.isEmpty());
   }
 
-  public ReceivedVersionsIterator receivedVersionsIterator() {
-    ReceivedVersionsIteratorB result = new ReceivedVersionsIteratorB();
-    result.initForForwardIteration();
-    return result;
+  public ReceivedVersionsReverseIterator receivedVersionsReverseIterator() {
+    return new ReceivedVersionsReverseIteratorB();
   }
 
   @Override
@@ -244,21 +225,19 @@ public class RVVExceptionB extends RVVException {
 
   }
 
-
-
   /** it's a shame that BitSet has no iterator */
-  protected class ReceivedVersionsIteratorB extends ReceivedVersionsIterator {
+  protected class ReceivedVersionsReverseIteratorB extends ReceivedVersionsReverseIterator {
     int index;
     int nextIndex;
 
-    void initForForwardIteration() {
+    ReceivedVersionsReverseIteratorB() {
       this.index = -1;
       if (received == null) {
-        this.nextIndex = -1;
+        nextIndex = -1;
       } else {
-        this.nextIndex = received.nextSetBit((int) (previousVersion - receivedBaseVersion + 1));
-        if (this.nextIndex + receivedBaseVersion >= nextVersion) {
-          this.nextIndex = -1;
+        this.nextIndex = received.previousSetBit((int) (nextVersion - receivedBaseVersion - 1));
+        if (nextIndex + receivedBaseVersion <= previousVersion) {
+          nextIndex = -1;
         }
       }
     }
@@ -272,7 +251,10 @@ public class RVVExceptionB extends RVVException {
       if (this.index < 0) {
         throw new NoSuchElementException("no more elements available");
       }
-      advance();
+      this.nextIndex = received.previousSetBit(this.index - 1);
+      if (nextIndex + receivedBaseVersion <= previousVersion) {
+        nextIndex = -1;
+      }
       return this.index + receivedBaseVersion;
     }
 
@@ -282,13 +264,5 @@ public class RVVExceptionB extends RVVException {
       }
       received.clear(this.index);
     }
-
-    private void advance() {
-      this.nextIndex = received.nextSetBit(this.index + 1);
-      if ((this.nextIndex + receivedBaseVersion) >= nextVersion) {
-        this.nextIndex = -1;
-      }
-    }
-
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/versions/RegionVersionHolderJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/versions/RegionVersionHolderJUnitTest.java
@@ -19,7 +19,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.net.InetAddress;
+import java.util.ArrayList;
 import java.util.BitSet;
+import java.util.List;
 
 import org.junit.After;
 import org.junit.Before;
@@ -27,7 +29,6 @@ import org.junit.Test;
 
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.Assert;
-import org.apache.geode.internal.cache.versions.RVVException.ReceivedVersionsIterator;
 
 public class RegionVersionHolderJUnitTest {
 
@@ -1481,6 +1482,34 @@ public class RegionVersionHolderJUnitTest {
 
   }
 
+  // Using huge values here to ensure we're efficiently creating canonicalExceptions
+  private static final int NUM_TEST_EXCEPTIONS = 10;
+  private static final int TEST_EXCEPTION_SIZE = 200000;
+
+  @Test
+  public void testCanonicalExceptions() {
+    List<RVVException> exceptionList = new ArrayList<>();
+    for (int i = NUM_TEST_EXCEPTIONS; i > 0; --i) {
+      long start = i * TEST_EXCEPTION_SIZE;
+      long end = start + TEST_EXCEPTION_SIZE;
+      RVVException testException = RVVException.createException(start, end);
+      for (long j = start + 2; j < end; j += 2) {
+        testException.add(j);
+      }
+      exceptionList.add(testException);
+    }
+
+    List<RVVException> canonicalExceptions = RegionVersionHolder.canonicalExceptions(exceptionList);
+
+    long expectedStart = NUM_TEST_EXCEPTIONS * TEST_EXCEPTION_SIZE + TEST_EXCEPTION_SIZE - 2;
+    for (RVVException exception : canonicalExceptions) {
+      assertEquals(expectedStart, exception.previousVersion);
+      assertEquals(expectedStart + 2, exception.nextVersion);
+      assertTrue(exception.isEmpty());
+      expectedStart -= 2;
+    }
+  }
+
   /**
    * Test merging two version holders
    */
@@ -1887,7 +1916,8 @@ public class RegionVersionHolderJUnitTest {
               "bad next and previous next=" + ex.nextVersion + ", previous=" + ex.previousVersion);
         }
 
-        for (ReceivedVersionsIterator it = ex.receivedVersionsIterator(); it.hasNext();) {
+        for (RVVException.ReceivedVersionsReverseIterator it =
+            ex.receivedVersionsReverseIterator(); it.hasNext();) {
           Long received = it.next();
           if (received >= ex.nextVersion) {
             Assert.assertTrue(false, "received greater than next next=" + ex.nextVersion


### PR DESCRIPTION
This modifies the RVVException to iterate over the received version newest to
oldest, which makes generating the canonical exceptions much more
straightforward.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
