### PR TITLE
GEODE-5475: rule improvement

### DIFF
--- a/geode-dunit/src/main/java/org/apache/geode/test/junit/rules/ServerStarterRule.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/junit/rules/ServerStarterRule.java
@@ -171,20 +171,33 @@ public class ServerStarterRule extends MemberStarterRule<ServerStarterRule> impl
     return this;
   }
 
+  /**
+   * convenience method to create a region with customized regionFactory
+   *
+   * @param regionFactoryConsumer a lamda that allows you to customize the regionFactory
+   */
   public Region createRegion(RegionShortcut type, String name,
       Consumer<RegionFactory> regionFactoryConsumer) {
-    RegionFactory factory = getCache().createRegionFactory(type);
-    regionFactoryConsumer.accept(factory);
-    return factory.create(name);
+    RegionFactory regionFactory = getCache().createRegionFactory(type);
+    regionFactoryConsumer.accept(regionFactory);
+    return regionFactory.create(name);
   }
 
-  public Region createPRRegion(String name, Consumer<RegionFactory> regionFactoryConsumer,
-      Consumer<PartitionAttributesFactory> prAttributesFactory) {
+  /**
+   * convenience method to create a partition region with customized regionFactory and a customized
+   * PartitionAttributeFactory
+   *
+   * @param regionFactoryConsumer a lamda that allows you to customize the regionFactory
+   * @param attributesFactoryConsumer a lamda that allows you to customize the
+   *        partitionAttributeFactory
+   */
+  public Region createPartitionRegion(String name, Consumer<RegionFactory> regionFactoryConsumer,
+      Consumer<PartitionAttributesFactory> attributesFactoryConsumer) {
     return createRegion(RegionShortcut.PARTITION, name, rf -> {
       regionFactoryConsumer.accept(rf);
-      PartitionAttributesFactory factory = new PartitionAttributesFactory();
-      prAttributesFactory.accept(factory);
-      rf.setPartitionAttributes(factory.create());
+      PartitionAttributesFactory attributeFactory = new PartitionAttributesFactory();
+      attributesFactoryConsumer.accept(attributeFactory);
+      rf.setPartitionAttributes(attributeFactory.create());
     });
   }
 


### PR DESCRIPTION
1. add a method to get a default dunit locator port in case servers want to join with that locator instead.
2. ServerStartupRule can start with cache only (no cache server started if needed)
3. create convenience methods to create regions with different region attributes setup.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
