### PR TITLE
GEODE-5589: lastResultReceived set after msg sent

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/ServerToClientFunctionResultSender.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/ServerToClientFunctionResultSender.java
@@ -88,7 +88,6 @@ public class ServerToClientFunctionResultSender implements ResultSender {
     if (lastResultReceived) {
       return;
     }
-    this.lastResultReceived = true;
     if (!isOkayToSendResult()) {
       if (logger.isDebugEnabled()) {
         logger.debug(
@@ -120,6 +119,7 @@ public class ServerToClientFunctionResultSender implements ResultSender {
       this.msg.addObjPart(oneResult);
       this.msg.setLastChunk(true);
       this.msg.sendChunk(this.sc);
+      this.lastResultReceived = true;
       this.sc.setAsTrue(Command.RESPONDED);
 
       FunctionStats.getFunctionStats(fn.getId()).incResultsReturned();
@@ -137,7 +137,6 @@ public class ServerToClientFunctionResultSender implements ResultSender {
     if (lastResultReceived) {
       return;
     }
-    this.lastResultReceived = true;
     if (!isOkayToSendResult()) {
       if (logger.isDebugEnabled()) {
         logger.debug(
@@ -168,6 +167,7 @@ public class ServerToClientFunctionResultSender implements ResultSender {
       this.msg.addObjPart(oneResult);
       this.msg.setLastChunk(true);
       this.msg.sendChunk(this.sc);
+      this.lastResultReceived = true;
       this.sc.setAsTrue(Command.RESPONDED);
       FunctionStats.getFunctionStats(fn.getId()).incResultsReturned();
     } catch (IOException ex) {
@@ -311,7 +311,6 @@ public class ServerToClientFunctionResultSender implements ResultSender {
     if (lastResultReceived) {
       return;
     }
-    this.lastResultReceived = true;
     if (logger.isDebugEnabled()) {
       logger.debug("ServerToClientFunctionResultSender setting exception {} ", exception);
     }
@@ -331,13 +330,14 @@ public class ServerToClientFunctionResultSender implements ResultSender {
             logger.debug("ServerToClientFunctionResultSender sending Function Exception : ");
           }
           writeFunctionExceptionResponse(msg, exceptionMessage, exception);
+          this.lastResultReceived = true;
         } catch (IOException ignoreAsSocketIsClosed) {
         }
       }
     }
   }
 
-  protected boolean isOkayToSendResult() {
+  public boolean isOkayToSendResult() {
     return (sc.getAcceptor().isRunning() && !ids.isDisconnecting()
         && !sc.getCachedRegionHelper().getCache().isClosed() && !alreadySendException.get());
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/ServerToClientFunctionResultSender65.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/ServerToClientFunctionResultSender65.java
@@ -51,7 +51,6 @@ public class ServerToClientFunctionResultSender65 extends ServerToClientFunction
     if (this.lastResultReceived) {
       return;
     }
-    this.lastResultReceived = true;
     if (!isOkayToSendResult()) {
       if (logger.isDebugEnabled()) {
         logger.debug(
@@ -96,6 +95,7 @@ public class ServerToClientFunctionResultSender65 extends ServerToClientFunction
         this.msg.addObjPart(result2);
       }
       this.msg.sendChunk(this.sc);
+      this.lastResultReceived = true;
       this.sc.setAsTrue(Command.RESPONDED);
       FunctionStats.getFunctionStats(fn.getId()).incResultsReturned();
     } catch (IOException ex) {
@@ -113,7 +113,6 @@ public class ServerToClientFunctionResultSender65 extends ServerToClientFunction
     if (lastResultReceived) {
       return;
     }
-    this.lastResultReceived = true;
     if (!isOkayToSendResult()) {
       if (logger.isDebugEnabled()) {
         logger.debug(
@@ -160,6 +159,7 @@ public class ServerToClientFunctionResultSender65 extends ServerToClientFunction
         this.msg.addObjPart(result2);
       }
       this.msg.sendChunk(this.sc);
+      this.lastResultReceived = true;
       this.sc.setAsTrue(Command.RESPONDED);
       FunctionStats.getFunctionStats(fn.getId()).incResultsReturned();
     } catch (IOException ex) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/ExecuteFunction66.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/ExecuteFunction66.java
@@ -330,7 +330,8 @@ public class ExecuteFunction66 extends BaseCommand {
 
     if (fn.hasResult()) {
       fn.execute(cx);
-      if (!((ServerToClientFunctionResultSender65) sender).isLastResultReceived()
+      if (sender.isOkayToSendResult()
+          && !((ServerToClientFunctionResultSender65) sender).isLastResultReceived()
           && fn.hasResult()) {
         throw new FunctionException(
             LocalizedStrings.ExecuteFunction_THE_FUNCTION_0_DID_NOT_SENT_LAST_RESULT

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/execute/ServerToClientFunctionResultSender65JUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/execute/ServerToClientFunctionResultSender65JUnitTest.java
@@ -15,12 +15,29 @@
 package org.apache.geode.internal.cache.execute;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.apache.geode.cache.execute.Function;
+import org.apache.geode.cache.operations.ExecuteFunctionOperationContext;
+import org.apache.geode.internal.cache.tier.sockets.AcceptorImpl;
+import org.apache.geode.internal.cache.tier.sockets.ChunkedMessage;
+import org.apache.geode.internal.cache.tier.sockets.ServerConnection;
 
 public class ServerToClientFunctionResultSender65JUnitTest
     extends ServerToClientFunctionResultSenderJUnitTest {
 
   @Override
   protected ServerToClientFunctionResultSender getResultSender() {
-    return mock(ServerToClientFunctionResultSender65.class);
+    ChunkedMessage msg = mock(ChunkedMessage.class);
+    serverConnection = mock(ServerConnection.class);
+    Function function = mock(Function.class);
+    ExecuteFunctionOperationContext executeFunctionOperationContext =
+        mock(ExecuteFunctionOperationContext.class);
+    AcceptorImpl acceptor = mock(AcceptorImpl.class);
+    when(serverConnection.getAcceptor()).thenReturn(acceptor);
+    when(acceptor.isSelector()).thenReturn(true);
+    when(acceptor.isRunning()).thenReturn(true);
+    return new ServerToClientFunctionResultSender65(msg, 1, serverConnection, function,
+        executeFunctionOperationContext);
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/execute/ServerToClientFunctionResultSenderJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/execute/ServerToClientFunctionResultSenderJUnitTest.java
@@ -14,49 +14,104 @@
  */
 package org.apache.geode.internal.cache.execute;
 
+import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import java.io.IOException;
+
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
+import org.apache.geode.cache.execute.Function;
+import org.apache.geode.cache.operations.ExecuteFunctionOperationContext;
 import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.distributed.internal.InternalDistributedSystem;
+import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.tier.CachedRegionHelper;
+import org.apache.geode.internal.cache.tier.sockets.AcceptorImpl;
+import org.apache.geode.internal.cache.tier.sockets.ChunkedMessage;
+import org.apache.geode.internal.cache.tier.sockets.ServerConnection;
+import org.apache.geode.security.NotAuthorizedException;
 
 public class ServerToClientFunctionResultSenderJUnitTest {
 
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
+
+  ServerConnection serverConnection;
+
   protected ServerToClientFunctionResultSender getResultSender() {
-    return mock(ServerToClientFunctionResultSender.class);
+    ChunkedMessage msg = mock(ChunkedMessage.class);
+    serverConnection = mock(ServerConnection.class);
+    Function function = mock(Function.class);
+    ExecuteFunctionOperationContext executeFunctionOperationContext =
+        mock(ExecuteFunctionOperationContext.class);
+    // sc.getAcceptor().isSelector();
+    AcceptorImpl acceptor = mock(AcceptorImpl.class);
+    when(serverConnection.getAcceptor()).thenReturn(acceptor);
+    when(acceptor.isSelector()).thenReturn(true);
+    when(acceptor.isRunning()).thenReturn(true);
+
+    return new ServerToClientFunctionResultSender(msg, 1, serverConnection, function,
+        executeFunctionOperationContext);
   }
 
   @Test
-  public void whenLastResultReceivedIsSetThenLastResultMustReturnImmediately() {
+  public void whenLastResultReceivedIsSetThenLastResultMustReturnImmediately() throws IOException {
     ServerToClientFunctionResultSender resultSender = getResultSender();
     resultSender.lastResultReceived = true;
 
     Object object = mock(Object.class);
     DistributedMember memberId = mock(DistributedMember.class);
     resultSender.lastResult(object, memberId);
-    verify(resultSender, times(0)).isOkayToSendResult();
+    verify(serverConnection, times(0)).getPostAuthzRequest();
 
 
     resultSender.lastResult(object);
-    verify(resultSender, times(0)).isOkayToSendResult();
+    verify(serverConnection, times(0)).getPostAuthzRequest();
 
   }
 
   @Test
-  public void whenLastResultReceivedIsSetThenSendResultMustReturnImmediately() {
+  public void whenExceptionOccursThenLastResultReceivedMustNotBeSet() throws Exception {
+    ServerToClientFunctionResultSender resultSender = getResultSender();
+    resultSender.ids = mock(InternalDistributedSystem.class);
+    when(resultSender.ids.isDisconnecting()).thenReturn(false);
+    Object object = mock(Object.class);
+    resultSender.lastResultReceived = false;
+    DistributedMember distributedMember = mock(DistributedMember.class);
+    when(serverConnection.getPostAuthzRequest())
+        .thenThrow(new NotAuthorizedException("Should catch this exception"));
+    CachedRegionHelper cachedRegionHelper = mock(CachedRegionHelper.class);
+    when(serverConnection.getCachedRegionHelper()).thenReturn(cachedRegionHelper);
+    InternalCache cache = mock(InternalCache.class);
+    when(cachedRegionHelper.getCache()).thenReturn(cache);
+    when(cache.isClosed()).thenReturn(false);
+    expectedException.expect(NotAuthorizedException.class);
+    resultSender.lastResult(object, distributedMember);
+    assertFalse(resultSender.lastResultReceived);
+
+    resultSender.lastResult(object);
+    assertFalse(resultSender.lastResultReceived);
+  }
+
+  @Test
+  public void whenLastResultReceivedIsSetThenSendResultMustReturnImmediately() throws IOException {
     ServerToClientFunctionResultSender resultSender = getResultSender();
     resultSender.lastResultReceived = true;
 
     Object object = mock(Object.class);
     DistributedMember memberId = mock(DistributedMember.class);
     resultSender.sendResult(object, memberId);
-    verify(resultSender, times(0)).isOkayToSendResult();
+    verify(serverConnection, times(0)).getPostAuthzRequest();
 
 
     resultSender.sendResult(object);
-    verify(resultSender, times(0)).isOkayToSendResult();
+    verify(serverConnection, times(0)).getPostAuthzRequest();
 
   }
 


### PR DESCRIPTION
	* To prevent situations where exceptions thrown in lastResult in not sent to the client.
	* This happens if we set the lastResultReceived and then an exception occurs.
	* exception is not sent back because the flag is set.
	* solution is now to set the flag only after the msg is sent from lastResult.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
