### PR TITLE
GEODE-5353: gfsh hint should be case independent

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/HintCommandIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/HintCommandIntegrationTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.management.internal.cli.commands;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.management.internal.cli.help.Helper;
+import org.apache.geode.test.junit.categories.GfshTest;
+import org.apache.geode.test.junit.rules.GfshCommandRule;
+
+@Category(GfshTest.class)
+public class HintCommandIntegrationTest {
+  private static Helper hintHelper;
+
+  @ClassRule
+  public static GfshCommandRule gfsh = new GfshCommandRule();
+
+  @BeforeClass
+  public static void beforeClass() {
+    hintHelper = new Helper();
+  }
+
+  @Test
+  public void hintCommandShouldSucceedWhenTopicDoesNotExist() {
+    gfsh.executeAndAssertThat("hint invalidTopic").statusIsSuccess()
+        .containsOutput("Unknown topic", "Use hint to view the list of available topics.");
+  }
+
+  @Test
+  public void hintCommandWithNoParametersShouldReturnAllTopics() {
+    gfsh.executeAndAssertThat("hint").statusIsSuccess()
+        .containsOutput(hintHelper.getTopicNames().toArray(new String[0]))
+        .doesNotContainOutput("Unknown topic");
+  }
+
+  @Test
+  public void hintCommandShouldReturnHintForAllKnownTopics() {
+    hintHelper.getTopicNames().forEach(
+        topic -> gfsh.executeAndAssertThat("hint " + topic).statusIsSuccess()
+            .doesNotContainOutput("Unknown topic"));
+  }
+
+  @Test
+  public void hintCommandShouldIgnoreCase() {
+    hintHelper.getTopicNames().forEach(
+        topic -> {
+          gfsh.executeAndAssertThat("hint " + topic.toLowerCase()).statusIsSuccess()
+              .doesNotContainOutput("Unknown topic");
+          gfsh.executeAndAssertThat("hint " + topic.toUpperCase()).statusIsSuccess()
+              .doesNotContainOutput("Unknown topic");
+        });
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/help/Helper.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/help/Helper.java
@@ -50,23 +50,22 @@ public class Helper {
   static final String OPTIONS_NAME = "PARAMETERS";
   static final String IS_AVAILABLE_NAME = "IS AVAILABLE";
 
-  static final String REQUIRED_SUB_NAME = "Required: ";
-  static final String SYNONYMS_SUB_NAME = "Synonyms: ";
-  static final String SPECIFIEDDEFAULTVALUE_SUB_NAME =
+  private static final String REQUIRED_SUB_NAME = "Required: ";
+  private static final String SYNONYMS_SUB_NAME = "Synonyms: ";
+  private static final String SPECIFIEDDEFAULTVALUE_SUB_NAME =
       "Default (if the parameter is specified without value): ";
-  static final String UNSPECIFIEDDEFAULTVALUE_VALUE_SUB_NAME =
+  private static final String UNSPECIFIEDDEFAULTVALUE_VALUE_SUB_NAME =
       "Default (if the parameter is not specified): ";
 
-  static final String VALUE_FIELD = "value";
-  static final String TRUE_TOKEN = "true";
-  static final String FALSE_TOKEN = "false";
-  static final String AVAILABLE = "Available";
-  static final String NOT_AVAILABLE = "Not Available";
+  private static final String VALUE_FIELD = "value";
+  private static final String TRUE_TOKEN = "true";
+  private static final String FALSE_TOKEN = "false";
+  private static final String AVAILABLE = "Available";
+  private static final String NOT_AVAILABLE = "Not Available";
 
-  private final Map<String, Topic> topics = new HashMap<>();
-  private final Map<String, Method> commands = new TreeMap<String, Method>();
-  private final Map<String, MethodTarget> availabilityIndicators =
-      new HashMap<String, MethodTarget>();
+  private final Map<String, Topic> topics = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+  private final Map<String, Method> commands = new TreeMap<>();
+  private final Map<String, MethodTarget> availabilityIndicators = new HashMap<>();
 
   public Helper() {
     initTopic(CliStrings.DEFAULT_TOPIC_GEODE, CliStrings.DEFAULT_TOPIC_GEODE__DESC);
@@ -96,9 +95,7 @@ public class Helper {
 
   public void addCommand(CliCommand command, Method commandMethod) {
     // put all the command synonyms in the command map
-    Arrays.stream(command.value()).forEach(cmd -> {
-      commands.put(cmd, commandMethod);
-    });
+    Arrays.stream(command.value()).forEach(cmd -> commands.put(cmd, commandMethod));
 
     // resolve the hint message for each method
     CliMetaData cliMetaData = commandMethod.getDeclaredAnnotation(CliMetaData.class);
@@ -121,9 +118,8 @@ public class Helper {
   }
 
   public void addAvailabilityIndicator(CliAvailabilityIndicator availability, MethodTarget target) {
-    Arrays.stream(availability.value()).forEach(command -> {
-      availabilityIndicators.put(command, target);
-    });
+    Arrays.stream(availability.value())
+        .forEach(command -> availabilityIndicators.put(command, target));
   }
 
   /**
@@ -175,7 +171,7 @@ public class Helper {
     return topics.keySet();
   }
 
-  boolean isAvailable(String command) {
+  private boolean isAvailable(String command) {
     MethodTarget target = availabilityIndicators.get(command);
     if (target == null) {
       return true;
@@ -193,9 +189,9 @@ public class Helper {
 
   HelpBlock getHelp() {
     HelpBlock root = new HelpBlock();
-    commands.keySet().stream().sorted().map(commands::get).forEach(method -> {
-      root.addChild(getHelp(method.getDeclaredAnnotation(CliCommand.class), null, null));
-    });
+    commands.keySet().stream().sorted().map(commands::get).forEach(method -> root
+        .addChild(getHelp(method.getDeclaredAnnotation(CliCommand.class), null, null)));
+
     return root;
   }
 
@@ -251,11 +247,12 @@ public class Helper {
     // Detailed description of all the Options
     if (annotations.length > 0) {
       HelpBlock options = new HelpBlock(OPTIONS_NAME);
-      for (int i = 0; i < annotations.length; i++) {
-        CliOption cliOption = getAnnotation(annotations[i], CliOption.class);
+      for (Annotation[] annotation : annotations) {
+        CliOption cliOption = getAnnotation(annotation, CliOption.class);
         HelpBlock optionNode = getOptionDetail(cliOption);
         options.addChild(optionNode);
       }
+
       root.addChild(options);
     }
     return root;
@@ -298,7 +295,7 @@ public class Helper {
   }
 
   String getSyntaxString(String commandName, Annotation[][] annotations, Class[] parameterTypes) {
-    StringBuffer buffer = new StringBuffer();
+    StringBuilder buffer = new StringBuilder();
     buffer.append(commandName);
     for (int i = 0; i < annotations.length; i++) {
       CliOption cliOption = getAnnotation(annotations[i], CliOption.class);
@@ -324,7 +321,7 @@ public class Helper {
       return (cliOption.key()[1]);
     }
 
-    StringBuffer buffer = new StringBuffer();
+    StringBuilder buffer = new StringBuilder();
     buffer.append(GfshParser.LONG_OPTION_SPECIFIER).append(key0);
 
     boolean hasSpecifiedDefault = !isNullOrBlank(cliOption.specifiedDefaultValue());

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/i18n/CliStrings.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/i18n/CliStrings.java
@@ -1547,7 +1547,7 @@ public class CliStrings {
   public static final String HINT__MSG__SHELL_NOT_INITIALIZED =
       "Shell is not initialized properly. Please restart the shell. Check gfsh-<timestamp>.log for errors.";
   public static final String HINT__MSG__UNKNOWN_TOPIC =
-      "Unknown topic: {0}. Use " + HINT + "; to view the list of available topics.";
+      "Unknown topic: {0}. Use " + HINT + " to view the list of available topics.";
   public static final String HINT__MSG__TOPICS_AVAILABLE =
       "Hints are available for the following topics. Use \"" + HINT
           + " <topic-name>\" for a specific hint.";


### PR DESCRIPTION
GEODE-5353: gfsh hint should be case independent

- Added integration tests for `gfsh hint` command.
- Removed some minor warnings from the `Helper` class.
- Replaced the internal `HashMap` containing the `topics` for a
  `TreeMap` with the `String.CASE_INSENSITIVE_ORDER` comparator.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
