### PR TITLE
GEODE-5641: add no-arg constructor to DiskDirRule

### DIFF
--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/rules/DistributedDiskDirRule.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/rules/DistributedDiskDirRule.java
@@ -109,13 +109,19 @@ public class DistributedDiskDirRule extends DiskDirRule implements SerializableT
   }
 
   public DistributedDiskDirRule(Builder builder) {
-    this(builder.fillIn(), new RemoteInvoker());
+    this(builder, new RemoteInvoker());
   }
 
   protected DistributedDiskDirRule(Builder builder, RemoteInvoker invoker) {
-    super(builder.initializeHelperRules, null, null);
-    temporaryFolder = builder.temporaryFolder;
-    testName = builder.testName;
+    this(builder.initializeHelperRules, builder.temporaryFolder, builder.testName, invoker);
+  }
+
+  protected DistributedDiskDirRule(boolean initializeHelperRules,
+      SerializableTemporaryFolder temporaryFolder, SerializableTestName testName,
+      RemoteInvoker invoker) {
+    super(initializeHelperRules, null, null);
+    this.temporaryFolder = temporaryFolder;
+    this.testName = testName;
     this.invoker = invoker;
   }
 
@@ -236,8 +242,8 @@ public class DistributedDiskDirRule extends DiskDirRule implements SerializableT
    */
   public static class Builder {
     private boolean initializeHelperRules = true;
-    private SerializableTemporaryFolder temporaryFolder;
-    private SerializableTestName testName;
+    private SerializableTemporaryFolder temporaryFolder = new SerializableTemporaryFolder();
+    private SerializableTestName testName = new SerializableTestName();
 
     public Builder() {
       // nothing
@@ -264,18 +270,7 @@ public class DistributedDiskDirRule extends DiskDirRule implements SerializableT
     }
 
     public DistributedDiskDirRule build() {
-      fillIn();
       return new DistributedDiskDirRule(this);
-    }
-
-    private Builder fillIn() {
-      if (temporaryFolder == null) {
-        temporaryFolder = new SerializableTemporaryFolder();
-      }
-      if (testName == null) {
-        testName = new SerializableTestName();
-      }
-      return this;
     }
   }
 }

--- a/geode-dunit/src/main/java/org/apache/geode/test/junit/rules/DiskDirRule.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/junit/rules/DiskDirRule.java
@@ -43,6 +43,10 @@ public class DiskDirRule extends DescribedExternalResource {
 
   private String originalValue;
 
+  public DiskDirRule() {
+    this(new Builder());
+  }
+
   public DiskDirRule(TemporaryFolder temporaryFolder) {
     this(new Builder().temporaryFolder(temporaryFolder));
   }
@@ -57,10 +61,6 @@ public class DiskDirRule extends DescribedExternalResource {
 
   public DiskDirRule(Builder builder) {
     this(builder.initializeHelperRules, builder.temporaryFolder, builder.testName);
-  }
-
-  protected DiskDirRule() {
-    this(false, null, null);
   }
 
   protected DiskDirRule(boolean initializeHelperRules, TemporaryFolder temporaryFolder,
@@ -143,8 +143,8 @@ public class DiskDirRule extends DescribedExternalResource {
    */
   public static class Builder {
     private boolean initializeHelperRules = true;
-    private TemporaryFolder temporaryFolder;
-    private TestName testName;
+    private TemporaryFolder temporaryFolder = new TemporaryFolder();
+    private TestName testName = new TestName();
 
     public Builder() {
       // nothing
@@ -171,18 +171,7 @@ public class DiskDirRule extends DescribedExternalResource {
     }
 
     public DiskDirRule build() {
-      fillIn();
       return new DiskDirRule(this);
-    }
-
-    private Builder fillIn() {
-      if (temporaryFolder == null) {
-        temporaryFolder = new TemporaryFolder();
-      }
-      if (testName == null) {
-        testName = new TestName();
-      }
-      return this;
     }
   }
 }


### PR DESCRIPTION
To redirect Geode default disk store to a TemporaryFolder, you can simply
add this to any test:
```java
@Rule
public DiskDirRule diskDirRule = new DiskDirRule();
```
Or in a DistributedTest use:
```java
@Rule
public DistributedDiskDirRule diskDirRule = new DistributedDiskDirRule();
```