### PR TITLE
GEODE-5615: Removing gradle build scan plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,13 +31,11 @@ buildscript {
     classpath "me.champeau.gradle:jmh-gradle-plugin:0.3.1"
     classpath "com.pedjak.gradle.plugins:dockerized-test:0.5.6.2-SNAPSHOT"
     classpath 'com.github.ben-manes:gradle-versions-plugin:0.17.0'
-    classpath "com.gradle:build-scan-plugin:1.13.4"
     classpath "com.netflix.nebula:nebula-project-plugin:4.0.1"
   }
 }
 
 apply plugin: 'wrapper'
-apply plugin: 'com.gradle.build-scan'
 apply plugin: 'nebula.facet'
 
 wrapper {


### PR DESCRIPTION
The build scan plugin appears to be buffering all test output in memory, causing
the gradle daemon to run out of memory for DistributedTest. We're not even using
the build scan plugin by default. Removing this fixed the OOMEs.
