### PR TITLE
GEODE-5560 member becomes coordinator but then stops when it receives…

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeaveJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeaveJUnitTest.java
@@ -654,6 +654,25 @@ public class GMSJoinLeaveJUnitTest {
   }
 
   @Test
+  public void testBecomeCoordinatorThroughViewChangeWhenCoordinatorIsShuttingDown()
+      throws Exception {
+    initMocks();
+    prepareAndInstallView(mockMembers[0], createMemberList(mockMembers[0], gmsJoinLeaveMemberId));
+    NetView oldView = gmsJoinLeave.getView();
+    oldView.add(gmsJoinLeaveMemberId);
+    NetView view = new NetView(oldView, oldView.getViewId() + 1);
+    InternalDistributedMember creator = view.getCreator();
+    LeaveRequestMessage leaveRequestMessage =
+        new LeaveRequestMessage(gmsJoinLeaveMemberId, mockMembers[0], "leaving for test");
+    gmsJoinLeave.processMessage(leaveRequestMessage);
+    assertTrue(gmsJoinLeave.isCoordinator());
+    InstallViewMessage msg = getInstallViewMessage(view, creator, false);
+    msg.setSender(creator);
+    gmsJoinLeave.processMessage(msg);
+    assertTrue("Expected it to remain coordinator", gmsJoinLeave.isCoordinator());
+  }
+
+  @Test
   public void testBecomeParticipantThroughViewChange() throws Exception {
     initMocks();
     prepareAndInstallView(mockMembers[0], createMemberList(mockMembers[0], gmsJoinLeaveMemberId));


### PR DESCRIPTION
… a view

Upgraded the check to see if the receiver of a new membership view should
become the coordinator.  If we've received a Leave message from the coordinator
or the coordinator is scheduled to be kicked out of the system we take over
the role of coordinator if necessary.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
