### PR TITLE
GEODE-5481: Extended wait duration in security tests

### DIFF
--- a/geode-dunit/src/main/java/org/apache/geode/security/ClientAuthorizationTestCase.java
+++ b/geode-dunit/src/main/java/org/apache/geode/security/ClientAuthorizationTestCase.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.security;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_CLIENT_ACCESSOR;
 import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_CLIENT_ACCESSOR_PP;
 import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_CLIENT_AUTHENTICATOR;
@@ -29,7 +31,6 @@ import static org.apache.geode.security.SecurityTestUtils.concatProperties;
 import static org.apache.geode.security.SecurityTestUtils.getCache;
 import static org.apache.geode.security.SecurityTestUtils.getLocalValue;
 import static org.apache.geode.security.SecurityTestUtils.registerExpectedExceptions;
-import static org.apache.geode.security.SecurityTestUtils.waitForCondition;
 import static org.apache.geode.test.dunit.Assert.assertEquals;
 import static org.apache.geode.test.dunit.Assert.assertFalse;
 import static org.apache.geode.test.dunit.Assert.assertNotNull;
@@ -38,6 +39,7 @@ import static org.apache.geode.test.dunit.Assert.assertTrue;
 import static org.apache.geode.test.dunit.Assert.fail;
 import static org.apache.geode.test.dunit.Host.getHost;
 import static org.apache.geode.test.dunit.Wait.waitForCriterion;
+import static org.awaitility.Awaitility.waitAtMost;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -282,14 +284,16 @@ public abstract class ClientAuthorizationTestCase extends JUnit4DistributedTestC
       if ((flags & OpFlags.NO_CREATE_SUBREGION) > 0) {
         if ((flags & OpFlags.CHECK_NOREGION) > 0) {
           // Wait for some time for DRF update to come
-          waitForCondition(() -> getSubregion() == null);
+          waitAtMost(5, MINUTES).pollInterval(200, MILLISECONDS)
+              .until(() -> getSubregion() == null);
           subregion = getSubregion();
           assertNull(subregion);
           return;
 
         } else {
           // Wait for some time for DRF update to come
-          waitForCondition(() -> getSubregion() != null);
+          waitAtMost(5, MINUTES).pollInterval(200, MILLISECONDS)
+              .until(() -> getSubregion() != null);
           subregion = getSubregion();
           assertNotNull(subregion);
         }
@@ -303,7 +307,8 @@ public abstract class ClientAuthorizationTestCase extends JUnit4DistributedTestC
 
     } else if ((flags & OpFlags.CHECK_NOREGION) > 0) {
       // Wait for some time for region destroy update to come
-      waitForCondition(() -> getRegion() == null);
+      waitAtMost(5, MINUTES).pollInterval(200, MILLISECONDS)
+          .until(() -> getRegion() == null);
       region = getRegion();
       assertNull(region);
       return;
@@ -403,7 +408,8 @@ public abstract class ClientAuthorizationTestCase extends JUnit4DistributedTestC
                 return this;
               }
             }.init(region);
-            waitForCondition(condition);
+            waitAtMost(5, MINUTES).pollInterval(200, MILLISECONDS)
+                .until(condition);
 
             value = getLocalValue(region, key);
 

--- a/geode-dunit/src/main/java/org/apache/geode/security/SecurityTestUtils.java
+++ b/geode-dunit/src/main/java/org/apache/geode/security/SecurityTestUtils.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.security;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.apache.geode.cache30.ClientServerTestCase.configureConnectionPoolWithNameAndFactory;
 import static org.apache.geode.cache30.ClientServerTestCase.disconnectFromDS;
 import static org.apache.geode.distributed.ConfigurationProperties.DURABLE_CLIENT_ID;
@@ -33,7 +35,7 @@ import static org.apache.geode.test.dunit.Assert.fail;
 import static org.apache.geode.test.dunit.DistributedTestUtils.getDUnitLocatorPort;
 import static org.apache.geode.test.dunit.LogWriterUtils.getLogWriter;
 import static org.apache.geode.test.dunit.NetworkUtils.getIPLiteral;
-import static org.apache.geode.test.dunit.Wait.waitForCriterion;
+import static org.awaitility.Awaitility.waitAtMost;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -49,7 +51,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.concurrent.Callable;
 
 import javax.net.ServerSocketFactory;
 import javax.net.SocketFactory;
@@ -95,7 +96,6 @@ import org.apache.geode.pdx.PdxReader;
 import org.apache.geode.pdx.PdxSerializable;
 import org.apache.geode.pdx.PdxWriter;
 import org.apache.geode.security.templates.UsernamePrincipal;
-import org.apache.geode.test.dunit.WaitCriterion;
 import org.apache.geode.test.dunit.internal.JUnit4DistributedTestCase;
 
 /**
@@ -598,31 +598,6 @@ public class SecurityTestUtils {
 
   protected static Cache getCache() {
     return cache;
-  }
-
-  protected static void waitForCondition(final Callable<Boolean> condition) {
-    waitForCondition(condition, 100, 120);
-  }
-
-  protected static void waitForCondition(final Callable<Boolean> condition, final int sleepMillis,
-      final int numTries) {
-    WaitCriterion ev = new WaitCriterion() {
-      @Override
-      public boolean done() {
-        try {
-          return condition.call();
-        } catch (Exception e) {
-          fail("Unexpected exception", e);
-        }
-        return false; // NOTREACHED
-      }
-
-      @Override
-      public String description() {
-        return null;
-      }
-    };
-    waitForCriterion(ev, sleepMillis * numTries, 200, true);
   }
 
   protected static Object getLocalValue(final Region region, final Object key) {
@@ -1645,7 +1620,8 @@ public class SecurityTestUtils {
     for (int index = 0; index < num; ++index) {
       final String key = KEYS[index];
       final String expectedVal = vals[index];
-      waitForCondition(() -> expectedVal.equals(getLocalValue(region, key)), 1000, 30 / num);
+      waitAtMost(5, MINUTES).pollInterval(200, MILLISECONDS)
+          .until(() -> expectedVal.equals(getLocalValue(region, key)));
     }
 
     for (int index = 0; index < num; ++index) {


### PR DESCRIPTION
CLientAUthorizationDUnitTest was only waiting 7 seconds for an event to
occur. Switching to Awaitility and waiting for 5 minutes.

Co-authored-by: Dale Emery <demery@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
