### PR TITLE
GEODE-5562 Reading the values of LocalRegion.memoryThresholdReached and DistributedRegion.memoryThresholdReachedMembers must be atomic

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/management/MemoryThresholdsDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/management/MemoryThresholdsDUnitTest.java
@@ -303,7 +303,7 @@ public class MemoryThresholdsDUnitTest extends ClientServerTestCase {
 
           public boolean done() {
             DistributedRegion dr = (DistributedRegion) getRootRegion().getSubregion(regionName);
-            return dr.getMemoryThresholdReachedMembers().size() == 0;
+            return dr.getAtomicThresholdInfo().getMembersThatReachedThreshold().size() == 0;
           }
         };
         Wait.waitForCriterion(wc, 30000, 10, true);

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/management/MemoryThresholdsOffHeapDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/management/MemoryThresholdsOffHeapDUnitTest.java
@@ -602,7 +602,7 @@ public class MemoryThresholdsOffHeapDUnitTest extends ClientServerTestCase {
               }
 
               public boolean done() {
-                return r.memoryThresholdReached.get();
+                return r.isMemoryThresholdReached();
               }
             };
             Wait.waitForCriterion(wc, 30 * 1000, 10, true);
@@ -618,7 +618,7 @@ public class MemoryThresholdsOffHeapDUnitTest extends ClientServerTestCase {
               }
 
               public boolean done() {
-                return !r.memoryThresholdReached.get();
+                return !r.isMemoryThresholdReached();
               }
             };
             Wait.waitForCriterion(wc, 30 * 1000, 10, true);
@@ -670,7 +670,7 @@ public class MemoryThresholdsOffHeapDUnitTest extends ClientServerTestCase {
           }
 
           public boolean done() {
-            return r.memoryThresholdReached.get();
+            return r.isMemoryThresholdReached();
           }
         };
         Wait.waitForCriterion(wc, 30 * 1000, 10, true);
@@ -686,7 +686,7 @@ public class MemoryThresholdsOffHeapDUnitTest extends ClientServerTestCase {
           }
 
           public boolean done() {
-            return !r.memoryThresholdReached.get();
+            return !r.isMemoryThresholdReached();
           }
         };
         Wait.waitForCriterion(wc, 30 * 1000, 10, true);
@@ -1235,7 +1235,7 @@ public class MemoryThresholdsOffHeapDUnitTest extends ClientServerTestCase {
           }
 
           public boolean done() {
-            return r.memoryThresholdReached.get();
+            return r.isMemoryThresholdReached();
           }
         };
         Wait.waitForCriterion(wc, 30 * 1000, 10, true);
@@ -1258,7 +1258,7 @@ public class MemoryThresholdsOffHeapDUnitTest extends ClientServerTestCase {
           }
 
           public boolean done() {
-            return !r.memoryThresholdReached.get();
+            return !r.isMemoryThresholdReached();
           }
         };
         Wait.waitForCriterion(wc, 30 * 1000, 10, true);
@@ -1514,12 +1514,12 @@ public class MemoryThresholdsOffHeapDUnitTest extends ClientServerTestCase {
             @Override
             public String description() {
               return "Expected to go critical: isCritical=" + ohm.getState().isCritical()
-                  + " memoryThresholdReached=" + r.memoryThresholdReached.get();
+                  + " memoryThresholdReached=" + r.isMemoryThresholdReached();
             }
 
             @Override
             public boolean done() {
-              return ohm.getState().isCritical() && r.memoryThresholdReached.get();
+              return ohm.getState().isCritical() && r.isMemoryThresholdReached();
             }
           };
         }

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/management/MemoryThresholdsOffHeapDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/management/MemoryThresholdsOffHeapDUnitTest.java
@@ -494,7 +494,7 @@ public class MemoryThresholdsOffHeapDUnitTest extends ClientServerTestCase {
 
           public boolean done() {
             DistributedRegion dr = (DistributedRegion) getRootRegion().getSubregion(regionName);
-            return dr.getMemoryThresholdReachedMembers().size() == 0;
+            return dr.getAtomicThresholdInfo().getMembersThatReachedThreshold().size() == 0;
           }
         };
         Wait.waitForCriterion(wc, 10000, 10, true);

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/DefaultQueryService.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/DefaultQueryService.java
@@ -68,7 +68,9 @@ import org.apache.geode.cache.query.internal.parse.OQLLexerTokenTypes;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.internal.cache.ForceReattemptException;
 import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.MemoryThresholdInfo;
 import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.internal.cache.control.MemoryThresholds;
 import org.apache.geode.internal.i18n.LocalizedStrings;
