### PR TITLE
feature/GEODE-5505 Cache listener not invoked on a retried destroy() operation

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/cache30/PRBucketSynchronizationDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache30/PRBucketSynchronizationDUnitTest.java
@@ -20,6 +20,7 @@ import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
 
+import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Test;
 
@@ -45,8 +46,6 @@ import org.apache.geode.test.dunit.DistributedTestUtils;
 import org.apache.geode.test.dunit.Host;
 import org.apache.geode.test.dunit.IgnoredException;
 import org.apache.geode.test.dunit.VM;
-import org.apache.geode.test.dunit.Wait;
-import org.apache.geode.test.dunit.WaitCriterion;
 import org.apache.geode.test.dunit.cache.CacheTestCase;
 
 /**
@@ -211,44 +210,22 @@ public class PRBucketSynchronizationDUnitTest extends CacheTestCase {
       PartitionedRegion pr = (PartitionedRegion) testRegion;
       final BucketRegion bucket = pr.getDataStore().getLocalBucketById(0);
 
-      Wait.waitForCriterion(new WaitCriterion() {
-        String waitingFor = "primary is still in membership view: " + crashedMember;
-        boolean dumped = false;
-
-        @Override
-        public boolean done() {
-          if (testRegion.getCache().getDistributionManager().isCurrentMember(crashedMember)) {
-            return false;
-          }
-          if (!testRegion.containsKey("Object3")) {
-            waitingFor = "entry for Object3 not found";
-            return false;
-          }
-          RegionEntry re = bucket.getRegionMap().getEntry("Object5");
-          if (re == null) {
-            if (!dumped) {
-              dumped = true;
-              bucket.dumpBackingMap();
-            }
-            waitingFor = "entry for Object5 not found";
-            return false;
-          }
-          if (!re.isTombstone()) {
-            if (!dumped) {
-              dumped = true;
-              bucket.dumpBackingMap();
-            }
-            waitingFor = "Object5 is not a tombstone but should be: " + re;
-            return false;
-          }
-          return true;
+      Awaitility.await().until(() -> {
+        if (testRegion.getCache().getDistributionManager().isCurrentMember(crashedMember)) {
+          return false;
         }
-
-        @Override
-        public String description() {
-          return waitingFor;
+        if (!testRegion.containsKey("Object3")) {
+          return false;
         }
-      }, 30000, 5000, true);
+        RegionEntry re = bucket.getRegionMap().getEntry("Object5");
+        if (re == null) {
+          return false;
+        }
+        if (!re.isTombstone()) {
+          return false;
+        }
+        return true;
+      });
     });
   }
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache30/RRSynchronizationDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache30/RRSynchronizationDUnitTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.Properties;
 
+import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Test;
 
@@ -42,8 +43,6 @@ import org.apache.geode.test.dunit.DistributedTestUtils;
 import org.apache.geode.test.dunit.Host;
 import org.apache.geode.test.dunit.IgnoredException;
 import org.apache.geode.test.dunit.VM;
-import org.apache.geode.test.dunit.Wait;
-import org.apache.geode.test.dunit.WaitCriterion;
 import org.apache.geode.test.dunit.cache.CacheTestCase;
 
 /**
@@ -171,45 +170,23 @@ public class RRSynchronizationDUnitTest extends CacheTestCase {
   private void verifySynchronized(VM vm, final InternalDistributedMember crashedMember) {
     vm.invoke("check that synchronization happened", () -> {
       final DistributedRegion dr = (DistributedRegion) testRegion;
+      Awaitility.await().until(() -> {
 
-      Wait.waitForCriterion(new WaitCriterion() {
-        String waitingFor = "crashed member is still in membership view: " + crashedMember;
-        boolean dumped = false;
-
-        @Override
-        public boolean done() {
-          if (testRegion.getCache().getDistributionManager().isCurrentMember(crashedMember)) {
-            return false;
-          }
-          if (!testRegion.containsKey("Object3")) {
-            waitingFor = "entry for Object3 not found";
-            return false;
-          }
-          RegionEntry re = dr.getRegionMap().getEntry("Object5");
-          if (re == null) {
-            if (!dumped) {
-              dumped = true;
-              dr.dumpBackingMap();
-            }
-            waitingFor = "entry for Object5 not found";
-            return false;
-          }
-          if (!re.isTombstone()) {
-            if (!dumped) {
-              dumped = true;
-              dr.dumpBackingMap();
-            }
-            waitingFor = "Object5 is not a tombstone but should be: " + re;
-            return false;
-          }
-          return true;
+        if (testRegion.getCache().getDistributionManager().isCurrentMember(crashedMember)) {
+          return false;
         }
-
-        @Override
-        public String description() {
-          return waitingFor;
+        if (!testRegion.containsKey("Object3")) {
+          return false;
         }
-      }, 30000, 5000, true);
+        RegionEntry re = dr.getRegionMap().getEntry("Object5");
+        if (re == null) {
+          return false;
+        }
+        if (!re.isTombstone()) {
+          return false;
+        }
+        return true;
+      });
     });
   }
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionAdvisor.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionAdvisor.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -39,6 +40,7 @@ import org.apache.geode.distributed.internal.membership.InternalDistributedMembe
 import org.apache.geode.internal.Assert;
 import org.apache.geode.internal.DataSerializableFixedID;
 import org.apache.geode.internal.InternalDataSerializer;
+import org.apache.geode.internal.SystemTimer;
 import org.apache.geode.internal.Version;
 import org.apache.geode.internal.cache.CacheDistributionAdvisor.CacheProfile;
 import org.apache.geode.internal.cache.DistributedRegion;
@@ -256,11 +258,23 @@ public class DistributionAdvisor {
 
     final boolean isDebugEnabled = logger.isDebugEnabled();
     if (isDebugEnabled) {
-      logger.debug("da.syncForCrashedMember will sync region in waiting thread pool: {}", dr);
+      logger.debug("da.syncForCrashedMember will sync region in cache's timer for region: {}", dr);
     }
-    dr.getDistributionManager().getWaitingThreadPool().execute(new Runnable() {
-      // bug #49601 - don't synchronize until GII has been performed
-      public void run() {
+    // schedule the synchronization for execution in the future based on the client health monitor
+    // interval. This allows client caches to retry an operation that might otherwise be recovered
+    // through the sync operation. Without associated event information this could cause the
+    // retried operation to be mishandled. See GEODE-5505
+    long delay;
+    try {
+      delay = dr.getGemFireCache().getCacheServers().stream().max(
+          (o1, o2) -> o1.getMaximumTimeBetweenPings() - o2.getMaximumTimeBetweenPings()).get()
+          .getMaximumTimeBetweenPings();
+    } catch (NoSuchElementException e) {
+      delay = 0;
+    }
+    dr.getGemFireCache().getCCPTimer().schedule(new SystemTimer.SystemTimerTask() {
+      @Override
+      public void run2() {
         while (!dr.isInitialized()) {
           if (dr.isDestroyed()) {
             return;
@@ -300,7 +314,7 @@ public class DistributionAdvisor {
         }
         dr.synchronizeForLostMember(id, lostVersionID);
       }
-    });
+    }, delay);
   }
 
   /** find the region for a delta-gii operation (synch) */

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
@@ -381,8 +381,8 @@ public class DistributedRegion extends LocalRegion implements InternalDistribute
         // if the listeners have already seen this event, then it has already
         // been successfully applied to the cache. Distributed messages and
         // return
