### PR TITLE
GEODE-5627: ConcurrencyRule passes when not used.

### DIFF
--- a/geode-junit/src/main/java/org/apache/geode/test/junit/rules/ConcurrencyRule.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/junit/rules/ConcurrencyRule.java
@@ -88,11 +88,7 @@ public class ConcurrencyRule extends SerializableExternalResource {
    * A default constructor that sets the timeout to a default of 30 seconds
    */
   public ConcurrencyRule() {
-    toInvoke = new ArrayList<>();
-    futures = new ArrayList<>();
-    timeout = Duration.ofSeconds(300);
-    errorCollector = new ProtectedErrorCollector();
-    allThreadsExecuted.set(false);
+    this(Duration.ofSeconds(300));
   }
 
   /**
@@ -106,7 +102,7 @@ public class ConcurrencyRule extends SerializableExternalResource {
     futures = new ArrayList<>();
     this.timeout = timeout;
     errorCollector = new ProtectedErrorCollector();
-    allThreadsExecuted.set(false);
+    allThreadsExecuted.set(true);
   }
 
   @Override

--- a/geode-junit/src/test/java/org/apache/geode/test/junit/rules/ConcurrencyRuleTest.java
+++ b/geode-junit/src/test/java/org/apache/geode/test/junit/rules/ConcurrencyRuleTest.java
@@ -442,6 +442,13 @@ public class ConcurrencyRuleTest {
     concurrencyRule.clear(); // so that this test's after succeeds
   }
 
+  /**
+   * There was an issue where the rule would fail a test if it had never been used. This is an issue
+   * for test classes like this one, where the rule is used for some tests and not for others.
+   */
+  @Test
+  public void afterSucceedsIfRuleWasNotUsed() {}
+
   @SuppressWarnings("unused")
   private enum Execution {
     EXECUTE_IN_SERIES(concurrencyRule -> {


### PR DESCRIPTION
Before this, if ConcurrencyRule was used for a test it failed because
`allthreadsExecuted` was `false`.

Also delegate to the non-default constructor with the default
constructor.
@balesh2 