@@ -226,12 +228,15 @@ public class DefaultQueryService implements InternalQueryService {
     // UnsupportedOperationException(LocalizedStrings.DefaultQueryService_INDEX_CREATION_IS_NOT_SUPPORTED_FOR_REGIONS_WHICH_OVERFLOW_TO_DISK_THE_REGION_INVOLVED_IS_0.toLocalizedString(regionPath));
     // }
     // if its a pr the create index on all of the local buckets.
-    if (((LocalRegion) region).memoryThresholdReached.get()
-        && !MemoryThresholds.isLowMemoryExceptionDisabled()) {
-      LocalRegion lr = (LocalRegion) region;
-      throw new LowMemoryException(
-          LocalizedStrings.ResourceManager_LOW_MEMORY_FOR_INDEX.toLocalizedString(region.getName()),
-          lr.getMemoryThresholdReachedMembers());
+    if (!MemoryThresholds.isLowMemoryExceptionDisabled()) {
+      InternalRegion internalRegion = (InternalRegion) region;
+      MemoryThresholdInfo info = internalRegion.getAtomicThresholdInfo();
+      if (info.isMemoryThresholdReached()) {
+        throw new LowMemoryException(
+            LocalizedStrings.ResourceManager_LOW_MEMORY_FOR_INDEX
+                .toLocalizedString(region.getName()),
+            info.getMembersThatReachedThreshold());
+      }
     }
     if (region instanceof PartitionedRegion) {
       try {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/CacheDistributionAdvisor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/CacheDistributionAdvisor.java
@@ -1103,7 +1103,7 @@ public class CacheDistributionAdvisor extends DistributionAdvisor {
       logger.debug("CDA: removing profile {}", profile);
     }
     if (getAdvisee() instanceof LocalRegion && profile != null) {
-      ((LocalRegion) getAdvisee()).removeMemberFromCriticalList(profile.getDistributedMember());
+      ((LocalRegion) getAdvisee()).removeCriticalMember(profile.getDistributedMember());
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
@@ -3769,7 +3769,7 @@ public class DistributedRegion extends LocalRegion implements InternalDistribute
     synchronized (this.memoryThresholdReachedMembers) {
       this.memoryThresholdReachedMembers.remove(member);
       if (this.memoryThresholdReachedMembers.size() == 0) {
-        memoryThresholdReached.set(false);
+        setMemoryThresholdReached(false);
       }
     }
   }
@@ -3799,16 +3799,19 @@ public class DistributedRegion extends LocalRegion implements InternalDistribute
     synchronized (this.memoryThresholdReachedMembers) {
       this.memoryThresholdReachedMembers.add(idm);
       if (this.memoryThresholdReachedMembers.size() > 0) {
-        memoryThresholdReached.set(true);
+        setMemoryThresholdReached(true);
       }
     }
   }
 
   @Override
-  protected MemoryThresholdInfo getAtomicThresholdInfo() {
-    synchronized (this.memoryThresholdReachedMembers) {
-      return new MemoryThresholdInfo(this.memoryThresholdReached.get(),
-          new HashSet<DistributedMember>(getMemoryThresholdReachedMembers()));
+  public MemoryThresholdInfo getAtomicThresholdInfo() {
+    if (!isMemoryThresholdReached()) {
+      return MemoryThresholdInfo.getNotReached();
+    }
+    synchronized (memoryThresholdReachedMembers) {
+      return new MemoryThresholdInfo(isMemoryThresholdReached(),
+          new HashSet<DistributedMember>(memoryThresholdReachedMembers));
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -1113,8 +1112,7 @@ public class DistributedRegion extends LocalRegion implements InternalDistribute
   /**
    * A reference counter to protected the memoryThresholdReached boolean
    */
-  private final Set<DistributedMember> memoryThresholdReachedMembers =
-      new CopyOnWriteArraySet<>();
+  private final Set<DistributedMember> memoryThresholdReachedMembers = new HashSet<>();
 
   // TODO: cleanup getInitialImageAndRecovery
   private void getInitialImageAndRecovery(InputStream snapshotInputStream,
@@ -3752,32 +3750,25 @@ public class DistributedRegion extends LocalRegion implements InternalDistribute
       if (event.getState().isCritical() && !event.getPreviousState().isCritical()
           && (event.getType() == ResourceType.HEAP_MEMORY
               || (event.getType() == ResourceType.OFFHEAP_MEMORY && getOffHeap()))) {
-        setMemoryThresholdReachedCounterTrue(event.getMember());
+        addCriticalMember(event.getMember());
       } else if (!event.getState().isCritical() && event.getPreviousState().isCritical()
           && (event.getType() == ResourceType.HEAP_MEMORY
               || (event.getType() == ResourceType.OFFHEAP_MEMORY && getOffHeap()))) {
-        removeMemberFromCriticalList(event.getMember());
+        removeCriticalMember(event.getMember());
       }
     }
   }
 
   @Override
-  public void removeMemberFromCriticalList(DistributedMember member) {
+  public void removeCriticalMember(DistributedMember member) {
     if (logger.isDebugEnabled()) {
       logger.debug("DR: removing member {} from critical member list", member);
     }
     synchronized (this.memoryThresholdReachedMembers) {
       this.memoryThresholdReachedMembers.remove(member);
-      if (this.memoryThresholdReachedMembers.size() == 0) {
+      if (this.memoryThresholdReachedMembers.isEmpty()) {
         setMemoryThresholdReached(false);
       }
-    }
-  }
-
-  @Override
-  public Set<DistributedMember> getMemoryThresholdReachedMembers() {
-    synchronized (this.memoryThresholdReachedMembers) {
-      return Collections.unmodifiableSet(this.memoryThresholdReachedMembers);
     }
   }
 
@@ -3787,7 +3778,7 @@ public class DistributedRegion extends LocalRegion implements InternalDistribute
     Set<InternalDistributedMember> others = getCacheDistributionAdvisor().adviseGeneric();
     for (InternalDistributedMember idm : criticalMembers) {
       if (others.contains(idm)) {
-        setMemoryThresholdReachedCounterTrue(idm);
+        addCriticalMember(idm);
       }
     }
   }
@@ -3795,12 +3786,12 @@ public class DistributedRegion extends LocalRegion implements InternalDistribute
   /**
    * @param idm member whose threshold has been exceeded
    */
-  protected void setMemoryThresholdReachedCounterTrue(final DistributedMember idm) {
+  protected void addCriticalMember(final DistributedMember idm) {
     synchronized (this.memoryThresholdReachedMembers) {
-      this.memoryThresholdReachedMembers.add(idm);
-      if (this.memoryThresholdReachedMembers.size() > 0) {
+      if (this.memoryThresholdReachedMembers.isEmpty()) {
         setMemoryThresholdReached(true);
       }
+      this.memoryThresholdReachedMembers.add(idm);
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
@@ -1113,7 +1113,8 @@ public class DistributedRegion extends LocalRegion implements InternalDistribute
   /**
    * A reference counter to protected the memoryThresholdReached boolean
    */
-  private final Set<DistributedMember> memoryThresholdReachedMembers = new CopyOnWriteArraySet<>();
+  private final Set<DistributedMember> memoryThresholdReachedMembers =
+      new CopyOnWriteArraySet<>();
 
   // TODO: cleanup getInitialImageAndRecovery
   private void getInitialImageAndRecovery(InputStream snapshotInputStream,
@@ -3794,12 +3795,20 @@ public class DistributedRegion extends LocalRegion implements InternalDistribute
   /**
    * @param idm member whose threshold has been exceeded
    */
-  private void setMemoryThresholdReachedCounterTrue(final DistributedMember idm) {
+  protected void setMemoryThresholdReachedCounterTrue(final DistributedMember idm) {
     synchronized (this.memoryThresholdReachedMembers) {
       this.memoryThresholdReachedMembers.add(idm);
       if (this.memoryThresholdReachedMembers.size() > 0) {
         memoryThresholdReached.set(true);
       }
+    }
+  }
+
+  @Override
+  protected MemoryThresholdInfo getAtomicThresholdInfo() {
+    synchronized (this.memoryThresholdReachedMembers) {
+      return new MemoryThresholdInfo(this.memoryThresholdReached.get(),
+          new HashSet<DistributedMember>(getMemoryThresholdReachedMembers()));
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalRegion.java
@@ -408,4 +408,6 @@ public interface InternalRegion extends Region, HasCachePerfStats, RegionEntryCo
 
   default void handleWANEvent(EntryEventImpl event) {}
 
+  MemoryThresholdInfo getAtomicThresholdInfo();
+
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
@@ -5756,7 +5756,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
       return MemoryThresholdInfo.getNotReached();
     }
     return new MemoryThresholdInfo(isMemoryThresholdReached(),
-        getMemoryThresholdReachedMembers());
+        Collections.singleton(this.cache.getMyId()));
   }
 
   /**
@@ -10758,13 +10758,6 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
     return resultCollector;
   }
 
-  /**
-   * @return the set of members which are known to be critical
-   */
-  public Set<DistributedMember> getMemoryThresholdReachedMembers() {
-    return Collections.singleton(this.cache.getMyId());
-  }
-
   @Override
   public void onEvent(MemoryEvent event) {
     if (logger.isDebugEnabled()) {
@@ -10847,7 +10840,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
    * This method is meant to be overridden by DistributedRegion and PartitionedRegions to cleanup
    * CRITICAL state
    */
-  public void removeMemberFromCriticalList(DistributedMember member) {
+  public void removeCriticalMember(DistributedMember member) {
     // should not be called for LocalRegion
     Assert.assertTrue(false);
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/MemoryThresholdInfo.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/MemoryThresholdInfo.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache;
+
+import java.util.Set;
+
+import org.apache.geode.distributed.DistributedMember;
+
+class MemoryThresholdInfo {
+  private final boolean memoryThresholdReached;
+  private final Set<DistributedMember> membersThatReachedThreshold;
+
+  MemoryThresholdInfo(boolean memoryThresholdReached,
+      Set<DistributedMember> membersThatReachedThreshold) {
+    this.memoryThresholdReached = memoryThresholdReached;
+    this.membersThatReachedThreshold = membersThatReachedThreshold;
+  }
+
+  Set<DistributedMember> getMembersThatReachedThreshold() {
+    return membersThatReachedThreshold;
+  }
+
+  boolean isMemoryThresholdReached() {
+    return memoryThresholdReached;
+  }
+
+  @Override
+  public String toString() {
+    return "MemoryThresholdInfo{" +
+        "memoryThresholdReached=" + memoryThresholdReached +
+        ", membersThatReachedThreshold=" + membersThatReachedThreshold +
+        '}';
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/MemoryThresholdInfo.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/MemoryThresholdInfo.java
@@ -14,13 +14,16 @@
  */
 package org.apache.geode.internal.cache;
 
+import java.util.Collections;
 import java.util.Set;
 
 import org.apache.geode.distributed.DistributedMember;
 
-class MemoryThresholdInfo {
+public class MemoryThresholdInfo {
   private final boolean memoryThresholdReached;
   private final Set<DistributedMember> membersThatReachedThreshold;
+  private static final MemoryThresholdInfo NOT_REACHED = new MemoryThresholdInfo(false,
+      Collections.EMPTY_SET);
 
   MemoryThresholdInfo(boolean memoryThresholdReached,
       Set<DistributedMember> membersThatReachedThreshold) {
@@ -28,12 +31,16 @@ class MemoryThresholdInfo {
     this.membersThatReachedThreshold = membersThatReachedThreshold;
   }
 
-  Set<DistributedMember> getMembersThatReachedThreshold() {
+  public Set<DistributedMember> getMembersThatReachedThreshold() {
     return membersThatReachedThreshold;
   }
 
-  boolean isMemoryThresholdReached() {
+  public boolean isMemoryThresholdReached() {
     return memoryThresholdReached;
+  }
+
+  static MemoryThresholdInfo getNotReached() {
+    return NOT_REACHED;
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
@@ -9274,7 +9274,7 @@ public class PartitionedRegion extends LocalRegion
   }
 
   @Override
-  public void removeMemberFromCriticalList(DistributedMember member) {
+  public void removeCriticalMember(DistributedMember member) {
     if (logger.isDebugEnabled()) {
       logger.debug("PR: removing member {} from critical member list", member);
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/control/HeapMemoryMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/control/HeapMemoryMonitor.java
@@ -144,7 +144,7 @@ public class HeapMemoryMonitor implements NotificationListener, MemoryMonitor {
   }
 
   private volatile MemoryThresholds thresholds = new MemoryThresholds(tenuredPoolMaxMemory);
-  protected volatile MemoryEvent mostRecentEvent = new MemoryEvent(ResourceType.HEAP_MEMORY,
+  private volatile MemoryEvent mostRecentEvent = new MemoryEvent(ResourceType.HEAP_MEMORY,
       MemoryState.DISABLED, MemoryState.DISABLED, null, 0L, true, this.thresholds);
   private volatile MemoryState currentState = MemoryState.DISABLED;
 
@@ -738,9 +738,9 @@ public class HeapMemoryMonitor implements NotificationListener, MemoryMonitor {
   }
 
   protected Set<DistributedMember> getHeapCriticalMembersFrom(Set<DistributedMember> members) {
-    Set<DistributedMember> result = new HashSet<>(members);
-    result.retainAll(getCriticalMembers());
-    return result;
+    Set<DistributedMember> criticalMembers = getCriticalMembers();
+    criticalMembers.retainAll(members);
+    return criticalMembers;
   }
 
   private Set<DistributedMember> getCriticalMembers() {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/control/HeapMemoryMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/control/HeapMemoryMonitor.java
@@ -18,6 +18,8 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
 import java.lang.management.MemoryPoolMXBean;
 import java.lang.management.MemoryType;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Executors;
@@ -36,9 +38,11 @@ import org.apache.logging.log4j.Logger;
 import org.apache.geode.CancelException;
 import org.apache.geode.SystemFailure;
 import org.apache.geode.cache.CacheClosedException;
+import org.apache.geode.cache.LowMemoryException;
+import org.apache.geode.cache.execute.Function;
+import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
-import org.apache.geode.internal.SetUtils;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.control.InternalResourceManager.ResourceType;
 import org.apache.geode.internal.cache.control.MemoryThresholds.MemoryState;
@@ -140,7 +144,7 @@ public class HeapMemoryMonitor implements NotificationListener, MemoryMonitor {
   }
 
   private volatile MemoryThresholds thresholds = new MemoryThresholds(tenuredPoolMaxMemory);
-  private volatile MemoryEvent mostRecentEvent = new MemoryEvent(ResourceType.HEAP_MEMORY,
+  protected volatile MemoryEvent mostRecentEvent = new MemoryEvent(ResourceType.HEAP_MEMORY,
       MemoryState.DISABLED, MemoryState.DISABLED, null, 0L, true, this.thresholds);
   private volatile MemoryState currentState = MemoryState.DISABLED;
 
@@ -733,19 +737,48 @@ public class HeapMemoryMonitor implements NotificationListener, MemoryMonitor {
     });
   }
 
-  /**
-   * Given a set of members, determine if any member in the set is above critical threshold.
-   *
-   * @param members The set of members to check.
-   * @return True if the set contains a member above critical threshold, false otherwise
-   */
-  public boolean containsHeapCriticalMembers(final Set<InternalDistributedMember> members) {
-    if (members.contains(this.cache.getMyId()) && this.mostRecentEvent.getState().isCritical()) {
-      return true;
+  protected Set<DistributedMember> getHeapCriticalMembersFrom(Set<DistributedMember> members) {
+    Set<DistributedMember> result = new HashSet(members);
+    if (!this.mostRecentEvent.getState().isCritical()) {
+      result.remove(cache.getMyId());
     }
-
-    return SetUtils.intersectsWith(members, this.resourceAdvisor.adviseCritialMembers());
+    result.retainAll(resourceAdvisor.adviseCriticalMembers());
+    return result;
   }
+
+  public void checkForLowMemory(Function function, DistributedMember targetMember) {
+    Set<DistributedMember> targetMembers = Collections.singleton(targetMember);
+    checkForLowMemory(function, targetMembers);
+  }
+
+  public void checkForLowMemory(Function function, Set<DistributedMember> dest) {
+    LowMemoryException exception = createLowMemoryIfNeeded(function, dest);
+    if (exception != null) {
+      throw exception;
+    }
+  }
+
+  public LowMemoryException createLowMemoryIfNeeded(Function function,
+      DistributedMember targetMember) {
+    Set<DistributedMember> targetMembers = Collections.singleton(targetMember);
+    return createLowMemoryIfNeeded(function, targetMembers);
+  }
+
+  public LowMemoryException createLowMemoryIfNeeded(Function function,
+      Set<DistributedMember> memberSet) {
+    if (function.optimizeForWrite()
+        && !MemoryThresholds.isLowMemoryExceptionDisabled()) {
+      Set<DistributedMember> criticalMembersFrom = getHeapCriticalMembersFrom(memberSet);
+      if (!criticalMembersFrom.isEmpty()) {
+        return new LowMemoryException(
+            LocalizedStrings.ResourceManager_LOW_MEMORY_FOR_0_FUNCEXEC_MEMBERS_1
+                .toLocalizedString(function.getId(), criticalMembersFrom),
+            criticalMembersFrom);
+      }
+    }
+    return null;
+  }
+
 
   /**
    * Determines if the given member is in a heap critical state.
@@ -759,6 +792,16 @@ public class HeapMemoryMonitor implements NotificationListener, MemoryMonitor {
       return this.mostRecentEvent.getState().isCritical();
     }
     return this.resourceAdvisor.isHeapCritical(member);
+  }
+
+  protected MemoryEvent getMostRecentEvent() {
+    return mostRecentEvent;
+  }
+
+  protected HeapMemoryMonitor setMostRecentEvent(
+      MemoryEvent mostRecentEvent) {
+    this.mostRecentEvent = mostRecentEvent;
+    return this;
   }
 
   class LocalHeapStatListener implements LocalStatListener {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/control/HeapMemoryMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/control/HeapMemoryMonitor.java
@@ -738,12 +738,17 @@ public class HeapMemoryMonitor implements NotificationListener, MemoryMonitor {
   }
 
   protected Set<DistributedMember> getHeapCriticalMembersFrom(Set<DistributedMember> members) {
-    Set<DistributedMember> result = new HashSet(members);
-    if (!this.mostRecentEvent.getState().isCritical()) {
-      result.remove(cache.getMyId());
-    }
-    result.retainAll(resourceAdvisor.adviseCriticalMembers());
+    Set<DistributedMember> result = new HashSet<>(members);
+    result.retainAll(getCriticalMembers());
     return result;
+  }
+
+  private Set<DistributedMember> getCriticalMembers() {
+    Set<DistributedMember> criticalMembers = new HashSet<>(resourceAdvisor.adviseCriticalMembers());
+    if (this.mostRecentEvent.getState().isCritical()) {
+      criticalMembers.add(cache.getMyId());
+    }
+    return criticalMembers;
   }
 
   public void checkForLowMemory(Function function, DistributedMember targetMember) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/control/ResourceAdvisor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/control/ResourceAdvisor.java
@@ -425,7 +425,7 @@ public class ResourceAdvisor extends DistributionAdvisor {
    *
    * @return a mutable set of members in the critical state otherwise {@link Collections#EMPTY_SET}
    */
-  public Set<InternalDistributedMember> adviseCritialMembers() {
+  public Set<InternalDistributedMember> adviseCriticalMembers() {
     return adviseFilter(new Filter() {
       @Override
       public boolean include(Profile profile) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/PartitionedRegionRebalanceOp.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/PartitionedRegionRebalanceOp.java
@@ -454,7 +454,7 @@ public class PartitionedRegionRebalanceOp {
     int redundantCopies = leaderRegion.getRedundantCopies();
     int totalNumberOfBuckets = leaderRegion.getTotalNumberOfBuckets();
     Set<InternalDistributedMember> criticalMembers =
-        resourceManager.getResourceAdvisor().adviseCritialMembers();;
+        resourceManager.getResourceAdvisor().adviseCriticalMembers();;
     boolean removeOverRedundancy = true;
 
     debug("Building Model for rebalancing " + leaderRegion + ". redundantCopies=" + redundantCopies

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/RegionAdvisor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/RegionAdvisor.java
@@ -1822,7 +1822,7 @@ public class RegionAdvisor extends CacheDistributionAdvisor {
       logger.debug("RA: removing profile {}", profile);
     }
     if (getAdvisee() instanceof PartitionedRegion) {
-      ((PartitionedRegion) getAdvisee()).removeMemberFromCriticalList(profile.peerMemberId);
+      ((PartitionedRegion) getAdvisee()).removeCriticalMember(profile.peerMemberId);
     }
 
     if (this.buckets != null) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/RegionAdvisor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/RegionAdvisor.java
@@ -474,7 +474,7 @@ public class RegionAdvisor extends CacheDistributionAdvisor {
 
     } else {
       ResourceAdvisor advisor = getPartitionedRegion().getCache().getResourceAdvisor();
-      boolean sick = advisor.adviseCritialMembers().contains(member);
+      boolean sick = advisor.adviseCriticalMembers().contains(member);
       if (logger.isDebugEnabled()) {
         logger.debug("updateBucketStatus:({}):member:{}:sick:{}",
             getPartitionedRegion().bucketStringForLogs(bucketId), member, sick);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/ExecuteFunction65.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/ExecuteFunction65.java
@@ -15,22 +15,15 @@
 package org.apache.geode.internal.cache.tier.sockets.command;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.Set;
 
-import org.apache.geode.cache.LowMemoryException;
 import org.apache.geode.cache.execute.Function;
 import org.apache.geode.cache.execute.FunctionContext;
 import org.apache.geode.cache.execute.FunctionException;
 import org.apache.geode.cache.execute.FunctionService;
 import org.apache.geode.cache.execute.ResultSender;
 import org.apache.geode.cache.operations.ExecuteFunctionOperationContext;
-import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.InternalCache;
-import org.apache.geode.internal.cache.control.HeapMemoryMonitor;
-import org.apache.geode.internal.cache.control.InternalResourceManager;
-import org.apache.geode.internal.cache.control.MemoryThresholds;
 import org.apache.geode.internal.cache.execute.AbstractExecution;
 import org.apache.geode.internal.cache.execute.FunctionContextImpl;
 import org.apache.geode.internal.cache.execute.FunctionStats;
@@ -190,16 +183,9 @@ public class ExecuteFunction65 extends BaseCommand {
               context);
         }
 
-        HeapMemoryMonitor hmm =
-            ((InternalResourceManager) cache.getResourceManager()).getHeapMonitor();
-        if (functionObject.optimizeForWrite() && cache != null && hmm.getState().isCritical()
-            && !MemoryThresholds.isLowMemoryExceptionDisabled()) {
-          Set<DistributedMember> sm = Collections.singleton((DistributedMember) cache.getMyId());
-          Exception e = new LowMemoryException(
-              LocalizedStrings.ResourceManager_LOW_MEMORY_FOR_0_FUNCEXEC_MEMBERS_1
-                  .toLocalizedString(new Object[] {functionObject.getId(), sm}),
-              sm);
-
+        Exception e = cache.getInternalResourceManager().getHeapMonitor()
+            .createLowMemoryIfNeeded(functionObject, cache.getMyId());
+        if (e != null) {
           sendException(hasResult, clientMessage, e.getMessage(), serverConnection, e);
           return;
         }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/DistributedRegionJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/DistributedRegionJUnitTest.java
@@ -160,12 +160,13 @@ public class DistributedRegionJUnitTest extends AbstractDistributedRegionJUnitTe
   public void testThatMemoryThresholdInfoRelectsStateOfRegion() {
     InternalDistributedMember internalDM = mock(InternalDistributedMember.class);
     DistributedRegion distRegion = prepare(true, false);
-    distRegion.setMemoryThresholdReachedCounterTrue(internalDM);
+    distRegion.addCriticalMember(internalDM);
 
     MemoryThresholdInfo info = distRegion.getAtomicThresholdInfo();
 
     assertThat(distRegion.isMemoryThresholdReached()).isTrue();
-    assertThat(distRegion.getMemoryThresholdReachedMembers()).containsExactly(internalDM);
+    assertThat(distRegion.getAtomicThresholdInfo().getMembersThatReachedThreshold())
+        .containsExactly(internalDM);
     assertThat(info.isMemoryThresholdReached()).isTrue();
     assertThat(info.getMembersThatReachedThreshold()).containsExactly(internalDM);
   }
@@ -176,10 +177,11 @@ public class DistributedRegionJUnitTest extends AbstractDistributedRegionJUnitTe
     DistributedRegion distRegion = prepare(true, false);
 
     MemoryThresholdInfo info = distRegion.getAtomicThresholdInfo();
-    distRegion.setMemoryThresholdReachedCounterTrue(internalDM);
+    distRegion.addCriticalMember(internalDM);
 
     assertThat(distRegion.isMemoryThresholdReached()).isTrue();
-    assertThat(distRegion.getMemoryThresholdReachedMembers()).containsExactly(internalDM);
+    assertThat(distRegion.getAtomicThresholdInfo().getMembersThatReachedThreshold())
+        .containsExactly(internalDM);
     assertThat(info.isMemoryThresholdReached()).isFalse();
     assertThat(info.getMembersThatReachedThreshold()).isEmpty();
   }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/DistributedRegionJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/DistributedRegionJUnitTest.java
@@ -157,20 +157,28 @@ public class DistributedRegionJUnitTest extends AbstractDistributedRegionJUnitTe
   }
 
   @Test
-  public void testThatMemoryThresholdInfoDoesNotChangeWhenDistributedRegionChanges() {
+  public void testThatMemoryThresholdInfoRelectsStateOfRegion() {
+    InternalDistributedMember internalDM = mock(InternalDistributedMember.class);
+    DistributedRegion distRegion = prepare(true, false);
+    distRegion.setMemoryThresholdReachedCounterTrue(internalDM);
+
+    MemoryThresholdInfo info = distRegion.getAtomicThresholdInfo();
+
+    assertThat(distRegion.isMemoryThresholdReached()).isTrue();
+    assertThat(distRegion.getMemoryThresholdReachedMembers()).containsExactly(internalDM);
+    assertThat(info.isMemoryThresholdReached()).isTrue();
+    assertThat(info.getMembersThatReachedThreshold()).containsExactly(internalDM);
+  }
+
+  @Test
+  public void testThatMemoryThresholdInfoDoesNotChangeWhenRegionChanges() {
     InternalDistributedMember internalDM = mock(InternalDistributedMember.class);
     DistributedRegion distRegion = prepare(true, false);
 
     MemoryThresholdInfo info = distRegion.getAtomicThresholdInfo();
-
-    assertThat(distRegion.memoryThresholdReached.get()).isFalse();
-    assertThat(distRegion.getMemoryThresholdReachedMembers()).isEmpty();
-    assertThat(info.isMemoryThresholdReached()).isFalse();
-    assertThat(info.getMembersThatReachedThreshold()).isEmpty();
-
     distRegion.setMemoryThresholdReachedCounterTrue(internalDM);
 
-    assertThat(distRegion.memoryThresholdReached.get()).isTrue();
+    assertThat(distRegion.isMemoryThresholdReached()).isTrue();
     assertThat(distRegion.getMemoryThresholdReachedMembers()).containsExactly(internalDM);
     assertThat(info.isMemoryThresholdReached()).isFalse();
     assertThat(info.getMembersThatReachedThreshold()).isEmpty();

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/DistributedRegionJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/DistributedRegionJUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
@@ -33,6 +34,7 @@ import org.junit.Test;
 import org.apache.geode.cache.Operation;
 import org.apache.geode.cache.RegionAttributes;
 import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.event.BulkOperationHolder;
 import org.apache.geode.internal.cache.event.EventTracker;
 import org.apache.geode.internal.cache.ha.ThreadIdentifier;
@@ -152,6 +154,26 @@ public class DistributedRegionJUnitTest extends AbstractDistributedRegionJUnitTe
       events[i].setVersionTag(mock(VersionTag.class));
       eventTracker.recordEvent(events[i]);
     }
+  }
+
+  @Test
+  public void testThatMemoryThresholdInfoDoesNotChangeWhenDistributedRegionChanges() {
+    InternalDistributedMember internalDM = mock(InternalDistributedMember.class);
+    DistributedRegion distRegion = prepare(true, false);
+
+    MemoryThresholdInfo info = distRegion.getAtomicThresholdInfo();
+
+    assertThat(distRegion.memoryThresholdReached.get()).isFalse();
+    assertThat(distRegion.getMemoryThresholdReachedMembers()).isEmpty();
+    assertThat(info.isMemoryThresholdReached()).isFalse();
+    assertThat(info.getMembersThatReachedThreshold()).isEmpty();
+
+    distRegion.setMemoryThresholdReachedCounterTrue(internalDM);
+
+    assertThat(distRegion.memoryThresholdReached.get()).isTrue();
+    assertThat(distRegion.getMemoryThresholdReachedMembers()).containsExactly(internalDM);
+    assertThat(info.isMemoryThresholdReached()).isFalse();
+    assertThat(info.getMembersThatReachedThreshold()).isEmpty();
   }
 
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/MemoryThresholdInfoTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/MemoryThresholdInfoTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class MemoryThresholdInfoTest {
+
+  @Test
+  public void getNotReachedReturnsIdenticalResults() {
+    MemoryThresholdInfo info1 = MemoryThresholdInfo.getNotReached();
+    MemoryThresholdInfo info2 = MemoryThresholdInfo.getNotReached();
+
+    assertThat(info1).isSameAs(info2);
+    assertThat(info1.getMembersThatReachedThreshold())
+        .isSameAs(info2.getMembersThatReachedThreshold());
+  }
+
+  @Test
+  public void getNotReachedReturnsEmptyMembersReached() {
+    MemoryThresholdInfo info1 = MemoryThresholdInfo.getNotReached();
+
+    assertThat(info1.getMembersThatReachedThreshold()).isEmpty();
+  }
+
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/control/HeapMemoryMonitorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/control/HeapMemoryMonitorTest.java
@@ -66,9 +66,9 @@ public class HeapMemoryMonitorTest {
     heapMonitor = new HeapMemoryMonitor(null, internalCache, null);
     memberSet = new HashSet<>();
     memberSet.add(member);
-    heapMonitor.mostRecentEvent = new MemoryEvent(InternalResourceManager.ResourceType.HEAP_MEMORY,
+    heapMonitor.setMostRecentEvent(new MemoryEvent(InternalResourceManager.ResourceType.HEAP_MEMORY,
         MemoryThresholds.MemoryState.DISABLED, MemoryThresholds.MemoryState.DISABLED, null, 0L,
-        true, null); // myself is not critical
+        true, null)); // myself is not critical
   }
 
   // ========== tests for getHeapCriticalMembersFrom ==========
@@ -136,9 +136,9 @@ public class HeapMemoryMonitorTest {
   @Test
   public void getHeapCriticalMembersFrom_IncludesMyselfWhenCritical() throws Exception {
     Set advisorSet = new HashSet(memberSet);
-    heapMonitor.mostRecentEvent = new MemoryEvent(InternalResourceManager.ResourceType.HEAP_MEMORY,
+    heapMonitor.setMostRecentEvent(new MemoryEvent(InternalResourceManager.ResourceType.HEAP_MEMORY,
         MemoryThresholds.MemoryState.DISABLED, MemoryThresholds.MemoryState.CRITICAL, null, 0L,
-        true, null);
+        true, null));
     memberSet.add(myself);
 
     getHeapCriticalMembersFrom_returnsNonEmptySet(advisorSet,

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/control/HeapMemoryMonitorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/control/HeapMemoryMonitorTest.java
@@ -1,0 +1,318 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.control;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import org.apache.geode.cache.LowMemoryException;
+import org.apache.geode.cache.execute.Function;
+import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.distributed.DistributedSystem;
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
+import org.apache.geode.internal.cache.InternalCache;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({MemoryThresholds.class})
+public class HeapMemoryMonitorTest {
+
+  private HeapMemoryMonitor heapMonitor;
+  private Function function;
+  private Set memberSet;
+  private DistributedMember member;
+  private InternalDistributedMember myself;
+  private ResourceAdvisor resourceAdvisor;
+  private static final String LOW_MEMORY_REGEX =
+      "Function: null cannot be executed because the members.*are running low on memory";
+
+  @Before
+  public void setup() {
+    InternalCache internalCache = mock(InternalCache.class);
+    DistributedSystem distributedSystem = mock(DistributedSystem.class);
+    function = mock(Function.class);
+    member = mock(InternalDistributedMember.class);
+    myself = mock(InternalDistributedMember.class);
+    resourceAdvisor = mock(ResourceAdvisor.class);
+
+    when(internalCache.getDistributedSystem()).thenReturn(distributedSystem);
+    when(internalCache.getDistributionAdvisor()).thenReturn(resourceAdvisor);
+    when(internalCache.getMyId()).thenReturn(myself);
+
+    heapMonitor = new HeapMemoryMonitor(null, internalCache, null);
+    memberSet = new HashSet<>();
+    memberSet.add(member);
+  }
+
+  // ========== tests for getHeapCriticalMembersFrom ==========
+  @Test
+  public void getHeapCriticalMembersFrom_WithEmptyCriticalMembersReturnsEmptySet() {
+    getHeapCriticalMembersFrom_returnsEmptySet(Collections.emptySet(), memberSet);
+  }
+
+  @Test
+  public void getHeapCriticalMembersFrom_WithEmptyArgReturnsEmptySet() {
+    getHeapCriticalMembersFrom_returnsEmptySet(memberSet, Collections.emptySet());
+  }
+
+  @Test
+  public void getHeapCriticalMembersFromWithEmptySetsReturnsEmptySet() {
+    getHeapCriticalMembersFrom_returnsEmptySet(Collections.emptySet(), Collections.emptySet());
+  }
+
+  @Test
+  public void getHeapCriticalMembersFrom_WithDisjointSetsReturnsEmptySet() {
+    Set argSet = new HashSet();
+    argSet.add(mock(InternalDistributedMember.class));
+
+    getHeapCriticalMembersFrom_returnsEmptySet(memberSet, argSet);
+  }
+
+  @Test
+  public void getHeapCriticalMembersFrom_WithEqualSetsReturnsMember() {
+    getHeapCriticalMembersFrom_returnsNonEmptySet(memberSet, Collections.unmodifiableSet(memberSet),
+        new HashSet(memberSet));
+  }
+
+  @Test
+  public void getHeapCriticalMembersFrom_ReturnsMultipleMembers() {
+    DistributedMember member1 = mock(InternalDistributedMember.class);
+    DistributedMember member2 = mock(InternalDistributedMember.class);
+    DistributedMember member3 = mock(InternalDistributedMember.class);
+    DistributedMember member4 = mock(InternalDistributedMember.class);
+    Set advisorSet = new HashSet();
+    advisorSet.add(member1);
+    advisorSet.add(member2);
+    advisorSet.add(member4);
+    Set argSet = new HashSet(memberSet);
+    argSet.add(member1);
+    argSet.add(member3);
+    argSet.add(member4);
+    Set expectedResult = new HashSet();
+    expectedResult.add(member1);
+    expectedResult.add(member4);
+
+    getHeapCriticalMembersFrom_returnsNonEmptySet(advisorSet, argSet, expectedResult);
+  }
+
+  @Test
+  public void getHeapCriticalMembersFrom_DoesNotReturnMyselfWhenNotCritical() {
+    Set expectedResult = new HashSet(memberSet);
+    memberSet.add(myself);
+
+    getHeapCriticalMembersFrom_returnsNonEmptySet(memberSet, Collections.unmodifiableSet(memberSet),
+        expectedResult);
+  }
+
+  @Test
+  public void getHeapCriticalMembersFrom_IncludesMyselfWhenCritical() throws Exception {
+    heapMonitor.mostRecentEvent = new MemoryEvent(InternalResourceManager.ResourceType.HEAP_MEMORY,
+        MemoryThresholds.MemoryState.DISABLED, MemoryThresholds.MemoryState.CRITICAL, null, 0L,
+        true, null);
+    memberSet.add(myself);
+
+    getHeapCriticalMembersFrom_returnsNonEmptySet(memberSet, Collections.unmodifiableSet(memberSet),
+        new HashSet(memberSet));
+  }
+
+  // ========== tests for createLowMemoryIfNeeded (with Set argument) ==========
+  @Test
+  public void createLowMemoryIfNeededWithSetArg_ReturnsNullWhenNotOptimizedForWrite()
+      throws Exception {
+    createLowMemoryIfNeededWithSetArg_returnsNull(false, false, memberSet);
+  }
+
+  @Test
+  public void createLowMemoryIfNeededWithSetArg_ReturnsNullWhenLowMemoryExceptionDisabled()
+      throws Exception {
+    createLowMemoryIfNeededWithSetArg_returnsNull(true, true, memberSet);
+  }
+
+  @Test
+  public void createLowMemoryIfNeededWithSetArg_ReturnsNullWhenNoCriticalMembers()
+      throws Exception {
+    createLowMemoryIfNeededWithSetArg_returnsNull(true, false, Collections.emptySet());
+  }
+
+  @Test
+  public void createLowMemoryIfNeededWithSetArg_ReturnsException() throws Exception {
+    setMocking(true, false, memberSet);
+
+    LowMemoryException exception = heapMonitor.createLowMemoryIfNeeded(function, memberSet);
+
+    assertLowMemoryException(exception);
+  }
+
+  // ========== tests for createLowMemoryIfNeeded (with DistributedMember argument) ==========
+  @Test
+  public void createLowMemoryIfNeededWithMemberArg_ReturnsNullWhenNotOptimizedForWrite()
+      throws Exception {
+    createLowMemoryIfNeededWithMemberArg_returnsNull(false, false, member);
+  }
+
+  @Test
+  public void createLowMemoryIfNeededWithMemberArg_ReturnsNullWhenLowMemoryExceptionDisabled()
+      throws Exception {
+    createLowMemoryIfNeededWithMemberArg_returnsNull(true, true, member);
+  }
+
+  @Test
+  public void createLowMemoryIfNeededWithMemberArg_ReturnsNullWhenNoCriticalMembers()
+      throws Exception {
+    createLowMemoryIfNeededWithMemberArg_returnsNull(true, false, member);
+  }
+
+  @Test
+  public void createLowMemoryIfNeededWithMemberArg_ReturnsException() throws Exception {
+    setMocking(true, false, memberSet);
+
+    LowMemoryException exception = heapMonitor.createLowMemoryIfNeeded(function, member);
+
+    assertLowMemoryException(exception);
+  }
+
+  // ========== tests for checkForLowMemory (with Set argument) ==========
+  @Test
+  public void checkForLowMemoryWithSetArg_DoesNotThrowWhenNotOptimizedForWrite() throws Exception {
+    checkForLowMemoryWithSetArg_doesNotThrow(false, false, memberSet);
+  }
+
+  @Test
+  public void checkForLowMemoryWithSetArg_DoesNotThrowWhenLowMemoryExceptionDisabled()
+      throws Exception {
+    checkForLowMemoryWithSetArg_doesNotThrow(true, true, memberSet);
+  }
+
+  @Test
+  public void checkForLowMemoryWithSetArg_DoesNotThrowWhenNoCriticalMembers() throws Exception {
+    checkForLowMemoryWithSetArg_doesNotThrow(true, false, Collections.emptySet());
+  }
+
+  @Test
+  public void checkForLowMemoryWithSetArg_ThrowsLowMemoryException() throws Exception {
+    setMocking(true, false, memberSet);
+
+    assertThatThrownBy(() -> heapMonitor.checkForLowMemory(function, memberSet))
+        .isExactlyInstanceOf(LowMemoryException.class);
+  }
+
+  // ========== tests for checkForLowMemory (with DistributedMember argument) ==========
+  @Test
+  public void checkForLowMemoryIfNeededWithMemberArg_ReturnsNullWhenNotOptimizedForWrite()
+      throws Exception {
+    checkForLowMemoryWithMemberArg_doesNotThrow(false, false, member);
+  }
+
+  @Test
+  public void checkForLowMemoryIfNeededWithMemberArg_ReturnsNullWhenLowMemoryExceptionDisabled()
+      throws Exception {
+    checkForLowMemoryWithMemberArg_doesNotThrow(true, true, member);
+  }
+
+  @Test
+  public void checkForLowMemoryIfNeededWithMemberArg_ReturnsNullWhenNoCriticalMembers()
+      throws Exception {
+    checkForLowMemoryWithMemberArg_doesNotThrow(true, false, member);
+  }
+
+  @Test
+  public void checkForLowMemoryWithMemberArg_ReturnsException() throws Exception {
+    setMocking(true, false, memberSet);
+
+    assertThatThrownBy(() -> heapMonitor.checkForLowMemory(function, member))
+        .isExactlyInstanceOf(LowMemoryException.class).hasMessageMatching(LOW_MEMORY_REGEX);
+  }
+
+  // ========== private methods ==========
+  private void getHeapCriticalMembersFrom_returnsEmptySet(Set adviseCriticalMembers, Set argSet) {
+    when(resourceAdvisor.adviseCriticalMembers()).thenReturn(adviseCriticalMembers);
+
+    Set<DistributedMember> criticalMembers = heapMonitor.getHeapCriticalMembersFrom(argSet);
+
+    assertThat(criticalMembers).isEmpty();
+  }
+
+  private void getHeapCriticalMembersFrom_returnsNonEmptySet(Set adviseCriticalMembers, Set argSet,
+      Set expectedResult) {
+    when(resourceAdvisor.adviseCriticalMembers()).thenReturn(adviseCriticalMembers);
+
+    Set<DistributedMember> criticalMembers = heapMonitor.getHeapCriticalMembersFrom(argSet);
+
+    assertThat(criticalMembers).containsExactlyElementsOf(expectedResult);
+  }
+
+  private void createLowMemoryIfNeededWithSetArg_returnsNull(boolean optimizeForWrite,
+      boolean isLowMemoryExceptionDisabled, Set memberSetArg) throws Exception {
+    setMocking(optimizeForWrite, isLowMemoryExceptionDisabled, memberSetArg);
+
+    LowMemoryException exception = heapMonitor.createLowMemoryIfNeeded(function, memberSetArg);
+
+    assertThat(exception).isNull();
+  }
+
+  private void createLowMemoryIfNeededWithMemberArg_returnsNull(boolean optimizeForWrite,
+      boolean isLowMemoryExceptionDisabled, DistributedMember memberArg) throws Exception {
+    setMocking(optimizeForWrite, isLowMemoryExceptionDisabled, Collections.emptySet());
+
+    LowMemoryException exception = heapMonitor.createLowMemoryIfNeeded(function, memberArg);
+
+    assertThat(exception).isNull();
+  }
+
+  private void checkForLowMemoryWithSetArg_doesNotThrow(boolean optimizeForWrite,
+      boolean isLowMemoryExceptionDisabled, Set memberSetArg) throws Exception {
+    setMocking(optimizeForWrite, isLowMemoryExceptionDisabled, memberSetArg);
+
+    heapMonitor.checkForLowMemory(function, memberSetArg);
+  }
+
+  private void checkForLowMemoryWithMemberArg_doesNotThrow(boolean optimizeForWrite,
+      boolean isLowMemoryExceptionDisabled, DistributedMember memberArg) throws Exception {
+    setMocking(optimizeForWrite, isLowMemoryExceptionDisabled, Collections.emptySet());
+
+    heapMonitor.checkForLowMemory(function, memberArg);
+  }
+
+  private void setMocking(boolean optimizeForWrite, boolean isLowMemoryExceptionDisabled,
+      Set argSet) throws Exception {
+    when(function.optimizeForWrite()).thenReturn(optimizeForWrite);
+    setIsLowMemoryExceptionDisabled(isLowMemoryExceptionDisabled);
+    when(resourceAdvisor.adviseCriticalMembers()).thenReturn(argSet);
+  }
+
+  private void assertLowMemoryException(LowMemoryException exception) {
+    assertThat(exception).isExactlyInstanceOf(LowMemoryException.class);
+    assertThat(exception.getMessage()).containsPattern(LOW_MEMORY_REGEX);
+  }
+
+  private void setIsLowMemoryExceptionDisabled(boolean isLowMemoryExceptionDisabled)
+      throws Exception {
+    PowerMockito.mockStatic(MemoryThresholds.class);
+    PowerMockito.when(MemoryThresholds.class, MemoryThresholds.isLowMemoryExceptionDisabled())
+        .thenReturn(isLowMemoryExceptionDisabled);
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/ExecuteFunction66Test.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/ExecuteFunction66Test.java
@@ -45,6 +45,7 @@ import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.control.HeapMemoryMonitor;
 import org.apache.geode.internal.cache.control.InternalResourceManager;
 import org.apache.geode.internal.cache.tier.CachedRegionHelper;
 import org.apache.geode.internal.cache.tier.ServerSideHandshake;
@@ -124,6 +125,7 @@ public class ExecuteFunction66Test {
     when(this.cache.getCancelCriterion()).thenReturn(mock(CancelCriterion.class));
     when(this.cache.getDistributedSystem()).thenReturn(mock(InternalDistributedSystem.class));
     when(this.cache.getResourceManager()).thenReturn(this.internalResourceManager);
+    when(this.cache.getInternalResourceManager()).thenReturn(this.internalResourceManager);
 
     when(this.callbackArgPart.getObject()).thenReturn(CALLBACK_ARG);
 
@@ -148,6 +150,8 @@ public class ExecuteFunction66Test {
     when(this.serverConnection.getReplyMessage()).thenReturn(this.replyMessage);
     when(this.serverConnection.getAcceptor()).thenReturn(this.acceptor);
     when(this.serverConnection.getHandshake()).thenReturn(mock(ServerSideHandshake.class));
+
+    when(this.internalResourceManager.getHeapMonitor()).thenReturn(mock(HeapMemoryMonitor.class));
 
     PowerMockito.mockStatic(FunctionService.class);
     PowerMockito.when(FunctionService.getFunction(eq(FUNCTION))).thenReturn(this.functionObject);


### PR DESCRIPTION
There is an AtomicBoolean (memoryThresholdReached) in LocalRegion.
In DistributedRegion, a subclass of LocalRegion, there is a CopyOnWriteArraySet (memoryThresholdReachedMembers).

In DistributedRegion, these two fields are set together by synchronizing on memoryThresholdReachedMembers.
If the boolean is true (meaning we crossed the critical threshold), the set must contain the members
that are low on memory.

In LocalRegion, these two fields were being read without synchronization, so the boolean and set could be
inconsistent with each other. The boolean could be read as true, but the set could be read as empty.
This can occur when the reading thread reads the boolean, then another thread calls a method that sets
both fields, then the reading thread reads the set.

This fix adds a new method to DistributedRegion (getAtomicThresholdInfo) that reads the two fields with synchronization.          