-        if (logger.isDebugEnabled()) {
-          logger.debug("DR.virtualPut: this cache has already seen this event {}", event);
+        if (isTraceEnabled) {
+          logger.trace("DR.virtualPut: this cache has already seen this event {}", event);
         }
 
         // Fix 39014: when hasSeenEvent, put will still distribute

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/map/RegionMapDestroy.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/map/RegionMapDestroy.java
@@ -551,9 +551,6 @@ public class RegionMapDestroy {
         if (regionEntry == null) {
           regionEntry = newRegionEntry;
         }
-        // invoke listeners and inform clients
-        internalRegion.basicDestroyPart2(regionEntry, event, inTokenMode,
-            false, duringRI, true);
         doPart3 = true;
       }
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Put61.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Put61.java
@@ -235,7 +235,7 @@ public class Put61 extends BaseCommand {
     } catch (InvalidDeltaException ide) {
       logger.info(LocalizedMessage.create(
           LocalizedStrings.UpdateOperation_ERROR_APPLYING_DELTA_FOR_KEY_0_OF_REGION_1,
-          new Object[] {key, regionName, ide.getMessage()}));
+          new Object[] {key, regionName}));
       writeException(clientMessage, MessageType.PUT_DELTA_ERROR, ide, false, serverConnection);
       serverConnection.setAsTrue(RESPONDED);
       region.getCachePerfStats().incDeltaFullValuesRequested();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Put65.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Put65.java
@@ -420,7 +420,7 @@ public class Put65 extends BaseCommand {
     } catch (InvalidDeltaException ide) {
       logger.info(LocalizedMessage.create(
           LocalizedStrings.UpdateOperation_ERROR_APPLYING_DELTA_FOR_KEY_0_OF_REGION_1,
-          new Object[] {key, regionName, ide.getMessage()}));
+          new Object[] {key, regionName}));
       writeException(clientMessage, MessageType.PUT_DELTA_ERROR, ide, false, serverConnection);
       serverConnection.setAsTrue(RESPONDED);
       region.getCachePerfStats().incDeltaFullValuesRequested();

