### PR TITLE
GEODE-5594: Rename SSL hostname validation property name

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/SSLConfigJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/SSLConfigJUnitTest.java
@@ -51,6 +51,9 @@ import static org.apache.geode.distributed.ConfigurationProperties.SERVER_SSL_PR
 import static org.apache.geode.distributed.ConfigurationProperties.SERVER_SSL_REQUIRE_AUTHENTICATION;
 import static org.apache.geode.distributed.ConfigurationProperties.SERVER_SSL_TRUSTSTORE;
 import static org.apache.geode.distributed.ConfigurationProperties.SERVER_SSL_TRUSTSTORE_PASSWORD;
+import static org.apache.geode.distributed.ConfigurationProperties.SSL_ENDPOINT_IDENTIFICATION_ENABLED;
+import static org.apache.geode.internal.security.SecurableCommunicationChannel.ALL;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
@@ -64,6 +67,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import org.apache.geode.distributed.internal.DistributionConfigImpl;
+import org.apache.geode.internal.admin.SSLConfig;
 import org.apache.geode.internal.net.SSLConfigurationFactory;
 import org.apache.geode.test.junit.categories.SecurityTest;
 
@@ -1080,6 +1084,21 @@ public class SSLConfigJUnitTest {
     isEqual(CLUSTER_SSL_PROPS_MAP.get(CLUSTER_SSL_TRUSTSTORE), config.getJmxManagerSSLTrustStore());
     isEqual(CLUSTER_SSL_PROPS_MAP.get(CLUSTER_SSL_TRUSTSTORE_PASSWORD),
         config.getJmxManagerSSLTrustStorePassword());
+  }
+
+  @Test
+  public void testEndpointIdentificationSSLConfig() {
+    Properties props = new Properties();
+
+    props.put("ssl-enabled-components", ALL);
+    props.put("ssl-endpoint-identification-enabled", "true");
+
+    SSLConfig sslConfig = SSLConfigurationFactory.getSSLConfigForComponent(props, ALL);
+    assertThat(sslConfig.doEndpointIdentification()).isTrue();
+
+    props.put(SSL_ENDPOINT_IDENTIFICATION_ENABLED, "false");
+    sslConfig = SSLConfigurationFactory.getSSLConfigForComponent(props, ALL);
+    assertThat(sslConfig.doEndpointIdentification()).isFalse();
   }
 
   private static Properties getGfSecurityPropertiesSSL() {

--- a/geode-core/src/main/java/org/apache/geode/distributed/ConfigurationProperties.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/ConfigurationProperties.java
@@ -1939,7 +1939,7 @@ public interface ConfigurationProperties {
    * <U>Default</U>: code>"false"</code>
    * <U>Since</U>: Geode 1.8
    */
-  String SSL_ENDPOINT_IDENTIFICATION_ENABLED = "ssl-enable-endpoint-identification";
+  String SSL_ENDPOINT_IDENTIFICATION_ENABLED = "ssl-endpoint-identification-enabled";
   /**
    * The static String definition of the <i>"ssl-enabled-components"</i> property <a
    * name="ssl-enabled-components"/a>


### PR DESCRIPTION
   renamed ssl-enable-endpoint-identification
   to ssl-endpoint-identification-enabled.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
