### PR TITLE
GEODE-5565: Release off heap memory if unable to set value 

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/EntryEventImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/EntryEventImpl.java
@@ -1713,7 +1713,11 @@ public class EntryEventImpl implements InternalEntryEvent, InternalCacheEvent,
       success = true;
     } finally {
       if (!success && reentry instanceof OffHeapRegionEntry && v instanceof StoredObject) {
-        OffHeapRegionEntryHelper.releaseEntry((OffHeapRegionEntry) reentry, (StoredObject) v);
+        if (!calledSetValue) {
+          OffHeapHelper.release(v);
+        } else {
+          OffHeapRegionEntryHelper.releaseEntry((OffHeapRegionEntry) reentry, (StoredObject) v);
+        }
       }
     }
     if (logger.isTraceEnabled()) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/AbstractDiskRegionEntry.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/AbstractDiskRegionEntry.java
@@ -21,6 +21,7 @@ import org.apache.geode.internal.cache.RegionClearedException;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.wan.GatewaySenderEventImpl;
 import org.apache.geode.internal.cache.wan.serial.SerialGatewaySenderQueue;
+import org.apache.geode.internal.offheap.annotations.Unretained;
 
 public abstract class AbstractDiskRegionEntry extends AbstractRegionEntry implements DiskEntry {
   protected AbstractDiskRegionEntry(RegionEntryContext context, Object value) {
@@ -28,12 +29,13 @@ public abstract class AbstractDiskRegionEntry extends AbstractRegionEntry implem
   }
 
   @Override
-  public void setValue(RegionEntryContext context, Object v) throws RegionClearedException {
+  public void setValue(RegionEntryContext context, @Unretained Object v)
+      throws RegionClearedException {
     setValue(context, v, null);
   }
 
   @Override
-  public void setValue(RegionEntryContext context, Object value, EntryEventImpl event)
+  public void setValue(RegionEntryContext context, @Unretained Object value, EntryEventImpl event)
       throws RegionClearedException {
     Helper.update(this, (LocalRegion) context, value, event);
     setRecentlyUsed(context); // fix for bug #42284 - entry just put into the cache is evicted
@@ -46,7 +48,7 @@ public abstract class AbstractDiskRegionEntry extends AbstractRegionEntry implem
    * @param value an entry value.
    */
   @Override
-  public void setValueWithContext(RegionEntryContext context, Object value) {
+  public void setValueWithContext(RegionEntryContext context, @Unretained Object value) {
     _setValue(value);
     releaseOffHeapRefIfRegionBeingClosedOrDestroyed(context, value);
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/DiskEntry.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/DiskEntry.java
@@ -85,7 +85,7 @@ public interface DiskEntry extends RegionEntry {
    * @param context the value's context.
    * @param value an entry value.
    */
-  void setValueWithContext(RegionEntryContext context, Object value);
+  void setValueWithContext(RegionEntryContext context, @Unretained Object value);
 
   /**
    * In some cases we need to do something just before we drop the value from a DiskEntry that is
@@ -829,7 +829,7 @@ public interface DiskEntry extends RegionEntry {
       region.getDiskRegion().put(entry, region, vw, async);
     }
 
-    public static void update(DiskEntry entry, InternalRegion region, Object newValue)
+    public static void update(DiskEntry entry, InternalRegion region, @Unretained Object newValue)
         throws RegionClearedException {
       update(entry, region, newValue, null);
     }
@@ -838,40 +838,53 @@ public interface DiskEntry extends RegionEntry {
      * Updates the value of the disk entry with a new value. This allows us to free up disk space in
      * the non-backup case.
      */
-    public static void update(DiskEntry entry, InternalRegion region, Object newValue,
+    public static void update(DiskEntry entry, InternalRegion region, @Unretained Object newValue,
         EntryEventImpl event) throws RegionClearedException {
       if (newValue == null) {
         throw new NullPointerException(
             LocalizedStrings.DiskEntry_ENTRYS_VALUE_SHOULD_NOT_BE_NULL.toLocalizedString());
       }
-
-      AsyncDiskEntry asyncDiskEntry = null;
-      DiskRegion dr = region.getDiskRegion();
-      DiskId did = entry.getDiskId();
-      Object syncObj = did;
-      if (syncObj == null) {
-        syncObj = entry;
-      }
-      if (syncObj == did) {
-        dr.acquireReadLock();
-      }
+      boolean basicUpdateCalled = false;
       try {
-        synchronized (syncObj) {
-          asyncDiskEntry = basicUpdate(entry, region, newValue, event);
+
+        AsyncDiskEntry asyncDiskEntry = null;
+        DiskRegion dr = region.getDiskRegion();
+        DiskId did = entry.getDiskId();
+        Object syncObj = did;
+        if (syncObj == null) {
+          syncObj = entry;
+        }
+        if (syncObj == did) {
+          dr.acquireReadLock();
+        }
+        try {
+          synchronized (syncObj) {
+            basicUpdateCalled = true;
+            asyncDiskEntry = basicUpdate(entry, region, newValue, event);
+          }
+        } finally {
+          if (syncObj == did) {
+            dr.releaseReadLock();
+          }
+        }
+        if (asyncDiskEntry != null && did.isPendingAsync()) {
+          // this needs to be done outside the above sync
+          scheduleAsyncWrite(asyncDiskEntry);
         }
       } finally {
-        if (syncObj == did) {
-          dr.releaseReadLock();
+        if (!basicUpdateCalled) {
+          OffHeapHelper.release(newValue);
         }
-      }
-      if (asyncDiskEntry != null && did.isPendingAsync()) {
-        // this needs to be done outside the above sync
-        scheduleAsyncWrite(asyncDiskEntry);
       }
     }
 
+    static AsyncDiskEntry basicUpdateForTesting(DiskEntry entry, InternalRegion region,
+        @Unretained Object newValue, EntryEventImpl event) throws RegionClearedException {
+      return basicUpdate(entry, region, newValue, event);
+    }
+
     private static AsyncDiskEntry basicUpdate(DiskEntry entry, InternalRegion region,
-        Object newValue, EntryEventImpl event) throws RegionClearedException {
+        @Unretained Object newValue, EntryEventImpl event) throws RegionClearedException {
       AsyncDiskEntry result = null;
       DiskRegion dr = region.getDiskRegion();
       DiskId did = entry.getDiskId();
@@ -903,67 +916,82 @@ public interface DiskEntry extends RegionEntry {
       } else if (newValue instanceof RecoveredEntry) {
         ((RecoveredEntry) newValue).applyToDiskEntry(entry, region, dr, did);
       } else {
-        // The new value in the entry needs to be set after the disk writing
-        // has succeeded.
+        boolean newValueStoredInEntry = false;
+        try {
+          // The new value in the entry needs to be set after the disk writing
+          // has succeeded.
 
-        // entry.setValueWithContext(region, newValue); // OFFHEAP newValue already prepared
+          // entry.setValueWithContext(region, newValue); // OFFHEAP newValue already prepared
 
-        if (did != null && did.isPendingAsync()) {
-          // if the entry was not yet written to disk, we didn't update
-          // the bytes on disk.
-          oldValueLength = 0;
-        } else {
-          oldValueLength = getValueLength(did);
-        }
-
-        if (dr.isBackup()) {
-          dr.testIsRecoveredAndClear(did); // fixes bug 41409
-          if (doSynchronousWrite(region, dr)) {
-            if (AbstractRegionEntry.isCompressible(dr, newValue)) {
-              // In case of compression the value is being set first
-              // so that writeToDisk can get it back from the entry
-              // decompressed if it does not have it already in the event.
-              // TODO: this may have introduced a bug with clear since
-              // writeToDisk can throw RegionClearedException which
-              // was supposed to stop us from changing entry.
-              entry.setValueWithContext(region, newValue); // OFFHEAP newValue already prepared
-              // newValue is prepared and compressed. We can't write compressed values to disk.
-              writeToDisk(entry, region, false, event);
-            } else {
-              writeBytesToDisk(entry, region, false, createValueWrapper(newValue, event));
-              entry.setValueWithContext(region, newValue); // OFFHEAP newValue already prepared
-            }
-
+          if (did != null && did.isPendingAsync()) {
+            // if the entry was not yet written to disk, we didn't update
+            // the bytes on disk.
+            oldValueLength = 0;
           } else {
-            // If we have concurrency checks enabled for a persistent region, we need
-            // to add an entry to the async queue for every update to maintain the RVV
-            boolean maintainRVV = region.getConcurrencyChecksEnabled();
-
-            if (!did.isPendingAsync() || maintainRVV) {
-              // if the entry is not async, we need to schedule it
-              // for regions with concurrency checks enabled, we add an entry
-              // to the queue for every entry.
-              did.setPendingAsync(true);
-              VersionTag tag = null;
-              VersionStamp stamp = entry.getVersionStamp();
-              if (stamp != null) {
-                tag = stamp.asVersionTag();
-              }
-              result = new AsyncDiskEntry(region, entry, tag);
-            }
-            entry.setValueWithContext(region, newValue); // OFFHEAP newValue already prepared
+            oldValueLength = getValueLength(did);
           }
-        } else if (did != null) {
-          entry.setValueWithContext(region, newValue); // OFFHEAP newValue already prepared
 
-          // Mark the id as needing to be written
-          // The disk remove that this section used to do caused bug 30961
-          // @todo this seems wrong. How does leaving it on disk fix the bug?
-          did.markForWriting();
-          // did.setValueSerializedSize(0);
-        } else {
-          entry.setValueWithContext(region, newValue);
+          if (dr.isBackup()) {
+            dr.testIsRecoveredAndClear(did); // fixes bug 41409
+            if (doSynchronousWrite(region, dr)) {
+              if (AbstractRegionEntry.isCompressible(dr, newValue)) {
+                // In case of compression the value is being set first
+                // so that writeToDisk can get it back from the entry
+                // decompressed if it does not have it already in the event.
+                // TODO: this may have introduced a bug with clear since
+                // writeToDisk can throw RegionClearedException which
+                // was supposed to stop us from changing entry.
+                newValueStoredInEntry = true;
+                entry.setValueWithContext(region, newValue); // OFFHEAP newValue already prepared
+                // newValue is prepared and compressed. We can't write compressed values to disk.
+                if (!region.isThisRegionBeingClosedOrDestroyed()) {
+                  writeToDisk(entry, region, false, event);
+                }
+              } else {
+                writeBytesToDisk(entry, region, false, createValueWrapper(newValue, event));
+                newValueStoredInEntry = true;
+                entry.setValueWithContext(region, newValue); // OFFHEAP newValue already prepared
+              }
+
+            } else {
+              // If we have concurrency checks enabled for a persistent region, we need
+              // to add an entry to the async queue for every update to maintain the RVV
+              boolean maintainRVV = region.getConcurrencyChecksEnabled();
+
+              if (!did.isPendingAsync() || maintainRVV) {
+                // if the entry is not async, we need to schedule it
+                // for regions with concurrency checks enabled, we add an entry
+                // to the queue for every entry.
+                did.setPendingAsync(true);
+                VersionTag tag = null;
+                VersionStamp stamp = entry.getVersionStamp();
+                if (stamp != null) {
+                  tag = stamp.asVersionTag();
+                }
+                result = new AsyncDiskEntry(region, entry, tag);
+              }
+              newValueStoredInEntry = true;
+              entry.setValueWithContext(region, newValue); // OFFHEAP newValue already prepared
+            }
+          } else if (did != null) {
+            newValueStoredInEntry = true;
+            entry.setValueWithContext(region, newValue); // OFFHEAP newValue already prepared
+
+            // Mark the id as needing to be written
+            // The disk remove that this section used to do caused bug 30961
+            // @todo this seems wrong. How does leaving it on disk fix the bug?
+            did.markForWriting();
+            // did.setValueSerializedSize(0);
+          } else {
+            newValueStoredInEntry = true;
+            entry.setValueWithContext(region, newValue);
+          }
+        } finally {
+          if (!newValueStoredInEntry) {
+            OffHeapHelper.release(newValue);
+          }
         }
+
 
         if (Token.isInvalidOrRemoved(newValue)) {
           if (oldValue == null) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/DiskEntry.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/DiskEntry.java
@@ -944,7 +944,7 @@ public interface DiskEntry extends RegionEntry {
                 newValueStoredInEntry = true;
                 entry.setValueWithContext(region, newValue); // OFFHEAP newValue already prepared
                 // newValue is prepared and compressed. We can't write compressed values to disk.
-                if (!region.isThisRegionBeingClosedOrDestroyed()) {
+                if (!entry.isRemovedFromDisk()) {
                   writeToDisk(entry, region, false, event);
                 }
               } else {

--- a/geode-core/src/main/java/org/apache/geode/internal/offheap/OffHeapRegionEntryHelper.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/offheap/OffHeapRegionEntryHelper.java
@@ -191,7 +191,7 @@ public class OffHeapRegionEntryHelper {
       @Released StoredObject expectedValue) {
     long oldAddress = objectToAddress(expectedValue);
     final long newAddress = objectToAddress(Token.REMOVED_PHASE2);
-    if (re.setAddress(oldAddress, newAddress) || re.getAddress() != newAddress) {
+    if (re.setAddress(oldAddress, newAddress)) {
       releaseAddress(oldAddress);
     } /*
        * else { if (!calledSetValue || re.getAddress() != newAddress) { expectedValue.release(); } }


### PR DESCRIPTION
 * If RegionDestroyedException is thrown while trying to set a value, but after memory has been allocated, we will now release the memory in a catch block.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