--- a/geode-core/src/main/java/org/apache/geode/internal/i18n/LocalizedStrings.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/i18n/LocalizedStrings.java
@@ -6236,7 +6236,7 @@ public class LocalizedStrings {
   public static final StringId RegionAttributesCreation__CLONING_ENABLE_IS_NOT_THE_SAME_THIS_0_OTHER_1 =
       new StringId(4741, "Cloning enabled is not the same: this:  {0}  other:  {1}");
   public static final StringId UpdateOperation_ERROR_APPLYING_DELTA_FOR_KEY_0_OF_REGION_1 =
-      new StringId(4742, "Error applying delta for key {0} of region {1}: {2}");
+      new StringId(4742, "Error applying delta for key {0} of region {1}");
   public static final StringId RequestEventValue_0_THE_EVENT_ID_FOR_THE_GET_EVENT_VALUE_REQUEST_IS_NULL =
       new StringId(4744, "{0}: The event id for the get event value request is null.");
   public static final StringId RequestEventValue_UNABLE_TO_FIND_A_CLIENT_UPDATE_MESSAGE_FOR_0 =

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/map/RegionMapDestroyTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/map/RegionMapDestroyTest.java
@@ -20,7 +20,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -36,7 +35,6 @@ import org.apache.geode.cache.DataPolicy;
 import org.apache.geode.cache.EntryNotFoundException;
 import org.apache.geode.cache.EvictionAttributes;
 import org.apache.geode.cache.Operation;
-import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.AbstractRegionMap;
 import org.apache.geode.internal.cache.CachePerfStats;
 import org.apache.geode.internal.cache.EntryEventImpl;
@@ -51,9 +49,7 @@ import org.apache.geode.internal.cache.VMLRURegionMap;
 import org.apache.geode.internal.cache.eviction.EvictableEntry;
 import org.apache.geode.internal.cache.eviction.EvictionController;
 import org.apache.geode.internal.cache.eviction.EvictionCounters;
-import org.apache.geode.internal.cache.tier.sockets.ClientProxyMembershipID;
 import org.apache.geode.internal.cache.versions.RegionVersionVector;
-import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap;
 
@@ -176,20 +172,6 @@ public class RegionMapDestroyTest {
     arm.getEntryMap().put(KEY, entry);
   }
 
-  private void givenExistingEntryWithValueAndVersion(Object value, VersionTag version) {
-    RegionEntry entry = arm.getEntryFactory().createEntry(arm._getOwner(), KEY, value);
-    ((VersionStamp) entry).setVersions(version);
-    arm.getEntryMap().put(KEY, entry);
-  }
-
-  private void givenExistingEntryWithValueAndSameVersion(Object value, VersionTag version) {
-    givenExistingEntryWithValueAndVersion(value, version);
-
-    RegionVersionVector<?> versionVector = mock(RegionVersionVector.class);
-    when(arm._getOwner().getVersionVector()).thenReturn(versionVector);
-    event.setVersionTag(version);
-  }
-
   private void givenExistingEntry(Object value) {
     RegionEntry entry = arm.getEntryFactory().createEntry(arm._getOwner(), KEY, value);
     arm.getEntryMap().put(KEY, entry);
@@ -239,23 +221,6 @@ public class RegionMapDestroyTest {
 
   private void givenOriginIsRemote() {
     event.setOriginRemote(true);
-  }
-
-  @Test
-  public void destroyWithDuplicateVersionInvokesListener() {
-    givenEmptyRegionMap();
-    givenConcurrencyChecks(true);
-    VersionTag version = VersionTag.create(new InternalDistributedMember("localhost", 123));
-    version.setEntryVersion(1);
-    version.setRegionVersion(1);
-    givenExistingEntryWithValueAndSameVersion(Token.TOMBSTONE, version);
-    // make this a client/server operation
-    event.setContext(new ClientProxyMembershipID());
-    assertThat(arm.destroy(event, inTokenMode, duringRI, cacheWrite, isEviction, expectedOldValue,
-        removeRecoveredEntry)).isTrue();
-    assertThat(event.getIsRedestroyedEntry()).isTrue();
-    verify(owner).basicDestroyPart2(isA(RegionEntry.class), isA(EntryEventImpl.class),
-        isA(Boolean.class), isA(Boolean.class), isA(Boolean.class), isA(Boolean.class));
   }
 
   @Test


### PR DESCRIPTION
This PR has two commits.  The first reverts the previous attempt to fix GEODE-5505.  Those changes only addressed destroy() operations but the problem could occur with any operation.

The second commit implements a delay in region synchronization operations to allow clients to retry their operations.  Region synchronization occurs when another server hosting the same region crashes.  It uses a RegionVersionVector to comb through other servers to find partially distributed operations and send the associated entries.

Without the delay it is possible for the sync to complete before a client retries its operation, so that the client's replay encounters the state change it already made in its previous attempt.

With this change a client's replay will either be on a server that didn't see the previous attempt, or it will be on a server that did see the previous attempt & has the operation recorded in its EventTracker.  In the first case the operation will be performed again and transmitted to other servers.  In the second case the server will not apply the operation to its cache but will forward it to other servers.

The delay is based on the server's "maximum time between pings interval", which defaults to 1 minute.




Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
