### PR TITLE
[GEODE-5591] If there is a BindException we should always throw.

### DIFF
--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/WANTestBase.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/WANTestBase.java
@@ -37,6 +37,7 @@ import static org.apache.geode.distributed.ConfigurationProperties.REMOTE_LOCATO
 import static org.apache.geode.distributed.ConfigurationProperties.START_LOCATOR;
 import static org.apache.geode.test.dunit.Host.getHost;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -2017,16 +2018,9 @@ public class WANTestBase extends DistributedTestCase {
     fact.setManualStart(true);
     fact.setBindAddress("200.112.204.10");
     GatewayReceiver receiver = fact.create();
-    try {
-      receiver.start();
-      fail("Expected GatewayReceiver Exception");
-    } catch (GatewayReceiverException gRE) {
-      logger.debug("Got the GatewayReceiverException", gRE);
-      assertTrue(gRE.getMessage().contains("Failed to create server socket on"));
-    } catch (IOException e) {
-      e.printStackTrace();
-      fail("Test " + test.getName() + " failed to start GatewayReceiver on port " + port);
-    }
+    assertThatThrownBy(receiver::start)
+        .isInstanceOf(GatewayReceiverException.class)
+        .hasMessageContaining("No available free port found in the given range");
   }
 
   public static int createReceiverWithSSL(int locPort) {

--- a/geode-wan/src/integrationTest/java/org/apache/geode/internal/cache/wan/misc/WANConfigurationJUnitTest.java
+++ b/geode-wan/src/integrationTest/java/org/apache/geode/internal/cache/wan/misc/WANConfigurationJUnitTest.java
@@ -437,25 +437,18 @@ public class WANConfigurationJUnitTest {
   public void test_ValidateGatewayReceiverAttributes_WrongBindAddress() {
     cache = new CacheFactory().set(MCAST_PORT, "0").create();
     GatewayReceiverFactory fact = cache.createGatewayReceiverFactory();
-    fact.setStartPort(50504);
+    fact.setStartPort(50505);
     fact.setMaximumTimeBetweenPings(1000);
     fact.setSocketBufferSize(4000);
-    fact.setEndPort(70707);
+    fact.setEndPort(50505);
     fact.setManualStart(true);
     fact.setBindAddress("200.112.204.10");
     GatewayTransportFilter myStreamFilter1 = new MyGatewayTransportFilter1();
     fact.addGatewayTransportFilter(myStreamFilter1);
 
+
     GatewayReceiver receiver = fact.create();
-    try {
-      receiver.start();
-      fail("Expected GatewayReceiverException");
-    } catch (GatewayReceiverException gRE) {
-      assertTrue(gRE.getMessage().contains("Failed to create server socket on"));
-    } catch (IOException e) {
-      e.printStackTrace();
-      fail("The test failed with IOException");
-    }
+    assertThatThrownBy(() -> receiver.start()).isInstanceOf(GatewayReceiverException.class);
   }
 
   @Test


### PR DESCRIPTION
This changes the behavior of GatewayReceiverImpl to be consistent with
other classes and throw unconditionally when an exception occurs in
.start()

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
