### PR TITLE
GEODE-5617: FIxing a race in AutoBalancerJUnitTest

### DIFF
--- a/geode-rebalancer/src/test/java/org/apache/geode/cache/util/AutoBalancerJUnitTest.java
+++ b/geode-rebalancer/src/test/java/org/apache/geode/cache/util/AutoBalancerJUnitTest.java
@@ -541,7 +541,7 @@ public class AutoBalancerJUnitTest {
     mockContext.checking(new Expectations() {
       {
         oneOf(mockAuditor).init(with(any(Properties.class)));
-        exactly(2).of(mockAuditor).execute();
+        atLeast(2).of(mockAuditor).execute();
         allowing(mockClock).currentTimeMillis();
         will(new CustomAction("returnTime") {
           @Override
@@ -558,7 +558,7 @@ public class AutoBalancerJUnitTest {
     assertEquals(3, latch.getCount());
     AutoBalancer autoR = new AutoBalancer(null, mockAuditor, mockClock, null);
     autoR.initialize(null, props);
-    assertTrue(latch.await(1, TimeUnit.SECONDS));
+    assertTrue(latch.await(1, TimeUnit.MINUTES));
   }
 
   @Test
@@ -592,7 +592,7 @@ public class AutoBalancerJUnitTest {
     assertEquals(2, latch.getCount());
     AutoBalancer autoR = new AutoBalancer(null, mockAuditor, mockClock, null);
     autoR.initialize(null, props);
-    assertTrue(latch.await(1, TimeUnit.SECONDS));
+    assertTrue(latch.await(1, TimeUnit.MINUTES));
 
     // after destroy no more execute will be called.
     autoR.destroy();


### PR DESCRIPTION
This test asserted that execute was invoked exactly twice by a
background timer task. But that task could invoke execute more times
than that if the main test thread is slow.
