### PR TITLE
GEODE-5623: Use Awaitility in StopLcoatorCommandDUnitTest

### DIFF
--- a/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/StopLocatorCommandDUnitTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/StopLocatorCommandDUnitTest.java
@@ -157,9 +157,9 @@ public class StopLocatorCommandDUnitTest {
         .getCommandString();
 
 
-    // The new locator is not immediately available to be stopped because it's mbean
+    // The new locator is not immediately available to be stopped because its mbean
     // has to be propagated to the existing locator that gfsh is connected to. Wait
-    // For the stop to work
+    // for the stop to work
     waitForCommandToSucceed(command);
     gfsh.executeAndAssertThat("list members").doesNotContainOutput(memberName);
   }
@@ -174,9 +174,9 @@ public class StopLocatorCommandDUnitTest {
         .addOption(STOP_LOCATOR__MEMBER, memberID)
         .getCommandString();
 
-    // The new locator is not immediately available to be stopped because it's mbean
+    // The new locator is not immediately available to be stopped because its mbean
     // has to be propagated to the existing locator that gfsh is connected to. Wait
-    // For the stop to work
+    // for the stop to work
     waitForCommandToSucceed(command);
 
     gfsh.executeAndAssertThat("list members").doesNotContainOutput(memberName);


### PR DESCRIPTION
Apparently members are not immmediately visible to stop after gfsh start
locator. Changing the test to use awaitility to wait until the members
can be stopped.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
