### PR TITLE
GEODE-5630: fix use of Awaitility in BucketCreationCrashCompletesRegr…

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/partitioned/BucketCreationCrashCompletesRegressionTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/partitioned/BucketCreationCrashCompletesRegressionTest.java
@@ -170,9 +170,7 @@ public class BucketCreationCrashCompletesRegressionTest implements Serializable 
         .getTotalNumBuckets(); i++) {
       int bucketId = i;
 
-      await().atMost(2, MINUTES).untilAsserted(() -> {
-        hasBucketOwners(partitionedRegion, bucketId);
-      });
+      await().atMost(2, MINUTES).until(() -> hasBucketOwners(partitionedRegion, bucketId));
 
       List owners = partitionedRegion.getBucketOwnersForValidation(bucketId);
       assertThat(owners).isNotNull();


### PR DESCRIPTION
…essionTest

BucketCreationCrashCompletesRegressionTest.hasBucketOwners returns boolean without performing any assertions, so it requires the use of await()...until() instead of untilAsserted().