### PR TITLE
GEODE-5212: new windows group on develop pipeline.

### DIFF
--- a/ci/pipelines/geode-build/jinja.template.yml
+++ b/ci/pipelines/geode-build/jinja.template.yml
@@ -44,11 +44,17 @@ groups:
 - name: main
   jobs:
   - Build
-  {% for test in (tests + windowstests) if not test.name=="StressNew" -%}
+  {% for test in (tests) if not test.name=="StressNew" -%}
   - {{test.name}}Test
   {% endfor -%}
   - UpdatePassingRef
   - PublishArtifacts
+- name: windows
+  jobs:
+  - Build
+  {% for test in (windowstests) if not test.name=="StressNew" -%}
+  - {{test.name}}Test
+  {% endfor %}
 
 resources:
 - name: geode-build-artifact


### PR DESCRIPTION
   Until builds are stable on Windows lets hide the jobs 
   on main pipeline and move them to a new group 'windows'

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
