### PR TITLE
GEODE-5597 Publish geode artifacts to maven repo on GCS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,7 @@ if (name == 'geode') {
   ext.scriptDir = 'gradle'
 }
 
-
+// utilities.gradle MUST be read before publish.gradle for reasons
 apply from: "${scriptDir}/utilities.gradle"
 apply from: "${scriptDir}/java.gradle"
 apply from: "${scriptDir}/dependency-resolution.gradle"

--- a/ci/pipelines/geode-build/deploy_pipeline.sh
+++ b/ci/pipelines/geode-build/deploy_pipeline.sh
@@ -73,6 +73,8 @@ pushd ${SCRIPTDIR} 2>&1 > /dev/null
   # Template and output share a directory with this script, but variables are shared in the parent directory.
   python3 ../render.py jinja.template.yml ../shared/jinja.variables.yml generated-pipeline.yml || exit 1
 
+  grep -n . generated-pipeline.yml
+
   fly login -t ${TARGET} \
             -n ${TEAM} \
             -c https://concourse.apachegeode-ci.info \

--- a/ci/pipelines/geode-build/jinja.template.yml
+++ b/ci/pipelines/geode-build/jinja.template.yml
@@ -47,6 +47,7 @@ groups:
   - {{test.name}}Test
   {% endfor -%}
   - UpdatePassingRef
+  - PublishArtifacts
 
 resources:
 - name: geode-build-artifact
@@ -168,6 +169,7 @@ jobs:
       - put: geode-build-version
         params:
           file: results/number
+
 - name: UpdatePassingRef
   public: true
   serial: true
@@ -181,6 +183,7 @@ jobs:
   - get: geode-ci
   - get: docker-geode-build-image
   - task: updatepassingref
+    image: docker-geode-build-image
     config:
       platform: linux
       params:
@@ -194,7 +197,41 @@ jobs:
       - name: geode-ci
       outputs:
       - name: results
-    image: docker-geode-build-image
+
+- name: PublishArtifacts
+  public: true
+  plan:
+  - get: geode
+    passed:
+    {% for test in tests if not test.name=="StressNew" -%}
+    - {{test.name}}Test
+    {% endfor %}
+    trigger: true
+  - get: geode-ci
+  - get: geode-build-version
+    params:
+      pre: build
+  - task: publish
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          password: ((!docker-password))
+          repository: gcr.io/apachegeode-ci/{{ pipeline_prefix() }}((!docker-image-name))
+          tag: latest
+          username: ((!docker-username))
+      params:
+        MAINTENANCE_VERSION: {{repository.branch}}
+        PUBLIC_BUCKET: ((!public-bucket))
+        SERVICE_ACCOUNT: ((!concourse-gcp-account))
+      run:
+        path: geode-ci/ci/scripts/publish.sh
+      inputs:
+      - name: geode
+      - name: geode-ci
+      - name: geode-build-version
+
 {% for test in tests if not test.name=="StressNew" %}
 - name: {{test.name}}Test
   public: true

