### PR TITLE
Reducing the parallelism of if distributedTest

### DIFF
--- a/ci/pipelines/geode-build/test-stubs/distributed.yml
+++ b/ci/pipelines/geode-build/test-stubs/distributed.yml
@@ -22,11 +22,11 @@ metadata:
     dunit:
       parallel: true
 # max number of docker containers to run, generally cpus/2
-      forks: 48
+      forks: 24
     cpus: 96
 # specified in Gigabytes.
     ram: 180
 # specified in seconds
-    call_stack_timeout: 3600
-    timeout: 1h15m
+    call_stack_timeout: 7200
+    timeout: 2h15m
     size: []


### PR DESCRIPTION
We are seeing 5% of our builds fail with membership errors due to
heartbeat timeouts. We also see that the DistributedTest job is running
with a 300 load average. Reducing the parallelism to avoid overloading
the machine.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:
