### PR TITLE
GEODE-5505 Cache listener not invoked on a retried destroy() operation

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/map/RegionMapDestroy.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/map/RegionMapDestroy.java
@@ -462,6 +462,11 @@ public class RegionMapDestroy {
         focusedRegionMap.processVersionTag(newRegionEntry, event);
         if (doPart3) {
           internalRegion.generateAndSetVersionTag(event, newRegionEntry);
+          if (!event.getVersionTag().isGatewayTag()) {
+            // invoke listeners and inform clients
+            internalRegion.basicDestroyPart2(regionEntry, event, inTokenMode,
+                false, duringRI, true);
+          }
         }
         try {
           internalRegion.recordEvent(event);
@@ -551,9 +556,6 @@ public class RegionMapDestroy {
         if (regionEntry == null) {
           regionEntry = newRegionEntry;
         }
-        // invoke listeners and inform clients
-        internalRegion.basicDestroyPart2(regionEntry, event, inTokenMode,
-            false, duringRI, true);
         doPart3 = true;
       }
     }


### PR DESCRIPTION
Moving listener notification to after processVersionTag and
generateVersionTag.  The previous fix for this bug could potentially
invoke listeners on a new Tombstone entry prior to a version being
generated.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
