### PR TITLE
GEODE-5632: import Assertions instead of AssertionsForClassTypes

### DIFF
--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/JdbcAsyncWriterTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/JdbcAsyncWriterTest.java
@@ -15,7 +15,7 @@
 package org.apache.geode.connectors.jdbc;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -46,7 +46,7 @@ public class JdbcAsyncWriterTest {
   private InternalCache cache;
 
   @Before
-  public void setup() {
+  public void setUp() {
     sqlHandler = mock(SqlHandler.class);
     region = mock(InternalRegion.class);
     cache = Fakes.cache();

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/JdbcWriterTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/JdbcWriterTest.java
@@ -15,7 +15,7 @@
 package org.apache.geode.connectors.jdbc;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;

--- a/geode-core/src/test/java/org/apache/geode/cache/client/internal/QueueConnectionImplJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/client/internal/QueueConnectionImplJUnitTest.java
@@ -14,7 +14,7 @@
  */
 package org.apache.geode.cache.client.internal;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
 import org.junit.Test;
@@ -23,11 +23,11 @@ import org.junit.experimental.categories.Category;
 import org.apache.geode.cache.client.internal.pooling.ConnectionDestroyedException;
 import org.apache.geode.test.junit.categories.ClientServerTest;
 
-@Category({ClientServerTest.class})
+@Category(ClientServerTest.class)
 public class QueueConnectionImplJUnitTest {
 
   @Test
-  public void testInternalDestroyFollowedByInternalClose() throws Exception {
+  public void testInternalDestroyFollowedByInternalClose() {
     // Mock ClientUpdater and Connection
     ClientUpdater updater = mock(ClientUpdater.class);
     Connection connection = mock(Connection.class);

--- a/geode-core/src/test/java/org/apache/geode/internal/datasource/GemFireBasicDataSourceJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/datasource/GemFireBasicDataSourceJUnitTest.java
@@ -12,33 +12,28 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package org.apache.geode.internal.datasource;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-
 public class GemFireBasicDataSourceJUnitTest {
+
   private GemFireBasicDataSource dataSource;
-  private Map params = new HashMap();
+  private Map<String, String> params;
 
   @Before
   public void setUp() {
+    params = new HashMap<>();
+
     params.put("connection-url", "jdbc:postgresql://myurl:5432");
     params.put("jdbc-driver-class", "org.apache.geode.internal.datasource.TestDriver");
     params.put("jndi-name", "datasource");
-  }
-
-  @After
-  public void cleanUp() {
-    params.clear();
   }
 
   @Test
@@ -59,7 +54,6 @@ public class GemFireBasicDataSourceJUnitTest {
         .hasMessage("Test Driver Connection attempted!");
   }
 
-
   @Test
   public void connectWithPasswordButNoUsername() throws DataSourceCreateException {
     params.put("password", "myPassword");
@@ -68,6 +62,5 @@ public class GemFireBasicDataSourceJUnitTest {
 
     assertThatThrownBy(() -> dataSource.getConnection())
         .hasMessage("Test Driver Connection attempted!");
-
   }
 }


### PR DESCRIPTION
I also fixed a couple warnings in the tests I changed.