### PR TITLE
GEODE-5615 Capturing more data in the case of hangs or OOMEs

### DIFF
--- a/ci/scripts/archive_results.sh
+++ b/ci/scripts/archive_results.sh
@@ -101,6 +101,7 @@ pushd ${GEODE_BUILD}
   find . -type d -name "test-results" >> ${directories_file}
   (find . -type d -name "*Test" | grep "build/[^/]*Test$") >> ${directories_file}
   find . -name "*-progress*txt" >> ${directories_file}
+  find . -name '*.hprof" >> ${directories_file}
   find . -type d -name "callstacks" >> ${directories_file}
   echo "Collecting the following artifacts..."
   cat ${directories_file}

--- a/ci/scripts/archive_results.sh
+++ b/ci/scripts/archive_results.sh
@@ -101,7 +101,7 @@ pushd ${GEODE_BUILD}
   find . -type d -name "test-results" >> ${directories_file}
   (find . -type d -name "*Test" | grep "build/[^/]*Test$") >> ${directories_file}
   find . -name "*-progress*txt" >> ${directories_file}
-  find . -name '*.hprof" >> ${directories_file}
+  find . -name "*.hprof" >> ${directories_file}
   find . -type d -name "callstacks" >> ${directories_file}
   echo "Collecting the following artifacts..."
   cat ${directories_file}

--- a/ci/scripts/capture-call-stacks.sh
+++ b/ci/scripts/capture-call-stacks.sh
@@ -64,7 +64,7 @@ for (( h=0; h<${COUNT}; h++)); do
 
         for (( i=0; i<${#containers[@]}; i++ )); do
             echo "Container: ${containers[i]}" | tee -a ${logfile};
-            mapfile -t processes < <(docker exec ${containers[i]} jps | grep ChildVM | cut -d ' ' -f 1)
+            mapfile -t processes < <(docker exec ${containers[i]} jps | cut -d ' ' -f 1)
             echo "Got past processes."
             for ((j=0; j<${#processes[@]}; j++ )); do
                   echo "********* Dumping stack for process ${processes[j]}:" | tee -a ${logfile}
@@ -72,7 +72,7 @@ for (( h=0; h<${COUNT}; h++)); do
             done
         done
     else
-        mapfile -t processes < <(jps | grep ChildVM | cut -d ' ' -f 1)
+        mapfile -t processes < <(jps | cut -d ' ' -f 1)
         echo "Got past processes."
         for ((j=0; j<${#processes[@]}; j++ )); do
               echo "********* Dumping stack for process ${processes[j]}:" | tee -a ${logfile}


### PR DESCRIPTION
We are seeing a lot of hangs and OOMEs in DistributedTest all of a sudden. Unfortunately, we are not capturing the call stacks and the hprof files we need to diagnose the issue. These changes should help.