--- a/ci/scripts/publish.sh
+++ b/ci/scripts/publish.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+set -e
+ROOT_DIR=$(pwd)
+BUILD_DATE=$(date +%s)
+EMAIL_SUBJECT="results/subject"
+EMAIL_BODY="results/body"
+
+GEODE_BUILD_VERSION_FILE=${ROOT_DIR}/geode-build-version/number
+GEODE_RESULTS_VERSION_FILE=${ROOT_DIR}/results/number
+GEODE_BUILD_VERSION_NUMBER=$(grep "versionNumber *=" geode/gradle.properties | awk -F "=" '{print $2}' | tr -d ' ')
+GEODE_BUILD_DIR=/tmp/geode-build
+GEODE_PULL_REQUEST_ID_FILE=${ROOT_DIR}/geode/.git/id
+if [ -e "${GEODE_PULL_REQUEST_ID_FILE}" ]; then
+  GEODE_PULL_REQUEST_ID=$(cat ${GEODE_PULL_REQUEST_ID_FILE})
+fi
+
+if [ ! -e "${GEODE_BUILD_VERSION_FILE}" ] && [ -z "${GEODE_PULL_REQUEST_ID}" ]; then
+  echo "${GEODE_BUILD_VERSION_FILE} file does not exist. Concourse is probably not configured correctly."
+  exit 1
+fi
+if [ -z ${MAINTENANCE_VERSION+x} ]; then
+  echo "MAINTENANCE_VERSION is unset. Check your pipeline configuration and make sure this script is called properly."
+  exit 1
+fi
+if [ -z ${SERVICE_ACCOUNT+x} ]; then
+  echo "SERVICE_ACCOUNT is unset. Check your pipeline configuration and make sure this script is called properly."
+  exit 1
+fi
+
+if [ -z ${PUBLIC_BUCKET+x} ]; then
+  echo "PUBLIC_BUCKET is unset. Check your pipeline configuration and make sure this script is called properly."
+  exit 1
+fi
+
+if [ -z ${GEODE_BUILD_VERSION_NUMBER+x} ]; then
+  echo "gradle.properties does not seem to contain a valid versionNumber. Please check the source tree."
+  exit 1
+fi
+
+if [ -z "${GEODE_PULL_REQUEST_ID}" ]; then
+  CONCOURSE_VERSION=$(cat ${GEODE_BUILD_VERSION_FILE})
+  CONCOURSE_PRODUCT_VERSION=${CONCOURSE_VERSION%%-*}
+  GEODE_PRODUCT_VERSION=${GEODE_BUILD_VERSION_NUMBER}
+  CONCOURSE_BUILD_SLUG=${CONCOURSE_VERSION##*-}
+  BUILD_ID=${CONCOURSE_VERSION##*.}
+  FULL_PRODUCT_VERSION=${GEODE_PRODUCT_VERSION}-${CONCOURSE_BUILD_SLUG}
+  echo "Concourse VERSION is ${CONCOURSE_VERSION}"
+  echo "Geode product VERSION is ${GEODE_PRODUCT_VERSION}"
+  echo "Build ID is ${BUILD_ID}"
+else
+  FULL_PRODUCT_VERSION="geode-pr-${GEODE_PULL_REQUEST_ID}"
+fi
+
+printf "\nUsing the following JDK:"
+java -version
+printf "\n\n"
+
+gcloud config set account ${SERVICE_ACCOUNT}
+
+export TERM=${TERM:-dumb}
+export DEST_DIR=${ROOT_DIR}/built-geode
+export TMPDIR=${DEST_DIR}/tmp
+mkdir -p ${TMPDIR}
+export BUILD_ARTIFACTS_DIR=${DEST_DIR}/test-artifacts
+mkdir -p ${BUILD_ARTIFACTS_DIR}
+
+ln -s ${ROOT_DIR}/geode ${GEODE_BUILD_DIR}
+
+pushd ${GEODE_BUILD_DIR}
+  set +e
+  set -x
+  ./gradlew --no-daemon --parallel -PbuildId=${BUILD_ID} publish
+  GRADLE_EXIT_STATUS=$?
+  set +x
+popd
+
+exit ${GRADLE_EXIT_STATUS}

--- a/geode-assembly/build.gradle
+++ b/geode-assembly/build.gradle
@@ -385,38 +385,17 @@ distributions {
       }
 
       into ('lib') {
-        from project(":geode-common").configurations.runtime
-        from project(":geode-common").configurations.archives.allArtifacts.files
-
-        from project(":geode-json").configurations.runtime
-        from project(":geode-json").configurations.archives.allArtifacts.files
-
-        from project(":geode-wan").configurations.runtime
-        from project(":geode-wan").configurations.archives.allArtifacts.files
-
-        from project(":geode-cq").configurations.runtime
-        from project(":geode-cq").configurations.archives.allArtifacts.files
-
-        from project(":geode-core").configurations.runtime
-        from project(":geode-core").configurations.archives.allArtifacts.files
-
-        from project(":geode-lucene").configurations.runtime
-        from project(":geode-lucene").configurations.archives.allArtifacts.files
-
-        from project(":geode-connectors").configurations.runtime
-        from project(":geode-connectors").configurations.archives.allArtifacts.files
-
-        from project(":geode-old-client-support").configurations.runtime
-        from project(":geode-old-client-support").configurations.archives.allArtifacts.files
-
-        from project(":geode-protobuf").configurations.runtime
-        from project(":geode-protobuf").configurations.archives.allArtifacts.files
-
-        from project(":geode-protobuf-messages").configurations.runtime
-        from project(":geode-protobuf-messages").configurations.archives.allArtifacts.files
-
-        from project(":geode-rebalancer").configurations.runtime
-        from project(":geode-rebalancer").configurations.archives.allArtifacts.files
+        from project(":geode-common").configurations.runtimeClasspath
+        from project(":geode-json").configurations.runtimeClasspath
+        from project(":geode-wan").configurations.runtimeClasspath
+        from project(":geode-cq").configurations.runtimeClasspath
+        from project(":geode-core").configurations.runtimeClasspath
+        from project(":geode-lucene").configurations.runtimeClasspath
+        from project(":geode-connectors").configurations.runtimeClasspath
+        from project(":geode-old-client-support").configurations.runtimeClasspath
+        from project(":geode-protobuf").configurations.runtimeClasspath
+        from project(":geode-protobuf-messages").configurations.runtimeClasspath
+        from project(":geode-rebalancer").configurations.runtimeClasspath
 
         from configurations.bundled
         from configurations.gfshDependencies

--- a/geode-assembly/build.gradle
+++ b/geode-assembly/build.gradle
@@ -27,6 +27,19 @@ extraArchive {
   tests = false
 }
 
+publishing {
+  publications {
+    maven {
+      artifactId = 'apache-geode'
+
+      artifacts = []
+
+      artifact distTar
+      artifact distZip
+    }
+  }
+}
+
 logger.info("Gradle doesn't automatically remove the jar artifact even though we disabled it")
 logger.info("this causes publishing to fail.  So we nuke all the disabled artifacts from all configurations.")
 configurations.all {

--- a/geode-assembly/build.gradle
+++ b/geode-assembly/build.gradle
@@ -187,7 +187,7 @@ def cp = {
   // then add all the dependencies of the dependent jars
   jars += ' ' + configurations.archives.dependencies.collect {
     it.dependencyProject.findAll { !(it.name.contains('web-api') || it.name.contains('pulse')) }
-      .collect { it.configurations.runtime.collect { it.getName() }.findAll {
+      .collect { it.configurations.runtimeClasspath.collect { it.getName() }.findAll {
         // depedencies from geode-core
         it.contains('antlr') ||
         it.contains('commons-io') ||

--- a/geode-assembly/build.gradle
+++ b/geode-assembly/build.gradle
@@ -386,16 +386,27 @@ distributions {
 
       into ('lib') {
         from project(":geode-common").configurations.runtimeClasspath
+        from project(":geode-common").configurations.archives.allArtifacts.files
         from project(":geode-json").configurations.runtimeClasspath
+        from project(":geode-json").configurations.archives.allArtifacts.files
         from project(":geode-wan").configurations.runtimeClasspath
+        from project(":geode-wan").configurations.archives.allArtifacts.files
         from project(":geode-cq").configurations.runtimeClasspath
+        from project(":geode-cq").configurations.archives.allArtifacts.files
         from project(":geode-core").configurations.runtimeClasspath
+        from project(":geode-core").configurations.archives.allArtifacts.files
         from project(":geode-lucene").configurations.runtimeClasspath
+        from project(":geode-lucene").configurations.archives.allArtifacts.files
         from project(":geode-connectors").configurations.runtimeClasspath
+        from project(":geode-connectors").configurations.archives.allArtifacts.files
         from project(":geode-old-client-support").configurations.runtimeClasspath
+        from project(":geode-old-client-support").configurations.archives.allArtifacts.files
         from project(":geode-protobuf").configurations.runtimeClasspath
+        from project(":geode-protobuf").configurations.archives.allArtifacts.files
         from project(":geode-protobuf-messages").configurations.runtimeClasspath
+        from project(":geode-protobuf-messages").configurations.archives.allArtifacts.files
         from project(":geode-rebalancer").configurations.runtimeClasspath
+        from project(":geode-rebalancer").configurations.archives.allArtifacts.files
 
         from configurations.bundled
         from configurations.gfshDependencies

--- a/geode-assembly/src/integrationTest/resources/expected_jars.txt
+++ b/geode-assembly/src/integrationTest/resources/expected_jars.txt
@@ -5,6 +5,7 @@ byte-buddy
 classgraph
 classmate
 commons-beanutils
+commons-codec
 commons-collections
 commons-digester
 commons-fileupload
@@ -46,6 +47,7 @@ log4j-jcl
 log4j-jul
 log4j-slf4j-impl
 lucene-analyzers-common
+lucene-analyzers-phonetic
 lucene-core
 lucene-queries
 lucene-queryparser

--- a/geode-assembly/src/integrationTest/resources/expected_jars.txt
+++ b/geode-assembly/src/integrationTest/resources/expected_jars.txt
@@ -5,7 +5,6 @@ byte-buddy
 classgraph
 classmate
 commons-beanutils
-commons-codec
 commons-collections
 commons-digester
 commons-fileupload
@@ -47,7 +46,6 @@ log4j-jcl
 log4j-jul
 log4j-slf4j-impl
 lucene-analyzers-common
-lucene-analyzers-phonetic
 lucene-core
 lucene-queries
 lucene-queryparser

--- a/geode-core/build.gradle
+++ b/geode-core/build.gradle
@@ -21,8 +21,8 @@ apply plugin: 'me.champeau.gradle.jmh'
 
 sourceSets {
   jca {
-    compileClasspath += configurations.compile
-    runtimeClasspath += configurations.runtime
+    compileClasspath += configurations.compileClasspath
+    runtimeClasspath += configurations.runtimeClasspath
   }
 }
 

--- a/geode-core/build.gradle
+++ b/geode-core/build.gradle
@@ -86,19 +86,19 @@ dependencies {
 
   compile 'org.apache.logging.log4j:log4j-api:' + project.'log4j.version'
   compile 'org.apache.logging.log4j:log4j-core:' + project.'log4j.version'
-  runtime('org.fusesource.jansi:jansi:' + project.'jansi.version') {
+  runtimeOnly ('org.fusesource.jansi:jansi:' + project.'jansi.version') {
     ext.optional = true
   }
-  runtime 'org.slf4j:slf4j-api:' + project.'slf4j-api.version'
+  runtimeOnly 'org.slf4j:slf4j-api:' + project.'slf4j-api.version'
 
-  runtime('org.apache.logging.log4j:log4j-slf4j-impl:' + project.'log4j.version') {
+  runtimeOnly ('org.apache.logging.log4j:log4j-slf4j-impl:' + project.'log4j.version') {
     exclude module: 'slf4j-api'
     ext.optional = true
   }
-  runtime('org.apache.logging.log4j:log4j-jcl:' + project.'log4j.version') {
+  runtimeOnly ('org.apache.logging.log4j:log4j-jcl:' + project.'log4j.version') {
     ext.optional = true
   }
-  runtime('org.apache.logging.log4j:log4j-jul:' + project.'log4j.version') {
+  runtimeOnly ('org.apache.logging.log4j:log4j-jul:' + project.'log4j.version') {
     ext.optional = true
   }
   compile('org.eclipse.jetty:jetty-webapp:' + project.'jetty.version') {

--- a/geode-junit/build.gradle
+++ b/geode-junit/build.gradle
@@ -35,7 +35,7 @@ dependencies {
   }
   compile 'org.hamcrest:hamcrest-all:' + project.'hamcrest-all.version'
 
-  runtime project(":geode-old-versions")
+  runtimeOnly project(":geode-old-versions")
 }
 
 test {

--- a/geode-lucene/build.gradle
+++ b/geode-lucene/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     exclude module: 'lucene-sandbox'
   }
 
-  runtime 'org.apache.lucene:lucene-analyzers-phonetic:' + project.'lucene.version'
+  runtimeOnly 'org.apache.lucene:lucene-analyzers-phonetic:' + project.'lucene.version'
 
   testCompile project(':geode-junit')
   testCompile project(':geode-lucene/geode-lucene-test')

--- a/geode-pulse/build.gradle
+++ b/geode-pulse/build.gradle
@@ -1,5 +1,3 @@
-import org.apache.geode.gradle.TestPropertiesWriter
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -123,7 +121,7 @@ artifacts {
 
 war {
   duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-  classpath configurations.runtime
+  classpath configurations.runtimeClasspath
   classpath project(':geode-core').webJar.archivePath
 }
 war.dependsOn(':geode-core:webJar')

--- a/geode-pulse/build.gradle
+++ b/geode-pulse/build.gradle
@@ -31,10 +31,10 @@ dependencies {
   compile 'commons-digester:commons-digester:' + project.'commons-digester.version'
   compile 'commons-lang:commons-lang:' + project.'commons-lang.version'
   compile 'org.springframework.ldap:spring-ldap-core:' + project.'spring-ldap-core.version'
-  runtime 'org.springframework:spring-expression:' + project.'springframework.version'
+  runtimeOnly 'org.springframework:spring-expression:' + project.'springframework.version'
 
   // added only to ensure common version with other geode modules
-  runtime 'org.slf4j:slf4j-api:' + project.'slf4j-api.version'
+  runtimeOnly 'org.slf4j:slf4j-api:' + project.'slf4j-api.version'
 
   compile ('org.springframework.security:spring-security-config:' + project.'spring-security.version') {
     exclude module: 'aopalliance'
@@ -54,7 +54,7 @@ dependencies {
   }
   compile ('org.springframework:spring-context:' + project.'springframework.version');
   compile ('org.springframework:spring-web:' + project.'springframework.version');
-  runtime ('org.springframework:spring-webmvc:' + project.'springframework.version') {
+  runtimeOnly ('org.springframework:spring-webmvc:' + project.'springframework.version') {
     exclude module: 'aopalliance'
     exclude module: 'aspectjweaver'
   }

--- a/geode-web-api/build.gradle
+++ b/geode-web-api/build.gradle
@@ -73,5 +73,5 @@ war {
   duplicatesStrategy = DuplicatesStrategy.EXCLUDE
   // this shouldn't be necessary but if it's not specified we're missing some of the jars
   // from the runtime classpath
-  classpath configurations.runtime
+  classpath configurations.runtimeClasspath
 }

--- a/geode-web/build.gradle
+++ b/geode-web/build.gradle
@@ -89,6 +89,6 @@ integrationTest.dependsOn(war)
 war {
   dependsOn ':geode-core:webJar'
   duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-  classpath configurations.runtime
+  classpath configurations.runtimeClasspath
   classpath project(':geode-core').webJar.archivePath
 }

--- a/geode-web/build.gradle
+++ b/geode-web/build.gradle
@@ -21,22 +21,22 @@ dependencies {
   compileOnly 'javax.servlet:javax.servlet-api:' + project.'javax.servlet-api.version'
   compileOnly project(path: ':geode-core', configuration: 'classesOutput')
 
-  runtime ('org.springframework:spring-aspects:' + project.'springframework.version') {
+  runtimeOnly ('org.springframework:spring-aspects:' + project.'springframework.version') {
     exclude module: 'aspectjweaver'
     exclude module: 'aopalliance'
     exclude module: 'spring-core'
   }
-  runtime('org.springframework:spring-oxm:' + project.'springframework.version') {
+  runtimeOnly('org.springframework:spring-oxm:' + project.'springframework.version') {
     exclude module: 'commons-logging'
     exclude module: 'spring-beans'
     exclude module: 'spring-core'
   }
-  runtime('org.springframework:spring-webmvc:' + project.'springframework.version') {
+  runtimeOnly('org.springframework:spring-webmvc:' + project.'springframework.version') {
     exclude module: 'aopalliance'
     exclude module: 'aspectjweaver'
     exclude module: 'spring-core'
   }
-  runtime('commons-fileupload:commons-fileupload:' + project.'commons-fileupload.version') {
+  runtimeOnly('commons-fileupload:commons-fileupload:' + project.'commons-fileupload.version') {
     exclude module: 'commons-io'
   }
 

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -137,6 +137,24 @@ subprojects {
         if (! getTasksByName('javadocJar', false).isEmpty()) {
           artifact javadocJar
         }
+        pom{
+          name = 'Apache Geode'
+          description = 'Apache Geode provides a database-like consistency model, reliable transaction processing and a shared-nothing architecture to maintain very low latency performance with high concurrency processing'
+          url = 'http://geode.apache.org'
+
+          scm {
+            url = 'https://github.com/apache/geode'
+            connection = 'scm:git:https://github.com:apache/geode.git'
+            developerConnection = 'scm:git:https://github.com:apache/geode.git'
+          }
+
+          licenses {
+            license {
+              name = 'The Apache Software License, Version 2.0'
+              url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+            }
+          }
+        }
       }
     }
     repositories {

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -24,14 +24,14 @@ subprojects {
     javadoc = true
     tests = false
   }
-  
+
   nexus {
     sign = Boolean.parseBoolean(nexusSignArchives)
     repositoryUrl = 'https://repository.apache.org/service/local/staging/deploy/maven2'
     snapshotRepositoryUrl = 'https://repository.apache.org/content/repositories/snapshots'
   }
 
-  
+
   modifyPom {
     withXml {
       def elem = asElement()
@@ -55,12 +55,14 @@ subprojects {
 
       elem.insertBefore(hdr, elem.getFirstChild())
 
-  
+
       //This black magic checks to see if a dependency has the flag ext.optional=true
       //set on it, and if so marks the dependency as optional in the maven pom
       def depMap = project.configurations.compile.dependencies.collectEntries { [it.name, it] }
       def runtimeDeps = project.configurations.runtime.dependencies.collectEntries { [it.name, it] }
+      def runtimeOnlyDeps = project.configurations.runtimeOnly.dependencies.collectEntries { [it.name, it] }
       depMap.putAll(runtimeDeps)
+      depMap.putAll(runtimeOnlyDeps)
       asNode().dependencies.dependency.findAll {
         def dep = depMap.get(it.artifactId.text())
         return dep?.hasProperty('optional') && dep.optional
@@ -77,20 +79,20 @@ subprojects {
       name 'Apache Geode'
       description 'Apache Geode provides a database-like consistency model, reliable transaction processing and a shared-nothing architecture to maintain very low latency performance with high concurrency processing'
       url 'http://geode.apache.org'
-  
+
       scm {
         url 'https://github.com/apache/geode'
         connection 'scm:git:https://github.com:apache/geode.git'
         developerConnection 'scm:git:https://github.com:apache/geode.git'
       }
-  
+
       licenses {
         license {
           name 'The Apache Software License, Version 2.0'
           url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
         }
       }
-  
+
       repositories {
         repository {
           id 'libs-release'
@@ -100,7 +102,7 @@ subprojects {
       }
     }
   }
-  
+
   // The nexus plugin reads authentication from ~/.gradle/gradle.properties but the
   // jenkins server stores publishing credentials in ~/.m2/settings.xml (maven).
   // We match on the expected snapshot repository id.
@@ -131,13 +133,14 @@ subprojects {
         from components.java
 
         // uses the tasks created by nexus for sources and javadoc
-        if (! getTasksByName('sourcesJar', false).isEmpty()) {
+        if (!getTasksByName('sourcesJar', false).isEmpty()) {
           artifact sourcesJar
         }
-        if (! getTasksByName('javadocJar', false).isEmpty()) {
+        if (!getTasksByName('javadocJar', false).isEmpty()) {
           artifact javadocJar
         }
-        pom{
+
+        pom {
           name = 'Apache Geode'
           description = 'Apache Geode provides a database-like consistency model, reliable transaction processing and a shared-nothing architecture to maintain very low latency performance with high concurrency processing'
           url = 'http://geode.apache.org'
@@ -153,6 +156,49 @@ subprojects {
               name = 'The Apache Software License, Version 2.0'
               url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
             }
+          }
+
+          withXml {
+            //This black magic checks to see if a dependency has the flag ext.optional=true
+            //set on it, and if so marks the dependency as optional in the maven pom
+            def depMap = project.configurations.compile.dependencies.collectEntries { [it.name, it] }
+            def runtimeDeps = project.configurations.runtime.dependencies.collectEntries { [it.name, it] }
+            def runtimeOnlyDeps = project.configurations.runtimeOnly.dependencies.collectEntries { [it.name, it] }
+            depMap.putAll(runtimeDeps)
+            depMap.putAll(runtimeOnlyDeps)
+            asNode().dependencies.dependency.findAll {
+              def dep = depMap.get(it.artifactId.text())
+              return dep?.hasProperty('optional') && dep.optional
+            }.each {
+              if (it.optional) {
+                it.optional.value = 'true'
+              } else {
+                it.appendNode('optional', 'true')
+              }
+            }
+          }
+        }
+        pom {
+          withXml {
+            def elem = asElement()
+            def hdr = elem.ownerDocument().createComment(
+                    '''
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  ''')
+            elem.insertBefore(hdr, elem.firstChild)
           }
         }
       }
@@ -186,7 +232,7 @@ gradle.taskGraph.whenReady { taskGraph ->
 
       if(!project.hasProperty('signing.password')) {
         def password = PasswordDialog.askPassword("Please enter your password to unlock your gpg keyring for signing artifacts")
-        
+
         subprojects { ext."signing.password" = password }
       }
     }
@@ -200,7 +246,7 @@ gradle.taskGraph.whenReady { taskGraph ->
 
       if(!project.hasProperty('nexusPassword')) {
         def password = PasswordDialog.askPassword("Please enter your apache password to uploadArchives to nexus")
-        
+
         subprojects { ext."nexusPassword" = password }
       }
     }

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -17,7 +17,8 @@
 
 subprojects {
   apply plugin: 'com.bmuschko.nexus'
-  
+  apply plugin: 'maven-publish'
+
   extraArchive {
     sources = true
     javadoc = true
@@ -122,7 +123,37 @@ subprojects {
       }
     }
   }
-}
+
+
+  publishing {
+    publications {
+      maven(MavenPublication) {
+        from components.java
+
+        // uses the tasks created by nexus for sources and javadoc
+        if (! getTasksByName('sourcesJar', false).isEmpty()) {
+          artifact sourcesJar
+        }
+        if (! getTasksByName('javadocJar', false).isEmpty()) {
+          artifact javadocJar
+        }
+      }
+    }
+    repositories {
+      maven {
+        if (project.hasProperty("mavenRepository")) {
+          url = project.mavenRepository
+        } else {
+          if (version.endsWith('SNAPSHOT')) {
+            url = "gcs://maven.apachegeode-ci.info/snapshots"
+          }
+        }
+      }
+    }
+  }
+
+
+} // subprojects
 
 //Prompt the user for a password to sign archives or upload artifacts, if requested
 gradle.taskGraph.whenReady { taskGraph ->

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -121,6 +121,14 @@ subprojects {
     }
   }
 
+  // Facets does not extend the new runtimeOnly configurations
+  configurations.integrationTestRuntimeOnly.extendsFrom(configurations.runtimeOnly)
+  configurations.distributedTestRuntimeOnly.extendsFrom(configurations.runtimeOnly)
+  configurations.performanceTestRuntimeOnly.extendsFrom(configurations.runtimeOnly)
+  configurations.acceptanceTestRuntimeOnly.extendsFrom(configurations.runtimeOnly)
+  configurations.uiTestRuntimeOnly.extendsFrom(configurations.runtimeOnly)
+  configurations.upgradeTestRuntimeOnly.extendsFrom(configurations.runtimeOnly)
+
   dependencies {
     integrationTestCompile 'org.jmock:jmock-junit4:' + project.'jmock.version'
     integrationTestCompile 'org.jmock:jmock-legacy:' + project.'jmock.version'

--- a/gradle/utilities.gradle
+++ b/gradle/utilities.gradle
@@ -43,6 +43,9 @@ allprojects {
       afterEvaluate {
         install.enabled = false
         uploadArchives.enabled = false
+        tasks.withType(PublishToMavenRepository) {
+          it.enabled = false
+        }
       }
     }
     disableSigning = {


### PR DESCRIPTION
Uses vanilla maven-publish Gradle plugin, instead of nexus (nexus is
still used for release artifact publishing)
GCS credentials are inherited from the concourse worker

Co-authored-by: Finn Southerland <fsoutherland@pivotal.io>
Co-authored-by: Jake Barrett <bjarrett@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
