### PR TITLE
GEODE-5387: Adding job to the pr pipeline to stress new tests

### DIFF
--- a/ci/pipelines/pull-request/base.yml
+++ b/ci/pipelines/pull-request/base.yml
@@ -71,6 +71,7 @@ groups:
   - AcceptanceTest
   - IntegrationTest
   - UpgradeTest
+  - StressNewTests
 
 jobs:
 - name: Build

--- a/ci/pipelines/pull-request/deploy_pr_pipeline.sh
+++ b/ci/pipelines/pull-request/deploy_pr_pipeline.sh
@@ -71,6 +71,18 @@ for i in ${GEODEBUILDDIR}/test-stubs/*.yml; do
     ${i} > ${TMP_DIR}/${X}
 done
 
+for i in ${SCRIPTDIR}/test-stubs/*.yml; do
+  X=pull-request-$(basename $i)
+  echo "Merging ${i} into ${TMP_DIR}/${X}"
+  ${SPRUCE} merge --prune metadata \
+    <(echo "metadata:"; \
+      echo "  geode-build-branch: ${GEODE_BRANCH}"; \
+      echo "  geode-fork: ${GEODE_FORK}"; \
+      echo "  ") \
+    ${SCRIPTDIR}/pr-template.yml \
+    ${i} > ${TMP_DIR}/${X}
+done
+
 echo "Spruce branch-name into resources"
 ${SPRUCE} merge --prune metadata \
   ${SCRIPTDIR}/base.yml \

--- a/ci/pipelines/pull-request/pr-template.yml
+++ b/ci/pipelines/pull-request/pr-template.yml
@@ -107,7 +107,7 @@ jobs:
           GRADLE_TASK_OPTIONS: (( grab metadata.job.gradle_task_options || "" ))
           ARTIFACT_SLUG: (( grab metadata.job.artifact_slug ))
         run:
-          path: geode-ci/ci/scripts/execute_tests.sh
+          path: (( grab metadata.job.execute_command || "geode/ci/scripts/execute_tests.sh" ))
     on_success:
       do:
       - put: pull-request-job-success

--- a/ci/pipelines/pull-request/test-stubs/newtests.yml
+++ b/ci/pipelines/pull-request/test-stubs/newtests.yml
@@ -23,11 +23,11 @@ metadata:
     dunit:
       parallel: true
 # max number of docker containers to run, generally cpus/2
-      forks: 48
+      forks: 24
     cpus: 96
 # specified in Gigabytes.
     ram: 210
 # specified in seconds
-    call_stack_timeout: 3600
-    timeout: 1h15m
+    call_stack_timeout: 7200
+    timeout: 2h15m
     size: []

--- a/ci/pipelines/pull-request/test-stubs/newtests.yml
+++ b/ci/pipelines/pull-request/test-stubs/newtests.yml
@@ -1,0 +1,33 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+metadata:
+  job:
+    name: StressNewTests
+    gradle_task: repeatTest
+    artifact_slug: stressnewtestfiles
+    execute_command: geode/ci/scripts/repeat-new-tests.sh
+    dunit:
+      parallel: true
+# max number of docker containers to run, generally cpus/2
+      forks: 48
+    cpus: 96
+# specified in Gigabytes.
+    ram: 210
+# specified in seconds
+    call_stack_timeout: 3600
+    timeout: 1h15m
+    size: []

--- a/ci/scripts/archive_results.sh
+++ b/ci/scripts/archive_results.sh
@@ -113,7 +113,7 @@ TEST_RESULTS_DESTINATION="${ARTIFACTS_DESTINATION}/test-results/${SANITIZED_GRAD
 TEST_ARTIFACTS_DESTINATION="${ARTIFACTS_DESTINATION}/test-artifacts/${BUILD_TIMESTAMP}/"
 
 
-if [ ! -d "${GEODE_BUILD}/build/reports/combined" ]; then
+if [ ! -f "${GEODE_BUILD}/build/reports/combined/index.html" ]; then
     echo "No tests exist, compile failed."
     mkdir -p ${GEODE_BUILD}/build/reports/combined
     echo "<html><head><title>No Test Results Were Captured</title></head><body><h1>No Test Results Were Captured</h1></body></html>" > ${GEODE_BUILD}/build/reports/combined/index.html

--- a/ci/scripts/repeat-new-tests.sh
+++ b/ci/scripts/repeat-new-tests.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -e
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  SCRIPTDIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+SCRIPTDIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+CHANGED_FILES=$(cd geode && git diff --name-only HEAD $(git merge-base HEAD origin/develop)  -- */src/test/java */src/integrationTest/java */src/distributedTest/java)
+
+CHANGED_FILES_ARRAY=( $CHANGED_FILES )
+NUM_CHANGED_FILES=${#CHANGED_FILES_ARRAY[@]}
+
+TESTS_FLAG=""
+
+echo "${NUM_CHANGED_FILES} changed tests"
+
+if [  ${NUM_CHANGED_FILES} -eq 0 ]
+  then
+    echo "No changed test files, nothing to test."
+    exit 0
+fi
+
+if [ ${NUM_CHANGED_FILES} -gt 25 ]
+  then
+    echo "${NUM_CHANGED_FILES} is many changed tests to stress test. Allowing this job to pass without stress testing."
+    exit 0
+fi
+
+
+for FILENAME in $CHANGED_FILES ; do
+  SHORT_NAME=$(basename $FILENAME)
+  SHORT_NAME="${SHORT_NAME%.java}"
+  TESTS_FLAG="$TESTS_FLAG --tests $SHORT_NAME"
+done
+
+export GRADLE_TASK='compileTestJava compileIntegrationTestJava compileDistributedTestJava repeatTest'
+export GRADLE_TASK_OPTIONS="--no-parallel -Prepeat=50 -PfailOnNoMatchingTests=false $TESTS_FLAG"
+
+echo "GRADLE_TASK_OPTIONS=${GRADLE_TASK_OPTIONS}"
+
+${SCRIPTDIR}/execute_tests.sh
+

--- a/ci/scripts/repeat-new-tests.sh
+++ b/ci/scripts/repeat-new-tests.sh
@@ -20,7 +20,7 @@
 set -e
 
 SOURCE="${BASH_SOURCE[0]}"
-while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+while [[ -h "$SOURCE" ]]; do # resolve $SOURCE until the file is no longer a symlink
   SCRIPTDIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
   SOURCE="$(readlink "$SOURCE")"
   [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
@@ -36,13 +36,13 @@ TESTS_FLAG=""
 
 echo "${NUM_CHANGED_FILES} changed tests"
 
-if [  ${NUM_CHANGED_FILES} -eq 0 ]
+if [[  "${NUM_CHANGED_FILES}" -eq 0 ]]
   then
     echo "No changed test files, nothing to test."
     exit 0
 fi
 
-if [ ${NUM_CHANGED_FILES} -gt 25 ]
+if [[ "${NUM_CHANGED_FILES}" -gt 25 ]]
   then
     echo "${NUM_CHANGED_FILES} is many changed tests to stress test. Allowing this job to pass without stress testing."
     exit 0

--- a/ci/scripts/repeat-new-tests.sh
+++ b/ci/scripts/repeat-new-tests.sh
@@ -27,7 +27,7 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
 done
 SCRIPTDIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
-CHANGED_FILES=$(cd geode && git diff --name-only HEAD $(git merge-base HEAD origin/develop)  -- */src/test/java */src/integrationTest/java */src/distributedTest/java)
+CHANGED_FILES=$(cd geode && git diff --name-only HEAD $(git merge-base HEAD origin/develop)  -- */src/test/java */src/integrationTest/java */src/distributedTest/java */src/upgradeTest/java)
 
 CHANGED_FILES_ARRAY=( $CHANGED_FILES )
 NUM_CHANGED_FILES=${#CHANGED_FILES_ARRAY[@]}

--- a/ci/scripts/repeat-new-tests.sh
+++ b/ci/scripts/repeat-new-tests.sh
@@ -27,7 +27,7 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
 done
 SCRIPTDIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
-CHANGED_FILES=$(cd geode && git diff --name-only HEAD $(git merge-base HEAD origin/develop)  -- */src/test/java */src/integrationTest/java */src/distributedTest/java */src/upgradeTest/java)
+CHANGED_FILES=$(cd geode && git diff --name-only HEAD $(git merge-base HEAD origin/develop)  -- */src/test/java */src/integrationTest/java */src/distributedTest/java */src/upgradeTest/java */src/acceptanceTest/java )
 
 CHANGED_FILES_ARRAY=( $CHANGED_FILES )
 NUM_CHANGED_FILES=${#CHANGED_FILES_ARRAY[@]}

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -209,6 +209,8 @@ subprojects {
     testClassesDirs += project.sourceSets.integrationTest.output.classesDirs
     classpath += project.sourceSets.upgradeTest.runtimeClasspath
     testClassesDirs += project.sourceSets.upgradeTest.output.classesDirs
+    classpath += project.sourceSets.acceptanceTest.runtimeClasspath
+    testClassesDirs += project.sourceSets.acceptanceTest.output.classesDirs
 
     if(project.hasProperty("failOnNoMatchingTests")) {
       filter {

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -207,6 +207,8 @@ subprojects {
     testClassesDirs += project.sourceSets.distributedTest.output.classesDirs
     classpath += project.sourceSets.integrationTest.runtimeClasspath
     testClassesDirs += project.sourceSets.integrationTest.output.classesDirs
+    classpath += project.sourceSets.upgradeTest.runtimeClasspath
+    testClassesDirs += project.sourceSets.upgradeTest.output.classesDirs
 
     if(project.hasProperty("failOnNoMatchingTests")) {
       filter {


### PR DESCRIPTION
Adding a job to the PR pipeline that finds new or modified test files
and runs them many times. The goal is to fail PRs that create new flaky
tests.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
