### PR TITLE
GEODE-5480: Changing wait blocks to use a while loop

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/management/UniversalMembershipListenerAdapterDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/UniversalMembershipListenerAdapterDUnitTest.java
@@ -585,17 +585,17 @@ public class UniversalMembershipListenerAdapterDUnitTest extends ClientServerTes
 
     // should trigger both adapter and bridge listener but not system listener
     synchronized (adapter) {
-      if (!firedAdapter[JOINED]) {
+      while (!firedAdapter[JOINED]) {
         adapter.wait(ASYNC_EVENT_WAIT_MILLIS);
       }
     }
     synchronized (bridgeListener) {
-      if (!firedBridge[JOINED]) {
+      while (!firedBridge[JOINED]) {
         bridgeListener.wait(ASYNC_EVENT_WAIT_MILLIS);
       }
     }
     synchronized (systemListener) {
-      if (!firedSystem[JOINED]) {
+      while (!firedSystem[JOINED]) {
         systemListener.wait(ASYNC_EVENT_WAIT_MILLIS);
       }
     }
@@ -665,12 +665,12 @@ public class UniversalMembershipListenerAdapterDUnitTest extends ClientServerTes
     });
 
     synchronized (adapter) {
-      if (!firedAdapter[LEFT]) {
+      while (!firedAdapter[LEFT]) {
         adapter.wait(ASYNC_EVENT_WAIT_MILLIS);
       }
     }
     synchronized (bridgeListener) {
-      if (!firedBridge[LEFT]) {
+      while (!firedBridge[LEFT]) {
         bridgeListener.wait(ASYNC_EVENT_WAIT_MILLIS);
       }
     }
@@ -726,12 +726,12 @@ public class UniversalMembershipListenerAdapterDUnitTest extends ClientServerTes
     clientMemberId = clientMember.getId();
 
     synchronized (adapter) {
-      if (!firedAdapter[JOINED]) {
+      while (!firedAdapter[JOINED]) {
         adapter.wait(ASYNC_EVENT_WAIT_MILLIS);
       }
     }
     synchronized (bridgeListener) {
-      if (!firedBridge[JOINED]) {
+      while (!firedBridge[JOINED]) {
         bridgeListener.wait(ASYNC_EVENT_WAIT_MILLIS);
       }
     }
@@ -801,17 +801,17 @@ public class UniversalMembershipListenerAdapterDUnitTest extends ClientServerTes
     });
 
     synchronized (adapter) {
-      if (!firedAdapter[LEFT]) {
+      while (!firedAdapter[LEFT]) {
         adapter.wait(ASYNC_EVENT_WAIT_MILLIS);
       }
     }
     synchronized (systemListener) {
-      if (!firedSystem[LEFT]) {
+      while (!firedSystem[LEFT]) {
         systemListener.wait(ASYNC_EVENT_WAIT_MILLIS);
       }
     }
     synchronized (bridgeListener) {
-      if (!firedBridge[LEFT]) {
+      while (!firedBridge[LEFT]) {
         bridgeListener.wait(ASYNC_EVENT_WAIT_MILLIS);
       }
     }
@@ -867,17 +867,17 @@ public class UniversalMembershipListenerAdapterDUnitTest extends ClientServerTes
     clientMemberId = clientMember.getId();
 
     synchronized (adapter) {
-      if (!firedAdapter[JOINED]) {
+      while (!firedAdapter[JOINED]) {
         adapter.wait(ASYNC_EVENT_WAIT_MILLIS);
       }
     }
     synchronized (systemListener) {
-      if (!firedSystem[JOINED]) {
+      while (!firedSystem[JOINED]) {
         systemListener.wait(ASYNC_EVENT_WAIT_MILLIS);
       }
     }
     synchronized (bridgeListener) {
-      if (!firedBridge[JOINED]) {
+      while (!firedBridge[JOINED]) {
         bridgeListener.wait(ASYNC_EVENT_WAIT_MILLIS);
       }
     }
@@ -949,12 +949,12 @@ public class UniversalMembershipListenerAdapterDUnitTest extends ClientServerTes
     });
 
     synchronized (adapter) {
-      if (!firedAdapter[CRASHED]) {
+      while (!firedAdapter[CRASHED]) {
         adapter.wait(ASYNC_EVENT_WAIT_MILLIS);
       }
     }
     synchronized (bridgeListener) {
-      if (!firedBridge[CRASHED]) {
+      while (!firedBridge[CRASHED]) {
         bridgeListener.wait(ASYNC_EVENT_WAIT_MILLIS);
       }
     }


### PR DESCRIPTION
This test has many wait blocks that just used an if. So if the thread
was notified by some other event, it would leave the wait without the
expected event being delivered.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
