### PR TITLE
GEODE-5622: Add unique port supplier that remembers supplied ports

### DIFF
--- a/geode-dunit/src/main/java/org/apache/geode/test/junit/rules/MemberStarterRule.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/junit/rules/MemberStarterRule.java
@@ -251,8 +251,9 @@ public abstract class MemberStarterRule<T> extends SerializableExternalResource 
   public T withHttpService(boolean useDefaultPort) {
     properties.setProperty(HTTP_SERVICE_BIND_ADDRESS, "localhost");
     if (!useDefaultPort) {
-      httpPort = portSupplier.getAvailablePort();
-      properties.put(HTTP_SERVICE_PORT, httpPort + "");
+      properties.putIfAbsent(HTTP_SERVICE_PORT,
+          portSupplier.getAvailablePort() + "");
+      this.httpPort = Integer.parseInt(properties.getProperty(HTTP_SERVICE_PORT));
     } else {
       // indicate start http service but with default port
       // (different from Gemfire properties, 0 means do not start http service)

--- a/geode-dunit/src/main/java/org/apache/geode/test/junit/rules/MemberStarterRule.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/junit/rules/MemberStarterRule.java
@@ -235,9 +235,10 @@ public abstract class MemberStarterRule<T> extends SerializableExternalResource 
    */
   public T withJMXManager(boolean useProductDefaultPorts) {
     if (!useProductDefaultPorts) {
-      jmxPort = portSupplier.getAvailablePort();
       // do no override these properties if already exists
-      properties.putIfAbsent(JMX_MANAGER_PORT, jmxPort + "");
+      properties.putIfAbsent(JMX_MANAGER_PORT,
+          portSupplier.getAvailablePort() + "");
+      this.jmxPort = Integer.parseInt(properties.getProperty(JMX_MANAGER_PORT));
     } else {
       // the real port numbers will be set after we started the server/locator.
       this.jmxPort = 0;

--- a/geode-junit/src/main/java/org/apache/geode/internal/UniquePortSupplier.java
+++ b/geode-junit/src/main/java/org/apache/geode/internal/UniquePortSupplier.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.IntSupplier;
+import java.util.stream.IntStream;
+
+/**
+ * Supplies unique ports that have not already been supplied by this instance of PortSupplier
+ */
+public class UniquePortSupplier {
+
+  private final IntSupplier supplier;
+  Set<Integer> usedPorts = new HashSet<>();
+
+  public UniquePortSupplier() {
+    supplier = () -> AvailablePortHelper.getRandomAvailableTCPPort();
+  }
+
+  public UniquePortSupplier(IntSupplier supplier) {
+    this.supplier = supplier;
+  }
+
+  public synchronized int getAvailablePort() {
+    int result = IntStream.generate(supplier)
+        .filter(port -> !usedPorts.contains(port))
+        .findFirst()
+        .getAsInt();
+
+    usedPorts.add(result);
+    return result;
+  }
+}

--- a/geode-junit/src/main/java/org/apache/geode/internal/UniquePortSupplier.java
+++ b/geode-junit/src/main/java/org/apache/geode/internal/UniquePortSupplier.java
@@ -25,7 +25,7 @@ import java.util.stream.IntStream;
 public class UniquePortSupplier {
 
   private final IntSupplier supplier;
-  Set<Integer> usedPorts = new HashSet<>();
+  private final Set<Integer> usedPorts = new HashSet<>();
 
   public UniquePortSupplier() {
     supplier = () -> AvailablePortHelper.getRandomAvailableTCPPort();

--- a/geode-junit/src/test/java/org/apache/geode/internal/UniquePortSupplierTest.java
+++ b/geode-junit/src/test/java/org/apache/geode/internal/UniquePortSupplierTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.PrimitiveIterator;
+import java.util.stream.IntStream;
+
+import org.junit.Test;
+
+public class UniquePortSupplierTest {
+
+  @Test
+  public void returnsUniquePorts() {
+    // Create a stream that returns the same number more than once, make sure we find
+    // a unique port
+    PrimitiveIterator.OfInt iterator = IntStream.of(0, 0, 0, 0, 0, 1).iterator();
+    UniquePortSupplier supplier = new UniquePortSupplier(iterator::nextInt);
+    int port0 = supplier.getAvailablePort();
+    int port1 = supplier.getAvailablePort();
+
+    assertThat(port0).isEqualTo(0);
+    assertThat(port1).isEqualTo(1);
+  }
+
+  @Test
+  public void getsPortsFromProvidedSupplier() {
+    int expectedPort = 555;
+
+    UniquePortSupplier supplier = new UniquePortSupplier(() -> expectedPort);
+    int port = supplier.getAvailablePort();
+
+    assertThat(port).isEqualTo(expectedPort);
+  }
+}


### PR DESCRIPTION
Adding a utility to hand out unique ports that don't conflict with
each other, and using that in the MemberStarterRule. This should fix port
conflicts in AlterRuntimeCommandDUnitTest and others.

Co-authored-by: Dale Emery <dale@dhemery.com>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
