### PR TITLE
GEODE-5607: Replace Jmock with Mockito

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/OplogRVVJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/OplogRVVJUnitTest.java
@@ -14,29 +14,32 @@
  */
 package org.apache.geode.internal.cache;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
-import java.net.UnknownHostException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.apache.commons.io.FileUtils;
-import org.jmock.Expectations;
-import org.jmock.Mockery;
-import org.jmock.lib.concurrent.Synchroniser;
-import org.jmock.lib.legacy.ClassImposteriser;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import org.apache.geode.CancelCriterion;
+import org.apache.geode.Statistics;
 import org.apache.geode.StatisticsFactory;
-import org.apache.geode.i18n.LogWriterI18n;
 import org.apache.geode.internal.cache.DiskInitFile.DiskRegionFlag;
 import org.apache.geode.internal.cache.DiskStoreImpl.OplogEntryIdSet;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
@@ -44,14 +47,7 @@ import org.apache.geode.internal.cache.persistence.DiskStoreID;
 import org.apache.geode.internal.cache.versions.DiskRegionVersionVector;
 
 public class OplogRVVJUnitTest {
-
   private File testDirectory;
-  private Mockery context = new Mockery() {
-    {
-      setImposteriser(ClassImposteriser.INSTANCE);
-      setThreadingPolicy(new Synchroniser());
-    }
-  };
 
   @Rule
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -68,59 +64,37 @@ public class OplogRVVJUnitTest {
   }
 
   @Test
-  public void testRecoverRVV() throws UnknownHostException {
-    final DiskInitFile df = context.mock(DiskInitFile.class);
-    final LogWriterI18n logger = context.mock(LogWriterI18n.class);
-    final GemFireCacheImpl cache = context.mock(GemFireCacheImpl.class);
+  public void testRecoverRVV() {
+    final DiskInitFile df = mock(DiskInitFile.class);
+    final GemFireCacheImpl cache = mock(GemFireCacheImpl.class);
+
     // Create a mock disk store impl.
-    final DiskStoreImpl parent = context.mock(DiskStoreImpl.class);
-    final StatisticsFactory sf = context.mock(StatisticsFactory.class);
+    final DiskStoreImpl parent = mock(DiskStoreImpl.class);
+    final StatisticsFactory sf = mock(StatisticsFactory.class);
     final DiskStoreID ownerId = DiskStoreID.random();
     final DiskStoreID m1 = DiskStoreID.random();
     final DiskStoreID m2 = DiskStoreID.random();
-    final DiskRecoveryStore drs = context.mock(DiskRecoveryStore.class);
+    final DiskRecoveryStore drs = mock(DiskRecoveryStore.class);
+    when(df.getOrCreateCanonicalId(m1)).thenReturn(1);
+    when(df.getOrCreateCanonicalId(m2)).thenReturn(2);
+    when(df.getOrCreateCanonicalId(ownerId)).thenReturn(3);
+    when(df.getCanonicalObject(1)).thenReturn(m1);
+    when(df.getCanonicalObject(2)).thenReturn(m2);
+    when(df.getCanonicalObject(3)).thenReturn(ownerId);
+    when(sf.createStatistics(any(), anyString())).thenReturn(mock(Statistics.class));
+    when(sf.createAtomicStatistics(any(), anyString())).thenReturn(mock(Statistics.class));
 
-    context.checking(new Expectations() {
-      {
-        ignoring(sf);
-        allowing(df).getOrCreateCanonicalId(m1);
-        will(returnValue(1));
-        allowing(df).getOrCreateCanonicalId(m2);
-        will(returnValue(2));
-        allowing(df).getOrCreateCanonicalId(ownerId);
-        will(returnValue(3));
-        allowing(df).getCanonicalObject(1);
-        will(returnValue(m1));
-        allowing(df).getCanonicalObject(2);
-        will(returnValue(m2));
-        allowing(df).getCanonicalObject(3);
-        will(returnValue(ownerId));
-        ignoring(df);
-      }
-    });
     DirectoryHolder dirHolder = new DirectoryHolder(sf, testDirectory, 0, 0);
-
-    context.checking(new Expectations() {
-      {
-        ignoring(logger);
-        allowing(cache).getLoggerI18n();
-        will(returnValue(logger));
-        allowing(cache).cacheTimeMillis();
-        will(returnValue(System.currentTimeMillis()));
-        allowing(parent).getCache();
-        will(returnValue(cache));
-        allowing(parent).getMaxOplogSizeInBytes();
-        will(returnValue(10000L));
-        allowing(parent).getName();
-        will(returnValue("test"));
-        allowing(parent).getStats();
-        will(returnValue(new DiskStoreStats(sf, "stats")));
-        allowing(parent).getDiskInitFile();
-        will(returnValue(df));
-        allowing(parent).getDiskStoreID();
-        will(returnValue(DiskStoreID.random()));
-      }
-    });
+    when(cache.cacheTimeMillis()).thenReturn(System.currentTimeMillis());
+    when(parent.getCache()).thenReturn(cache);
+    when(parent.getMaxOplogSizeInBytes()).thenReturn(10000L);
+    when(parent.getName()).thenReturn("test");
+    DiskStoreStats diskStoreStats = new DiskStoreStats(sf, "stats");
+    when(parent.getStats()).thenReturn(diskStoreStats);
+    when(parent.getDiskInitFile()).thenReturn(df);
+    when(parent.getDiskStoreID()).thenReturn(DiskStoreID.random());
+    when(parent.getBackupLock()).thenReturn(mock(ReentrantLock.class));
+    when(parent.getCancelCriterion()).thenReturn(mock(CancelCriterion.class));
 
     final DiskRegionVersionVector rvv = new DiskRegionVersionVector(ownerId);
     rvv.recordVersion(m1, 0);
@@ -135,57 +109,36 @@ public class OplogRVVJUnitTest {
     rvv.recordGCVersion(m2, 0);
 
     // create the oplog
-
-    final AbstractDiskRegion diskRegion = context.mock(AbstractDiskRegion.class);
-    final PersistentOplogSet oplogSet = context.mock(PersistentOplogSet.class);
-    final Map<Long, AbstractDiskRegion> map = new HashMap<Long, AbstractDiskRegion>();
+    final AbstractDiskRegion diskRegion = mock(AbstractDiskRegion.class);
+    final PersistentOplogSet oplogSet = mock(PersistentOplogSet.class);
+    final Map<Long, AbstractDiskRegion> map = new HashMap<>();
     map.put(5L, diskRegion);
-    context.checking(new Expectations() {
-      {
-        allowing(diskRegion).getRegionVersionVector();
-        will(returnValue(rvv));
-        allowing(diskRegion).getRVVTrusted();
-        will(returnValue(true));
-        allowing(parent).getAllDiskRegions();
-        will(returnValue(map));
-        allowing(oplogSet).getCurrentlyRecovering(5L);
-        will(returnValue(drs));
-        allowing(oplogSet).getParent();
-        will(returnValue(parent));
-        ignoring(oplogSet);
-        ignoring(parent);
-        allowing(diskRegion).getFlags();
-        will(returnValue(EnumSet.of(DiskRegionFlag.IS_WITH_VERSIONING)));
-      }
-    });
-
-    Map<Long, AbstractDiskRegion> regions = parent.getAllDiskRegions();
+    when(diskRegion.getRegionVersionVector()).thenReturn(rvv);
+    when(diskRegion.getRVVTrusted()).thenReturn(true);
+    when(parent.getAllDiskRegions()).thenReturn(map);
+    when(oplogSet.getCurrentlyRecovering(5L)).thenReturn(drs);
+    when(oplogSet.getParent()).thenReturn(parent);
+    when(diskRegion.getFlags()).thenReturn(EnumSet.of(DiskRegionFlag.IS_WITH_VERSIONING));
 
     Oplog oplog = new Oplog(1, oplogSet, dirHolder);
     oplog.close();
 
-    context.checking(new Expectations() {
-      {
-        one(drs).recordRecoveredGCVersion(m1, 1);
-        one(drs).recordRecoveredGCVersion(m2, 0);
-        one(drs).recordRecoveredVersonHolder(ownerId, rvv.getMemberToVersion().get(ownerId), true);
-        one(drs).recordRecoveredVersonHolder(m1, rvv.getMemberToVersion().get(m1), true);
-        one(drs).recordRecoveredVersonHolder(m2, rvv.getMemberToVersion().get(m2), true);
-        one(drs).setRVVTrusted(true);
-      }
-    });
-
     oplog = new Oplog(1, oplogSet);
     Collection<File> drfFiles = FileUtils.listFiles(testDirectory, new String[] {"drf"}, true);
-    assertEquals(1, drfFiles.size());
+    assertThat(1).isEqualTo(drfFiles.size());
     Collection<File> crfFiles = FileUtils.listFiles(testDirectory, new String[] {"crf"}, true);
-    assertEquals(1, crfFiles.size());
+    assertThat(1).isEqualTo(crfFiles.size());
     oplog.addRecoveredFile(drfFiles.iterator().next(), dirHolder);
     oplog.addRecoveredFile(crfFiles.iterator().next(), dirHolder);
     OplogEntryIdSet deletedIds = new OplogEntryIdSet();
     oplog.recoverDrf(deletedIds, false, true);
     oplog.recoverCrf(deletedIds, true, true, false, Collections.singleton(oplog), true);
-    context.assertIsSatisfied();
+    verify(drs, times(1)).recordRecoveredGCVersion(m1, 1);
+    verify(drs, times(1)).recordRecoveredGCVersion(m2, 0);
+    verify(drs, times(1)).recordRecoveredVersonHolder(ownerId,
+        rvv.getMemberToVersion().get(ownerId), true);
+    verify(drs, times(1)).recordRecoveredVersonHolder(m1, rvv.getMemberToVersion().get(m1), true);
+    verify(drs, times(1)).recordRecoveredVersonHolder(m2, rvv.getMemberToVersion().get(m2), true);
+    verify(drs, times(1)).setRVVTrusted(true);
   }
-
 }

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/OplogRVVJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/OplogRVVJUnitTest.java
@@ -125,9 +125,9 @@ public class OplogRVVJUnitTest {
 
     oplog = new Oplog(1, oplogSet);
     Collection<File> drfFiles = FileUtils.listFiles(testDirectory, new String[] {"drf"}, true);
-    assertThat(1).isEqualTo(drfFiles.size());
+    assertThat(drfFiles.size()).isEqualTo(1);
     Collection<File> crfFiles = FileUtils.listFiles(testDirectory, new String[] {"crf"}, true);
-    assertThat(1).isEqualTo(crfFiles.size());
+    assertThat(crfFiles.size()).isEqualTo(1);
     oplog.addRecoveredFile(drfFiles.iterator().next(), dirHolder);
     oplog.addRecoveredFile(crfFiles.iterator().next(), dirHolder);
     OplogEntryIdSet deletedIds = new OplogEntryIdSet();

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/statistics/LinuxSystemStatsTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/statistics/LinuxSystemStatsTest.java
@@ -19,13 +19,12 @@ import static org.mockito.ArgumentMatchers.anyString;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.io.IOUtils;
-import org.apache.tools.ant.filters.StringInputStream;
+import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -47,6 +46,7 @@ import org.apache.geode.internal.statistics.platform.LinuxProcFsStatistics;
 import org.apache.geode.internal.statistics.platform.LinuxSystemStats;
 import org.apache.geode.test.junit.categories.StatisticsTest;
 
+
 /**
  * Technically a linux only test - the file handling is all mocked up so the test can run on any
  * host os.
@@ -67,13 +67,12 @@ public class LinuxSystemStatsTest extends StatSamplerTestCase {
   private long[] longs;
   private double[] doubles;
   private LocalStatisticsFactory statisticsFactory;
-  private File testDir;
 
   @Before
   public void setUp() throws Exception {
-    this.testDir = this.temporaryFolder.getRoot();
-    assertTrue(this.testDir.exists());
-    System.setProperty(SimpleStatSampler.ARCHIVE_FILE_NAME_PROPERTY, this.testDir.getAbsolutePath()
+    File testDir = this.temporaryFolder.getRoot();
+    assertTrue(testDir.exists());
+    System.setProperty(SimpleStatSampler.ARCHIVE_FILE_NAME_PROPERTY, testDir.getAbsolutePath()
         + File.separator + SimpleStatSampler.DEFAULT_ARCHIVE_FILE_NAME);
     LinuxProcFsStatistics.init();
     initStats();
@@ -162,10 +161,8 @@ public class LinuxSystemStatsTest extends StatSamplerTestCase {
    */
   private File writeStringToFile(String mockProcStatFileContents) throws IOException {
     File mockFile = temporaryFolder.newFile();
-    StringInputStream sis = new StringInputStream(mockProcStatFileContents);
-    FileOutputStream mockFileOutputStream = new FileOutputStream(mockFile);
-    IOUtils.copy(sis, mockFileOutputStream);
-    IOUtils.closeQuietly(mockFileOutputStream);
+    FileUtils.writeStringToFile(mockFile, mockProcStatFileContents, (Charset) null);
+
     return mockFile;
   }
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/statistics/LinuxSystemStatsTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/statistics/LinuxSystemStatsTest.java
@@ -14,7 +14,7 @@
  */
 package org.apache.geode.internal.statistics;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 
 import java.io.File;
@@ -51,7 +51,7 @@ import org.apache.geode.test.junit.categories.StatisticsTest;
  * Technically a linux only test - the file handling is all mocked up so the test can run on any
  * host os.
  */
-@Category({StatisticsTest.class})
+@Category(StatisticsTest.class)
 @RunWith(PowerMockRunner.class)
 @PowerMockIgnore("*.IntegrationTest")
 @PrepareForTest(LinuxProcFsStatistics.class)
@@ -71,7 +71,7 @@ public class LinuxSystemStatsTest extends StatSamplerTestCase {
   @Before
   public void setUp() throws Exception {
     File testDir = this.temporaryFolder.getRoot();
-    assertTrue(testDir.exists());
+    assertThat(testDir.exists()).isTrue();
     System.setProperty(SimpleStatSampler.ARCHIVE_FILE_NAME_PROPERTY, testDir.getAbsolutePath()
         + File.separator + SimpleStatSampler.DEFAULT_ARCHIVE_FILE_NAME);
     LinuxProcFsStatistics.init();

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/statistics/ValueMonitorIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/statistics/ValueMonitorIntegrationTest.java
@@ -81,7 +81,7 @@ public class ValueMonitorIntegrationTest {
 
       @Override
       public Iterator<StatisticId> iterator() {
-        throw null;
+        return null;
       }
 
       @Override
@@ -140,13 +140,13 @@ public class ValueMonitorIntegrationTest {
 
     monitor.addListener(listener);
     monitor.notifyListeners(notification);
-    assertThat(1).isEqualTo(notifications.size());
+    assertThat(notifications.size()).isEqualTo(1);
     notification = notifications.remove(0);
     assertThat(notification).isNotNull();
-    assertThat(timeStamp).isEqualTo(notification.getTimeStamp());
-    assertThat(type).isEqualTo(notification.getType());
+    assertThat(notification.getTimeStamp()).isEqualTo(timeStamp);
+    assertThat(notification.getType()).isEqualTo(type);
     StatisticId statId = mock(StatisticId.class);
-    assertThat(value).isEqualTo(notification.getValue(statId));
+    assertThat(notification.getValue(statId)).isEqualTo(value);
 
     monitor.removeListener(listener);
     monitor.notifyListeners(notification);
@@ -159,7 +159,7 @@ public class ValueMonitorIntegrationTest {
     for (StatisticId statId : notification) {
       Number value = expectedValues.remove(statId.getStatisticDescriptor().getName());
       assertThat(value).isNotNull();
-      assertThat(value).isEqualTo(notification.getValue(statId));
+      assertThat(notification.getValue(statId)).isEqualTo(value);
       statCount++;
     }
 
@@ -204,10 +204,10 @@ public class ValueMonitorIntegrationTest {
     sampleCollector.sample(timeStamp);
     Awaitility.await().atMost(2, TimeUnit.SECONDS).pollInterval(10, TimeUnit.MILLISECONDS)
         .until(() -> notifications.size() > 0);
-    assertThat(1).isEqualTo(notifications.size());
+    assertThat(notifications.size()).isEqualTo(1);
 
     StatisticsNotification notification = notifications.remove(0);
-    assertThat(StatisticsNotification.Type.VALUE_CHANGED).isEqualTo(notification.getType());
+    assertThat(notification.getType()).isEqualTo(StatisticsNotification.Type.VALUE_CHANGED);
 
     // validate 1 notification occurs with all 3 stats of st1_1
     st1_1.incDouble("double_counter_1", 1.1);
@@ -217,16 +217,16 @@ public class ValueMonitorIntegrationTest {
     sampleCollector.sample(timeStamp);
     Awaitility.await().atMost(2, TimeUnit.SECONDS).pollInterval(10, TimeUnit.MILLISECONDS)
         .until(() -> notifications.size() > 0);
-    assertThat(1).isEqualTo(notifications.size());
+    assertThat(notifications.size()).isEqualTo(1);
     notification = notifications.remove(0);
-    assertThat(StatisticsNotification.Type.VALUE_CHANGED).isEqualTo(notification.getType());
+    assertThat(notification.getType()).isEqualTo(StatisticsNotification.Type.VALUE_CHANGED);
 
     Map<String, Number> expectedValues = new HashMap<>();
     expectedValues.put("double_counter_1", 1001.1001);
     expectedValues.put("int_counter_2", 4);
     expectedValues.put("long_counter_3", 3333333336L);
     int statCount = assertStatisticsNotification(notification, expectedValues);
-    assertThat(3).isEqualTo(statCount);
+    assertThat(statCount).isEqualTo(3);
 
     // validate no notification occurs when no stats are updated
     timeStamp += NanoTimer.millisToNanos(1000);
@@ -248,17 +248,17 @@ public class ValueMonitorIntegrationTest {
     // validate notification only contains stats added to monitor
     st1_1.incInt("int_counter_2", 100);
     st1_2.incInt("int_counter_2", 200);
-    assertThat(2).isEqualTo(sampleCollector.currentHandlersForTesting().size());
+    assertThat(sampleCollector.currentHandlersForTesting().size()).isEqualTo(2);
     timeStamp += NanoTimer.millisToNanos(1000);
     sampleCollector.sample(timeStamp);
     Awaitility.await().atMost(2, TimeUnit.SECONDS).pollInterval(10, TimeUnit.MILLISECONDS)
         .until(() -> notifications.size() > 0);
-    assertThat(1).isEqualTo(notifications.size());
+    assertThat(notifications.size()).isEqualTo(1);
     notification = notifications.remove(0);
-    assertThat(StatisticsNotification.Type.VALUE_CHANGED).isEqualTo(notification.getType());
+    assertThat(notification.getType()).isEqualTo(StatisticsNotification.Type.VALUE_CHANGED);
     expectedValues = new HashMap<>();
     expectedValues.put("int_counter_2", 104);
     statCount = assertStatisticsNotification(notification, expectedValues);
-    assertThat(1).isEqualTo(statCount);
+    assertThat(statCount).isEqualTo(1);
   }
 }

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/statistics/ValueMonitorIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/statistics/ValueMonitorIntegrationTest.java
@@ -14,10 +14,9 @@
  */
 package org.apache.geode.internal.statistics;
 
-import static org.apache.geode.test.dunit.Wait.waitForCriterion;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -25,12 +24,9 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
-import org.jmock.Expectations;
-import org.jmock.Mockery;
-import org.jmock.lib.concurrent.Synchroniser;
-import org.jmock.lib.legacy.ClassImposteriser;
-import org.junit.After;
+import org.awaitility.Awaitility;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -43,7 +39,6 @@ import org.apache.geode.StatisticsType;
 import org.apache.geode.internal.NanoTimer;
 import org.apache.geode.internal.io.MainWithChildrenRollingFileHandler;
 import org.apache.geode.internal.statistics.StatisticsNotification.Type;
-import org.apache.geode.test.dunit.WaitCriterion;
 import org.apache.geode.test.junit.categories.StatisticsTest;
 
 /**
@@ -51,284 +46,27 @@ import org.apache.geode.test.junit.categories.StatisticsTest;
  *
  * @since GemFire 7.0
  */
-@Category({StatisticsTest.class})
+@Category(StatisticsTest.class)
 public class ValueMonitorIntegrationTest {
-
-  private Mockery mockContext;
+  private StatArchiveHandlerConfig mockStatArchiveHandlerConfig;
 
   @Rule
   public TestName testName = new TestName();
 
   @Before
-  public void setUp() throws Exception {
-    this.mockContext = new Mockery() {
-      {
-        setImposteriser(ClassImposteriser.INSTANCE);
-        setThreadingPolicy(new Synchroniser());
-      }
-    };
+  public void setUp() {
+    mockStatArchiveHandlerConfig = mock(StatArchiveHandlerConfig.class,
+        testName.getMethodName() + "$StatArchiveHandlerConfig");
+    when(mockStatArchiveHandlerConfig.getArchiveFileName()).thenReturn(new File(""));
+    when(mockStatArchiveHandlerConfig.getArchiveFileSizeLimit()).thenReturn(0L);
+    when(mockStatArchiveHandlerConfig.getArchiveDiskSpaceLimit()).thenReturn(0L);
+    when(mockStatArchiveHandlerConfig.getSystemId()).thenReturn(1L);
+    when(mockStatArchiveHandlerConfig.getSystemDirectoryPath()).thenReturn("");
+    when(mockStatArchiveHandlerConfig.getProductDescription()).thenReturn("Geode");
   }
 
-  @After
-  public void tearDown() throws Exception {
-    this.mockContext.assertIsSatisfied();
-    this.mockContext = null;
-  }
-
-  @Test
-  public void testAddRemoveListener() throws Exception {
-    long startTime = System.currentTimeMillis();
-    List<Statistics> statsList = new ArrayList<Statistics>();
-    StatisticsManager mockStatisticsManager = this.mockContext.mock(StatisticsManager.class,
-        testName.getMethodName() + "$StatisticsManager");
-    this.mockContext.checking(new Expectations() {
-      {
-        allowing(mockStatisticsManager).getName();
-        will(returnValue("mockStatisticsManager"));
-        allowing(mockStatisticsManager).getId();
-        will(returnValue(1));
-        allowing(mockStatisticsManager).getStartTime();
-        will(returnValue(startTime));
-        allowing(mockStatisticsManager).getStatListModCount();
-        will(returnValue(0));
-        allowing(mockStatisticsManager).getStatsList();
-        will(returnValue(statsList));
-      }
-    });
-
-    StatisticsSampler mockStatisticsSampler = this.mockContext.mock(StatisticsSampler.class,
-        testName.getMethodName() + "$StatisticsSampler");
-    this.mockContext.checking(new Expectations() {
-      {
-        allowing(mockStatisticsSampler).getStatisticsModCount();
-        will(returnValue(0));
-        allowing(mockStatisticsSampler).getStatistics();
-        will(returnValue(new Statistics[] {}));
-      }
-    });
-
-    StatArchiveHandlerConfig mockStatArchiveHandlerConfig = this.mockContext.mock(
-        StatArchiveHandlerConfig.class, testName.getMethodName() + "$StatArchiveHandlerConfig");
-    this.mockContext.checking(new Expectations() {
-      {
-        allowing(mockStatArchiveHandlerConfig).getArchiveFileName();
-        will(returnValue(new File("")));
-        allowing(mockStatArchiveHandlerConfig).getArchiveFileSizeLimit();
-        will(returnValue(0));
-        allowing(mockStatArchiveHandlerConfig).getArchiveDiskSpaceLimit();
-        will(returnValue(0));
-        allowing(mockStatArchiveHandlerConfig).getSystemId();
-        will(returnValue(1));
-        allowing(mockStatArchiveHandlerConfig).getSystemStartTime();
-        will(returnValue(startTime));
-        allowing(mockStatArchiveHandlerConfig).getSystemDirectoryPath();
-        will(returnValue(""));
-        allowing(mockStatArchiveHandlerConfig).getProductDescription();
-        will(returnValue("testAddRemoveListener"));
-      }
-    });
-
-    // need a real SampleCollector for this test or the monitor can't get the handler
-    SampleCollector sampleCollector = new SampleCollector(mockStatisticsSampler);
-    sampleCollector.initialize(mockStatArchiveHandlerConfig, NanoTimer.getTime(),
-        new MainWithChildrenRollingFileHandler());
-
-    List<StatisticsNotification> notifications = new ArrayList<>();
-    StatisticsListener listener = (final StatisticsNotification notification) -> {
-      notifications.add(notification);
-    };
-    ValueMonitor monitor = new ValueMonitor();
-
-    long timeStamp = System.currentTimeMillis();
-    Type type = Type.VALUE_CHANGED;
-    Number value = 43;
-
-    StatisticsNotification notification = createStatisticsNotification(timeStamp, type, value);
-    monitor.notifyListeners(notification);
-
-    assertTrue(notifications.isEmpty());
-
-    monitor.addListener(listener);
-    monitor.notifyListeners(notification);
-
-    assertEquals(1, notifications.size());
-    notification = notifications.remove(0);
-    assertNotNull(notification);
-
-    assertEquals(timeStamp, notification.getTimeStamp());
-    assertEquals(type, notification.getType());
-    StatisticId statId = createStatisticId(null, null);
-    assertEquals(value, notification.getValue(statId));
-
-    monitor.removeListener(listener);
-    monitor.notifyListeners(notification);
-
-    assertTrue(notifications.isEmpty());
-  }
-
-  @Test
-  public void testValueMonitorListener() throws Exception {
-    long startTime = System.currentTimeMillis();
-    TestStatisticsManager manager =
-        new TestStatisticsManager(1, "ValueMonitorIntegrationTest", startTime);
-    StatisticsSampler sampler = new TestStatisticsSampler(manager);
-
-    StatArchiveHandlerConfig mockStatArchiveHandlerConfig = this.mockContext.mock(
-        StatArchiveHandlerConfig.class, testName.getMethodName() + "$StatArchiveHandlerConfig");
-    this.mockContext.checking(new Expectations() {
-      {
-        allowing(mockStatArchiveHandlerConfig).getArchiveFileName();
-        will(returnValue(new File("")));
-        allowing(mockStatArchiveHandlerConfig).getArchiveFileSizeLimit();
-        will(returnValue(0));
-        allowing(mockStatArchiveHandlerConfig).getArchiveDiskSpaceLimit();
-        will(returnValue(0));
-        allowing(mockStatArchiveHandlerConfig).getSystemId();
-        will(returnValue(1));
-        allowing(mockStatArchiveHandlerConfig).getSystemStartTime();
-        will(returnValue(startTime));
-        allowing(mockStatArchiveHandlerConfig).getSystemDirectoryPath();
-        will(returnValue(""));
-        allowing(mockStatArchiveHandlerConfig).getProductDescription();
-        will(returnValue("testFoo"));
-      }
-    });
-
-    SampleCollector sampleCollector = new SampleCollector(sampler);
-    sampleCollector.initialize(mockStatArchiveHandlerConfig, NanoTimer.getTime(),
-        new MainWithChildrenRollingFileHandler());
-
-    StatisticDescriptor[] statsST1 = new StatisticDescriptor[] {
-        manager.createDoubleCounter("double_counter_1", "double_counter_1_desc",
-            "double_counter_1_units"),
-        manager.createIntCounter("int_counter_2", "int_counter_2_desc", "int_counter_2_units"),
-        manager.createLongCounter("long_counter_3", "long_counter_3_desc", "long_counter_3_units")};
-    StatisticsType ST1 = manager.createType("ST1_name", "ST1_desc", statsST1);
-    Statistics st1_1 = manager.createAtomicStatistics(ST1, "st1_1_text", 1);
-    Statistics st1_2 = manager.createAtomicStatistics(ST1, "st1_2_text", 2);
-
-    st1_1.incDouble("double_counter_1", 1000.0001);
-    st1_1.incInt("int_counter_2", 2);
-    st1_1.incLong("long_counter_3", 3333333333L);
-
-    st1_2.incDouble("double_counter_1", 2000.0002);
-    st1_2.incInt("int_counter_2", 3);
-    st1_2.incLong("long_counter_3", 4444444444L);
-
-    List<StatisticsNotification> notifications = new ArrayList<>();
-    StatisticsListener listener = (final StatisticsNotification notification) -> {
-      notifications.add(notification);
-    };
-    ValueMonitor monitor = new ValueMonitor().addStatistics(st1_1);
-    monitor.addListener(listener);
-
-    assertTrue("Unexpected notifications: " + notifications, notifications.isEmpty());
-
-    long timeStamp = NanoTimer.getTime();
-    sampleCollector.sample(timeStamp);
-
-    awaitAtLeastTimeoutOrUntilNotifications(notifications, 2 * 1000);
-    assertEquals("Unexpected notifications: " + notifications, 1, notifications.size());
-
-    StatisticsNotification notification = notifications.remove(0);
-    assertEquals(StatisticsNotification.Type.VALUE_CHANGED, notification.getType());
-
-    // validate 1 notification occurs with all 3 stats of st1_1
-
-    st1_1.incDouble("double_counter_1", 1.1);
-    st1_1.incInt("int_counter_2", 2);
-    st1_1.incLong("long_counter_3", 3);
-
-    timeStamp += NanoTimer.millisToNanos(1000);
-    sampleCollector.sample(timeStamp);
-
-    awaitAtLeastTimeoutOrUntilNotifications(notifications, 2 * 1000);
-    assertEquals("Unexpected notifications: " + notifications, 1, notifications.size());
-
-    notification = notifications.remove(0);
-    assertEquals(StatisticsNotification.Type.VALUE_CHANGED, notification.getType());
-
-    int statCount = 0;
-    Map<String, Number> expectedValues = new HashMap<>();
-    expectedValues.put("double_counter_1", 1001.1001);
-    expectedValues.put("int_counter_2", 4);
-    expectedValues.put("long_counter_3", 3333333336L);
-
-    for (StatisticId statId : notification) {
-      Number value = expectedValues.remove(statId.getStatisticDescriptor().getName());
-      assertNotNull(value);
-      assertEquals(value, notification.getValue(statId));
-      statCount++;
-    }
-    assertEquals(3, statCount);
-
-    // validate no notification occurs when no stats are updated
-
-    timeStamp += NanoTimer.millisToNanos(1000);
-    sampleCollector.sample(timeStamp);
-
-    awaitAtLeastTimeoutOrUntilNotifications(notifications, 2 * 1000);
-    assertTrue("Unexpected notifications: " + notifications, notifications.isEmpty());
-
-    // validate no notification occurs when only other stats are updated
-
-    st1_2.incDouble("double_counter_1", 3.3);
-    st1_2.incInt("int_counter_2", 1);
-    st1_2.incLong("long_counter_3", 2);
-
-    timeStamp += NanoTimer.millisToNanos(1000);
-    sampleCollector.sample(timeStamp);
-
-    awaitAtLeastTimeoutOrUntilNotifications(notifications, 2 * 1000);
-    assertTrue("Unexpected notifications: " + notifications, notifications.isEmpty());
-
-    // validate notification only contains stats added to monitor
-
-    st1_1.incInt("int_counter_2", 100);
-    st1_2.incInt("int_counter_2", 200);
-
-    assertEquals(2, sampleCollector.currentHandlersForTesting().size());
-
-    timeStamp += NanoTimer.millisToNanos(1000);
-    sampleCollector.sample(timeStamp);
-
-    awaitAtLeastTimeoutOrUntilNotifications(notifications, 2 * 1000);
-    assertEquals("Unexpected notifications: " + notifications, 1, notifications.size());
-
-    notification = notifications.remove(0);
-    assertEquals(StatisticsNotification.Type.VALUE_CHANGED, notification.getType());
-
-    statCount = 0;
-    expectedValues = new HashMap<>();
-    expectedValues.put("int_counter_2", 104);
-
-    for (StatisticId statId : notification) {
-      Number value = expectedValues.remove(statId.getStatisticDescriptor().getName());
-      assertNotNull(value);
-      assertEquals(value, notification.getValue(statId));
-      statCount++;
-    }
-    assertEquals(1, statCount);
-  }
-
-  private StatisticId createStatisticId(final StatisticDescriptor descriptor,
-      final Statistics stats) {
-    return new StatisticId() {
-
-      @Override
-      public StatisticDescriptor getStatisticDescriptor() {
-        return descriptor;
-      }
-
-      @Override
-      public Statistics getStatistics() {
-        return stats;
-      }
-    };
-  }
-
-  protected StatisticsNotification createStatisticsNotification(final long timeStamp,
-      final Type type, final Number value) {
+  private StatisticsNotification createStatisticsNotification(final long timeStamp, final Type type,
+      final Number value) {
     return new StatisticsNotification() {
 
       @Override
@@ -343,7 +81,7 @@ public class ValueMonitorIntegrationTest {
 
       @Override
       public Iterator<StatisticId> iterator() {
-        return null;
+        throw null;
       }
 
       @Override
@@ -362,30 +100,165 @@ public class ValueMonitorIntegrationTest {
       }
 
       @Override
-      public Number getValue(final StatisticId statId) throws StatisticNotFoundException {
+      public Number getValue(final StatisticId statId) {
         return value;
       }
     };
   }
 
-  /**
-   * Wait for at least the specified time or until notifications is >0.
-   */
-  private static void awaitAtLeastTimeoutOrUntilNotifications(
-      final List<StatisticsNotification> notifications, final long timeoutMillis) {
-    long pollingIntervalMillis = 10;
-    boolean throwOnTimeout = false;
-    WaitCriterion wc = new WaitCriterion() {
-      @Override
-      public boolean done() {
-        return notifications.size() > 0;
-      }
+  @Test
+  public void testAddRemoveListener() throws Exception {
+    long startTime = System.currentTimeMillis();
+    StatisticsManager mockStatisticsManager =
+        mock(StatisticsManager.class, testName.getMethodName() + "$StatisticsManager");
+    when(mockStatisticsManager.getName()).thenReturn("mockStatisticsManager");
+    when(mockStatisticsManager.getId()).thenReturn(1L);
+    when(mockStatisticsManager.getStartTime()).thenReturn(startTime);
+    when(mockStatisticsManager.getStatListModCount()).thenReturn(0);
+    when(mockStatisticsManager.getStatsList()).thenReturn(new ArrayList<>());
 
-      @Override
-      public String description() {
-        return "waiting for notification";
-      }
-    };
-    waitForCriterion(wc, timeoutMillis, pollingIntervalMillis, throwOnTimeout);
+    StatisticsSampler mockStatisticsSampler =
+        mock(StatisticsSampler.class, testName.getMethodName() + "$StatisticsSampler");
+    when(mockStatisticsSampler.getStatisticsModCount()).thenReturn(0);
+    when(mockStatisticsSampler.getStatistics()).thenReturn(new Statistics[] {});
+
+    // need a real SampleCollector for this test or the monitor can't get the handler
+    SampleCollector sampleCollector = new SampleCollector(mockStatisticsSampler);
+    sampleCollector.initialize(mockStatArchiveHandlerConfig, NanoTimer.getTime(),
+        new MainWithChildrenRollingFileHandler());
+
+    List<StatisticsNotification> notifications = new ArrayList<>();
+    StatisticsListener listener = notifications::add;
+
+    ValueMonitor monitor = new ValueMonitor();
+    Number value = 43;
+    Type type = Type.VALUE_CHANGED;
+    long timeStamp = System.currentTimeMillis();
+    StatisticsNotification notification = createStatisticsNotification(timeStamp, type, value);
+    monitor.notifyListeners(notification);
+    assertThat(notifications.isEmpty()).isTrue();
+
+    monitor.addListener(listener);
+    monitor.notifyListeners(notification);
+    assertThat(1).isEqualTo(notifications.size());
+    notification = notifications.remove(0);
+    assertThat(notification).isNotNull();
+    assertThat(timeStamp).isEqualTo(notification.getTimeStamp());
+    assertThat(type).isEqualTo(notification.getType());
+    StatisticId statId = mock(StatisticId.class);
+    assertThat(value).isEqualTo(notification.getValue(statId));
+
+    monitor.removeListener(listener);
+    monitor.notifyListeners(notification);
+    assertThat(notifications.isEmpty()).isTrue();
+  }
+
+  private int assertStatisticsNotification(StatisticsNotification notification,
+      Map<String, Number> expectedValues) throws StatisticNotFoundException {
+    int statCount = 0;
+    for (StatisticId statId : notification) {
+      Number value = expectedValues.remove(statId.getStatisticDescriptor().getName());
+      assertThat(value).isNotNull();
+      assertThat(value).isEqualTo(notification.getValue(statId));
+      statCount++;
+    }
+
+    return statCount;
+  }
+
+  @Test
+  public void testValueMonitorListener() throws Exception {
+    long startTime = System.currentTimeMillis();
+    TestStatisticsManager manager =
+        new TestStatisticsManager(1, "ValueMonitorIntegrationTest", startTime);
+    StatisticsSampler sampler = new TestStatisticsSampler(manager);
+    SampleCollector sampleCollector = new SampleCollector(sampler);
+    sampleCollector.initialize(mockStatArchiveHandlerConfig, NanoTimer.getTime(),
+        new MainWithChildrenRollingFileHandler());
+
+    StatisticDescriptor[] statsST1 = new StatisticDescriptor[] {
+        manager.createDoubleCounter("double_counter_1", "double_counter_1_desc",
+            "double_counter_1_units"),
+        manager.createIntCounter("int_counter_2", "int_counter_2_desc", "int_counter_2_units"),
+        manager.createLongCounter("long_counter_3", "long_counter_3_desc", "long_counter_3_units")};
+    StatisticsType ST1 = manager.createType("ST1_name", "ST1_desc", statsST1);
+
+    Statistics st1_1 = manager.createAtomicStatistics(ST1, "st1_1_text", 1);
+    st1_1.incDouble("double_counter_1", 1000.0001);
+    st1_1.incInt("int_counter_2", 2);
+    st1_1.incLong("long_counter_3", 3333333333L);
+
+    Statistics st1_2 = manager.createAtomicStatistics(ST1, "st1_2_text", 2);
+    st1_2.incDouble("double_counter_1", 2000.0002);
+    st1_2.incInt("int_counter_2", 3);
+    st1_2.incLong("long_counter_3", 4444444444L);
+
+    List<StatisticsNotification> notifications = new ArrayList<>();
+    StatisticsListener listener = notifications::add;
+
+    ValueMonitor monitor = new ValueMonitor().addStatistics(st1_1);
+    monitor.addListener(listener);
+    assertThat(notifications.isEmpty()).isTrue();
+
+    long timeStamp = NanoTimer.getTime();
+    sampleCollector.sample(timeStamp);
+    Awaitility.await().atMost(2, TimeUnit.SECONDS).pollInterval(10, TimeUnit.MILLISECONDS)
+        .until(() -> notifications.size() > 0);
+    assertThat(1).isEqualTo(notifications.size());
+
+    StatisticsNotification notification = notifications.remove(0);
+    assertThat(StatisticsNotification.Type.VALUE_CHANGED).isEqualTo(notification.getType());
+
+    // validate 1 notification occurs with all 3 stats of st1_1
+    st1_1.incDouble("double_counter_1", 1.1);
+    st1_1.incInt("int_counter_2", 2);
+    st1_1.incLong("long_counter_3", 3);
+    timeStamp += NanoTimer.millisToNanos(1000);
+    sampleCollector.sample(timeStamp);
+    Awaitility.await().atMost(2, TimeUnit.SECONDS).pollInterval(10, TimeUnit.MILLISECONDS)
+        .until(() -> notifications.size() > 0);
+    assertThat(1).isEqualTo(notifications.size());
+    notification = notifications.remove(0);
+    assertThat(StatisticsNotification.Type.VALUE_CHANGED).isEqualTo(notification.getType());
+
+    Map<String, Number> expectedValues = new HashMap<>();
+    expectedValues.put("double_counter_1", 1001.1001);
+    expectedValues.put("int_counter_2", 4);
+    expectedValues.put("long_counter_3", 3333333336L);
+    int statCount = assertStatisticsNotification(notification, expectedValues);
+    assertThat(3).isEqualTo(statCount);
+
+    // validate no notification occurs when no stats are updated
+    timeStamp += NanoTimer.millisToNanos(1000);
+    sampleCollector.sample(timeStamp);
+    Awaitility.await().atMost(2, TimeUnit.SECONDS).pollInterval(10, TimeUnit.MILLISECONDS)
+        .until(() -> notifications.size() == 0);
+    assertThat(notifications.isEmpty()).isTrue();
+
+    // validate no notification occurs when only other stats are updated
+    st1_2.incDouble("double_counter_1", 3.3);
+    st1_2.incInt("int_counter_2", 1);
+    st1_2.incLong("long_counter_3", 2);
+    timeStamp += NanoTimer.millisToNanos(1000);
+    sampleCollector.sample(timeStamp);
+    Awaitility.await().atMost(2, TimeUnit.SECONDS).pollInterval(10, TimeUnit.MILLISECONDS)
+        .until(() -> notifications.size() == 0);
+    assertThat(notifications.isEmpty()).isTrue();
+
+    // validate notification only contains stats added to monitor
+    st1_1.incInt("int_counter_2", 100);
+    st1_2.incInt("int_counter_2", 200);
+    assertThat(2).isEqualTo(sampleCollector.currentHandlersForTesting().size());
+    timeStamp += NanoTimer.millisToNanos(1000);
+    sampleCollector.sample(timeStamp);
+    Awaitility.await().atMost(2, TimeUnit.SECONDS).pollInterval(10, TimeUnit.MILLISECONDS)
+        .until(() -> notifications.size() > 0);
+    assertThat(1).isEqualTo(notifications.size());
+    notification = notifications.remove(0);
+    assertThat(StatisticsNotification.Type.VALUE_CHANGED).isEqualTo(notification.getType());
+    expectedValues = new HashMap<>();
+    expectedValues.put("int_counter_2", 104);
+    statCount = assertStatisticsNotification(notification, expectedValues);
+    assertThat(1).isEqualTo(statCount);
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/cache/query/internal/CompiledAggregateFunctionJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/internal/CompiledAggregateFunctionJUnitTest.java
@@ -14,16 +14,13 @@
  */
 package org.apache.geode.cache.query.internal;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 import java.lang.reflect.Field;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
-import org.jmock.Mockery;
-import org.jmock.lib.concurrent.Synchroniser;
-import org.jmock.lib.legacy.ClassImposteriser;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -46,125 +43,116 @@ import org.apache.geode.cache.query.internal.parse.OQLLexerTokenTypes;
 import org.apache.geode.internal.cache.InternalCache;
 
 public class CompiledAggregateFunctionJUnitTest {
-
-  private Mockery context;
   private InternalCache cache;
-  private List bucketList;
+  private List<Integer> bucketList;
 
   @Before
   public void setUp() throws Exception {
-    context = new Mockery() {
-      {
-        setImposteriser(ClassImposteriser.INSTANCE);
-        setThreadingPolicy(new Synchroniser());
-      }
-    };
-    cache = context.mock(InternalCache.class);
-    bucketList = new ArrayList();
-    bucketList.add(1);
+    cache = mock(InternalCache.class);
+    bucketList = Collections.singletonList(1);
   }
 
   @Test
   public void testCount() throws Exception {
     CompiledAggregateFunction caf1 = new CompiledAggregateFunction(null, OQLLexerTokenTypes.COUNT);
     ExecutionContext context1 = new ExecutionContext(null, cache);
-    assertTrue(caf1.evaluate(context1) instanceof Count);
+    assertThat(caf1.evaluate(context1)).isInstanceOf(Count.class);
 
     CompiledAggregateFunction caf2 =
         new CompiledAggregateFunction(null, OQLLexerTokenTypes.COUNT, true);
     ExecutionContext context2 = new ExecutionContext(null, cache);
-    assertTrue(caf2.evaluate(context2) instanceof CountDistinct);
+    assertThat(caf2.evaluate(context2)).isInstanceOf(CountDistinct.class);
 
     CompiledAggregateFunction caf3 = new CompiledAggregateFunction(null, OQLLexerTokenTypes.COUNT);
     ExecutionContext context3 = new ExecutionContext(null, cache);
     context3.setIsPRQueryNode(true);
-    assertTrue(caf3.evaluate(context3) instanceof CountPRQueryNode);
+    assertThat(caf3.evaluate(context3)).isInstanceOf(CountPRQueryNode.class);
 
     CompiledAggregateFunction caf4 = new CompiledAggregateFunction(null, OQLLexerTokenTypes.COUNT);
     QueryExecutionContext context4 = new QueryExecutionContext(null, cache);
 
     context4.setBucketList(bucketList);
-    assertTrue(caf4.evaluate(context4) instanceof Count);
+    assertThat(caf4.evaluate(context4)).isInstanceOf(Count.class);
 
     CompiledAggregateFunction caf5 =
         new CompiledAggregateFunction(null, OQLLexerTokenTypes.COUNT, true);
     ExecutionContext context5 = new ExecutionContext(null, cache);
     context5.setIsPRQueryNode(true);
-    assertTrue(caf5.evaluate(context5) instanceof CountDistinctPRQueryNode);
+    assertThat(caf5.evaluate(context5)).isInstanceOf(CountDistinctPRQueryNode.class);
 
     CompiledAggregateFunction caf6 =
         new CompiledAggregateFunction(null, OQLLexerTokenTypes.COUNT, true);
     QueryExecutionContext context6 = new QueryExecutionContext(null, cache);
     context6.setBucketList(bucketList);
-    assertTrue(caf6.evaluate(context6) instanceof DistinctAggregator);
+    assertThat(caf6.evaluate(context6)).isInstanceOf(DistinctAggregator.class);
   }
 
   @Test
   public void testSum() throws Exception {
     CompiledAggregateFunction caf1 = new CompiledAggregateFunction(null, OQLLexerTokenTypes.SUM);
     ExecutionContext context1 = new ExecutionContext(null, cache);
-    assertTrue(caf1.evaluate(context1) instanceof Sum);
+    assertThat(caf1.evaluate(context1)).isInstanceOf(Sum.class);
 
     CompiledAggregateFunction caf2 =
         new CompiledAggregateFunction(null, OQLLexerTokenTypes.SUM, true);
     ExecutionContext context2 = new ExecutionContext(null, cache);
-    assertTrue(caf2.evaluate(context2) instanceof SumDistinct);
+    assertThat(caf2.evaluate(context2)).isInstanceOf(SumDistinct.class);
 
     CompiledAggregateFunction caf3 = new CompiledAggregateFunction(null, OQLLexerTokenTypes.SUM);
     ExecutionContext context3 = new ExecutionContext(null, cache);
     context3.setIsPRQueryNode(true);
-    assertTrue(caf3.evaluate(context3) instanceof Sum);
+    assertThat(caf3.evaluate(context3)).isInstanceOf(Sum.class);
 
     CompiledAggregateFunction caf4 = new CompiledAggregateFunction(null, OQLLexerTokenTypes.SUM);
     QueryExecutionContext context4 = new QueryExecutionContext(null, cache);
     context4.setBucketList(bucketList);
-    assertTrue(caf4.evaluate(context4) instanceof Sum);
+    assertThat(caf4.evaluate(context4)).isInstanceOf(Sum.class);
 
     CompiledAggregateFunction caf5 =
         new CompiledAggregateFunction(null, OQLLexerTokenTypes.SUM, true);
     ExecutionContext context5 = new ExecutionContext(null, cache);
     context5.setIsPRQueryNode(true);
-    assertTrue(caf5.evaluate(context5) instanceof SumDistinctPRQueryNode);
+    assertThat(caf5.evaluate(context5)).isInstanceOf(SumDistinctPRQueryNode.class);
 
     CompiledAggregateFunction caf6 =
         new CompiledAggregateFunction(null, OQLLexerTokenTypes.SUM, true);
     QueryExecutionContext context6 = new QueryExecutionContext(null, cache);
     context6.setBucketList(bucketList);
-    assertTrue(caf6.evaluate(context6) instanceof DistinctAggregator);
+    assertThat(caf6.evaluate(context6)).isInstanceOf(DistinctAggregator.class);
   }
 
   @Test
   public void testAvg() throws Exception {
     CompiledAggregateFunction caf1 = new CompiledAggregateFunction(null, OQLLexerTokenTypes.AVG);
     ExecutionContext context1 = new ExecutionContext(null, cache);
-    assertTrue(caf1.evaluate(context1) instanceof Avg);
+    assertThat(caf1.evaluate(context1)).isInstanceOf(Avg.class);
 
     CompiledAggregateFunction caf2 =
         new CompiledAggregateFunction(null, OQLLexerTokenTypes.AVG, true);
     ExecutionContext context2 = new ExecutionContext(null, cache);
-    assertTrue(caf2.evaluate(context2) instanceof AvgDistinct);
+    assertThat(caf2.evaluate(context2)).isInstanceOf(AvgDistinct.class);
 
     CompiledAggregateFunction caf3 = new CompiledAggregateFunction(null, OQLLexerTokenTypes.AVG);
     ExecutionContext context3 = new ExecutionContext(null, cache);
     context3.setIsPRQueryNode(true);
-    assertTrue(caf3.evaluate(context3) instanceof AvgPRQueryNode);
+    assertThat(caf3.evaluate(context3)).isInstanceOf(AvgPRQueryNode.class);
 
     CompiledAggregateFunction caf4 = new CompiledAggregateFunction(null, OQLLexerTokenTypes.AVG);
     QueryExecutionContext context4 = new QueryExecutionContext(null, cache);
     context4.setBucketList(this.bucketList);
-    assertTrue(caf4.evaluate(context4) instanceof AvgBucketNode);
+    assertThat(caf4.evaluate(context4)).isInstanceOf(AvgBucketNode.class);
 
     CompiledAggregateFunction caf5 =
         new CompiledAggregateFunction(null, OQLLexerTokenTypes.AVG, true);
     ExecutionContext context5 = new ExecutionContext(null, cache);
     context5.setIsPRQueryNode(true);
-    assertTrue(caf5.evaluate(context5) instanceof AvgDistinctPRQueryNode);
+    assertThat(caf5.evaluate(context5)).isInstanceOf(AvgDistinctPRQueryNode.class);
 
     CompiledAggregateFunction caf6 =
         new CompiledAggregateFunction(null, OQLLexerTokenTypes.AVG, true);
     QueryExecutionContext context6 = new QueryExecutionContext(null, cache);
     context6.setBucketList(this.bucketList);
-    assertTrue(caf6.evaluate(context6) instanceof DistinctAggregator);
+    assertThat(caf6.evaluate(context6)).isInstanceOf(DistinctAggregator.class);
   }
 
   @Test
@@ -172,18 +160,17 @@ public class CompiledAggregateFunctionJUnitTest {
     CompiledAggregateFunction caf1 = new CompiledAggregateFunction(null, OQLLexerTokenTypes.MAX);
     ExecutionContext context1 = new ExecutionContext(null, cache);
     Aggregator agg = (Aggregator) caf1.evaluate(context1);
-    assertTrue(agg instanceof MaxMin);
+    assertThat(agg).isInstanceOf(MaxMin.class);
     MaxMin maxMin = (MaxMin) agg;
     Class maxMinClass = MaxMin.class;
     Field findMax = maxMinClass.getDeclaredField("findMax");
     findMax.setAccessible(true);
-    assertTrue((Boolean) findMax.get(maxMin));
+    assertThat(findMax.get(maxMin)).isEqualTo(Boolean.TRUE);
 
     CompiledAggregateFunction caf2 = new CompiledAggregateFunction(null, OQLLexerTokenTypes.MIN);
-    ExecutionContext context2 = new ExecutionContext(null, cache);
     Aggregator agg1 = (Aggregator) caf2.evaluate(context1);
-    assertTrue(agg1 instanceof MaxMin);
+    assertThat(agg1).isInstanceOf(MaxMin.class);
     MaxMin maxMin1 = (MaxMin) agg1;
-    assertFalse((Boolean) findMax.get(maxMin1));
+    assertThat(findMax.get(maxMin1)).isEqualTo(Boolean.FALSE);
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/TxCommitMessageTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/TxCommitMessageTest.java
@@ -15,18 +15,22 @@
 
 package org.apache.geode.internal.cache;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 
-import org.jmock.Expectations;
-import org.jmock.Mockery;
-import org.jmock.Sequence;
-import org.jmock.lib.concurrent.Synchroniser;
-import org.jmock.lib.legacy.ClassImposteriser;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
+import org.mockito.InOrder;
 
 import org.apache.geode.cache.Scope;
 import org.apache.geode.distributed.internal.DistributionManager;
@@ -40,1087 +44,26 @@ import org.apache.geode.internal.cache.versions.VersionSource;
  */
 public class TxCommitMessageTest {
 
-  private Mockery mockContext;
-
-  @Before
-  public void setUp() {
-    mockContext = new Mockery() {
-      {
-        setImposteriser(ClassImposteriser.INSTANCE);
-        setThreadingPolicy(new Synchroniser());
-      }
-    };
+  interface VersionedDataOutput extends DataOutput, VersionedDataStream {
   }
 
-  @After
-  public void tearDown() {
-    mockContext.assertIsSatisfied();
-    mockContext = null;
+  interface VersionedDataInput extends DataInput, VersionedDataStream {
   }
 
-  public interface VersionedDataOutput extends DataOutput, VersionedDataStream {
-
-  }
-
-  public interface VersionedDataInput extends DataInput, VersionedDataStream {
-
-  }
-
-  @Test
-  public void toDataWithShadowKeyPre180Server() throws IOException {
-    final Sequence toData = mockContext.sequence("toData");
-    final VersionedDataOutput mockDataOutput = mockContext.mock(VersionedDataOutput.class);
-    mockContext.checking(new Expectations() {
-      {
-        allowing(mockDataOutput).getVersion();
-        will(returnValue(Version.GEODE_170));
-        // processor id
-        oneOf(mockDataOutput).writeInt(with(any(int.class)));
-        inSequence(toData);
-        // txId.uniqId
-        oneOf(mockDataOutput).writeInt(0);
-        inSequence(toData);
-        // lockId
-        oneOf(mockDataOutput).writeBoolean(false);
-        inSequence(toData);
-        // totalMaxSize
-        oneOf(mockDataOutput).writeInt(0);
-        inSequence(toData);
-        // txState.membershipId
-        oneOf(mockDataOutput).writeByte(-1);
-        inSequence(toData);
-        // txState.baseThreadId
-        oneOf(mockDataOutput).writeLong(with(any(long.class)));
-        inSequence(toData);
-        // txState.baseSequenceId
-        oneOf(mockDataOutput).writeLong(with(any(long.class)));
-        inSequence(toData);
-        // txState.needsLargeModCount
-        oneOf(mockDataOutput).writeBoolean(false);
-        inSequence(toData);
-        // regionsSize
-        oneOf(mockDataOutput).writeInt(1);
-        inSequence(toData);
-
-        // regionPath: "/r"
-        oneOf(mockDataOutput).writeByte(87);
-        inSequence(toData);
-        oneOf(mockDataOutput).writeShort(2);
-        inSequence(toData);
-        oneOf(mockDataOutput).writeBytes("/r");
-        inSequence(toData);
-        // parentRegionPath: null string
-        oneOf(mockDataOutput).writeByte(69);
-        inSequence(toData);
-        // opKeys size
-        oneOf(mockDataOutput).writeInt(1);
-        inSequence(toData);
-        // needsLargeModCount
-        oneOf(mockDataOutput).writeBoolean(false);
-        inSequence(toData);
-        // versionMember
-        oneOf(mockDataOutput).writeByte(1);
-        inSequence(toData);
-        oneOf(mockDataOutput).writeByte(1);
-        inSequence(toData);
-        // opKeys[0]
-        oneOf(mockDataOutput).writeByte(87);
-        inSequence(toData);
-        oneOf(mockDataOutput).writeShort(3);
-        inSequence(toData);
-        oneOf(mockDataOutput).writeBytes("key");
-        inSequence(toData);
-        // farSideData[0]
-        oneOf(mockDataOutput).writeByte(17);
-        inSequence(toData);
-        oneOf(mockDataOutput).writeByte(0);
-        inSequence(toData);
-        oneOf(mockDataOutput).writeByte(41);
-        inSequence(toData);
-        oneOf(mockDataOutput).writeByte(41);
-        inSequence(toData);
-        oneOf(mockDataOutput).writeByte(41);
-        inSequence(toData);
-        // shadowkey
-        oneOf(mockDataOutput).writeLong(-1L);
-        inSequence(toData);
-        // offset
-        oneOf(mockDataOutput).writeInt(with(any(int.class)));
-        inSequence(toData);
-        oneOf(mockDataOutput).writeBoolean(false);
-        inSequence(toData);
-
-        // bridgeContext
-        oneOf(mockDataOutput).writeByte(41);
-        inSequence(toData);
-        // farSiders
-        oneOf(mockDataOutput).writeByte(-1);
-        inSequence(toData);
-      }
-    });
-
+  private InternalDistributedMember createInternalDistributedMember() {
     final InternalDistributedMember mockInternalDistributedMember =
-        createInternalDistributedMember();
+        mock(InternalDistributedMember.class);
+    when(mockInternalDistributedMember.getDSFID()).thenReturn(1);
+    when(mockInternalDistributedMember.getSerializationVersions()).thenReturn(null);
 
-    final TXId txId = new TXId(mockInternalDistributedMember, 0);
-    final TXState txState = new TXState(null, false);
-    final TXCommitMessage txCommitMessage = new TXCommitMessage(txId, null, txState);
-
-    final InternalRegion mockInternalRegion =
-        createMockInternalRegion(mockInternalDistributedMember);
-    txCommitMessage.startRegion(mockInternalRegion, 0);
-    final EntryEventImpl mockEntryEventImpl = createMockEntryEvent(mockInternalRegion);
-    final TXEntryState txEntryState = createTxEntryState(mockInternalRegion, mockEntryEventImpl);
-    txCommitMessage.addOp(null, "key", txEntryState, null);
-    txCommitMessage.finishRegionComplete();
-
-    txCommitMessage.toData(mockDataOutput);
-  }
-
-  @Test
-  public void toDataWithoutShadowKeyPre180Client() throws IOException {
-    final Sequence toData = mockContext.sequence("toData");
-    final VersionedDataOutput mockDataOutput = mockContext.mock(VersionedDataOutput.class);
-    mockContext.checking(new Expectations() {
-      {
-        allowing(mockDataOutput).getVersion();
-        will(returnValue(Version.GEODE_170));
-        // processor id
-        oneOf(mockDataOutput).writeInt(with(any(int.class)));
-        inSequence(toData);
-        // txId.uniqId
-        oneOf(mockDataOutput).writeInt(0);
-        inSequence(toData);
-        // lockId
-        oneOf(mockDataOutput).writeBoolean(false);
-        inSequence(toData);
-        // totalMaxSize
-        oneOf(mockDataOutput).writeInt(0);
-        inSequence(toData);
-        // txState.membershipId
-        oneOf(mockDataOutput).writeByte(-1);
-        inSequence(toData);
-        // txState.baseThreadId
-        oneOf(mockDataOutput).writeLong(with(any(long.class)));
-        inSequence(toData);
-        // txState.baseSequenceId
-        oneOf(mockDataOutput).writeLong(with(any(long.class)));
-        inSequence(toData);
-        // txState.needsLargeModCount
-        oneOf(mockDataOutput).writeBoolean(false);
-        inSequence(toData);
-        // regionsSize
-        oneOf(mockDataOutput).writeInt(1);
-        inSequence(toData);
-
-        // regionPath: "/r"
-        oneOf(mockDataOutput).writeByte(87);
-        inSequence(toData);
-        oneOf(mockDataOutput).writeShort(2);
-        inSequence(toData);
-        oneOf(mockDataOutput).writeBytes("/r");
-        inSequence(toData);
-        // parentRegionPath: null string
-        oneOf(mockDataOutput).writeByte(69);
-        inSequence(toData);
-        // opKeys size
-        oneOf(mockDataOutput).writeInt(1);
-        inSequence(toData);
-        // needsLargeModCount
-        oneOf(mockDataOutput).writeBoolean(false);
-        inSequence(toData);
-        // versionMember
-        oneOf(mockDataOutput).writeByte(1);
-        inSequence(toData);
-        oneOf(mockDataOutput).writeByte(1);
-        inSequence(toData);
-        // opKeys[0]
-        oneOf(mockDataOutput).writeByte(87);
-        inSequence(toData);
-        oneOf(mockDataOutput).writeShort(3);
-        inSequence(toData);
-        oneOf(mockDataOutput).writeBytes("key");
-        inSequence(toData);
-        // farSideData[0]
-        oneOf(mockDataOutput).writeByte(17);
-        inSequence(toData);
-        oneOf(mockDataOutput).writeByte(0);
-        inSequence(toData);
-        oneOf(mockDataOutput).writeByte(41);
-        inSequence(toData);
-        oneOf(mockDataOutput).writeByte(41);
-        inSequence(toData);
-        oneOf(mockDataOutput).writeByte(41);
-        inSequence(toData);
-        // no shadowkey
-        // offset
-        oneOf(mockDataOutput).writeInt(with(any(int.class)));
-        inSequence(toData);
-        oneOf(mockDataOutput).writeBoolean(false);
-        inSequence(toData);
-
-        // bridgeContext
-        oneOf(mockDataOutput).writeByte(41);
-        inSequence(toData);
-        // farSiders
-        oneOf(mockDataOutput).writeByte(-1);
-        inSequence(toData);
-      }
-    });
-
-    final InternalDistributedMember mockInternalDistributedMember =
-        createInternalDistributedMember();
-
-    final TXId txId = new TXId(mockInternalDistributedMember, 0);
-    final TXState txState = new TXState(null, false);
-    final TXCommitMessage txCommitMessage = new TXCommitMessage(txId, null, txState);
-    txCommitMessage.setClientVersion(Version.GEODE_170);
-
-    final InternalRegion mockInternalRegion =
-        createMockInternalRegion(mockInternalDistributedMember);
-    txCommitMessage.startRegion(mockInternalRegion, 0);
-    final EntryEventImpl mockEntryEventImpl = createMockEntryEvent(mockInternalRegion);
-    final TXEntryState txEntryState = createTxEntryState(mockInternalRegion, mockEntryEventImpl);
-    txCommitMessage.addOp(null, "key", txEntryState, null);
-    txCommitMessage.finishRegionComplete();
-
-    txCommitMessage.toData(mockDataOutput);
-  }
-
-  @Test
-  public void toDataWithShadowKeyPost180Server() throws IOException {
-    final Sequence toData = mockContext.sequence("toData");
-    final VersionedDataOutput mockDataOutput = mockContext.mock(VersionedDataOutput.class);
-    mockContext.checking(new Expectations() {
-      {
-        allowing(mockDataOutput).getVersion();
-        will(returnValue(Version.CURRENT));
-        // processor id
-        oneOf(mockDataOutput).writeInt(with(any(int.class)));
-        inSequence(toData);
-        // txId.uniqId
-        oneOf(mockDataOutput).writeInt(0);
-        inSequence(toData);
-        // lockId
-        oneOf(mockDataOutput).writeBoolean(false);
-        inSequence(toData);
-        // totalMaxSize
-        oneOf(mockDataOutput).writeInt(0);
-        inSequence(toData);
-        // txState.membershipId
-        oneOf(mockDataOutput).writeByte(-1);
-        inSequence(toData);
-        // txState.baseThreadId
-        oneOf(mockDataOutput).writeLong(with(any(long.class)));
-        inSequence(toData);
-        // txState.baseSequenceId
-        oneOf(mockDataOutput).writeLong(with(any(long.class)));
-        inSequence(toData);
-        // txState.needsLargeModCount
-        oneOf(mockDataOutput).writeBoolean(false);
-        inSequence(toData);
-        // hasShadowKeys
-        oneOf(mockDataOutput).writeBoolean(true);
-        inSequence(toData);
-        // regionsSize
-        oneOf(mockDataOutput).writeInt(1);
-        inSequence(toData);
-
-        // regionPath: "/r"
-        oneOf(mockDataOutput).writeByte(87);
-        inSequence(toData);
-        oneOf(mockDataOutput).writeShort(2);
-        inSequence(toData);
-        oneOf(mockDataOutput).writeBytes("/r");
-        inSequence(toData);
-        // parentRegionPath: null string
-        oneOf(mockDataOutput).writeByte(69);
-        inSequence(toData);
-        // opKeys size
-        oneOf(mockDataOutput).writeInt(1);
-        inSequence(toData);
-        // needsLargeModCount
-        oneOf(mockDataOutput).writeBoolean(false);
-        inSequence(toData);
-        // versionMember
-        oneOf(mockDataOutput).writeByte(1);
-        inSequence(toData);
-        oneOf(mockDataOutput).writeByte(1);
-        inSequence(toData);
-        // opKeys[0]
-        oneOf(mockDataOutput).writeByte(87);
-        inSequence(toData);
-        oneOf(mockDataOutput).writeShort(3);
-        inSequence(toData);
-        oneOf(mockDataOutput).writeBytes("key");
-        inSequence(toData);
-        // farSideData[0]
-        oneOf(mockDataOutput).writeByte(17);
-        inSequence(toData);
-        oneOf(mockDataOutput).writeByte(0);
-        inSequence(toData);
-        oneOf(mockDataOutput).writeByte(41);
-        inSequence(toData);
-        oneOf(mockDataOutput).writeByte(41);
-        inSequence(toData);
-        oneOf(mockDataOutput).writeByte(41);
-        inSequence(toData);
-        // shadowkey
-        oneOf(mockDataOutput).writeLong(-1L);
-        inSequence(toData);
-        // offset
-        oneOf(mockDataOutput).writeInt(with(any(int.class)));
-        inSequence(toData);
-        oneOf(mockDataOutput).writeBoolean(false);
-        inSequence(toData);
-
-        // bridgeContext
-        oneOf(mockDataOutput).writeByte(41);
-        inSequence(toData);
-        // farSiders
-        oneOf(mockDataOutput).writeByte(-1);
-        inSequence(toData);
-      }
-    });
-
-    final InternalDistributedMember mockInternalDistributedMember =
-        createInternalDistributedMember();
-
-    final TXId txId = new TXId(mockInternalDistributedMember, 0);
-    final TXState txState = new TXState(null, false);
-    final TXCommitMessage txCommitMessage = new TXCommitMessage(txId, null, txState);
-
-    final InternalRegion mockInternalRegion =
-        createMockInternalRegion(mockInternalDistributedMember);
-    txCommitMessage.startRegion(mockInternalRegion, 0);
-    final EntryEventImpl mockEntryEventImpl = createMockEntryEvent(mockInternalRegion);
-    final TXEntryState txEntryState = createTxEntryState(mockInternalRegion, mockEntryEventImpl);
-    txCommitMessage.addOp(null, "key", txEntryState, null);
-    txCommitMessage.finishRegionComplete();
-
-    txCommitMessage.toData(mockDataOutput);
-  }
-
-  @Test
-  public void toDataWithoutShadowKeyPost180Client() throws IOException {
-    final Sequence toData = mockContext.sequence("toData");
-    final VersionedDataOutput mockDataOutput = mockContext.mock(VersionedDataOutput.class);
-    mockContext.checking(new Expectations() {
-      {
-        allowing(mockDataOutput).getVersion();
-        will(returnValue(Version.CURRENT));
-        // processor id
-        oneOf(mockDataOutput).writeInt(with(any(int.class)));
-        inSequence(toData);
-        // txId.uniqId
-        oneOf(mockDataOutput).writeInt(0);
-        inSequence(toData);
-        // lockId
-        oneOf(mockDataOutput).writeBoolean(false);
-        inSequence(toData);
-        // totalMaxSize
-        oneOf(mockDataOutput).writeInt(0);
-        inSequence(toData);
-        // txState.membershipId
-        oneOf(mockDataOutput).writeByte(-1);
-        inSequence(toData);
-        // txState.baseThreadId
-        oneOf(mockDataOutput).writeLong(with(any(long.class)));
-        inSequence(toData);
-        // txState.baseSequenceId
-        oneOf(mockDataOutput).writeLong(with(any(long.class)));
-        inSequence(toData);
-        // txState.needsLargeModCount
-        oneOf(mockDataOutput).writeBoolean(false);
-        inSequence(toData);
-        // hasShadowKeys
-        oneOf(mockDataOutput).writeBoolean(false);
-        inSequence(toData);
-        // regionsSize
-        oneOf(mockDataOutput).writeInt(1);
-        inSequence(toData);
-
-        // regionPath: "/r"
-        oneOf(mockDataOutput).writeByte(87);
-        inSequence(toData);
-        oneOf(mockDataOutput).writeShort(2);
-        inSequence(toData);
-        oneOf(mockDataOutput).writeBytes("/r");
-        inSequence(toData);
-        // parentRegionPath: null string
-        oneOf(mockDataOutput).writeByte(69);
-        inSequence(toData);
-        // opKeys size
-        oneOf(mockDataOutput).writeInt(1);
-        inSequence(toData);
-        // needsLargeModCount
-        oneOf(mockDataOutput).writeBoolean(false);
-        inSequence(toData);
-        // versionMember
-        oneOf(mockDataOutput).writeByte(1);
-        inSequence(toData);
-        oneOf(mockDataOutput).writeByte(1);
-        inSequence(toData);
-        // opKeys[0]
-        oneOf(mockDataOutput).writeByte(87);
-        inSequence(toData);
-        oneOf(mockDataOutput).writeShort(3);
-        inSequence(toData);
-        oneOf(mockDataOutput).writeBytes("key");
-        inSequence(toData);
-        // farSideData[0]
-        oneOf(mockDataOutput).writeByte(17);
-        inSequence(toData);
-        oneOf(mockDataOutput).writeByte(0);
-        inSequence(toData);
-        oneOf(mockDataOutput).writeByte(41);
-        inSequence(toData);
-        oneOf(mockDataOutput).writeByte(41);
-        inSequence(toData);
-        oneOf(mockDataOutput).writeByte(41);
-        inSequence(toData);
-        // no shadowkey
-        // offset
-        oneOf(mockDataOutput).writeInt(with(any(int.class)));
-        inSequence(toData);
-        oneOf(mockDataOutput).writeBoolean(false);
-        inSequence(toData);
-
-        // bridgeContext
-        oneOf(mockDataOutput).writeByte(41);
-        inSequence(toData);
-        // farSiders
-        oneOf(mockDataOutput).writeByte(-1);
-        inSequence(toData);
-      }
-    });
-
-    final InternalDistributedMember mockInternalDistributedMember =
-        createInternalDistributedMember();
-
-    final TXId txId = new TXId(mockInternalDistributedMember, 0);
-    final TXState txState = new TXState(null, false);
-    final TXCommitMessage txCommitMessage = new TXCommitMessage(txId, null, txState);
-    txCommitMessage.setClientVersion(Version.CURRENT);
-
-    final InternalRegion mockInternalRegion =
-        createMockInternalRegion(mockInternalDistributedMember);
-    txCommitMessage.startRegion(mockInternalRegion, 0);
-    final EntryEventImpl mockEntryEventImpl = createMockEntryEvent(mockInternalRegion);
-    final TXEntryState txEntryState = createTxEntryState(mockInternalRegion, mockEntryEventImpl);
-    txCommitMessage.addOp(null, "key", txEntryState, null);
-    txCommitMessage.finishRegionComplete();
-
-    txCommitMessage.toData(mockDataOutput);
-  }
-
-  @Test
-  public void fromDataWithShadowKeyPre180Server() throws Exception {
-    final Sequence fromData = mockContext.sequence("fromData");
-    final VersionedDataInput mockDataInput = mockContext.mock(VersionedDataInput.class);
-    mockContext.checking(new Expectations() {
-      {
-        allowing(mockDataInput).getVersion();
-        will(returnValue(Version.GEODE_170));
-        // processor id
-        oneOf(mockDataInput).readInt();
-        will(returnValue(0));
-        inSequence(fromData);
-        // txId.uniqId
-        oneOf(mockDataInput).readInt();
-        will(returnValue(0));
-        inSequence(fromData);
-        // member version
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) -1));
-        inSequence(fromData);
-        oneOf(mockDataInput).readInt();
-        will(returnValue(0));
-        inSequence(fromData);
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) 69));
-        inSequence(fromData);
-        oneOf(mockDataInput).readUnsignedByte();
-        will(returnValue(0));
-        inSequence(fromData);
-        oneOf(mockDataInput).readInt();
-        will(returnValue(0));
-        inSequence(fromData);
-        oneOf(mockDataInput).readInt();
-        will(returnValue(0));
-        inSequence(fromData);
-        oneOf(mockDataInput).readUnsignedByte();
-        will(returnValue(1));
-        inSequence(fromData);
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) -1));
-        inSequence(fromData);
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) 69));
-        inSequence(fromData);
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) 69));
-        inSequence(fromData);
-        // durableId
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) 87));
-        inSequence(fromData);
-        oneOf(mockDataInput).readUnsignedShort();
-        will(returnValue(0));
-        inSequence(fromData);
-        oneOf(mockDataInput)
-            .readFully(with(any(byte[].class)), with(any(int.class)), with(any(int.class)));
-        inSequence(fromData);
-
-        oneOf(mockDataInput).readInt();
-        will(returnValue(0));
-        inSequence(fromData);
-        oneOf(mockDataInput).readLong();
-        will(returnValue(0L));
-        inSequence(fromData);
-        oneOf(mockDataInput).readLong();
-        will(returnValue(0L));
-        inSequence(fromData);
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) 0));
-        inSequence(fromData);
-
-        // lockId
-        oneOf(mockDataInput).readBoolean();
-        will(returnValue(false));
-        inSequence(fromData);
-        // totalMaxSize
-        oneOf(mockDataInput).readInt();
-        will(returnValue(0));
-        inSequence(fromData);
-        // txState.membershipId
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) -1));
-        inSequence(fromData);
-        // txState.baseThreadId
-        oneOf(mockDataInput).readLong();
-        will(returnValue(0L));
-        inSequence(fromData);
-        // txState.baseSequenceId
-        oneOf(mockDataInput).readLong();
-        will(returnValue(0L));
-        inSequence(fromData);
-        // txState.needsLargeModCount
-        oneOf(mockDataInput).readBoolean();
-        will(returnValue(false));
-        inSequence(fromData);
-
-        // regionsSize
-        oneOf(mockDataInput).readInt();
-        will(returnValue(1));
-        inSequence(fromData);
-
-        // regionPath: "/r"
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) 87));
-        inSequence(fromData);
-        oneOf(mockDataInput).readUnsignedShort();
-        will(returnValue(2));
-        inSequence(fromData);
-        oneOf(mockDataInput)
-            .readFully(with(any(byte[].class)), with(any(int.class)), with(any(int.class)));
-        inSequence(fromData);
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) 69));
-        inSequence(fromData);
-        // opKeys size
-        oneOf(mockDataInput).readInt();
-        will(returnValue(1));
-        inSequence(fromData);
-        // needsLargeModCount
-        oneOf(mockDataInput).readBoolean();
-        will(returnValue(false));
-        inSequence(fromData);
-        // versionMember
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) 41));
-        inSequence(fromData);
-
-        // opKeys[0]
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) 87));
-        inSequence(fromData);
-        oneOf(mockDataInput).readUnsignedShort();
-        will(returnValue(3));
-        inSequence(fromData);
-        oneOf(mockDataInput)
-            .readFully(with(any(byte[].class)), with(any(int.class)), with(any(int.class)));
-        inSequence(fromData);
-        // farSideData[0]
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) 17));
-        inSequence(fromData);
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) 0));
-        inSequence(fromData);
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) 41));
-        inSequence(fromData);
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) 41));
-        inSequence(fromData);
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) 41));
-        inSequence(fromData);
-        // shadowkey
-        oneOf(mockDataInput).readLong();
-        will(returnValue(-1L));
-        inSequence(fromData);
-        // offset
-        oneOf(mockDataInput).readInt();
-        will(returnValue(0));
-        inSequence(fromData);
-        oneOf(mockDataInput).readBoolean();
-        will(returnValue(false));
-        inSequence(fromData);
-
-        // bridgeContext
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) 41));
-        inSequence(fromData);
-        // farSiders
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) -1));
-        inSequence(fromData);
-      }
-    });
-
-    final DistributionManager mockDistributionManager =
-        mockContext.mock(DistributionManager.class);
-    mockContext.checking(new Expectations() {
-      {
-        allowing(mockDistributionManager).getCache();
-        will(returnValue(null));
-        allowing(mockDistributionManager).isLoner();
-        will(returnValue(false));
-      }
-    });
-
-    final TXCommitMessage txCommitMessage = new TXCommitMessage();
-    txCommitMessage.setDM(mockDistributionManager);
-    txCommitMessage.fromData(mockDataInput);
-  }
-
-  @Test
-  public void fromDataWithShadowKeyPost180Server() throws Exception {
-    final Sequence fromData = mockContext.sequence("fromData");
-    final DataInput mockDataInput = mockContext.mock(DataInput.class);
-    mockContext.checking(new Expectations() {
-      {
-        // processor id
-        oneOf(mockDataInput).readInt();
-        will(returnValue(0));
-        inSequence(fromData);
-        // txId.uniqId
-        oneOf(mockDataInput).readInt();
-        will(returnValue(0));
-        inSequence(fromData);
-        // member version
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) -1));
-        inSequence(fromData);
-        oneOf(mockDataInput).readInt();
-        will(returnValue(0));
-        inSequence(fromData);
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) 69));
-        inSequence(fromData);
-        oneOf(mockDataInput).readUnsignedByte();
-        will(returnValue(0));
-        inSequence(fromData);
-        oneOf(mockDataInput).readInt();
-        will(returnValue(0));
-        inSequence(fromData);
-        oneOf(mockDataInput).readInt();
-        will(returnValue(0));
-        inSequence(fromData);
-        oneOf(mockDataInput).readUnsignedByte();
-        will(returnValue(1));
-        inSequence(fromData);
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) -1));
-        inSequence(fromData);
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) 69));
-        inSequence(fromData);
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) 69));
-        inSequence(fromData);
-        // durableId
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) 87));
-        inSequence(fromData);
-        oneOf(mockDataInput).readUnsignedShort();
-        will(returnValue(0));
-        inSequence(fromData);
-        oneOf(mockDataInput)
-            .readFully(with(any(byte[].class)), with(any(int.class)), with(any(int.class)));
-        inSequence(fromData);
-
-        oneOf(mockDataInput).readInt();
-        will(returnValue(0));
-        inSequence(fromData);
-        oneOf(mockDataInput).readLong();
-        will(returnValue(0L));
-        inSequence(fromData);
-        oneOf(mockDataInput).readLong();
-        will(returnValue(0L));
-        inSequence(fromData);
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) 0));
-        inSequence(fromData);
-
-        // lockId
-        oneOf(mockDataInput).readBoolean();
-        will(returnValue(false));
-        inSequence(fromData);
-        // totalMaxSize
-        oneOf(mockDataInput).readInt();
-        will(returnValue(0));
-        inSequence(fromData);
-        // txState.membershipId
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) -1));
-        inSequence(fromData);
-        // txState.baseThreadId
-        oneOf(mockDataInput).readLong();
-        will(returnValue(0L));
-        inSequence(fromData);
-        // txState.baseSequenceId
-        oneOf(mockDataInput).readLong();
-        will(returnValue(0L));
-        inSequence(fromData);
-        // txState.needsLargeModCount
-        oneOf(mockDataInput).readBoolean();
-        will(returnValue(false));
-        inSequence(fromData);
-
-        // hasShadowKeys
-        oneOf(mockDataInput).readBoolean();
-        will(returnValue(true));
-        inSequence(fromData);
-
-        // regionsSize
-        oneOf(mockDataInput).readInt();
-        will(returnValue(1));
-        inSequence(fromData);
-
-        // regionPath: "/r"
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) 87));
-        inSequence(fromData);
-        oneOf(mockDataInput).readUnsignedShort();
-        will(returnValue(2));
-        inSequence(fromData);
-        oneOf(mockDataInput)
-            .readFully(with(any(byte[].class)), with(any(int.class)), with(any(int.class)));
-        inSequence(fromData);
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) 69));
-        inSequence(fromData);
-        // opKeys size
-        oneOf(mockDataInput).readInt();
-        will(returnValue(1));
-        inSequence(fromData);
-        // needsLargeModCount
-        oneOf(mockDataInput).readBoolean();
-        will(returnValue(false));
-        inSequence(fromData);
-        // versionMember
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) 41));
-        inSequence(fromData);
-
-        // opKeys[0]
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) 87));
-        inSequence(fromData);
-        oneOf(mockDataInput).readUnsignedShort();
-        will(returnValue(3));
-        inSequence(fromData);
-        oneOf(mockDataInput)
-            .readFully(with(any(byte[].class)), with(any(int.class)), with(any(int.class)));
-        inSequence(fromData);
-        // farSideData[0]
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) 17));
-        inSequence(fromData);
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) 0));
-        inSequence(fromData);
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) 41));
-        inSequence(fromData);
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) 41));
-        inSequence(fromData);
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) 41));
-        inSequence(fromData);
-        // shadowkey
-        oneOf(mockDataInput).readLong();
-        will(returnValue(-1L));
-        inSequence(fromData);
-        // offset
-        oneOf(mockDataInput).readInt();
-        will(returnValue(0));
-        inSequence(fromData);
-        oneOf(mockDataInput).readBoolean();
-        will(returnValue(false));
-        inSequence(fromData);
-
-        // bridgeContext
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) 41));
-        inSequence(fromData);
-        // farSiders
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) -1));
-        inSequence(fromData);
-      }
-    });
-
-    final DistributionManager mockDistributionManager =
-        mockContext.mock(DistributionManager.class);
-    mockContext.checking(new Expectations() {
-      {
-        allowing(mockDistributionManager).getCache();
-        will(returnValue(null));
-        allowing(mockDistributionManager).isLoner();
-        will(returnValue(false));
-      }
-    });
-
-    final TXCommitMessage txCommitMessage = new TXCommitMessage();
-    txCommitMessage.setDM(mockDistributionManager);
-    txCommitMessage.fromData(mockDataInput);
-  }
-
-  @Test
-  public void fromDataWithoutShadowKeyPost180Client() throws Exception {
-    final Sequence fromData = mockContext.sequence("fromData");
-    final DataInput mockDataInput = mockContext.mock(DataInput.class);
-    mockContext.checking(new Expectations() {
-      {
-        // processor id
-        oneOf(mockDataInput).readInt();
-        will(returnValue(0));
-        inSequence(fromData);
-        // txId.uniqId
-        oneOf(mockDataInput).readInt();
-        will(returnValue(0));
-        inSequence(fromData);
-        // member version
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) -1));
-        inSequence(fromData);
-        oneOf(mockDataInput).readInt();
-        will(returnValue(0));
-        inSequence(fromData);
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) 69));
-        inSequence(fromData);
-        oneOf(mockDataInput).readUnsignedByte();
-        will(returnValue(0));
-        inSequence(fromData);
-        oneOf(mockDataInput).readInt();
-        will(returnValue(0));
-        inSequence(fromData);
-        oneOf(mockDataInput).readInt();
-        will(returnValue(0));
-        inSequence(fromData);
-        oneOf(mockDataInput).readUnsignedByte();
-        will(returnValue(1));
-        inSequence(fromData);
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) -1));
-        inSequence(fromData);
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) 69));
-        inSequence(fromData);
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) 69));
-        inSequence(fromData);
-        // durableId
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) 87));
-        inSequence(fromData);
-        oneOf(mockDataInput).readUnsignedShort();
-        will(returnValue(0));
-        inSequence(fromData);
-        oneOf(mockDataInput)
-            .readFully(with(any(byte[].class)), with(any(int.class)), with(any(int.class)));
-        inSequence(fromData);
-
-        oneOf(mockDataInput).readInt();
-        will(returnValue(0));
-        inSequence(fromData);
-        oneOf(mockDataInput).readLong();
-        will(returnValue(0L));
-        inSequence(fromData);
-        oneOf(mockDataInput).readLong();
-        will(returnValue(0L));
-        inSequence(fromData);
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) 0));
-        inSequence(fromData);
-
-        // lockId
-        oneOf(mockDataInput).readBoolean();
-        will(returnValue(false));
-        inSequence(fromData);
-        // totalMaxSize
-        oneOf(mockDataInput).readInt();
-        will(returnValue(0));
-        inSequence(fromData);
-        // txState.membershipId
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) -1));
-        inSequence(fromData);
-        // txState.baseThreadId
-        oneOf(mockDataInput).readLong();
-        will(returnValue(0L));
-        inSequence(fromData);
-        // txState.baseSequenceId
-        oneOf(mockDataInput).readLong();
-        will(returnValue(0L));
-        inSequence(fromData);
-        // txState.needsLargeModCount
-        oneOf(mockDataInput).readBoolean();
-        will(returnValue(false));
-        inSequence(fromData);
-
-        // hasShadowKeys
-        oneOf(mockDataInput).readBoolean();
-        will(returnValue(false));
-        inSequence(fromData);
-
-        // regionsSize
-        oneOf(mockDataInput).readInt();
-        will(returnValue(1));
-        inSequence(fromData);
-
-        // regionPath: "/r"
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) 87));
-        inSequence(fromData);
-        oneOf(mockDataInput).readUnsignedShort();
-        will(returnValue(2));
-        inSequence(fromData);
-        oneOf(mockDataInput)
-            .readFully(with(any(byte[].class)), with(any(int.class)), with(any(int.class)));
-        inSequence(fromData);
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) 69));
-        inSequence(fromData);
-        // opKeys size
-        oneOf(mockDataInput).readInt();
-        will(returnValue(1));
-        inSequence(fromData);
-        // needsLargeModCount
-        oneOf(mockDataInput).readBoolean();
-        will(returnValue(false));
-        inSequence(fromData);
-        // versionMember
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) 41));
-        inSequence(fromData);
-
-        // opKeys[0]
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) 87));
-        inSequence(fromData);
-        oneOf(mockDataInput).readUnsignedShort();
-        will(returnValue(3));
-        inSequence(fromData);
-        oneOf(mockDataInput)
-            .readFully(with(any(byte[].class)), with(any(int.class)), with(any(int.class)));
-        inSequence(fromData);
-        // farSideData[0]
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) 17));
-        inSequence(fromData);
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) 0));
-        inSequence(fromData);
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) 41));
-        inSequence(fromData);
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) 41));
-        inSequence(fromData);
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) 41));
-        inSequence(fromData);
-        // no shadowkey
-        // offset
-        oneOf(mockDataInput).readInt();
-        will(returnValue(0));
-        inSequence(fromData);
-        oneOf(mockDataInput).readBoolean();
-        will(returnValue(false));
-        inSequence(fromData);
-
-        // bridgeContext
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) 41));
-        inSequence(fromData);
-        // farSiders
-        oneOf(mockDataInput).readByte();
-        will(returnValue((byte) -1));
-        inSequence(fromData);
-      }
-    });
-
-    final DistributionManager mockDistributionManager =
-        mockContext.mock(DistributionManager.class);
-    mockContext.checking(new Expectations() {
-      {
-        allowing(mockDistributionManager).getCache();
-        will(returnValue(null));
-        allowing(mockDistributionManager).isLoner();
-        will(returnValue(true));
-      }
-    });
-
-    final TXCommitMessage txCommitMessage = new TXCommitMessage();
-    txCommitMessage.setDM(mockDistributionManager);
-    txCommitMessage.fromData(mockDataInput);
-  }
-
-  private InternalDistributedMember createInternalDistributedMember() throws IOException {
-    final InternalDistributedMember mockInternalDistributedMember =
-        mockContext.mock(InternalDistributedMember.class);
-    mockContext.checking(new Expectations() {
-      {
-        allowing(mockInternalDistributedMember).getDSFID();
-        will(returnValue(1));
-        allowing(mockInternalDistributedMember).toData(with(any(DataOutput.class)));
-        allowing(mockInternalDistributedMember).getSerializationVersions();
-        will(returnValue(null));
-      }
-    });
     return mockInternalDistributedMember;
   }
 
   private EntryEventImpl createMockEntryEvent(InternalRegion mockInternalRegion) {
-    final EntryEventImpl mockEntryEventImpl = mockContext.mock(EntryEventImpl.class);
-    mockContext.checking(new Expectations() {
-      {
-        allowing(mockEntryEventImpl).isLocalInvalid();
-        will(returnValue(false));
-        allowing(mockEntryEventImpl).getRegion();
-        will(returnValue(mockInternalRegion));
-        ignoring(mockEntryEventImpl).putValueTXEntry(with(any(TXEntryState.class)));
-        ignoring(mockEntryEventImpl)
-            .setTXEntryOldValue(with(any(Object.class)), with(any(boolean.class)));
-      }
-    });
+    final EntryEventImpl mockEntryEventImpl = mock(EntryEventImpl.class);
+    when(mockEntryEventImpl.isLocalInvalid()).thenReturn(false);
+    when(mockEntryEventImpl.getRegion()).thenReturn(mockInternalRegion);
+
     return mockEntryEventImpl;
   }
 
@@ -1132,33 +75,408 @@ public class TxCommitMessageTest {
         TXEntryState.getFactory().createEntry(null, null, null, null, txRegionState, false);
     txEntryState.invalidate(mockEntryEventImpl);
     txEntryState.generateEventOffsets(txState);
+
     return txEntryState;
   }
 
   private InternalRegion createMockInternalRegion(VersionSource mockVersionSource) {
-    final InternalRegion mockInternalRegion = mockContext.mock(InternalRegion.class);
-    mockContext.checking(new Expectations() {
-      {
-        allowing(mockInternalRegion).requiresReliabilityCheck();
-        will(returnValue(false));
-        allowing(mockInternalRegion).getVersionMember();
-        will(returnValue(mockVersionSource));
-        allowing(mockInternalRegion).getFullPath();
-        will(returnValue("/r"));
-        allowing(mockInternalRegion).getPersistBackup();
-        will(returnValue(false));
-        allowing(mockInternalRegion).getScope();
-        will(returnValue(Scope.LOCAL));
-        allowing(mockInternalRegion).isEntryEvictionPossible();
-        will(returnValue(false));
-        allowing(mockInternalRegion).isEntryExpiryPossible();
-        will(returnValue(false));
-        ignoring(mockInternalRegion).setInUseByTransaction(true);
-        allowing(mockInternalRegion).getConcurrencyChecksEnabled();
-        will(returnValue(false));
-      }
-    });
+    final InternalRegion mockInternalRegion = mock(InternalRegion.class);
+    when(mockInternalRegion.requiresReliabilityCheck()).thenReturn(false);
+    when(mockInternalRegion.getVersionMember()).thenReturn(mockVersionSource);
+    when(mockInternalRegion.getFullPath()).thenReturn("/r");
+    when(mockInternalRegion.getPersistBackup()).thenReturn(false);
+    when(mockInternalRegion.getScope()).thenReturn(Scope.LOCAL);
+    when(mockInternalRegion.isEntryEvictionPossible()).thenReturn(false);
+    when(mockInternalRegion.isEntryExpiryPossible()).thenReturn(false);
+    when(mockInternalRegion.getConcurrencyChecksEnabled()).thenReturn(false);
+
     return mockInternalRegion;
   }
 
+  @Test
+  public void toDataWithShadowKeyPre180Server() throws IOException {
+    final VersionedDataOutput mockDataOutput = mock(VersionedDataOutput.class);
+    when(mockDataOutput.getVersion()).thenReturn(Version.GEODE_170);
+    final InternalDistributedMember mockInternalDistributedMember =
+        createInternalDistributedMember();
+    final TXId txId = new TXId(mockInternalDistributedMember, 0);
+    final TXState txState = new TXState(null, false);
+    final TXCommitMessage txCommitMessage = new TXCommitMessage(txId, null, txState);
+    final InternalRegion mockInternalRegion =
+        createMockInternalRegion(mockInternalDistributedMember);
+    txCommitMessage.startRegion(mockInternalRegion, 0);
+    final EntryEventImpl mockEntryEventImpl = createMockEntryEvent(mockInternalRegion);
+    final TXEntryState txEntryState = createTxEntryState(mockInternalRegion, mockEntryEventImpl);
+    txCommitMessage.addOp(null, "key", txEntryState, null);
+    txCommitMessage.finishRegionComplete();
+    txCommitMessage.toData(mockDataOutput);
+
+    // Asserts
+    InOrder dataOutputInOrder = inOrder(mockDataOutput);
+    // processor id
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeInt(anyInt());
+    // txId.uniqId
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeInt(0);
+    // lockId
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeBoolean(false);
+    // totalMaxSize
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeInt(0);
+    // txState.membershipId
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeByte(-1);
+    // txState.baseThreadId, txState.baseSequenceId
+    dataOutputInOrder.verify(mockDataOutput, times(2)).writeLong(anyLong());
+    // txState.needsLargeModCount
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeBoolean(false);
+    // regionsSize
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeInt(1);
+    // regionPath: "/r"
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeByte(87);
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeShort(2);
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeBytes("/r");
+    // parentRegionPath: null string
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeByte(69);
+    // opKeys size
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeInt(1);
+    // needsLargeModCount
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeBoolean(false);
+    // versionMember
+    dataOutputInOrder.verify(mockDataOutput, times(2)).writeByte(1);
+    // opKeys[0]
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeByte(87);
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeShort(3);
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeBytes("key");
+    // farSideData[0]
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeByte(17);
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeByte(0);
+    dataOutputInOrder.verify(mockDataOutput, times(3)).writeByte(41);
+    // shadowkey
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeLong(-1L);
+    // offset
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeInt(anyInt());
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeBoolean(false);
+    // bridgeContext
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeByte(41);
+    // farSiders
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeByte(-1);
+  }
+
+  @Test
+  public void toDataWithoutShadowKeyPre180Client() throws IOException {
+    final VersionedDataOutput mockDataOutput = mock(VersionedDataOutput.class);
+    when(mockDataOutput.getVersion()).thenReturn(Version.GEODE_170);
+    final InternalDistributedMember mockInternalDistributedMember =
+        createInternalDistributedMember();
+    final TXId txId = new TXId(mockInternalDistributedMember, 0);
+    final TXState txState = new TXState(null, false);
+    final TXCommitMessage txCommitMessage = new TXCommitMessage(txId, null, txState);
+    txCommitMessage.setClientVersion(Version.GEODE_170);
+    final InternalRegion mockInternalRegion =
+        createMockInternalRegion(mockInternalDistributedMember);
+    txCommitMessage.startRegion(mockInternalRegion, 0);
+    final EntryEventImpl mockEntryEventImpl = createMockEntryEvent(mockInternalRegion);
+    final TXEntryState txEntryState = createTxEntryState(mockInternalRegion, mockEntryEventImpl);
+    txCommitMessage.addOp(null, "key", txEntryState, null);
+    txCommitMessage.finishRegionComplete();
+    txCommitMessage.toData(mockDataOutput);
+
+    // Asserts
+    InOrder dataOutputInOrder = inOrder(mockDataOutput);
+    // processor id
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeInt(anyInt());
+    // txId.uniqId
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeInt(0);
+    // lockId
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeBoolean(false);
+    // totalMaxSize
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeInt(0);
+    // txState.membershipId
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeByte(-1);
+    // txState.baseThreadId, txState.baseSequenceId
+    dataOutputInOrder.verify(mockDataOutput, times(2)).writeLong(anyLong());
+    // txState.needsLargeModCount
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeBoolean(false);
+    // regionsSize
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeInt(1);
+    // regionPath: "/r"
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeByte(87);
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeShort(2);
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeBytes("/r");
+    // parentRegionPath: null string
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeByte(69);
+    // opKeys size
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeInt(1);
+    // needsLargeModCount
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeBoolean(false);
+    // versionMember
+    dataOutputInOrder.verify(mockDataOutput, times(2)).writeByte(1);
+    // opKeys[0]
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeByte(87);
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeShort(3);
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeBytes("key");
+    // farSideData[0]
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeByte(17);
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeByte(0);
+    dataOutputInOrder.verify(mockDataOutput, times(3)).writeByte(41);
+    // no shadowkey offset
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeInt(anyInt());
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeBoolean(false);
+    // bridgeContext
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeByte(41);
+    // farSiders
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeByte(-1);
+  }
+
+  @Test
+  public void toDataWithShadowKeyPost180Server() throws IOException {
+    final VersionedDataOutput mockDataOutput = mock(VersionedDataOutput.class);
+    when(mockDataOutput.getVersion()).thenReturn(Version.CURRENT);
+    final InternalDistributedMember mockInternalDistributedMember =
+        createInternalDistributedMember();
+    final TXId txId = new TXId(mockInternalDistributedMember, 0);
+    final TXState txState = new TXState(null, false);
+    final TXCommitMessage txCommitMessage = new TXCommitMessage(txId, null, txState);
+    final InternalRegion mockInternalRegion =
+        createMockInternalRegion(mockInternalDistributedMember);
+    txCommitMessage.startRegion(mockInternalRegion, 0);
+    final EntryEventImpl mockEntryEventImpl = createMockEntryEvent(mockInternalRegion);
+    final TXEntryState txEntryState = createTxEntryState(mockInternalRegion, mockEntryEventImpl);
+    txCommitMessage.addOp(null, "key", txEntryState, null);
+    txCommitMessage.finishRegionComplete();
+    txCommitMessage.toData(mockDataOutput);
+
+    // Asserts
+    InOrder dataOutputInOrder = inOrder(mockDataOutput);
+    // processor id
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeInt(anyInt());
+    // txId.uniqId
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeInt(0);
+    // lockId
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeBoolean(false);
+    // totalMaxSize
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeInt(0);
+    // txState.membershipId
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeByte(-1);
+    // txState.baseThreadId, txState.baseSequenceId
+    dataOutputInOrder.verify(mockDataOutput, times(2)).writeLong(anyLong());
+    // txState.needsLargeModCount
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeBoolean(false);
+    // hasShadowKeys
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeBoolean(true);
+    // regionsSize
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeInt(1);
+    // regionPath: "/r"
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeByte(87);
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeShort(2);
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeBytes("/r");
+    // parentRegionPath: null string
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeByte(69);
+    // opKeys size
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeInt(1);
+    // needsLargeModCount
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeBoolean(false);
+    // versionMember
+    dataOutputInOrder.verify(mockDataOutput, times(2)).writeByte(1);
+    // opKeys[0]
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeByte(87);
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeShort(3);
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeBytes("key");
+    // farSideData[0]
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeByte(17);
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeByte(0);
+    dataOutputInOrder.verify(mockDataOutput, times(3)).writeByte(41);
+    // shadowkey
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeLong(-1L);
+    // offset
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeInt(anyInt());
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeBoolean(false);
+    // bridgeContext
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeByte(41);
+    // farSiders
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeByte(-1);
+  }
+
+  @Test
+  public void toDataWithoutShadowKeyPost180Client() throws IOException {
+    final VersionedDataOutput mockDataOutput = mock(VersionedDataOutput.class);
+    when(mockDataOutput.getVersion()).thenReturn(Version.CURRENT);
+    final InternalDistributedMember mockInternalDistributedMember =
+        createInternalDistributedMember();
+    final TXId txId = new TXId(mockInternalDistributedMember, 0);
+    final TXState txState = new TXState(null, false);
+    final TXCommitMessage txCommitMessage = new TXCommitMessage(txId, null, txState);
+    txCommitMessage.setClientVersion(Version.CURRENT);
+    final InternalRegion mockInternalRegion =
+        createMockInternalRegion(mockInternalDistributedMember);
+    txCommitMessage.startRegion(mockInternalRegion, 0);
+    final EntryEventImpl mockEntryEventImpl = createMockEntryEvent(mockInternalRegion);
+    final TXEntryState txEntryState = createTxEntryState(mockInternalRegion, mockEntryEventImpl);
+    txCommitMessage.addOp(null, "key", txEntryState, null);
+    txCommitMessage.finishRegionComplete();
+    txCommitMessage.toData(mockDataOutput);
+
+    // Asserts
+    InOrder dataOutputInOrder = inOrder(mockDataOutput);
+    // processor id
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeInt(anyInt());
+    // txId.uniqId
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeInt(0);
+    // lockId
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeBoolean(false);
+    // totalMaxSize
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeInt(0);
+    // txState.membershipId
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeByte(-1);
+    // txState.baseThreadId, txState.baseSequenceId
+    dataOutputInOrder.verify(mockDataOutput, times(2)).writeLong(anyLong());
+    // txState.needsLargeModCount
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeBoolean(false);
+    // hasShadowKeys
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeBoolean(false);
+    // regionsSize
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeInt(1);
+    // regionPath: "/r"
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeByte(87);
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeShort(2);
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeBytes("/r");
+    // parentRegionPath: null string
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeByte(69);
+    // opKeys size
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeInt(1);
+    // needsLargeModCount
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeBoolean(false);
+    // versionMember
+    dataOutputInOrder.verify(mockDataOutput, times(2)).writeByte(1);
+    // opKeys[0]
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeByte(87);
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeShort(3);
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeBytes("key");
+    // farSideData[0]
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeByte(17);
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeByte(0);
+    dataOutputInOrder.verify(mockDataOutput, times(3)).writeByte(41);
+    // no shadowkeyoffset
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeInt(anyInt());
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeBoolean(false);
+    // bridgeContext
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeByte(41);
+    // farSiders
+    dataOutputInOrder.verify(mockDataOutput, times(1)).writeByte(-1);
+  }
+
+  @Test
+  public void fromDataWithShadowKeyPre180Server() throws Exception {
+    final VersionedDataInput mockDataInput = mock(VersionedDataInput.class);
+    when(mockDataInput.getVersion()).thenReturn(Version.GEODE_170);
+    when(mockDataInput.readInt()).thenReturn(/* processor id */0, /* txId.uniqId */0,
+        /* member version */0, 0, 0, 0, /* totalMaxSize */0, /* regionsSize */1,
+        /* opKeys size */ 1, /* offset */0);
+    when(mockDataInput.readByte()).thenReturn(/* member version */(byte) -1, (byte) 69, (byte) -1,
+        (byte) 69, (byte) 69, /* durableId */(byte) 87, (byte) 0,
+        /* txState.membershipId */(byte) -1, /* regionPath: "/r" */(byte) 87, (byte) 69,
+        /* versionMember */(byte) 41, /* opKeys[0] */(byte) 87, /* farSideData[0] */(byte) 17,
+        (byte) 0, (byte) 41, (byte) 41, (byte) 41, /* bridgeContext */(byte) 41,
+        /* farSiders */(byte) -1);
+    when(mockDataInput.readUnsignedByte()).thenReturn(/* member version */0, 1);
+    when(mockDataInput.readUnsignedShort()).thenReturn(/* durableId */0, 2, 3);
+    when(mockDataInput.readLong()).thenReturn(/* durableId */0L, 0L, /* txState.baseThreadId */0L,
+        /* txState.baseSequenceId */0L, /* shadowkey */ -1L);
+    when(mockDataInput.readBoolean()).thenReturn(/* lockId */false,
+        /* txState.needsLargeModCount */false, /* needsLargeModCount */false, false);
+
+    final DistributionManager mockDistributionManager = mock(DistributionManager.class);
+    when(mockDistributionManager.getCache()).thenReturn(null);
+    when(mockDistributionManager.isLoner()).thenReturn(false);
+    final TXCommitMessage txCommitMessage = new TXCommitMessage();
+    txCommitMessage.setDM(mockDistributionManager);
+    verify(mockDataInput, never()).readInt();
+    verify(mockDataInput, never()).readByte();
+    verify(mockDataInput, never()).readUnsignedByte();
+    verify(mockDataInput, never()).readUnsignedShort();
+    verify(mockDataInput, never()).readLong();
+    verify(mockDataInput, never()).readBoolean();
+    txCommitMessage.fromData(mockDataInput);
+
+    // Asserts
+    verify(mockDataInput, times(10)).readInt();
+    verify(mockDataInput, times(19)).readByte();
+    verify(mockDataInput, times(2)).readUnsignedByte();
+    verify(mockDataInput, times(3)).readUnsignedShort();
+    verify(mockDataInput, times(5)).readLong();
+    verify(mockDataInput, times(4)).readBoolean();
+    verify(mockDataInput, times(3)).readFully(any(byte[].class), anyInt(), anyInt());
+  }
+
+  @Test
+  public void fromDataWithShadowKeyPost180Server() throws Exception {
+    final DataInput mockDataInput = mock(DataInput.class);
+    when(mockDataInput.readInt()).thenReturn(/* processor id */0, /* txId.uniqId */0,
+        /* member version */0, 0, 0, 0, /* totalMaxSize */0, /* regionsSize */1,
+        /* opKeys size */ 1, /* offset */0);
+    when(mockDataInput.readByte()).thenReturn(/* member version */(byte) -1, (byte) 69, (byte) -1,
+        (byte) 69, (byte) 69, /* durableId */(byte) 87, (byte) 0,
+        /* txState.membershipId */(byte) -1, /* regionPath: "/r" */(byte) 87, (byte) 69,
+        /* versionMember */(byte) 41, /* opKeys[0] */(byte) 87, /* farSideData[0] */(byte) 17,
+        (byte) 0, (byte) 41, (byte) 41, (byte) 41, /* bridgeContext */(byte) 41,
+        /* farSiders */(byte) -1);
+    when(mockDataInput.readUnsignedByte()).thenReturn(/* member version */0, 1);
+    when(mockDataInput.readUnsignedShort()).thenReturn(/* durableId */0, 2, 3);
+    when(mockDataInput.readLong()).thenReturn(/* durableId */0L, 0L, /* txState.baseThreadId */0L,
+        /* txState.baseSequenceId */0L, /* shadowkey */ -1L);
+    when(mockDataInput.readBoolean()).thenReturn(/* lockId */false,
+        /* txState.needsLargeModCount */false, /* hasShadowKeys */true,
+        /* needsLargeModCount */false, false);
+
+    final DistributionManager mockDistributionManager = mock(DistributionManager.class);
+    when(mockDistributionManager.getCache()).thenReturn(null);
+    when(mockDistributionManager.isLoner()).thenReturn(false);
+    final TXCommitMessage txCommitMessage = new TXCommitMessage();
+    txCommitMessage.setDM(mockDistributionManager);
+    txCommitMessage.fromData(mockDataInput);
+
+    // Asserts
+    verify(mockDataInput, times(10)).readInt();
+    verify(mockDataInput, times(19)).readByte();
+    verify(mockDataInput, times(2)).readUnsignedByte();
+    verify(mockDataInput, times(3)).readUnsignedShort();
+    verify(mockDataInput, times(5)).readLong();
+    verify(mockDataInput, times(5)).readBoolean();
+    verify(mockDataInput, times(3)).readFully(any(byte[].class), anyInt(), anyInt());
+  }
+
+  @Test
+  public void fromDataWithoutShadowKeyPost180Client() throws Exception {
+    final DataInput mockDataInput = mock(DataInput.class);
+    when(mockDataInput.readInt()).thenReturn(/* processor id */0, /* txId.uniqId */0,
+        /* member version */0, 0, 0, 0, /* totalMaxSize */0, /* regionsSize */1,
+        /* opKeys size */ 1, /* offset */0);
+    when(mockDataInput.readByte()).thenReturn(/* member version */(byte) -1, (byte) 69, (byte) -1,
+        (byte) 69, (byte) 69, /* durableId */(byte) 87, (byte) 0,
+        /* txState.membershipId */(byte) -1, /* regionPath: "/r" */(byte) 87, (byte) 69,
+        /* versionMember */(byte) 41, /* opKeys[0] */(byte) 87, /* farSideData[0] */(byte) 17,
+        (byte) 0, (byte) 41, (byte) 41, (byte) 41, /* bridgeContext */(byte) 41,
+        /* farSiders */(byte) -1);
+    when(mockDataInput.readUnsignedByte()).thenReturn(/* member version */0, 1);
+    when(mockDataInput.readUnsignedShort()).thenReturn(/* durableId */0, 2, 3);
+    when(mockDataInput.readLong()).thenReturn(/* durableId */0L, 0L, /* txState.baseThreadId */0L,
+        /* txState.baseSequenceId */0L);
+    when(mockDataInput.readBoolean()).thenReturn(/* lockId */false,
+        /* txState.needsLargeModCount */false, /* hasShadowKeys */false,
+        /* needsLargeModCount */false, false);
+    final DistributionManager mockDistributionManager = mock(DistributionManager.class);
+    when(mockDistributionManager.getCache()).thenReturn(null);
+    when(mockDistributionManager.isLoner()).thenReturn(false);
+
+    final TXCommitMessage txCommitMessage = new TXCommitMessage();
+    txCommitMessage.setDM(mockDistributionManager);
+    txCommitMessage.fromData(mockDataInput);
+
+    // Asserts
+    verify(mockDataInput, times(10)).readInt();
+    verify(mockDataInput, times(19)).readByte();
+    verify(mockDataInput, times(2)).readUnsignedByte();
+    verify(mockDataInput, times(3)).readUnsignedShort();
+    verify(mockDataInput, times(4)).readLong();
+    verify(mockDataInput, times(5)).readBoolean();
+    verify(mockDataInput, times(3)).readFully(any(byte[].class), anyInt(), anyInt());
+  }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/io/CompositeOutputStreamJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/io/CompositeOutputStreamJUnitTest.java
@@ -14,21 +14,18 @@
  */
 package org.apache.geode.internal.io;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 
 import java.io.IOException;
 import java.io.OutputStream;
 
-import org.jmock.Expectations;
-import org.jmock.Mockery;
-import org.jmock.Sequence;
-import org.jmock.lib.concurrent.Synchroniser;
-import org.jmock.lib.legacy.ClassImposteriser;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
+import org.mockito.InOrder;
 
 
 /**
@@ -38,29 +35,11 @@ import org.junit.Test;
  */
 public class CompositeOutputStreamJUnitTest {
 
-  private Mockery mockContext;
-
-  @Before
-  public void setUp() {
-    mockContext = new Mockery() {
-      {
-        setImposteriser(ClassImposteriser.INSTANCE);
-        setThreadingPolicy(new Synchroniser());
-      }
-    };
-  }
-
-  @After
-  public void tearDown() {
-    mockContext.assertIsSatisfied();
-    mockContext = null;
-  }
-
   @Test
   public void testNewCompositeOutputStreamWithNoStreams() throws IOException {
     final CompositeOutputStream cos = new CompositeOutputStream();
-    assertTrue(cos.isEmpty());
-    assertEquals(0, cos.size());
+    assertThat(cos.isEmpty()).isTrue();
+    assertThat(0).isEqualTo(cos.size());
 
     cos.write(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 2, 3);
     cos.write(new byte[] {0, 1});
@@ -71,523 +50,235 @@ public class CompositeOutputStreamJUnitTest {
 
   @Test
   public void testMockOutputStream() throws IOException {
-    final OutputStream mockOutputStream = mockContext.mock(OutputStream.class, "OutputStream");
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockOutputStream).write(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 2, 3);
-        oneOf(mockOutputStream).write(new byte[] {0, 1});
-        oneOf(mockOutputStream).write(9);
-        oneOf(mockOutputStream).flush();
-        oneOf(mockOutputStream).close();
-      }
-    });
-
+    final OutputStream mockOutputStream = mock(OutputStream.class, "OutputStream");
     mockOutputStream.write(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 2, 3);
     mockOutputStream.write(new byte[] {0, 1});
     mockOutputStream.write(9);
     mockOutputStream.flush();
     mockOutputStream.close();
+
+    verify(mockOutputStream, times(1)).write(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 2, 3);
+    verify(mockOutputStream, times(1)).write(new byte[] {0, 1});
+    verify(mockOutputStream, times(1)).write(9);
+    verify(mockOutputStream, times(1)).flush();
+    verify(mockOutputStream, times(1)).close();
   }
 
   @Test
   public void testNewCompositeOutputStreamWithOneStream() throws IOException {
-    final Sequence seqStreamOne = mockContext.sequence("seqStreamOne");
-    final OutputStream streamOne = mockContext.mock(OutputStream.class, "streamOne");
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(streamOne).write(2);
-        inSequence(seqStreamOne);
-        oneOf(streamOne).write(3);
-        inSequence(seqStreamOne);
-        oneOf(streamOne).write(4);
-        inSequence(seqStreamOne);
-        oneOf(streamOne).write(0);
-        inSequence(seqStreamOne);
-        oneOf(streamOne).write(1);
-        inSequence(seqStreamOne);
-        oneOf(streamOne).write(9);
-        inSequence(seqStreamOne);
-        oneOf(streamOne).flush();
-        inSequence(seqStreamOne);
-        oneOf(streamOne).flush();
-        inSequence(seqStreamOne);
-        oneOf(streamOne).close();
-        inSequence(seqStreamOne);
-      }
-    });
+    final OutputStream mockStreamOne = mock(OutputStream.class, "streamOne");
+    final CompositeOutputStream compositeOutputStream = new CompositeOutputStream(mockStreamOne);
+    assertThat(compositeOutputStream.isEmpty()).isFalse();
+    assertThat(1).isEqualTo(compositeOutputStream.size());
+    compositeOutputStream.write(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 2, 3);
+    compositeOutputStream.write(new byte[] {0, 1});
+    compositeOutputStream.write(9);
+    compositeOutputStream.flush();
+    compositeOutputStream.close();
 
-    final CompositeOutputStream cos = new CompositeOutputStream(streamOne);
-
-    assertFalse(cos.isEmpty());
-    assertEquals(1, cos.size());
-
-    cos.write(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 2, 3);
-    cos.write(new byte[] {0, 1});
-    cos.write(9);
-    cos.flush();
-    cos.close();
+    InOrder inOrder = inOrder(mockStreamOne);
+    inOrder.verify(mockStreamOne, times(1)).write(2);
+    inOrder.verify(mockStreamOne, times(1)).write(3);
+    inOrder.verify(mockStreamOne, times(1)).write(4);
+    inOrder.verify(mockStreamOne, times(1)).write(0);
+    inOrder.verify(mockStreamOne, times(1)).write(1);
+    inOrder.verify(mockStreamOne, times(1)).write(9);
+    inOrder.verify(mockStreamOne, times(2)).flush();
+    inOrder.verify(mockStreamOne, times(1)).close();
   }
 
   @Test
   public void testNewCompositeOutputStreamWithTwoStreams() throws IOException {
-    final Sequence seqStreamOne = mockContext.sequence("seqStreamOne");
-    final OutputStream streamOne = mockContext.mock(OutputStream.class, "streamOne");
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(streamOne).write(2);
-        inSequence(seqStreamOne);
-        oneOf(streamOne).write(3);
-        inSequence(seqStreamOne);
-        oneOf(streamOne).write(4);
-        inSequence(seqStreamOne);
-        oneOf(streamOne).write(0);
-        inSequence(seqStreamOne);
-        oneOf(streamOne).write(1);
-        inSequence(seqStreamOne);
-        oneOf(streamOne).write(9);
-        inSequence(seqStreamOne);
-        oneOf(streamOne).flush();
-        inSequence(seqStreamOne);
-        oneOf(streamOne).flush();
-        inSequence(seqStreamOne);
-        oneOf(streamOne).close();
-        inSequence(seqStreamOne);
-      }
-    });
-
-    final Sequence seqStreamTwo = mockContext.sequence("seqStreamTwo");
-    final OutputStream streamTwo = mockContext.mock(OutputStream.class, "streamTwo");
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(streamTwo).write(2);
-        inSequence(seqStreamTwo);
-        oneOf(streamTwo).write(3);
-        inSequence(seqStreamTwo);
-        oneOf(streamTwo).write(4);
-        inSequence(seqStreamTwo);
-        oneOf(streamTwo).write(0);
-        inSequence(seqStreamTwo);
-        oneOf(streamTwo).write(1);
-        inSequence(seqStreamTwo);
-        oneOf(streamTwo).write(9);
-        inSequence(seqStreamTwo);
-        oneOf(streamTwo).flush();
-        inSequence(seqStreamTwo);
-        oneOf(streamTwo).flush();
-        inSequence(seqStreamTwo);
-        oneOf(streamTwo).close();
-        inSequence(seqStreamTwo);
-      }
-    });
-
+    final OutputStream streamOne = mock(OutputStream.class, "streamOne");
+    final OutputStream streamTwo = mock(OutputStream.class, "streamTwo");
     final CompositeOutputStream cos = new CompositeOutputStream(streamOne, streamTwo);
-
-    assertFalse(cos.isEmpty());
-    assertEquals(2, cos.size());
-
+    assertThat(cos.isEmpty()).isFalse();
+    assertThat(2).isEqualTo(cos.size());
     cos.write(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 2, 3);
     cos.write(new byte[] {0, 1});
     cos.write(9);
     cos.flush();
     cos.close();
+
+    InOrder inOrderStreams = inOrder(streamOne, streamTwo);
+    inOrderStreams.verify(streamOne, times(1)).write(2);
+    inOrderStreams.verify(streamOne, times(1)).write(3);
+    inOrderStreams.verify(streamOne, times(1)).write(4);
+    inOrderStreams.verify(streamOne, times(1)).write(0);
+    inOrderStreams.verify(streamOne, times(1)).write(1);
+    inOrderStreams.verify(streamOne, times(1)).write(9);
+    inOrderStreams.verify(streamOne, times(2)).flush();
+    inOrderStreams.verify(streamOne, times(1)).close();
   }
 
   @Test
   public void testAddOutputStreamWithTwoStreams() throws IOException {
-    final Sequence seqStreamOne = mockContext.sequence("seqStreamOne");
-    final OutputStream streamOne = mockContext.mock(OutputStream.class, "streamOne");
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(streamOne).write(2);
-        inSequence(seqStreamOne);
-        oneOf(streamOne).write(3);
-        inSequence(seqStreamOne);
-        oneOf(streamOne).write(4);
-        inSequence(seqStreamOne);
-        oneOf(streamOne).write(0);
-        inSequence(seqStreamOne);
-        oneOf(streamOne).write(1);
-        inSequence(seqStreamOne);
-        oneOf(streamOne).write(9);
-        inSequence(seqStreamOne);
-        oneOf(streamOne).flush();
-        inSequence(seqStreamOne);
-        oneOf(streamOne).flush();
-        inSequence(seqStreamOne);
-        oneOf(streamOne).close();
-        inSequence(seqStreamOne);
-      }
-    });
-
-    final Sequence seqStreamTwo = mockContext.sequence("seqStreamTwo");
-    final OutputStream streamTwo = mockContext.mock(OutputStream.class, "streamTwo");
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(streamTwo).write(2);
-        inSequence(seqStreamTwo);
-        oneOf(streamTwo).write(3);
-        inSequence(seqStreamTwo);
-        oneOf(streamTwo).write(4);
-        inSequence(seqStreamTwo);
-        oneOf(streamTwo).write(0);
-        inSequence(seqStreamTwo);
-        oneOf(streamTwo).write(1);
-        inSequence(seqStreamTwo);
-        oneOf(streamTwo).write(9);
-        inSequence(seqStreamTwo);
-        oneOf(streamTwo).flush();
-        inSequence(seqStreamTwo);
-        oneOf(streamTwo).flush();
-        inSequence(seqStreamTwo);
-        oneOf(streamTwo).close();
-        inSequence(seqStreamTwo);
-      }
-    });
-
-    final Sequence seqStreamThree = mockContext.sequence("seqStreamThree");
-    final OutputStream streamThree = mockContext.mock(OutputStream.class, "streamThree");
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(streamThree).write(2);
-        inSequence(seqStreamThree);
-        oneOf(streamThree).write(3);
-        inSequence(seqStreamThree);
-        oneOf(streamThree).write(4);
-        inSequence(seqStreamThree);
-        oneOf(streamThree).write(0);
-        inSequence(seqStreamThree);
-        oneOf(streamThree).write(1);
-        inSequence(seqStreamThree);
-        oneOf(streamThree).write(9);
-        inSequence(seqStreamThree);
-        oneOf(streamThree).flush();
-        inSequence(seqStreamThree);
-        oneOf(streamThree).flush();
-        inSequence(seqStreamThree);
-        oneOf(streamThree).close();
-        inSequence(seqStreamThree);
-      }
-    });
-
+    final OutputStream streamOne = mock(OutputStream.class, "streamOne");
+    final OutputStream streamTwo = mock(OutputStream.class, "streamTwo");
+    final OutputStream streamThree = mock(OutputStream.class, "streamThree");
     final CompositeOutputStream cos = new CompositeOutputStream(streamOne, streamTwo);
-
-    assertFalse(cos.isEmpty());
-    assertEquals(2, cos.size());
-
+    assertThat(cos.isEmpty()).isFalse();
+    assertThat(2).isEqualTo(cos.size());
     cos.addOutputStream(streamThree);
-    assertEquals(3, cos.size());
-
+    assertThat(3).isEqualTo(cos.size());
     cos.write(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 2, 3);
     cos.write(new byte[] {0, 1});
     cos.write(9);
     cos.flush();
     cos.close();
+
+    InOrder inOrderStreams = inOrder(streamOne, streamTwo, streamThree);
+    inOrderStreams.verify(streamOne, times(1)).write(2);
+    inOrderStreams.verify(streamOne, times(1)).write(3);
+    inOrderStreams.verify(streamOne, times(1)).write(4);
+    inOrderStreams.verify(streamOne, times(1)).write(0);
+    inOrderStreams.verify(streamOne, times(1)).write(1);
+    inOrderStreams.verify(streamOne, times(1)).write(9);
+    inOrderStreams.verify(streamOne, times(2)).flush();
+    inOrderStreams.verify(streamOne, times(1)).close();
   }
 
   @Test
   public void testAddOutputStreamWithOneStream() throws IOException {
-    final Sequence seqStreamOne = mockContext.sequence("seqStreamOne");
-    final OutputStream streamOne = mockContext.mock(OutputStream.class, "streamOne");
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(streamOne).write(2);
-        inSequence(seqStreamOne);
-        oneOf(streamOne).write(3);
-        inSequence(seqStreamOne);
-        oneOf(streamOne).write(4);
-        inSequence(seqStreamOne);
-        oneOf(streamOne).write(0);
-        inSequence(seqStreamOne);
-        oneOf(streamOne).write(1);
-        inSequence(seqStreamOne);
-        oneOf(streamOne).write(9);
-        inSequence(seqStreamOne);
-        oneOf(streamOne).flush();
-        inSequence(seqStreamOne);
-        oneOf(streamOne).flush();
-        inSequence(seqStreamOne);
-        oneOf(streamOne).close();
-        inSequence(seqStreamOne);
-      }
-    });
-
-    final Sequence seqStreamTwo = mockContext.sequence("seqStreamTwo");
-    final OutputStream streamTwo = mockContext.mock(OutputStream.class, "streamTwo");
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(streamTwo).write(2);
-        inSequence(seqStreamTwo);
-        oneOf(streamTwo).write(3);
-        inSequence(seqStreamTwo);
-        oneOf(streamTwo).write(4);
-        inSequence(seqStreamTwo);
-        oneOf(streamTwo).write(0);
-        inSequence(seqStreamTwo);
-        oneOf(streamTwo).write(1);
-        inSequence(seqStreamTwo);
-        oneOf(streamTwo).write(9);
-        inSequence(seqStreamTwo);
-        oneOf(streamTwo).flush();
-        inSequence(seqStreamTwo);
-        oneOf(streamTwo).flush();
-        inSequence(seqStreamTwo);
-        oneOf(streamTwo).close();
-        inSequence(seqStreamTwo);
-      }
-    });
-
+    final OutputStream streamOne = mock(OutputStream.class, "streamOne");
+    final OutputStream streamTwo = mock(OutputStream.class, "streamTwo");
     final CompositeOutputStream cos = new CompositeOutputStream(streamOne);
-
-    assertFalse(cos.isEmpty());
-    assertEquals(1, cos.size());
-
+    assertThat(cos.isEmpty()).isFalse();
+    assertThat(1).isEqualTo(cos.size());
     cos.addOutputStream(streamTwo);
-    assertEquals(2, cos.size());
-
+    assertThat(2).isEqualTo(cos.size());
     cos.write(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 2, 3);
     cos.write(new byte[] {0, 1});
     cos.write(9);
     cos.flush();
     cos.close();
+
+    InOrder inOrderStreams = inOrder(streamOne, streamTwo);
+    inOrderStreams.verify(streamOne, times(1)).write(2);
+    inOrderStreams.verify(streamOne, times(1)).write(3);
+    inOrderStreams.verify(streamOne, times(1)).write(4);
+    inOrderStreams.verify(streamOne, times(1)).write(0);
+    inOrderStreams.verify(streamOne, times(1)).write(1);
+    inOrderStreams.verify(streamOne, times(1)).write(9);
+    inOrderStreams.verify(streamOne, times(2)).flush();
+    inOrderStreams.verify(streamOne, times(1)).close();
   }
 
   @Test
   public void testAddOneOutputStreamWhenEmpty() throws IOException {
-    final Sequence seqStreamOne = mockContext.sequence("seqStreamOne");
-    final OutputStream streamOne = mockContext.mock(OutputStream.class, "streamOne");
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(streamOne).write(2);
-        inSequence(seqStreamOne);
-        oneOf(streamOne).write(3);
-        inSequence(seqStreamOne);
-        oneOf(streamOne).write(4);
-        inSequence(seqStreamOne);
-        oneOf(streamOne).write(0);
-        inSequence(seqStreamOne);
-        oneOf(streamOne).write(1);
-        inSequence(seqStreamOne);
-        oneOf(streamOne).write(9);
-        inSequence(seqStreamOne);
-        oneOf(streamOne).flush();
-        inSequence(seqStreamOne);
-        oneOf(streamOne).flush();
-        inSequence(seqStreamOne);
-        oneOf(streamOne).close();
-        inSequence(seqStreamOne);
-      }
-    });
-
+    final OutputStream streamOne = mock(OutputStream.class, "streamOne");
     final CompositeOutputStream cos = new CompositeOutputStream();
-
-    assertTrue(cos.isEmpty());
-    assertEquals(0, cos.size());
-
+    assertThat(cos.isEmpty()).isTrue();
+    assertThat(0).isEqualTo(cos.size());
     cos.addOutputStream(streamOne);
-    assertFalse(cos.isEmpty());
-    assertEquals(1, cos.size());
-
+    assertThat(cos.isEmpty()).isFalse();
+    assertThat(1).isEqualTo(cos.size());
     cos.write(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 2, 3);
     cos.write(new byte[] {0, 1});
     cos.write(9);
     cos.flush();
     cos.close();
+
+    InOrder inOrderStreams = inOrder(streamOne);
+    inOrderStreams.verify(streamOne, times(1)).write(2);
+    inOrderStreams.verify(streamOne, times(1)).write(3);
+    inOrderStreams.verify(streamOne, times(1)).write(4);
+    inOrderStreams.verify(streamOne, times(1)).write(0);
+    inOrderStreams.verify(streamOne, times(1)).write(1);
+    inOrderStreams.verify(streamOne, times(1)).write(9);
+    inOrderStreams.verify(streamOne, times(2)).flush();
+    inOrderStreams.verify(streamOne, times(1)).close();
   }
 
   @Test
   public void testAddTwoOutputStreamsWhenEmpty() throws IOException {
-    final Sequence seqStreamOne = mockContext.sequence("seqStreamOne");
-    final OutputStream streamOne = mockContext.mock(OutputStream.class, "streamOne");
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(streamOne).write(2);
-        inSequence(seqStreamOne);
-        oneOf(streamOne).write(3);
-        inSequence(seqStreamOne);
-        oneOf(streamOne).write(4);
-        inSequence(seqStreamOne);
-        oneOf(streamOne).write(0);
-        inSequence(seqStreamOne);
-        oneOf(streamOne).write(1);
-        inSequence(seqStreamOne);
-        oneOf(streamOne).write(9);
-        inSequence(seqStreamOne);
-        oneOf(streamOne).flush();
-        inSequence(seqStreamOne);
-        oneOf(streamOne).flush();
-        inSequence(seqStreamOne);
-        oneOf(streamOne).close();
-        inSequence(seqStreamOne);
-      }
-    });
-
-    final Sequence seqStreamTwo = mockContext.sequence("seqStreamTwo");
-    final OutputStream streamTwo = mockContext.mock(OutputStream.class, "streamTwo");
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(streamTwo).write(2);
-        inSequence(seqStreamTwo);
-        oneOf(streamTwo).write(3);
-        inSequence(seqStreamTwo);
-        oneOf(streamTwo).write(4);
-        inSequence(seqStreamTwo);
-        oneOf(streamTwo).write(0);
-        inSequence(seqStreamTwo);
-        oneOf(streamTwo).write(1);
-        inSequence(seqStreamTwo);
-        oneOf(streamTwo).write(9);
-        inSequence(seqStreamTwo);
-        oneOf(streamTwo).flush();
-        inSequence(seqStreamTwo);
-        oneOf(streamTwo).flush();
-        inSequence(seqStreamTwo);
-        oneOf(streamTwo).close();
-        inSequence(seqStreamTwo);
-      }
-    });
-
+    final OutputStream streamOne = mock(OutputStream.class, "streamOne");
+    final OutputStream streamTwo = mock(OutputStream.class, "streamTwo");
     final CompositeOutputStream cos = new CompositeOutputStream();
-
-    assertTrue(cos.isEmpty());
-    assertEquals(0, cos.size());
-
+    assertThat(cos.isEmpty()).isTrue();
+    assertThat(0).isEqualTo(cos.size());
     cos.addOutputStream(streamOne);
     cos.addOutputStream(streamTwo);
-    assertFalse(cos.isEmpty());
-    assertEquals(2, cos.size());
-
+    assertThat(cos.isEmpty()).isFalse();
+    assertThat(2).isEqualTo(cos.size());
     cos.write(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 2, 3);
     cos.write(new byte[] {0, 1});
     cos.write(9);
     cos.flush();
     cos.close();
+
+    InOrder inOrderStreams = inOrder(streamOne, streamTwo);
+    inOrderStreams.verify(streamOne, times(1)).write(2);
+    inOrderStreams.verify(streamOne, times(1)).write(3);
+    inOrderStreams.verify(streamOne, times(1)).write(4);
+    inOrderStreams.verify(streamOne, times(1)).write(0);
+    inOrderStreams.verify(streamOne, times(1)).write(1);
+    inOrderStreams.verify(streamOne, times(1)).write(9);
+    inOrderStreams.verify(streamOne, times(2)).flush();
+    inOrderStreams.verify(streamOne, times(1)).close();
   }
 
   @Test
   public void testRemoveOutputStreamWithTwoStreams() throws IOException {
-    final Sequence seqStreamOne = mockContext.sequence("seqStreamOne");
-    final OutputStream streamOne = mockContext.mock(OutputStream.class, "streamOne");
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(streamOne).write(2);
-        inSequence(seqStreamOne);
-        oneOf(streamOne).write(3);
-        inSequence(seqStreamOne);
-        oneOf(streamOne).write(4);
-        inSequence(seqStreamOne);
-        oneOf(streamOne).write(0);
-        inSequence(seqStreamOne);
-        oneOf(streamOne).write(1);
-        inSequence(seqStreamOne);
-        oneOf(streamOne).write(9);
-        inSequence(seqStreamOne);
-        oneOf(streamOne).flush();
-        inSequence(seqStreamOne);
-        oneOf(streamOne).flush();
-        inSequence(seqStreamOne);
-        oneOf(streamOne).close();
-        inSequence(seqStreamOne);
-      }
-    });
-
-    final OutputStream streamTwo = mockContext.mock(OutputStream.class, "streamTwo");
-    mockContext.checking(new Expectations() {
-      {
-        never(streamTwo).write(2);
-        never(streamTwo).write(3);
-        never(streamTwo).write(4);
-        never(streamTwo).write(0);
-        never(streamTwo).write(1);
-        never(streamTwo).write(9);
-        never(streamTwo).flush();
-        never(streamTwo).flush();
-        never(streamTwo).close();
-      }
-    });
-
+    final OutputStream streamOne = mock(OutputStream.class, "streamOne");
+    final OutputStream streamTwo = mock(OutputStream.class, "streamTwo");
     final CompositeOutputStream cos = new CompositeOutputStream(streamOne, streamTwo);
-
-    assertFalse(cos.isEmpty());
-    assertEquals(2, cos.size());
-
+    assertThat(cos.isEmpty()).isFalse();
+    assertThat(2).isEqualTo(cos.size());
     cos.removeOutputStream(streamTwo);
-
-    assertFalse(cos.isEmpty());
-    assertEquals(1, cos.size());
-
+    assertThat(cos.isEmpty()).isFalse();
+    assertThat(1).isEqualTo(cos.size());
     cos.write(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 2, 3);
     cos.write(new byte[] {0, 1});
     cos.write(9);
     cos.flush();
     cos.close();
+
+    verifyZeroInteractions(streamTwo);
+    InOrder inOrderStreams = inOrder(streamOne);
+    inOrderStreams.verify(streamOne, times(1)).write(2);
+    inOrderStreams.verify(streamOne, times(1)).write(3);
+    inOrderStreams.verify(streamOne, times(1)).write(4);
+    inOrderStreams.verify(streamOne, times(1)).write(0);
+    inOrderStreams.verify(streamOne, times(1)).write(1);
+    inOrderStreams.verify(streamOne, times(1)).write(9);
+    inOrderStreams.verify(streamOne, times(2)).flush();
+    inOrderStreams.verify(streamOne, times(1)).close();
   }
 
   @Test
   public void testRemoveOutputStreamWithOneStream() throws IOException {
-    final OutputStream streamOne = mockContext.mock(OutputStream.class, "streamOne");
-    mockContext.checking(new Expectations() {
-      {
-        never(streamOne).write(2);
-        never(streamOne).write(3);
-        never(streamOne).write(4);
-        never(streamOne).write(0);
-        never(streamOne).write(1);
-        never(streamOne).write(9);
-        never(streamOne).flush();
-        never(streamOne).flush();
-        never(streamOne).close();
-      }
-    });
-
+    final OutputStream streamOne = mock(OutputStream.class, "streamOne");
     final CompositeOutputStream cos = new CompositeOutputStream(streamOne);
-
-    assertFalse(cos.isEmpty());
-    assertEquals(1, cos.size());
-
+    assertThat(cos.isEmpty()).isFalse();
+    assertThat(1).isEqualTo(cos.size());
     cos.removeOutputStream(streamOne);
-
-    assertTrue(cos.isEmpty());
-    assertEquals(0, cos.size());
-
+    assertThat(cos.isEmpty()).isTrue();
+    assertThat(0).isEqualTo(cos.size());
     cos.write(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 2, 3);
     cos.write(new byte[] {0, 1});
     cos.write(9);
     cos.flush();
     cos.close();
+
+    verifyZeroInteractions(streamOne);
   }
 
   @Test
   public void testRemoveOutputStreamWhenEmpty() throws IOException {
-    final OutputStream streamOne = mockContext.mock(OutputStream.class, "streamOne");
-    mockContext.checking(new Expectations() {
-      {
-        never(streamOne).write(2);
-        never(streamOne).write(3);
-        never(streamOne).write(4);
-        never(streamOne).write(0);
-        never(streamOne).write(1);
-        never(streamOne).write(9);
-        never(streamOne).flush();
-        never(streamOne).flush();
-        never(streamOne).close();
-      }
-    });
-
+    final OutputStream streamOne = mock(OutputStream.class, "streamOne");
     final CompositeOutputStream cos = new CompositeOutputStream();
-
-    assertTrue(cos.isEmpty());
-    assertEquals(0, cos.size());
-
+    assertThat(cos.isEmpty()).isTrue();
+    assertThat(0).isEqualTo(cos.size());
     cos.removeOutputStream(streamOne);
-
-    assertTrue(cos.isEmpty());
-    assertEquals(0, cos.size());
-
+    assertThat(cos.isEmpty()).isTrue();
+    assertThat(0).isEqualTo(cos.size());
     cos.write(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 2, 3);
     cos.write(new byte[] {0, 1});
     cos.write(9);
     cos.flush();
     cos.close();
+
+    verifyZeroInteractions(streamOne);
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/io/CompositeOutputStreamJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/io/CompositeOutputStreamJUnitTest.java
@@ -39,7 +39,7 @@ public class CompositeOutputStreamJUnitTest {
   public void testNewCompositeOutputStreamWithNoStreams() throws IOException {
     final CompositeOutputStream cos = new CompositeOutputStream();
     assertThat(cos.isEmpty()).isTrue();
-    assertThat(0).isEqualTo(cos.size());
+    assertThat(cos.size()).isEqualTo(0);
 
     cos.write(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 2, 3);
     cos.write(new byte[] {0, 1});
@@ -69,7 +69,7 @@ public class CompositeOutputStreamJUnitTest {
     final OutputStream mockStreamOne = mock(OutputStream.class, "streamOne");
     final CompositeOutputStream compositeOutputStream = new CompositeOutputStream(mockStreamOne);
     assertThat(compositeOutputStream.isEmpty()).isFalse();
-    assertThat(1).isEqualTo(compositeOutputStream.size());
+    assertThat(compositeOutputStream.size()).isEqualTo(1);
     compositeOutputStream.write(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 2, 3);
     compositeOutputStream.write(new byte[] {0, 1});
     compositeOutputStream.write(9);
@@ -93,7 +93,7 @@ public class CompositeOutputStreamJUnitTest {
     final OutputStream streamTwo = mock(OutputStream.class, "streamTwo");
     final CompositeOutputStream cos = new CompositeOutputStream(streamOne, streamTwo);
     assertThat(cos.isEmpty()).isFalse();
-    assertThat(2).isEqualTo(cos.size());
+    assertThat(cos.size()).isEqualTo(2);
     cos.write(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 2, 3);
     cos.write(new byte[] {0, 1});
     cos.write(9);
@@ -118,9 +118,9 @@ public class CompositeOutputStreamJUnitTest {
     final OutputStream streamThree = mock(OutputStream.class, "streamThree");
     final CompositeOutputStream cos = new CompositeOutputStream(streamOne, streamTwo);
     assertThat(cos.isEmpty()).isFalse();
-    assertThat(2).isEqualTo(cos.size());
+    assertThat(cos.size()).isEqualTo(2);
     cos.addOutputStream(streamThree);
-    assertThat(3).isEqualTo(cos.size());
+    assertThat(cos.size()).isEqualTo(3);
     cos.write(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 2, 3);
     cos.write(new byte[] {0, 1});
     cos.write(9);
@@ -144,9 +144,9 @@ public class CompositeOutputStreamJUnitTest {
     final OutputStream streamTwo = mock(OutputStream.class, "streamTwo");
     final CompositeOutputStream cos = new CompositeOutputStream(streamOne);
     assertThat(cos.isEmpty()).isFalse();
-    assertThat(1).isEqualTo(cos.size());
+    assertThat(cos.size()).isEqualTo(1);
     cos.addOutputStream(streamTwo);
-    assertThat(2).isEqualTo(cos.size());
+    assertThat(cos.size()).isEqualTo(2);
     cos.write(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 2, 3);
     cos.write(new byte[] {0, 1});
     cos.write(9);
@@ -169,10 +169,10 @@ public class CompositeOutputStreamJUnitTest {
     final OutputStream streamOne = mock(OutputStream.class, "streamOne");
     final CompositeOutputStream cos = new CompositeOutputStream();
     assertThat(cos.isEmpty()).isTrue();
-    assertThat(0).isEqualTo(cos.size());
+    assertThat(cos.size()).isEqualTo(0);
     cos.addOutputStream(streamOne);
     assertThat(cos.isEmpty()).isFalse();
-    assertThat(1).isEqualTo(cos.size());
+    assertThat(cos.size()).isEqualTo(1);
     cos.write(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 2, 3);
     cos.write(new byte[] {0, 1});
     cos.write(9);
@@ -196,11 +196,11 @@ public class CompositeOutputStreamJUnitTest {
     final OutputStream streamTwo = mock(OutputStream.class, "streamTwo");
     final CompositeOutputStream cos = new CompositeOutputStream();
     assertThat(cos.isEmpty()).isTrue();
-    assertThat(0).isEqualTo(cos.size());
+    assertThat(cos.size()).isEqualTo(0);
     cos.addOutputStream(streamOne);
     cos.addOutputStream(streamTwo);
     assertThat(cos.isEmpty()).isFalse();
-    assertThat(2).isEqualTo(cos.size());
+    assertThat(cos.size()).isEqualTo(2);
     cos.write(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 2, 3);
     cos.write(new byte[] {0, 1});
     cos.write(9);
@@ -224,10 +224,10 @@ public class CompositeOutputStreamJUnitTest {
     final OutputStream streamTwo = mock(OutputStream.class, "streamTwo");
     final CompositeOutputStream cos = new CompositeOutputStream(streamOne, streamTwo);
     assertThat(cos.isEmpty()).isFalse();
-    assertThat(2).isEqualTo(cos.size());
+    assertThat(cos.size()).isEqualTo(2);
     cos.removeOutputStream(streamTwo);
     assertThat(cos.isEmpty()).isFalse();
-    assertThat(1).isEqualTo(cos.size());
+    assertThat(cos.size()).isEqualTo(1);
     cos.write(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 2, 3);
     cos.write(new byte[] {0, 1});
     cos.write(9);
@@ -251,10 +251,10 @@ public class CompositeOutputStreamJUnitTest {
     final OutputStream streamOne = mock(OutputStream.class, "streamOne");
     final CompositeOutputStream cos = new CompositeOutputStream(streamOne);
     assertThat(cos.isEmpty()).isFalse();
-    assertThat(1).isEqualTo(cos.size());
+    assertThat(cos.size()).isEqualTo(1);
     cos.removeOutputStream(streamOne);
     assertThat(cos.isEmpty()).isTrue();
-    assertThat(0).isEqualTo(cos.size());
+    assertThat(cos.size()).isEqualTo(0);
     cos.write(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 2, 3);
     cos.write(new byte[] {0, 1});
     cos.write(9);
@@ -269,10 +269,10 @@ public class CompositeOutputStreamJUnitTest {
     final OutputStream streamOne = mock(OutputStream.class, "streamOne");
     final CompositeOutputStream cos = new CompositeOutputStream();
     assertThat(cos.isEmpty()).isTrue();
-    assertThat(0).isEqualTo(cos.size());
+    assertThat(cos.size()).isEqualTo(0);
     cos.removeOutputStream(streamOne);
     assertThat(cos.isEmpty()).isTrue();
-    assertThat(0).isEqualTo(cos.size());
+    assertThat(cos.size()).isEqualTo(0);
     cos.write(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 2, 3);
     cos.write(new byte[] {0, 1});
     cos.write(9);

--- a/geode-core/src/test/java/org/apache/geode/internal/net/SocketUtilsJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/net/SocketUtilsJUnitTest.java
@@ -14,20 +14,17 @@
  */
 package org.apache.geode.internal.net;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.Socket;
 
-import org.jmock.Expectations;
-import org.jmock.Mockery;
-import org.jmock.lib.concurrent.Synchroniser;
-import org.jmock.lib.legacy.ClassImposteriser;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -39,106 +36,56 @@ import org.apache.geode.test.junit.categories.MembershipTest;
  * <p/>
  *
  * @see org.apache.geode.internal.net.SocketUtils
- * @see org.jmock.Expectations
- * @see org.jmock.Mockery
- * @see org.junit.Assert
  * @see org.junit.Test
  * @since GemFire 7.0
  */
-@Category({MembershipTest.class})
+@Category(MembershipTest.class)
 public class SocketUtilsJUnitTest {
-
-  private Mockery mockContext;
-
-  @Before
-  public void setup() {
-    mockContext = new Mockery() {
-      {
-        setImposteriser(ClassImposteriser.INSTANCE);
-        setThreadingPolicy(new Synchroniser());
-      }
-    };
-  }
-
-  @After
-  public void tearDown() {
-    mockContext.assertIsSatisfied();
-  }
 
   @Test
   public void testCloseSocket() throws IOException {
-    final Socket mockSocket = mockContext.mock(Socket.class, "closeSocketTest");
+    final Socket mockSocket = mock(Socket.class, "closeSocketTest");
+    doNothing().when(mockSocket).close();
 
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockSocket).close();
-      }
-    });
-
-    assertTrue(SocketUtils.close(mockSocket));
+    assertThat(SocketUtils.close(mockSocket)).isTrue();
+    verify(mockSocket, times(1)).close();
   }
 
   @Test
   public void testCloseSocketThrowsIOException() throws IOException {
-    final Socket mockSocket = mockContext.mock(Socket.class, "closeSocketThrowsIOExceptionTest");
+    final Socket mockSocket = mock(Socket.class, "closeSocketThrowsIOExceptionTest");
+    doThrow(new IOException("Mock Exception")).when(mockSocket).close();
 
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockSocket).close();
-        will(throwException(new IOException("test")));
-      }
-    });
-
-    try {
-      assertFalse(SocketUtils.close(mockSocket));
-    } catch (Throwable t) {
-      fail(
-          "Calling close on a Socket using SocketUtils threw an unexpected Throwable (" + t + ")!");
-    }
+    assertThat(SocketUtils.close(mockSocket)).isFalse();
+    verify(mockSocket, times(1)).close();
   }
 
   @Test
   public void testCloseSocketWithNull() {
-    assertTrue(SocketUtils.close((Socket) null));
+    assertThat(SocketUtils.close((Socket) null)).isTrue();
   }
 
   @Test
   public void testCloseServerSocket() throws IOException {
-    final ServerSocket mockServerSocket =
-        mockContext.mock(ServerSocket.class, "closeServerSocketTest");
+    final ServerSocket mockServerSocket = mock(ServerSocket.class, "closeServerSocketTest");
+    doNothing().when(mockServerSocket).close();
 
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockServerSocket).close();
-      }
-    });
-
-    assertTrue(SocketUtils.close(mockServerSocket));
+    assertThat(SocketUtils.close(mockServerSocket)).isTrue();
+    verify(mockServerSocket, times(1)).close();
   }
 
   @Test
   public void testCloseServerSocketThrowsIOException() throws IOException {
     final ServerSocket mockServerSocket =
-        mockContext.mock(ServerSocket.class, "closeServerSocketThrowsIOExceptionTest");
+        mock(ServerSocket.class, "closeServerSocketThrowsIOExceptionTest");
+    doThrow(new IOException("Mock Exception")).when(mockServerSocket).close();
 
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockServerSocket).close();
-        will(throwException(new IOException("test")));
-      }
-    });
-
-    try {
-      assertFalse(SocketUtils.close(mockServerSocket));
-    } catch (Throwable t) {
-      fail("Calling close on a ServerSocket using SocketUtils threw an unexpected Throwable (" + t
-          + ")!");
-    }
+    assertThat(SocketUtils.close(mockServerSocket)).isFalse();
+    verify(mockServerSocket, times(1)).close();
   }
 
   @Test
   public void testCloseServerSocketWithNull() {
-    assertTrue(SocketUtils.close((ServerSocket) null));
+    assertThat(SocketUtils.close((ServerSocket) null)).isTrue();
   }
-
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/util/IOUtilsJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/util/IOUtilsJUnitTest.java
@@ -70,15 +70,15 @@ public class IOUtilsJUnitTest {
   @Test
   public void testAppendToPath() {
     assertThat(IOUtils.appendToPath(null, (String[]) null)).isNull();
-    assertThat(File.separator).isEqualTo(IOUtils.appendToPath(null));
-    assertThat(File.separator).isEqualTo(IOUtils.appendToPath(""));
-    assertThat(File.separator).isEqualTo(IOUtils.appendToPath(" "));
-    assertThat(File.separator).isEqualTo(IOUtils.appendToPath(File.separator));
-    assertThat(toPathname("bin", "a.out")).isEqualTo(IOUtils.appendToPath(null, "bin", "a.out"));
-    assertThat(toPathname("bin", "a.out"))
-        .isEqualTo(IOUtils.appendToPath(File.separator, "bin", "a.out"));
-    assertThat(toPathname("usr", "local", "bin", "a.out"))
-        .isEqualTo(IOUtils.appendToPath(toPathname("usr", "local"), "bin", "a.out"));
+    assertThat(IOUtils.appendToPath(null)).isEqualTo(File.separator);
+    assertThat(IOUtils.appendToPath("")).isEqualTo(File.separator);
+    assertThat(IOUtils.appendToPath(" ")).isEqualTo(File.separator);
+    assertThat(IOUtils.appendToPath(File.separator)).isEqualTo(File.separator);
+    assertThat(IOUtils.appendToPath(null, "bin", "a.out")).isEqualTo(toPathname("bin", "a.out"));
+    assertThat(IOUtils.appendToPath(File.separator, "bin", "a.out"))
+        .isEqualTo(toPathname("bin", "a.out"));
+    assertThat(IOUtils.appendToPath(toPathname("usr", "local"), "bin", "a.out"))
+        .isEqualTo(toPathname("usr", "local", "bin", "a.out"));
   }
 
   @Test
@@ -97,35 +97,35 @@ public class IOUtilsJUnitTest {
 
   @Test
   public void testCreatePath() {
-    assertThat("").isEqualTo(IOUtils.createPath());
-    assertThat("/path/to/file.test".replace("/", File.separator))
-        .isEqualTo(IOUtils.createPath("path", "to", "file.test"));
-    assertThat("/path/to/a/directory".replace("/", File.separator))
-        .isEqualTo(IOUtils.createPath("path", "to", "a", "directory"));
+    assertThat(IOUtils.createPath()).isEqualTo("");
+    assertThat(IOUtils.createPath("path", "to", "file.test"))
+        .isEqualTo("/path/to/file.test".replace("/", File.separator));
+    assertThat(IOUtils.createPath("path", "to", "a", "directory"))
+        .isEqualTo("/path/to/a/directory".replace("/", File.separator));
   }
 
   @Test
   public void testCreatePathWithSeparator() {
-    assertThat("").isEqualTo(IOUtils.createPath(new String[0], "-"));
-    assertThat("-path-to-file.ext".replace("/", File.separator))
-        .isEqualTo(IOUtils.createPath(new String[] {"path", "to", "file.ext"}, "-"));
-    assertThat("-path-to-a-directory")
-        .isEqualTo(IOUtils.createPath(new String[] {"path", "to", "a", "directory"}, "-"));
+    assertThat(IOUtils.createPath(new String[0], "-")).isEqualTo("");
+    assertThat(IOUtils.createPath(new String[] {"path", "to", "file.ext"}, "-"))
+        .isEqualTo("-path-to-file.ext".replace("/", File.separator));
+    assertThat(IOUtils.createPath(new String[] {"path", "to", "a", "directory"}, "-"))
+        .isEqualTo("-path-to-a-directory");
   }
 
   @Test
   public void testGetFilename() {
     assertThat(IOUtils.getFilename(null)).isNull();
-    assertThat("").isEqualTo(IOUtils.getFilename(""));
-    assertThat("  ").isEqualTo(IOUtils.getFilename("  "));
-    assertThat("").isEqualTo(IOUtils.getFilename(File.separator));
-    assertThat("a.ext").isEqualTo(IOUtils.getFilename("a.ext"));
-    assertThat("b.ext").isEqualTo(IOUtils.getFilename(toPathname("b.ext")));
-    assertThat("c.ext").isEqualTo(IOUtils.getFilename(toPathname("path", "to", "c.ext")));
-    assertThat("filename.ext")
-        .isEqualTo(IOUtils.getFilename(toPathname("export", "path", "to", "some", "filename.ext")));
-    assertThat("").isEqualTo(
-        IOUtils.getFilename(toPathname("path", "to", "a", "directory") + File.separator));
+    assertThat(IOUtils.getFilename("")).isEqualTo("");
+    assertThat(IOUtils.getFilename("  ")).isEqualTo("  ");
+    assertThat(IOUtils.getFilename(File.separator)).isEqualTo("");
+    assertThat(IOUtils.getFilename("a.ext")).isEqualTo("a.ext");
+    assertThat(IOUtils.getFilename(toPathname("b.ext"))).isEqualTo("b.ext");
+    assertThat(IOUtils.getFilename(toPathname("path", "to", "c.ext"))).isEqualTo("c.ext");
+    assertThat(IOUtils.getFilename(toPathname("export", "path", "to", "some", "filename.ext")))
+        .isEqualTo("filename.ext");
+    assertThat(IOUtils.getFilename(toPathname("path", "to", "a", "directory") + File.separator))
+        .isEqualTo("");
   }
 
   @Test
@@ -147,7 +147,7 @@ public class IOUtilsJUnitTest {
 
     final Object nowObj = IOUtils.deserializeObject(nowBytes);
     assertThat(nowObj).isInstanceOf(Calendar.class);
-    assertThat(now.getTimeInMillis()).isEqualTo(((Calendar) nowObj).getTimeInMillis());
+    assertThat(((Calendar) nowObj).getTimeInMillis()).isEqualTo(now.getTimeInMillis());
   }
 
   @Test
@@ -161,7 +161,7 @@ public class IOUtilsJUnitTest {
     final Object piObj =
         IOUtils.deserializeObject(piBytes, IOUtilsJUnitTest.class.getClassLoader());
     assertThat(piObj).isInstanceOf(BigDecimal.class);
-    assertThat(pi).isEqualTo(piObj);
+    assertThat(piObj).isEqualTo(pi);
   }
 
   @Test
@@ -170,11 +170,8 @@ public class IOUtilsJUnitTest {
     final byte[] actual = IOUtils.toByteArray(new ByteArrayInputStream(expected));
 
     assertThat(actual).isNotNull();
-    assertThat(expected.length).isEqualTo(actual.length);
-
-    for (int index = 0; index < actual.length; index++) {
-      assertThat(expected[index]).isEqualTo(actual[index]);
-    }
+    assertThat(actual.length).isEqualTo(expected.length);
+    assertThat(actual).isEqualTo(expected);
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/internal/util/IOUtilsJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/util/IOUtilsJUnitTest.java
@@ -14,12 +14,15 @@
  */
 package org.apache.geode.internal.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayInputStream;
 import java.io.Closeable;
@@ -30,13 +33,9 @@ import java.io.InputStream;
 import java.math.BigDecimal;
 import java.util.Calendar;
 
-import org.jmock.Expectations;
-import org.jmock.Mockery;
-import org.jmock.lib.concurrent.Synchroniser;
-import org.jmock.lib.legacy.ClassImposteriser;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
 
 
 /**
@@ -44,30 +43,9 @@ import org.junit.Test;
  * <p/>
  *
  * @see org.apache.geode.internal.util.IOUtils
- * @see org.jmock.Expectations
- * @see org.jmock.Mockery
- * @see org.junit.Assert
  * @see org.junit.Test
  */
 public class IOUtilsJUnitTest {
-
-  private Mockery mockContext;
-
-  @Before
-  public void setup() {
-    mockContext = new Mockery() {
-      {
-        setImposteriser(ClassImposteriser.INSTANCE);
-        setThreadingPolicy(new Synchroniser());
-      }
-    };
-  }
-
-  @After
-  public void tearDown() {
-    mockContext.assertIsSatisfied();
-    mockContext = null;
-  }
 
   /**
    * Gets a fully-qualified path anchored at root.
@@ -91,239 +69,164 @@ public class IOUtilsJUnitTest {
 
   @Test
   public void testAppendToPath() {
-    assertEquals(null, IOUtils.appendToPath(null, (String[]) null));
-    assertEquals(File.separator, IOUtils.appendToPath(null));
-    assertEquals(File.separator, IOUtils.appendToPath(""));
-    assertEquals(File.separator, IOUtils.appendToPath(" "));
-    assertEquals(File.separator, IOUtils.appendToPath(File.separator));
-    assertEquals(toPathname("bin", "a.out"), IOUtils.appendToPath(null, "bin", "a.out"));
-    assertEquals(toPathname("bin", "a.out"), IOUtils.appendToPath(File.separator, "bin", "a.out"));
-    assertEquals(toPathname("usr", "local", "bin", "a.out"),
-        IOUtils.appendToPath(toPathname("usr", "local"), "bin", "a.out"));
+    assertThat(IOUtils.appendToPath(null, (String[]) null)).isNull();
+    assertThat(File.separator).isEqualTo(IOUtils.appendToPath(null));
+    assertThat(File.separator).isEqualTo(IOUtils.appendToPath(""));
+    assertThat(File.separator).isEqualTo(IOUtils.appendToPath(" "));
+    assertThat(File.separator).isEqualTo(IOUtils.appendToPath(File.separator));
+    assertThat(toPathname("bin", "a.out")).isEqualTo(IOUtils.appendToPath(null, "bin", "a.out"));
+    assertThat(toPathname("bin", "a.out"))
+        .isEqualTo(IOUtils.appendToPath(File.separator, "bin", "a.out"));
+    assertThat(toPathname("usr", "local", "bin", "a.out"))
+        .isEqualTo(IOUtils.appendToPath(toPathname("usr", "local"), "bin", "a.out"));
   }
 
   @Test
   public void testClose() throws IOException {
-    final Closeable mockCloseable = mockContext.mock(Closeable.class, "Closeable");
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockCloseable).close();
-      }
-    });
-
+    final Closeable mockCloseable = spy(Closeable.class);
     IOUtils.close(mockCloseable);
+    verify(mockCloseable, times(1)).close();
   }
 
   @Test
   public void testCloseIgnoresIOException() throws IOException {
-    final Closeable mockCloseable = mockContext.mock(Closeable.class, "Closeable");
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockCloseable).close();
-        will(throwException(new IOException("test")));
-      }
-    });
-
-    try {
-      IOUtils.close(mockCloseable);
-    } catch (Throwable unexpected) {
-      if (unexpected instanceof IOException) {
-        fail("Calling close on a Closeable object unexpectedly threw an IOException!");
-      }
-    }
+    final Closeable mockCloseable = mock(Closeable.class);
+    doThrow(new IOException("Mock Exception")).when(mockCloseable).close();
+    IOUtils.close(mockCloseable);
   }
 
   @Test
   public void testCreatePath() {
-    assertEquals("", IOUtils.createPath());
-    assertEquals("/path/to/file.test".replace("/", File.separator),
-        IOUtils.createPath("path", "to", "file.test"));
-    assertEquals("/path/to/a/directory".replace("/", File.separator),
-        IOUtils.createPath("path", "to", "a", "directory"));
+    assertThat("").isEqualTo(IOUtils.createPath());
+    assertThat("/path/to/file.test".replace("/", File.separator))
+        .isEqualTo(IOUtils.createPath("path", "to", "file.test"));
+    assertThat("/path/to/a/directory".replace("/", File.separator))
+        .isEqualTo(IOUtils.createPath("path", "to", "a", "directory"));
   }
 
   @Test
   public void testCreatePathWithSeparator() {
-    assertEquals("", IOUtils.createPath(new String[0], "-"));
-    assertEquals("-path-to-file.ext".replace("/", File.separator),
-        IOUtils.createPath(new String[] {"path", "to", "file.ext"}, "-"));
-    assertEquals("-path-to-a-directory",
-        IOUtils.createPath(new String[] {"path", "to", "a", "directory"}, "-"));
+    assertThat("").isEqualTo(IOUtils.createPath(new String[0], "-"));
+    assertThat("-path-to-file.ext".replace("/", File.separator))
+        .isEqualTo(IOUtils.createPath(new String[] {"path", "to", "file.ext"}, "-"));
+    assertThat("-path-to-a-directory")
+        .isEqualTo(IOUtils.createPath(new String[] {"path", "to", "a", "directory"}, "-"));
   }
 
   @Test
   public void testGetFilename() {
-    assertNull(IOUtils.getFilename(null));
-    assertEquals("", IOUtils.getFilename(""));
-    assertEquals("  ", IOUtils.getFilename("  "));
-    assertEquals("", IOUtils.getFilename(File.separator));
-    assertEquals("a.ext", IOUtils.getFilename("a.ext"));
-    assertEquals("b.ext", IOUtils.getFilename(toPathname("b.ext")));
-    assertEquals("c.ext", IOUtils.getFilename(toPathname("path", "to", "c.ext")));
-    assertEquals("filename.ext",
-        IOUtils.getFilename(toPathname("export", "path", "to", "some", "filename.ext")));
-    assertEquals("",
+    assertThat(IOUtils.getFilename(null)).isNull();
+    assertThat("").isEqualTo(IOUtils.getFilename(""));
+    assertThat("  ").isEqualTo(IOUtils.getFilename("  "));
+    assertThat("").isEqualTo(IOUtils.getFilename(File.separator));
+    assertThat("a.ext").isEqualTo(IOUtils.getFilename("a.ext"));
+    assertThat("b.ext").isEqualTo(IOUtils.getFilename(toPathname("b.ext")));
+    assertThat("c.ext").isEqualTo(IOUtils.getFilename(toPathname("path", "to", "c.ext")));
+    assertThat("filename.ext")
+        .isEqualTo(IOUtils.getFilename(toPathname("export", "path", "to", "some", "filename.ext")));
+    assertThat("").isEqualTo(
         IOUtils.getFilename(toPathname("path", "to", "a", "directory") + File.separator));
   }
 
   @Test
   public void testIsExistingPathname() {
-    assertTrue(IOUtils.isExistingPathname(System.getProperty("java.home")));
-    assertTrue(IOUtils.isExistingPathname(System.getProperty("user.home")));
-    assertFalse(IOUtils.isExistingPathname("/path/to/non_existing/directory/"));
-    assertFalse(IOUtils.isExistingPathname("/path/to/non_existing/file.ext"));
+    assertThat(IOUtils.isExistingPathname(System.getProperty("java.home"))).isTrue();
+    assertThat(IOUtils.isExistingPathname(System.getProperty("user.home"))).isTrue();
+    assertThat(IOUtils.isExistingPathname("/path/to/non_existing/directory/")).isFalse();
+    assertThat(IOUtils.isExistingPathname("/path/to/non_existing/file.ext")).isFalse();
   }
 
   @Test
   public void testObjectSerialization() throws IOException, ClassNotFoundException {
     final Calendar now = Calendar.getInstance();
-
-    assertNotNull(now);
+    assertThat(now).isNotNull();
 
     final byte[] nowBytes = IOUtils.serializeObject(now);
-
-    assertNotNull(nowBytes);
-    assertTrue(nowBytes.length != 0);
+    assertThat(nowBytes).isNotNull();
+    assertThat(nowBytes.length != 0).isTrue();
 
     final Object nowObj = IOUtils.deserializeObject(nowBytes);
-
-    assertTrue(nowObj instanceof Calendar);
-    assertEquals(now.getTimeInMillis(), ((Calendar) nowObj).getTimeInMillis());
+    assertThat(nowObj).isInstanceOf(Calendar.class);
+    assertThat(now.getTimeInMillis()).isEqualTo(((Calendar) nowObj).getTimeInMillis());
   }
 
   @Test
   public void testObjectSerializationWithClassLoader() throws IOException, ClassNotFoundException {
     final BigDecimal pi = new BigDecimal(Math.PI);
-
     final byte[] piBytes = IOUtils.serializeObject(pi);
 
-    assertNotNull(piBytes);
-    assertTrue(piBytes.length != 0);
+    assertThat(piBytes).isNotNull();
+    assertThat(piBytes.length != 0).isTrue();
 
     final Object piObj =
         IOUtils.deserializeObject(piBytes, IOUtilsJUnitTest.class.getClassLoader());
-
-    assertTrue(piObj instanceof BigDecimal);
-    assertEquals(pi, piObj);
+    assertThat(piObj).isInstanceOf(BigDecimal.class);
+    assertThat(pi).isEqualTo(piObj);
   }
 
   @Test
   public void testToByteArray() throws IOException {
     final byte[] expected = new byte[] {(byte) 0xCA, (byte) 0xFE, (byte) 0xBA, (byte) 0xBE};
-
     final byte[] actual = IOUtils.toByteArray(new ByteArrayInputStream(expected));
 
-    assertNotNull(actual);
-    assertEquals(expected.length, actual.length);
+    assertThat(actual).isNotNull();
+    assertThat(expected.length).isEqualTo(actual.length);
 
     for (int index = 0; index < actual.length; index++) {
-      assertEquals(expected[index], actual[index]);
+      assertThat(expected[index]).isEqualTo(actual[index]);
     }
   }
 
-  @Test(expected = IOException.class)
+  @Test
   public void testToByteArrayThrowsIOException() throws IOException {
-    final InputStream mockIn =
-        mockContext.mock(InputStream.class, "testToByteArrayThrowsIOException");
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockIn).read(with(aNonNull(byte[].class)));
-        will(throwException(new IOException("test")));
-        oneOf(mockIn).close();
-      }
-    });
-
-    IOUtils.toByteArray(mockIn);
-  }
-
-  @Test(expected = AssertionError.class)
-  public void testToByteArrayWithNull() throws IOException {
-    try {
-      IOUtils.toByteArray(null);
-    } catch (AssertionError expected) {
-      assertEquals("The input stream to read bytes from cannot be null!", expected.getMessage());
-      throw expected;
-    }
+    final InputStream mockIn = mock(InputStream.class, "testToByteArrayThrowsIOException");
+    when(mockIn.read(any())).thenThrow(new IOException("Mock IOException"));
+    assertThatThrownBy(() -> IOUtils.toByteArray(mockIn)).isInstanceOf(IOException.class)
+        .hasMessage("Mock IOException");
   }
 
   @Test
-  public void testTryGetCanonicalFileElseGetAbsoluteFile() throws Exception {
-    final MockFile file = (MockFile) IOUtils.tryGetCanonicalFileElseGetAbsoluteFile(
-        new MockFile("/path/to/non_existing/file.test", null));
-
-    assertNotNull(file);
-    assertFalse(file.exists());
-    assertTrue(file.isGetCanonicalFileCalled());
-    assertFalse(file.isGetAbsoluteFileCalled());
+  public void testToByteArrayWithNull() {
+    assertThatThrownBy(() -> IOUtils.toByteArray(null)).isInstanceOf(AssertionError.class)
+        .hasMessage("The input stream to read bytes from cannot be null!");
   }
 
   @Test
-  public void testTryGetCanonicalFileElseGetAbsoluteFileHandlesIOException() throws Exception {
-    final MockFile file = (MockFile) IOUtils.tryGetCanonicalFileElseGetAbsoluteFile(
-        new MockFile(System.getProperty("user.home"), new IOException("test")));
+  public void testTryGetCanonicalFileElseGetAbsoluteFile() throws IOException {
+    final File mockFile = mock(File.class);
+    when(mockFile.getCanonicalFile()).thenReturn(mock(File.class));
+    final File file = IOUtils.tryGetCanonicalFileElseGetAbsoluteFile(mockFile);
 
-    assertNotNull(file);
-    assertTrue(file.exists());
-    assertTrue(file.isGetCanonicalFileCalled());
-    assertTrue(file.isGetAbsoluteFileCalled());
+    assertThat(file).isNotNull();
+    assertThat(file.exists()).isFalse();
+    verify(mockFile, times(1)).getCanonicalFile();
+    verify(mockFile, times(0)).getAbsoluteFile();
+  }
+
+  @Test
+  public void testTryGetCanonicalFileElseGetAbsoluteFileHandlesIOException() throws IOException {
+    final File mockFile = mock(File.class);
+    when(mockFile.getAbsoluteFile()).thenReturn(mock(File.class));
+    when(mockFile.getCanonicalFile()).thenThrow(new IOException("Mock Exception"));
+    final File file = IOUtils.tryGetCanonicalFileElseGetAbsoluteFile(mockFile);
+
+    assertThat(file).isNotNull();
+    assertThat(file.exists()).isFalse();
+    InOrder inOrder = Mockito.inOrder(mockFile);
+    inOrder.verify(mockFile).getCanonicalFile();
+    inOrder.verify(mockFile).getAbsoluteFile();
   }
 
   @Test
   public void testVerifyPathnameExists() throws FileNotFoundException {
-    assertEquals(System.getProperty("java.io.tmpdir"),
-        IOUtils.verifyPathnameExists(System.getProperty("java.io.tmpdir")));
+    assertThat(System.getProperty("java.io.tmpdir"))
+        .isEqualTo(IOUtils.verifyPathnameExists(System.getProperty("java.io.tmpdir")));
   }
 
-  @Test(expected = FileNotFoundException.class)
-  public void testVerifyPathnameExistsWithNonExistingPathname() throws FileNotFoundException {
-    try {
-      IOUtils.verifyPathnameExists("/path/to/non_existing/file.test");
-    } catch (FileNotFoundException expected) {
-      assertEquals("Pathname (/path/to/non_existing/file.test) could not be found!",
-          expected.getMessage());
-      throw expected;
-    }
+  @Test
+  public void testVerifyPathnameExistsWithNonExistingPathname() {
+    assertThatThrownBy(() -> IOUtils.verifyPathnameExists("/path/to/non_existing/file.test"))
+        .isInstanceOf(FileNotFoundException.class)
+        .hasMessage("Pathname (/path/to/non_existing/file.test) could not be found!");
   }
-
-  private static class MockFile extends File {
-
-    private boolean isGetAbsoluteFileCalled = false;
-    private boolean isGetCanonicalFileCalled = false;
-
-    private final IOException e;
-
-    public MockFile(final String pathname, IOException e) {
-      super(pathname);
-      this.e = e;
-    }
-
-    @Override
-    public File getAbsoluteFile() {
-      isGetAbsoluteFileCalled = true;
-      return this;
-    }
-
-    protected boolean isGetAbsoluteFileCalled() {
-      return isGetAbsoluteFileCalled;
-    }
-
-    @Override
-    public File getCanonicalFile() throws IOException {
-      isGetCanonicalFileCalled = true;
-
-      if (e != null) {
-        throw e;
-      }
-
-      return this;
-    }
-
-    protected boolean isGetCanonicalFileCalled() {
-      return isGetCanonicalFileCalled;
-    }
-  }
-
 }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/JettyHelperJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/JettyHelperJUnitTest.java
@@ -56,7 +56,7 @@ public class JettyHelperJUnitTest {
         .getSSLConfigForComponent(distributionConfig, SecurableCommunicationChannel.WEB));
     assertThat(jetty).isNotNull();
     assertThat(jetty.getConnectors()[0]).isNotNull();
-    assertThat(8090).isEqualTo(((ServerConnector) jetty.getConnectors()[0]).getPort());
+    assertThat(((ServerConnector) jetty.getConnectors()[0]).getPort()).isEqualTo(8090);
   }
 
   @Test
@@ -65,6 +65,6 @@ public class JettyHelperJUnitTest {
         .getSSLConfigForComponent(distributionConfig, SecurableCommunicationChannel.WEB));
     assertThat(jetty).isNotNull();
     assertThat(jetty.getConnectors()[0]).isNotNull();
-    assertThat(10480).isEqualTo(((ServerConnector) jetty.getConnectors()[0]).getPort());
+    assertThat(((ServerConnector) jetty.getConnectors()[0]).getPort()).isEqualTo(10480);
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/JettyHelperJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/JettyHelperJUnitTest.java
@@ -14,9 +14,7 @@
  */
 package org.apache.geode.management.internal;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Properties;
 
@@ -26,7 +24,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.apache.geode.GemFireConfigException;
+import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.DistributionConfigImpl;
 import org.apache.geode.internal.net.SSLConfigurationFactory;
 import org.apache.geode.internal.security.SecurableCommunicationChannel;
@@ -36,15 +34,15 @@ import org.apache.geode.internal.security.SecurableCommunicationChannel;
  * functionality of the JettyHelper class. Does not start Jetty.
  *
  * @see org.apache.geode.management.internal.JettyHelper
- * @see org.jmock.Mockery
- * @see org.junit.Assert
  * @see org.junit.Test
  */
 public class JettyHelperJUnitTest {
+  private DistributionConfig distributionConfig;
 
   @Before
   public void setup() {
-    SSLConfigurationFactory.setDistributionConfig(new DistributionConfigImpl(new Properties()));
+    distributionConfig = new DistributionConfigImpl(new Properties());
+    SSLConfigurationFactory.setDistributionConfig(distributionConfig);
   }
 
   @After
@@ -53,31 +51,20 @@ public class JettyHelperJUnitTest {
   }
 
   @Test
-  public void testSetPortNoBindAddress() throws Exception {
-
-    final Server jetty;
-    try {
-      jetty = JettyHelper.initJetty(null, 8090,
-          SSLConfigurationFactory.getSSLConfigForComponent(SecurableCommunicationChannel.WEB));
-      assertNotNull(jetty);
-      assertNotNull(jetty.getConnectors()[0]);
-      assertEquals(8090, ((ServerConnector) jetty.getConnectors()[0]).getPort());
-    } catch (GemFireConfigException e) {
-      fail(e.getMessage());
-    }
+  public void testSetPortNoBindAddress() {
+    final Server jetty = JettyHelper.initJetty(null, 8090, SSLConfigurationFactory
+        .getSSLConfigForComponent(distributionConfig, SecurableCommunicationChannel.WEB));
+    assertThat(jetty).isNotNull();
+    assertThat(jetty.getConnectors()[0]).isNotNull();
+    assertThat(8090).isEqualTo(((ServerConnector) jetty.getConnectors()[0]).getPort());
   }
 
   @Test
-  public void testSetPortWithBindAddress() throws Exception {
-    try {
-      final Server jetty = JettyHelper.initJetty("10.123.50.1", 10480,
-          SSLConfigurationFactory.getSSLConfigForComponent(SecurableCommunicationChannel.WEB));
-
-      assertNotNull(jetty);
-      assertNotNull(jetty.getConnectors()[0]);
-      assertEquals(10480, ((ServerConnector) jetty.getConnectors()[0]).getPort());
-    } catch (GemFireConfigException e) {
-      fail(e.getMessage());
-    }
+  public void testSetPortWithBindAddress() {
+    final Server jetty = JettyHelper.initJetty("10.123.50.1", 10480, SSLConfigurationFactory
+        .getSSLConfigForComponent(distributionConfig, SecurableCommunicationChannel.WEB));
+    assertThat(jetty).isNotNull();
+    assertThat(jetty.getConnectors()[0]).isNotNull();
+    assertThat(10480).isEqualTo(((ServerConnector) jetty.getConnectors()[0]).getPort());
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DiskStoreCommandsJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DiskStoreCommandsJUnitTest.java
@@ -112,7 +112,7 @@ public class DiskStoreCommandsJUnitTest {
     final DiskStoreDetails actualDiskStoreDetails =
         describeDiskStoreCommand.getDiskStoreDescription(memberId, diskStoreName);
     AssertionsForClassTypes.assertThat(actualDiskStoreDetails).isNotNull();
-    AssertionsForClassTypes.assertThat(expectedDiskStoredDetails).isEqualTo(actualDiskStoreDetails);
+    AssertionsForClassTypes.assertThat(actualDiskStoreDetails).isEqualTo(expectedDiskStoredDetails);
   }
 
   @Test
@@ -175,7 +175,7 @@ public class DiskStoreCommandsJUnitTest {
     final List<DiskStoreDetails> actualDiskStores =
         listDiskStoresCommand.getDiskStoreListing(Collections.singleton(mockDistributedMember));
     assertThat(actualDiskStores).isNotNull();
-    assertThat(expectedDiskStores).isEqualTo(actualDiskStores);
+    assertThat(actualDiskStores).isEqualTo(expectedDiskStores);
     verify(mockFunctionExecutor, times(1)).setIgnoreDepartedMembers(true);
   }
 
@@ -204,7 +204,7 @@ public class DiskStoreCommandsJUnitTest {
     final List<DiskStoreDetails> actualDiskStores =
         listDiskStoresCommand.getDiskStoreListing(Collections.singleton(mockDistributedMember));
     assertThat(actualDiskStores).isNotNull();
-    assertThat(expectedDiskStores).isEqualTo(actualDiskStores);
+    assertThat(actualDiskStores).isEqualTo(expectedDiskStores);
     verify(mockFunctionExecutor, times(1)).setIgnoreDepartedMembers(true);
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DiskStoreCommandsJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DiskStoreCommandsJUnitTest.java
@@ -14,10 +14,16 @@
  */
 package org.apache.geode.management.internal.cli.commands;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -25,17 +31,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-import org.jmock.Expectations;
-import org.jmock.Mockery;
-import org.jmock.lib.concurrent.Synchroniser;
-import org.jmock.lib.legacy.ClassImposteriser;
-import org.junit.After;
-import org.junit.Assert;
+import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.apache.geode.cache.Cache;
-import org.apache.geode.cache.execute.Execution;
 import org.apache.geode.cache.execute.FunctionInvocationTargetException;
 import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.distributed.DistributedMember;
@@ -54,46 +53,44 @@ import org.apache.geode.management.internal.cli.i18n.CliStrings;
  * GemFire shell (gfsh) that access and modify disk stores in GemFire.
  *
  * @see org.apache.geode.management.internal.cli.commands.DescribeDiskStoreCommand
- * @see ListDiskStoresCommand
+ * @see org.apache.geode.management.internal.cli.commands.ListDiskStoresCommand
  * @see org.apache.geode.management.internal.cli.domain.DiskStoreDetails
  * @see org.apache.geode.management.internal.cli.functions.DescribeDiskStoreFunction
  * @see org.apache.geode.management.internal.cli.functions.ListDiskStoresFunction
- * @see org.jmock.Expectations
- * @see org.jmock.Mockery
- * @see org.jmock.lib.legacy.ClassImposteriser
- * @see org.junit.Assert
  * @see org.junit.Test
  *
  * @since GemFire 7.0
  */
 public class DiskStoreCommandsJUnitTest {
-
-  private Mockery mockContext;
+  private AbstractExecution mockFunctionExecutor;
+  private ResultCollector mockResultCollector;
+  private DistributedMember mockDistributedMember;
+  private ListDiskStoresCommand listDiskStoresCommand;
+  private DescribeDiskStoreCommand describeDiskStoreCommand;
 
   @Before
+  @SuppressWarnings("unchecked")
   public void setUp() {
-    mockContext = new Mockery() {
-      {
-        setImposteriser(ClassImposteriser.INSTANCE);
-        setThreadingPolicy(new Synchroniser());
-      }
-    };
-  }
+    listDiskStoresCommand = spy(ListDiskStoresCommand.class);
+    describeDiskStoreCommand = spy(DescribeDiskStoreCommand.class);
+    InternalCache mockCache = mock(InternalCache.class, "InternalCache");
+    mockResultCollector = mock(ResultCollector.class, "ResultCollector");
+    mockFunctionExecutor = mock(AbstractExecution.class, "Function Executor");
+    mockDistributedMember = mock(DistributedMember.class, "DistributedMember");
 
-  @After
-  public void tearDown() {
-    mockContext.assertIsSatisfied();
-    mockContext = null;
-  }
+    when(mockFunctionExecutor.setArguments(any())).thenReturn(mockFunctionExecutor);
 
-  private DescribeDiskStoreCommand createDescribeDiskStoreCommand(final InternalCache cache,
-      final DistributedMember distributedMember, final Execution functionExecutor) {
-    return new TestDescribeDiskStoreCommand(cache, distributedMember, functionExecutor);
-  }
+    when(listDiskStoresCommand.getCache()).thenReturn(mockCache);
+    doReturn(mockDistributedMember).when(listDiskStoresCommand).getMember(anyString());
+    doReturn(Collections.singleton(mockDistributedMember)).when(listDiskStoresCommand)
+        .getAllMembers();
+    doReturn(mockFunctionExecutor).when(listDiskStoresCommand).getMembersFunctionExecutor(any());
 
-  private ListDiskStoresCommand createListDiskStoreCommand(final InternalCache cache,
-      final DistributedMember distributedMember, final Execution functionExecutor) {
-    return new TestListDiskStoresCommand(cache, distributedMember, functionExecutor);
+    when(describeDiskStoreCommand.getCache()).thenReturn(mockCache);
+    doReturn(mockDistributedMember).when(describeDiskStoreCommand).getMember(anyString());
+    doReturn(Collections.singleton(mockDistributedMember)).when(describeDiskStoreCommand)
+        .getAllMembers();
+    doReturn(mockFunctionExecutor).when(describeDiskStoreCommand).getMembersFunctionExecutor(any());
   }
 
   private DiskStoreDetails createDiskStoreDetails(final String memberId,
@@ -103,339 +100,111 @@ public class DiskStoreCommandsJUnitTest {
 
   @Test
   public void testGetDiskStoreDescription() {
-    final String diskStoreName = "mockDiskStore";
     final String memberId = "mockMember";
-
-    final InternalCache mockCache = mockContext.mock(InternalCache.class, "InternalCache");
-
-    final DistributedMember mockMember =
-        mockContext.mock(DistributedMember.class, "DistributedMember");
-
-    final Execution mockFunctionExecutor = mockContext.mock(Execution.class, "Function Executor");
-
-    final ResultCollector mockResultCollector =
-        mockContext.mock(ResultCollector.class, "ResultCollector");
-
+    final String diskStoreName = "mockDiskStore";
     final DiskStoreDetails expectedDiskStoredDetails =
         createDiskStoreDetails(memberId, diskStoreName);
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockFunctionExecutor).setArguments(with(equal(diskStoreName)));
-        will(returnValue(mockFunctionExecutor));
-        oneOf(mockFunctionExecutor).execute(with(aNonNull(DescribeDiskStoreFunction.class)));
-        will(returnValue(mockResultCollector));
-        oneOf(mockResultCollector).getResult();
-        will(returnValue(Collections.singletonList(expectedDiskStoredDetails)));
-      }
-    });
-
-    final DescribeDiskStoreCommand describeCommand =
-        createDescribeDiskStoreCommand(mockCache, mockMember, mockFunctionExecutor);
+    when(mockFunctionExecutor.execute(any(DescribeDiskStoreFunction.class)))
+        .thenReturn(mockResultCollector);
+    when(mockResultCollector.getResult())
+        .thenReturn(Collections.singletonList(expectedDiskStoredDetails));
 
     final DiskStoreDetails actualDiskStoreDetails =
-        describeCommand.getDiskStoreDescription(memberId, diskStoreName);
-
-    assertNotNull(actualDiskStoreDetails);
-    assertEquals(expectedDiskStoredDetails, actualDiskStoreDetails);
+        describeDiskStoreCommand.getDiskStoreDescription(memberId, diskStoreName);
+    AssertionsForClassTypes.assertThat(actualDiskStoreDetails).isNotNull();
+    AssertionsForClassTypes.assertThat(expectedDiskStoredDetails).isEqualTo(actualDiskStoreDetails);
   }
 
-  @Test(expected = EntityNotFoundException.class)
+  @Test
   public void testGetDiskStoreDescriptionThrowsEntityNotFoundException() {
-    final String diskStoreName = "mockDiskStore";
     final String memberId = "mockMember";
+    final String diskStoreName = "mockDiskStore";
+    when(mockFunctionExecutor.execute(any(DescribeDiskStoreFunction.class)))
+        .thenThrow(new EntityNotFoundException("Mock Exception"));
 
-    final InternalCache mockCache = mockContext.mock(InternalCache.class, "InternalCache");
-
-    final DistributedMember mockMember =
-        mockContext.mock(DistributedMember.class, "DistributedMember");
-
-    final Execution mockFunctionExecutor = mockContext.mock(Execution.class, "Function Executor");
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockFunctionExecutor).setArguments(with(equal(diskStoreName)));
-        will(returnValue(mockFunctionExecutor));
-        oneOf(mockFunctionExecutor).execute(with(aNonNull(DescribeDiskStoreFunction.class)));
-        will(throwException(new EntityNotFoundException("expected")));
-      }
-    });
-
-    final DescribeDiskStoreCommand describeCommand =
-        createDescribeDiskStoreCommand(mockCache, mockMember, mockFunctionExecutor);
-
-    try {
-      describeCommand.getDiskStoreDescription(memberId, diskStoreName);
-    } catch (EntityNotFoundException expected) {
-      assertEquals("expected", expected.getMessage());
-      throw expected;
-    }
+    assertThatThrownBy(
+        () -> describeDiskStoreCommand.getDiskStoreDescription(memberId, diskStoreName))
+            .isInstanceOf(EntityNotFoundException.class).hasMessage("Mock Exception");
   }
 
-  @Test(expected = RuntimeException.class)
+  @Test
   public void testGetDiskStoreDescriptionThrowsRuntimeException() {
-    final String diskStoreName = "mockDiskStore";
     final String memberId = "mockMember";
+    final String diskStoreName = "mockDiskStore";
+    when(mockFunctionExecutor.execute(any(DescribeDiskStoreFunction.class)))
+        .thenThrow(new RuntimeException("Mock Exception"));
 
-    final InternalCache mockCache = mockContext.mock(InternalCache.class, "InternalCache");
-
-    final DistributedMember mockMember =
-        mockContext.mock(DistributedMember.class, "DistributedMember");
-
-    final Execution mockFunctionExecutor = mockContext.mock(Execution.class, "Function Executor");
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockFunctionExecutor).setArguments(with(equal(diskStoreName)));
-        will(returnValue(mockFunctionExecutor));
-        oneOf(mockFunctionExecutor).execute(with(aNonNull(DescribeDiskStoreFunction.class)));
-        will(throwException(new RuntimeException("expected")));
-      }
-    });
-
-    final DescribeDiskStoreCommand describeCommand =
-        createDescribeDiskStoreCommand(mockCache, mockMember, mockFunctionExecutor);
-
-    try {
-      describeCommand.getDiskStoreDescription(memberId, diskStoreName);
-    } catch (RuntimeException expected) {
-      assertEquals("expected", expected.getMessage());
-      throw expected;
-    }
+    assertThatThrownBy(
+        () -> describeDiskStoreCommand.getDiskStoreDescription(memberId, diskStoreName))
+            .isInstanceOf(RuntimeException.class).hasMessage("Mock Exception");
   }
 
-  @Test(expected = RuntimeException.class)
+  @Test
   public void testGetDiskStoreDescriptionWithInvalidFunctionResultReturnType() {
-    final String diskStoreName = "mockDiskStore";
     final String memberId = "mockMember";
+    final String diskStoreName = "mockDiskStore";
+    when(mockFunctionExecutor.execute(any(DescribeDiskStoreFunction.class)))
+        .thenReturn(mockResultCollector);
+    when(mockResultCollector.getResult()).thenReturn(Collections.singletonList(new Object()));
 
-    final InternalCache mockCache = mockContext.mock(InternalCache.class, "InternalCache");
-
-    final DistributedMember mockMember =
-        mockContext.mock(DistributedMember.class, "DistributedMember");
-
-    final Execution mockFunctionExecutor = mockContext.mock(Execution.class, "Function Executor");
-
-    final ResultCollector mockResultCollector =
-        mockContext.mock(ResultCollector.class, "ResultCollector");
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockFunctionExecutor).setArguments(with(equal(diskStoreName)));
-        will(returnValue(mockFunctionExecutor));
-        oneOf(mockFunctionExecutor).execute(with(aNonNull(DescribeDiskStoreFunction.class)));
-        will(returnValue(mockResultCollector));
-        oneOf(mockResultCollector).getResult();
-        will(returnValue(Collections.singletonList(new Object())));
-      }
-    });
-
-    final DescribeDiskStoreCommand describeCommand =
-        createDescribeDiskStoreCommand(mockCache, mockMember, mockFunctionExecutor);
-
-    try {
-      describeCommand.getDiskStoreDescription(memberId, diskStoreName);
-    } catch (RuntimeException expected) {
-      assertEquals(
-          CliStrings.format(CliStrings.UNEXPECTED_RETURN_TYPE_EXECUTING_COMMAND_ERROR_MESSAGE,
-              Object.class.getName(), CliStrings.DESCRIBE_DISK_STORE),
-          expected.getMessage());
-      assertNull(expected.getCause());
-      throw expected;
-    }
+    assertThatThrownBy(
+        () -> describeDiskStoreCommand.getDiskStoreDescription(memberId, diskStoreName))
+            .isInstanceOf(RuntimeException.class).hasNoCause().hasMessage(
+                CliStrings.format(CliStrings.UNEXPECTED_RETURN_TYPE_EXECUTING_COMMAND_ERROR_MESSAGE,
+                    Object.class.getName(), CliStrings.DESCRIBE_DISK_STORE));
   }
 
   @Test
   public void testGetDiskStoreList() {
-    final InternalCache mockCache = mockContext.mock(InternalCache.class, "InternalCache");
-
-    final DistributedMember mockDistributedMember =
-        mockContext.mock(DistributedMember.class, "DistributedMember");
-
-    final AbstractExecution mockFunctionExecutor =
-        mockContext.mock(AbstractExecution.class, "Function Executor");
-
-    final ResultCollector mockResultCollector =
-        mockContext.mock(ResultCollector.class, "ResultCollector");
-
-    final DiskStoreDetails diskStoreDetails1 =
-        createDiskStoreDetails("memberOne", "cacheServerDiskStore");
-    final DiskStoreDetails diskStoreDetails2 =
-        createDiskStoreDetails("memberOne", "gatewayDiskStore");
     final DiskStoreDetails diskStoreDetails3 = createDiskStoreDetails("memberTwo", "pdxDiskStore");
     final DiskStoreDetails diskStoreDetails4 =
         createDiskStoreDetails("memberTwo", "regionDiskStore");
-
+    final DiskStoreDetails diskStoreDetails2 =
+        createDiskStoreDetails("memberOne", "gatewayDiskStore");
+    final DiskStoreDetails diskStoreDetails1 =
+        createDiskStoreDetails("memberOne", "cacheServerDiskStore");
     final List<DiskStoreDetails> expectedDiskStores =
         Arrays.asList(diskStoreDetails1, diskStoreDetails2, diskStoreDetails3, diskStoreDetails4);
-
     final List<Set<DiskStoreDetails>> results = new ArrayList<>();
-
     results.add(CollectionUtils.asSet(diskStoreDetails4, diskStoreDetails3));
     results.add(CollectionUtils.asSet(diskStoreDetails1, diskStoreDetails2));
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockFunctionExecutor).setIgnoreDepartedMembers(with(equal(true)));
-        oneOf(mockFunctionExecutor).execute(with(aNonNull(ListDiskStoresFunction.class)));
-        will(returnValue(mockResultCollector));
-        oneOf(mockResultCollector).getResult();
-        will(returnValue(results));
-      }
-    });
-
-    final ListDiskStoresCommand listCommand =
-        createListDiskStoreCommand(mockCache, mockDistributedMember, mockFunctionExecutor);
+    when(mockFunctionExecutor.execute(any(ListDiskStoresFunction.class)))
+        .thenReturn(mockResultCollector);
+    when(mockResultCollector.getResult()).thenReturn(results);
 
     final List<DiskStoreDetails> actualDiskStores =
-        listCommand.getDiskStoreListing(Collections.singleton(mockDistributedMember));
-
-    Assert.assertNotNull(actualDiskStores);
-    assertEquals(expectedDiskStores, actualDiskStores);
+        listDiskStoresCommand.getDiskStoreListing(Collections.singleton(mockDistributedMember));
+    assertThat(actualDiskStores).isNotNull();
+    assertThat(expectedDiskStores).isEqualTo(actualDiskStores);
+    verify(mockFunctionExecutor, times(1)).setIgnoreDepartedMembers(true);
   }
 
-  @Test(expected = RuntimeException.class)
+  @Test
   public void testGetDiskStoreListThrowsRuntimeException() {
-    final InternalCache mockCache = mockContext.mock(InternalCache.class, "InternalCache");
+    when(mockFunctionExecutor.execute(any(ListDiskStoresFunction.class)))
+        .thenThrow(new RuntimeException("Expected Exception"));
 
-    final DistributedMember mockDistributedMember =
-        mockContext.mock(DistributedMember.class, "DistributedMember");
-
-    final Execution mockFunctionExecutor = mockContext.mock(Execution.class, "Function Executor");
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockFunctionExecutor).execute(with(aNonNull(ListDiskStoresFunction.class)));
-        will(throwException(new RuntimeException("expected")));
-      }
-    });
-
-    final ListDiskStoresCommand listCommand =
-        createListDiskStoreCommand(mockCache, mockDistributedMember, mockFunctionExecutor);
-
-    try {
-      listCommand.getDiskStoreListing(Collections.singleton(mockDistributedMember));
-    } catch (RuntimeException expected) {
-      assertEquals("expected", expected.getMessage());
-      throw expected;
-    }
+    assertThatThrownBy(() -> listDiskStoresCommand
+        .getDiskStoreListing(Collections.singleton(mockDistributedMember)))
+            .isInstanceOf(RuntimeException.class).hasMessage("Expected Exception");
   }
 
   @Test
   public void testGetDiskStoreListReturnsFunctionInvocationTargetExceptionInResults() {
-    final InternalCache mockCache = mockContext.mock(InternalCache.class, "InternalCache");
-
-    final DistributedMember mockDistributedMember =
-        mockContext.mock(DistributedMember.class, "DistributedMember");
-
-    final AbstractExecution mockFunctionExecutor =
-        mockContext.mock(AbstractExecution.class, "Function Executor");
-
-    final ResultCollector mockResultCollector =
-        mockContext.mock(ResultCollector.class, "ResultCollector");
-
     final DiskStoreDetails diskStoreDetails =
         createDiskStoreDetails("memberOne", "cacheServerDiskStore");
-
     final List<DiskStoreDetails> expectedDiskStores = Collections.singletonList(diskStoreDetails);
-
     final List<Object> results = new ArrayList<>();
-
     results.add(CollectionUtils.asSet(diskStoreDetails));
     results.add(new FunctionInvocationTargetException("expected"));
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockFunctionExecutor).setIgnoreDepartedMembers(with(equal(true)));
-        oneOf(mockFunctionExecutor).execute(with(aNonNull(ListDiskStoresFunction.class)));
-        will(returnValue(mockResultCollector));
-        oneOf(mockResultCollector).getResult();
-        will(returnValue(results));
-      }
-    });
-
-    final ListDiskStoresCommand listCommand =
-        createListDiskStoreCommand(mockCache, mockDistributedMember, mockFunctionExecutor);
+    when(mockFunctionExecutor.execute(any(ListDiskStoresFunction.class)))
+        .thenReturn(mockResultCollector);
+    when(mockResultCollector.getResult()).thenReturn(results);
 
     final List<DiskStoreDetails> actualDiskStores =
-        listCommand.getDiskStoreListing(Collections.singleton(mockDistributedMember));
-
-    Assert.assertNotNull(actualDiskStores);
-    assertEquals(expectedDiskStores, actualDiskStores);
-  }
-
-  private static class TestDescribeDiskStoreCommand extends DescribeDiskStoreCommand {
-
-    private final InternalCache cache;
-    private final DistributedMember distributedMember;
-    private final Execution functionExecutor;
-
-    TestDescribeDiskStoreCommand(final InternalCache cache,
-        final DistributedMember distributedMember, final Execution functionExecutor) {
-      assert cache != null : "The Cache cannot be null!";
-      this.cache = cache;
-      this.distributedMember = distributedMember;
-      this.functionExecutor = functionExecutor;
-    }
-
-    @Override
-    public Cache getCache() {
-      return this.cache;
-    }
-
-    @Override
-    public Set<DistributedMember> getAllMembers() {
-      assertSame(getCache(), cache);
-      return Collections.singleton(this.distributedMember);
-    }
-
-    @Override
-    public DistributedMember getMember(String nameOrId) {
-      assertSame(getCache(), cache);
-      return this.distributedMember;
-    }
-
-    @Override
-    public Execution getMembersFunctionExecutor(final Set<DistributedMember> members) {
-      Assert.assertNotNull(members);
-      return this.functionExecutor;
-    }
-  }
-
-  private static class TestListDiskStoresCommand extends ListDiskStoresCommand {
-    private final InternalCache cache;
-    private final DistributedMember distributedMember;
-    private final Execution functionExecutor;
-
-    TestListDiskStoresCommand(final InternalCache cache, final DistributedMember distributedMember,
-        final Execution functionExecutor) {
-      assert cache != null : "The Cache cannot be null!";
-      this.cache = cache;
-      this.distributedMember = distributedMember;
-      this.functionExecutor = functionExecutor;
-    }
-
-    @Override
-    public Cache getCache() {
-      return this.cache;
-    }
-
-    @Override
-    public Set<DistributedMember> getAllMembers() {
-      assertSame(getCache(), cache);
-      return Collections.singleton(this.distributedMember);
-    }
-
-    @Override
-    public DistributedMember getMember(String nameOrId) {
-      assertSame(getCache(), cache);
-      return this.distributedMember;
-    }
-
-    @Override
-    public Execution getMembersFunctionExecutor(final Set<DistributedMember> members) {
-      Assert.assertNotNull(members);
-      return this.functionExecutor;
-    }
+        listDiskStoresCommand.getDiskStoreListing(Collections.singleton(mockDistributedMember));
+    assertThat(actualDiskStores).isNotNull();
+    assertThat(expectedDiskStores).isEqualTo(actualDiskStores);
+    verify(mockFunctionExecutor, times(1)).setIgnoreDepartedMembers(true);
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DiskStoreCommandsJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DiskStoreCommandsJUnitTest.java
@@ -156,18 +156,19 @@ public class DiskStoreCommandsJUnitTest {
 
   @Test
   public void testGetDiskStoreList() {
-    final DiskStoreDetails diskStoreDetails3 = createDiskStoreDetails("memberTwo", "pdxDiskStore");
-    final DiskStoreDetails diskStoreDetails4 =
-        createDiskStoreDetails("memberTwo", "regionDiskStore");
-    final DiskStoreDetails diskStoreDetails2 =
-        createDiskStoreDetails("memberOne", "gatewayDiskStore");
     final DiskStoreDetails diskStoreDetails1 =
-        createDiskStoreDetails("memberOne", "cacheServerDiskStore");
+        createDiskStoreDetails("memberOne", "cacheServer1DiskStore1");
+    final DiskStoreDetails diskStoreDetails2 =
+        createDiskStoreDetails("memberOne", "cacheServer1DiskStore2");
+    final DiskStoreDetails diskStoreDetails3 =
+        createDiskStoreDetails("memberTwo", "cacheServer2DiskStore1");
+    final DiskStoreDetails diskStoreDetails4 =
+        createDiskStoreDetails("memberTwo", "cacheServer2DiskStore2");
     final List<DiskStoreDetails> expectedDiskStores =
         Arrays.asList(diskStoreDetails1, diskStoreDetails2, diskStoreDetails3, diskStoreDetails4);
     final List<Set<DiskStoreDetails>> results = new ArrayList<>();
-    results.add(CollectionUtils.asSet(diskStoreDetails4, diskStoreDetails3));
     results.add(CollectionUtils.asSet(diskStoreDetails1, diskStoreDetails2));
+    results.add(CollectionUtils.asSet(diskStoreDetails4, diskStoreDetails3));
     when(mockFunctionExecutor.execute(any(ListDiskStoresFunction.class)))
         .thenReturn(mockResultCollector);
     when(mockResultCollector.getResult()).thenReturn(results);

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ListIndexCommandJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ListIndexCommandJUnitTest.java
@@ -98,7 +98,7 @@ public class ListIndexCommandJUnitTest {
 
     final List<IndexDetails> actualIndexDetails = listIndexCommand.getIndexListing();
     assertThat(actualIndexDetails).isNotNull();
-    assertThat(expectedIndexDetails).isEqualTo(actualIndexDetails);
+    assertThat(actualIndexDetails).isEqualTo(expectedIndexDetails);
     verify(mockFunctionExecutor, times(1)).setIgnoreDepartedMembers(true);
     verify(mockFunctionExecutor, times(1)).execute(any(ListIndexFunction.class));
   }
@@ -114,7 +114,7 @@ public class ListIndexCommandJUnitTest {
 
     final List<IndexDetails> actualIndexDetails = listIndexCommand.getIndexListing();
     assertThat(actualIndexDetails).isNotNull();
-    assertThat(expectedIndexDetails).isEqualTo(actualIndexDetails);
+    assertThat(actualIndexDetails).isEqualTo(expectedIndexDetails);
     verify(mockFunctionExecutor, times(1)).setIgnoreDepartedMembers(true);
     verify(mockFunctionExecutor, times(1)).execute(any(ListIndexFunction.class));
   }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ListIndexCommandJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ListIndexCommandJUnitTest.java
@@ -14,9 +14,16 @@
  */
 package org.apache.geode.management.internal.cli.commands;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -24,21 +31,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-import org.jmock.Expectations;
-import org.jmock.Mockery;
-import org.jmock.lib.concurrent.Synchroniser;
-import org.jmock.lib.legacy.ClassImposteriser;
-import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.apache.geode.cache.Cache;
-import org.apache.geode.cache.execute.Execution;
 import org.apache.geode.cache.execute.FunctionInvocationTargetException;
 import org.apache.geode.cache.execute.ResultCollector;
-import org.apache.geode.distributed.DistributedMember;
-import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.execute.AbstractExecution;
 import org.apache.geode.internal.util.CollectionUtils;
 import org.apache.geode.management.internal.cli.domain.IndexDetails;
@@ -57,35 +54,23 @@ import org.apache.geode.management.internal.cli.functions.ListIndexFunction;
  * @see org.apache.geode.management.internal.cli.commands.ListIndexCommand
  * @see org.apache.geode.management.internal.cli.domain.IndexDetails
  * @see org.apache.geode.management.internal.cli.functions.ListIndexFunction
- * @see org.jmock.Expectations
- * @see org.jmock.Mockery
- * @see org.jmock.lib.legacy.ClassImposteriser
- * @see org.junit.Assert
  * @see org.junit.Test
  * @since GemFire 7.0
  */
 public class ListIndexCommandJUnitTest {
-  private Mockery mockContext;
+  private ListIndexCommand listIndexCommand;
+  private ResultCollector mockResultCollector;
+  private AbstractExecution mockFunctionExecutor;
 
   @Before
   public void setup() {
-    mockContext = new Mockery() {
-      {
-        setImposteriser(ClassImposteriser.INSTANCE);
-        setThreadingPolicy(new Synchroniser());
-      }
-    };
-  }
-
-  @After
-  public void tearDown() {
-    mockContext.assertIsSatisfied();
-    mockContext = null;
-  }
-
-  private ListIndexCommand createListIndexCommand(final InternalCache cache,
-      final Execution functionExecutor) {
-    return new TestListIndexCommands(cache, functionExecutor);
+    listIndexCommand = spy(ListIndexCommand.class);
+    mockResultCollector = mock(ResultCollector.class, "ResultCollector");
+    mockFunctionExecutor = mock(AbstractExecution.class, "Function Executor");
+    when(mockFunctionExecutor.execute(any(ListIndexFunction.class)))
+        .thenReturn(mockResultCollector);
+    doReturn(Collections.emptySet()).when(listIndexCommand).getAllMembers();
+    doReturn(mockFunctionExecutor).when(listIndexCommand).getMembersFunctionExecutor(any());
   }
 
   private IndexDetails createIndexDetails(final String memberId, final String indexName) {
@@ -93,129 +78,44 @@ public class ListIndexCommandJUnitTest {
   }
 
   @Test
-  public void testGetIndexListing() {
-    final InternalCache mockCache = mockContext.mock(InternalCache.class, "InternalCache");
-
-    final AbstractExecution mockFunctionExecutor =
-        mockContext.mock(AbstractExecution.class, "Function Executor");
-
-    final ResultCollector mockResultCollector =
-        mockContext.mock(ResultCollector.class, "ResultCollector");
-
-    final IndexDetails indexDetails1 = createIndexDetails("memberOne", "empIdIdx");
-    final IndexDetails indexDetails2 = createIndexDetails("memberOne", "empLastNameIdx");
-    final IndexDetails indexDetails3 = createIndexDetails("memberTwo", "empDobIdx");
-
-    final List<IndexDetails> expectedIndexDetails =
-        Arrays.asList(indexDetails1, indexDetails2, indexDetails3);
-
-    final List<Set<IndexDetails>> results = new ArrayList<>(2);
-
-    results.add(CollectionUtils.asSet(indexDetails2, indexDetails1));
-    results.add(CollectionUtils.asSet(indexDetails3));
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockFunctionExecutor).setIgnoreDepartedMembers(with(equal(true)));
-        oneOf(mockFunctionExecutor).execute(with(aNonNull(ListIndexFunction.class)));
-        will(returnValue(mockResultCollector));
-        oneOf(mockResultCollector).getResult();
-        will(returnValue(results));
-      }
-    });
-
-    final ListIndexCommand commands = createListIndexCommand(mockCache, mockFunctionExecutor);
-    final List<IndexDetails> actualIndexDetails = commands.getIndexListing();
-
-    assertNotNull(actualIndexDetails);
-    assertEquals(expectedIndexDetails, actualIndexDetails);
-  }
-
-  @Test(expected = RuntimeException.class)
-  public void testGetIndexListingThrowsRuntimeException() {
-    final InternalCache mockCache = mockContext.mock(InternalCache.class, "InternalCache");
-    final Execution mockFunctionExecutor = mockContext.mock(Execution.class, "Function Executor");
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockFunctionExecutor).execute(with(aNonNull(ListIndexFunction.class)));
-        will(throwException(new RuntimeException("expected")));
-      }
-    });
-
-    final ListIndexCommand commands = createListIndexCommand(mockCache, mockFunctionExecutor);
-
-    try {
-      commands.getIndexListing();
-    } catch (RuntimeException expected) {
-      assertEquals("expected", expected.getMessage());
-      throw expected;
-    }
+  public void getIndexListingShouldPropagateExceptionsThrownByTheInternalFunctionExecution() {
+    doThrow(new RuntimeException("Mock RuntimeException")).when(mockFunctionExecutor)
+        .execute(any(ListIndexFunction.class));
+    assertThatThrownBy(() -> listIndexCommand.getIndexListing())
+        .isInstanceOf(RuntimeException.class).hasMessageContaining("Mock RuntimeException");
   }
 
   @Test
-  public void testGetIndexListingReturnsFunctionInvocationTargetExceptionInResults() {
-    final InternalCache mockCache = mockContext.mock(InternalCache.class, "InternalCache");
+  public void getIndexListingShouldReturnTheIndexesOrdered() {
+    final IndexDetails indexDetails1 = createIndexDetails("memberOne", "empIdIdx");
+    final IndexDetails indexDetails2 = createIndexDetails("memberOne", "empLastNameIdx");
+    final IndexDetails indexDetails3 = createIndexDetails("memberTwo", "empDobIdx");
+    final List<Set<IndexDetails>> results = new ArrayList<>();
+    results.add(CollectionUtils.asSet(indexDetails2, indexDetails1, indexDetails3));
+    when(mockResultCollector.getResult()).thenReturn(results);
+    final List<IndexDetails> expectedIndexDetails =
+        Arrays.asList(indexDetails1, indexDetails2, indexDetails3);
 
-    final AbstractExecution mockFunctionExecutor =
-        mockContext.mock(AbstractExecution.class, "Function Executor");
-
-    final ResultCollector mockResultCollector =
-        mockContext.mock(ResultCollector.class, "ResultCollector");
-
-    final IndexDetails indexDetails = createIndexDetails("memberOne", "empIdIdx");
-
-    final List<IndexDetails> expectedIndexDetails = Collections.singletonList(indexDetails);
-
-    final List<Object> results = new ArrayList<>(2);
-
-    results.add(CollectionUtils.asSet(indexDetails));
-    results.add(new FunctionInvocationTargetException("expected"));
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockFunctionExecutor).setIgnoreDepartedMembers(with(equal(true)));
-        oneOf(mockFunctionExecutor).execute(with(aNonNull(ListIndexFunction.class)));
-        will(returnValue(mockResultCollector));
-        oneOf(mockResultCollector).getResult();
-        will(returnValue(results));
-      }
-    });
-
-    final ListIndexCommand commands = createListIndexCommand(mockCache, mockFunctionExecutor);
-
-    final List<IndexDetails> actualIndexDetails = commands.getIndexListing();
-
-    assertNotNull(actualIndexDetails);
-    assertEquals(expectedIndexDetails, actualIndexDetails);
+    final List<IndexDetails> actualIndexDetails = listIndexCommand.getIndexListing();
+    assertThat(actualIndexDetails).isNotNull();
+    assertThat(expectedIndexDetails).isEqualTo(actualIndexDetails);
+    verify(mockFunctionExecutor, times(1)).setIgnoreDepartedMembers(true);
+    verify(mockFunctionExecutor, times(1)).execute(any(ListIndexFunction.class));
   }
 
-  private static class TestListIndexCommands extends ListIndexCommand {
-    private final InternalCache cache;
-    private final Execution functionExecutor;
+  @Test
+  public void getIndexListingShouldIgnoreExceptionsReturnedAsResultsFromTheInternalFunctionExecution() {
+    final IndexDetails indexDetails = createIndexDetails("memberOne", "empIdIdx");
+    final List<Object> results = new ArrayList<>(2);
+    results.add(CollectionUtils.asSet(indexDetails));
+    results.add(new FunctionInvocationTargetException("Mock FunctionInvocationTargetException"));
+    when(mockResultCollector.getResult()).thenReturn(results);
+    final List<IndexDetails> expectedIndexDetails = Collections.singletonList(indexDetails);
 
-    TestListIndexCommands(final InternalCache cache, final Execution functionExecutor) {
-      assert cache != null : "The InternalCache cannot be null!";
-      assert functionExecutor != null : "The function executor cannot be null!";
-      this.cache = cache;
-      this.functionExecutor = functionExecutor;
-    }
-
-    @Override
-    public Cache getCache() {
-      return this.cache;
-    }
-
-    @Override
-    public Set<DistributedMember> getAllMembers() {
-      assertSame(getCache(), cache);
-      return Collections.emptySet();
-    }
-
-    @Override
-    public Execution getMembersFunctionExecutor(final Set<DistributedMember> members) {
-      Assert.assertNotNull(members);
-      return functionExecutor;
-    }
+    final List<IndexDetails> actualIndexDetails = listIndexCommand.getIndexListing();
+    assertThat(actualIndexDetails).isNotNull();
+    assertThat(expectedIndexDetails).isEqualTo(actualIndexDetails);
+    verify(mockFunctionExecutor, times(1)).setIgnoreDepartedMembers(true);
+    verify(mockFunctionExecutor, times(1)).execute(any(ListIndexFunction.class));
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/functions/DescribeDiskStoreFunctionJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/functions/DescribeDiskStoreFunctionJUnitTest.java
@@ -14,12 +14,13 @@
  */
 package org.apache.geode.management.internal.cli.functions;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.util.Arrays;
@@ -29,12 +30,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
-import org.apache.logging.log4j.Logger;
-import org.jmock.Expectations;
-import org.jmock.Mockery;
-import org.jmock.lib.concurrent.Synchroniser;
-import org.jmock.lib.legacy.ClassImposteriser;
-import org.junit.After;
+import edu.umd.cs.findbugs.annotations.SuppressWarnings;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -53,9 +49,7 @@ import org.apache.geode.cache.server.ClientSubscriptionConfig;
 import org.apache.geode.cache.wan.GatewaySender;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.InternalCache;
-import org.apache.geode.internal.lang.Filter;
 import org.apache.geode.internal.lang.ObjectUtils;
-import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.util.CollectionUtils;
 import org.apache.geode.management.internal.cli.domain.DiskStoreDetails;
 import org.apache.geode.management.internal.cli.exceptions.EntityNotFoundException;
@@ -67,32 +61,16 @@ import org.apache.geode.management.internal.cli.exceptions.EntityNotFoundExcepti
  * @see org.apache.geode.cache.DiskStore
  * @see org.apache.geode.management.internal.cli.domain.DiskStoreDetails
  * @see org.apache.geode.management.internal.cli.functions.DescribeDiskStoreFunction
- * @see org.jmock.Expectations
- * @see org.jmock.Mockery
- * @see org.junit.Assert
  * @see org.junit.Test
  * @since GemFire 7.0
  */
 @SuppressWarnings({"null", "unused"})
 public class DescribeDiskStoreFunctionJUnitTest {
-
-  private static final Logger logger = LogService.getLogger();
-
-  private Mockery mockContext;
   private InternalCache mockCache;
 
   @Before
   public void setup() {
-    mockContext = new Mockery();
-    mockContext.setImposteriser(ClassImposteriser.INSTANCE);
-    mockContext.setThreadingPolicy(new Synchroniser());
-    mockCache = mockContext.mock(InternalCache.class, "Cache");
-  }
-
-  @After
-  public void tearDown() {
-    mockContext.assertIsSatisfied();
-    mockContext = null;
+    mockCache = mock(InternalCache.class, "Cache");
   }
 
   private void assertAsyncEventQueueDetails(
@@ -102,21 +80,14 @@ public class DescribeDiskStoreFunctionJUnitTest {
 
     for (final DiskStoreDetails.AsyncEventQueueDetails actualAsyncEventQueueDetails : diskStoreDetails
         .iterateAsyncEventQueues()) {
-      final DiskStoreDetails.AsyncEventQueueDetails expectedAsyncEventQueueDetails =
-          CollectionUtils.findBy(expectedAsyncEventQueueDetailsSet,
-              new Filter<DiskStoreDetails.AsyncEventQueueDetails>() {
-                @Override
-                public boolean accept(
-                    final DiskStoreDetails.AsyncEventQueueDetails asyncEventQueueDetails) {
-                  return ObjectUtils.equals(asyncEventQueueDetails.getId(),
-                      actualAsyncEventQueueDetails.getId());
-                }
-              });
-
-      assertNotNull(expectedAsyncEventQueueDetails);
+      final DiskStoreDetails.AsyncEventQueueDetails expectedAsyncEventQueueDetails = CollectionUtils
+          .findBy(expectedAsyncEventQueueDetailsSet, asyncEventQueueDetails -> ObjectUtils
+              .equals(asyncEventQueueDetails.getId(), actualAsyncEventQueueDetails.getId()));
+      assertThat(expectedAsyncEventQueueDetails).isNotNull();
       actualCount++;
     }
-    assertEquals(expectedAsyncEventQueueDetailsSet.size(), actualCount);
+
+    assertThat(expectedAsyncEventQueueDetailsSet.size()).isEqualTo(actualCount);
   }
 
   private void assertCacheServerDetails(
@@ -126,23 +97,19 @@ public class DescribeDiskStoreFunctionJUnitTest {
 
     for (final DiskStoreDetails.CacheServerDetails actualCacheServerDetails : diskStoreDetails
         .iterateCacheServers()) {
-      final DiskStoreDetails.CacheServerDetails expectedCacheServerDetails = CollectionUtils
-          .findBy(expectedCacheServerDetailsSet, new Filter<DiskStoreDetails.CacheServerDetails>() {
-            public boolean accept(final DiskStoreDetails.CacheServerDetails cacheServerDetails) {
-              return ObjectUtils.equals(cacheServerDetails.getBindAddress(),
+      final DiskStoreDetails.CacheServerDetails expectedCacheServerDetails =
+          CollectionUtils.findBy(expectedCacheServerDetailsSet,
+              cacheServerDetails -> ObjectUtils.equals(cacheServerDetails.getBindAddress(),
                   actualCacheServerDetails.getBindAddress())
                   && ObjectUtils.equals(cacheServerDetails.getPort(),
-                      actualCacheServerDetails.getPort());
-            }
-          });
-
-      assertNotNull(expectedCacheServerDetails);
-      assertEquals(expectedCacheServerDetails.getHostName(),
-          actualCacheServerDetails.getHostName());
+                      actualCacheServerDetails.getPort()));
+      assertThat(expectedCacheServerDetails).isNotNull();
+      assertThat(expectedCacheServerDetails.getHostName())
+          .isEqualTo(actualCacheServerDetails.getHostName());
       actualCount++;
     }
 
-    assertEquals(expectedCacheServerDetailsSet.size(), actualCount);
+    assertThat(expectedCacheServerDetailsSet.size()).isEqualTo(actualCount);
   }
 
   private void assertGatewayDetails(
@@ -152,19 +119,16 @@ public class DescribeDiskStoreFunctionJUnitTest {
 
     for (final DiskStoreDetails.GatewayDetails actualGatewayDetails : diskStoreDetails
         .iterateGateways()) {
-      DiskStoreDetails.GatewayDetails expectedGatewayDetails = CollectionUtils
-          .findBy(expectedGatewayDetailsSet, new Filter<DiskStoreDetails.GatewayDetails>() {
-            public boolean accept(final DiskStoreDetails.GatewayDetails gatewayDetails) {
-              return ObjectUtils.equals(gatewayDetails.getId(), actualGatewayDetails.getId());
-            }
-          });
-
-      assertNotNull(expectedGatewayDetails);
-      assertEquals(expectedGatewayDetails.isPersistent(), actualGatewayDetails.isPersistent());
+      DiskStoreDetails.GatewayDetails expectedGatewayDetails =
+          CollectionUtils.findBy(expectedGatewayDetailsSet, gatewayDetails -> ObjectUtils
+              .equals(gatewayDetails.getId(), actualGatewayDetails.getId()));
+      assertThat(expectedGatewayDetails).isNotNull();
+      assertThat(expectedGatewayDetails.isPersistent())
+          .isEqualTo(actualGatewayDetails.isPersistent());
       actualCount++;
     }
 
-    assertEquals(expectedGatewayDetailsSet.size(), actualCount);
+    assertThat(expectedGatewayDetailsSet.size()).isEqualTo(actualCount);
   }
 
   private void assertRegionDetails(
@@ -174,23 +138,20 @@ public class DescribeDiskStoreFunctionJUnitTest {
 
     for (final DiskStoreDetails.RegionDetails actualRegionDetails : diskStoreDetails
         .iterateRegions()) {
-      final DiskStoreDetails.RegionDetails expectedRegionDetails = CollectionUtils
-          .findBy(expectedRegionDetailsSet, new Filter<DiskStoreDetails.RegionDetails>() {
-            public boolean accept(final DiskStoreDetails.RegionDetails regionDetails) {
-              return ObjectUtils.equals(regionDetails.getFullPath(),
-                  actualRegionDetails.getFullPath());
-            }
-          });
+      final DiskStoreDetails.RegionDetails expectedRegionDetails =
+          CollectionUtils.findBy(expectedRegionDetailsSet, regionDetails -> ObjectUtils
+              .equals(regionDetails.getFullPath(), actualRegionDetails.getFullPath()));
 
-      assertNotNull(expectedRegionDetails);
-      assertEquals(expectedRegionDetails.getName(), actualRegionDetails.getName());
-      assertEquals(expectedRegionDetails.isOverflowToDisk(),
-          actualRegionDetails.isOverflowToDisk());
-      assertEquals(expectedRegionDetails.isPersistent(), actualRegionDetails.isPersistent());
+      assertThat(expectedRegionDetails).isNotNull();
+      assertThat(expectedRegionDetails.getName()).isEqualTo(actualRegionDetails.getName());
+      assertThat(expectedRegionDetails.isOverflowToDisk())
+          .isEqualTo(actualRegionDetails.isOverflowToDisk());
+      assertThat(expectedRegionDetails.isPersistent())
+          .isEqualTo(actualRegionDetails.isPersistent());
       actualCount++;
     }
 
-    assertEquals(expectedRegionDetailsSet.size(), actualCount);
+    assertThat(expectedRegionDetailsSet.size()).isEqualTo(actualCount);
   }
 
   private DiskStoreDetails.AsyncEventQueueDetails createAsyncEventQueueDetails(final String id) {
@@ -202,6 +163,7 @@ public class DescribeDiskStoreFunctionJUnitTest {
     final DiskStoreDetails.CacheServerDetails cacheServerDetails =
         new DiskStoreDetails.CacheServerDetails(bindAddress, port);
     cacheServerDetails.setHostName(hostname);
+
     return cacheServerDetails;
   }
 
@@ -235,38 +197,20 @@ public class DescribeDiskStoreFunctionJUnitTest {
       final long maxOplogSize, final int queueSize, final long timeInterval,
       final int writeBufferSize, final File[] diskDirs, final int[] diskDirSizes,
       final float warningPercentage, final float criticalPercentage) {
-    final DiskStore mockDiskStore = mockContext.mock(DiskStore.class, name);
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockDiskStore).getAllowForceCompaction();
-        will(returnValue(allowForceCompaction));
-        oneOf(mockDiskStore).getAutoCompact();
-        will(returnValue(autoCompact));
-        oneOf(mockDiskStore).getCompactionThreshold();
-        will(returnValue(compactionThreshold));
-        atLeast(1).of(mockDiskStore).getDiskStoreUUID();
-        will(returnValue(diskStoreId));
-        oneOf(mockDiskStore).getMaxOplogSize();
-        will(returnValue(maxOplogSize));
-        atLeast(1).of(mockDiskStore).getName();
-        will(returnValue(name));
-        oneOf(mockDiskStore).getQueueSize();
-        will(returnValue(queueSize));
-        oneOf(mockDiskStore).getTimeInterval();
-        will(returnValue(timeInterval));
-        oneOf(mockDiskStore).getWriteBufferSize();
-        will(returnValue(writeBufferSize));
-        allowing(mockDiskStore).getDiskDirs();
-        will(returnValue(diskDirs));
-        allowing(mockDiskStore).getDiskDirSizes();
-        will(returnValue(diskDirSizes));
-        allowing(mockDiskStore).getDiskUsageWarningPercentage();
-        will(returnValue(warningPercentage));
-        allowing(mockDiskStore).getDiskUsageCriticalPercentage();
-        will(returnValue(criticalPercentage));
-      }
-    });
+    final DiskStore mockDiskStore = mock(DiskStore.class, name);
+    when(mockDiskStore.getAllowForceCompaction()).thenReturn(allowForceCompaction);
+    when(mockDiskStore.getAutoCompact()).thenReturn(autoCompact);
+    when(mockDiskStore.getCompactionThreshold()).thenReturn(compactionThreshold);
+    when(mockDiskStore.getDiskStoreUUID()).thenReturn(diskStoreId);
+    when(mockDiskStore.getMaxOplogSize()).thenReturn(maxOplogSize);
+    when(mockDiskStore.getName()).thenReturn(name);
+    when(mockDiskStore.getQueueSize()).thenReturn(queueSize);
+    when(mockDiskStore.getTimeInterval()).thenReturn(timeInterval);
+    when(mockDiskStore.getWriteBufferSize()).thenReturn(writeBufferSize);
+    when(mockDiskStore.getDiskDirs()).thenReturn(diskDirs);
+    when(mockDiskStore.getDiskDirSizes()).thenReturn(diskDirSizes);
+    when(mockDiskStore.getDiskUsageWarningPercentage()).thenReturn(warningPercentage);
+    when(mockDiskStore.getDiskUsageCriticalPercentage()).thenReturn(criticalPercentage);
 
     return mockDiskStore;
   }
@@ -277,7 +221,113 @@ public class DescribeDiskStoreFunctionJUnitTest {
         new DiskStoreDetails.RegionDetails(fullPath, name);
     regionDetails.setPersistent(persistent);
     regionDetails.setOverflowToDisk(overflow);
+
     return regionDetails;
+  }
+
+  @SuppressWarnings("unchecked")
+  private Set<DiskStoreDetails.RegionDetails> setupRegionsForTestExecute(
+      final InternalCache mockCache, final String diskStoreName) {
+    final Region mockUserRegion = mock(Region.class, "/UserRegion");
+    final Region mockGuestRegion = mock(Region.class, "/GuestRegion");
+    final Region mockSessionRegion = mock(Region.class, "/UserRegion/SessionRegion");
+    final RegionAttributes mockUserRegionAttributes =
+        mock(RegionAttributes.class, "UserRegionAttributes");
+    final RegionAttributes mockSessionRegionAttributes =
+        mock(RegionAttributes.class, "SessionRegionAttributes");
+    final RegionAttributes mockGuestRegionAttributes =
+        mock(RegionAttributes.class, "GuestRegionAttributes");
+    final EvictionAttributes mockUserEvictionAttributes =
+        mock(EvictionAttributes.class, "UserEvictionAttributes");
+    final EvictionAttributes mockSessionEvictionAttributes =
+        mock(EvictionAttributes.class, "SessionEvictionAttributes");
+    final EvictionAttributes mockGuestEvictionAttributes =
+        mock(EvictionAttributes.class, "GuestEvictionAttributes");
+
+    when(mockCache.rootRegions())
+        .thenReturn(CollectionUtils.asSet(mockUserRegion, mockGuestRegion));
+    when(mockUserRegion.getAttributes()).thenReturn(mockUserRegionAttributes);
+    when(mockUserRegion.getFullPath()).thenReturn("/UserRegion");
+    when(mockUserRegion.getName()).thenReturn("UserRegion");
+    when(mockUserRegion.subregions(false)).thenReturn(CollectionUtils.asSet(mockSessionRegion));
+    when(mockUserRegionAttributes.getDataPolicy()).thenReturn(DataPolicy.PERSISTENT_PARTITION);
+    when(mockUserRegionAttributes.getDiskStoreName()).thenReturn(diskStoreName);
+    when(mockUserRegionAttributes.getEvictionAttributes()).thenReturn(mockUserEvictionAttributes);
+    when(mockUserEvictionAttributes.getAction()).thenReturn(EvictionAction.LOCAL_DESTROY);
+    when(mockSessionRegion.getAttributes()).thenReturn(mockSessionRegionAttributes);
+    when(mockSessionRegion.getFullPath()).thenReturn("/UserRegion/SessionRegion");
+    when(mockSessionRegion.getName()).thenReturn("SessionRegion");
+    when(mockSessionRegion.subregions(false)).thenReturn(Collections.emptySet());
+    when(mockSessionRegionAttributes.getDataPolicy()).thenReturn(DataPolicy.REPLICATE);
+    when(mockSessionRegionAttributes.getDiskStoreName()).thenReturn(diskStoreName);
+    when(mockSessionRegionAttributes.getEvictionAttributes())
+        .thenReturn(mockSessionEvictionAttributes);
+    when(mockSessionEvictionAttributes.getAction()).thenReturn(EvictionAction.OVERFLOW_TO_DISK);
+    when(mockGuestRegion.getAttributes()).thenReturn(mockGuestRegionAttributes);
+    when(mockGuestRegion.subregions(false)).thenReturn(Collections.emptySet());
+    when(mockGuestRegionAttributes.getDataPolicy()).thenReturn(DataPolicy.REPLICATE);
+    when(mockGuestRegionAttributes.getDiskStoreName())
+        .thenReturn(DiskStoreDetails.DEFAULT_DISK_STORE_NAME);
+    when(mockGuestRegionAttributes.getEvictionAttributes()).thenReturn(mockGuestEvictionAttributes);
+    when(mockGuestEvictionAttributes.getAction()).thenReturn(EvictionAction.OVERFLOW_TO_DISK);
+
+    return CollectionUtils.asSet(createRegionDetails("/UserRegion", "UserRegion", true, false),
+        createRegionDetails("/UserRegion/SessionRegion", "SessionRegion", false, true));
+  }
+
+  private Set<DiskStoreDetails.GatewayDetails> setupGatewaysForTestExecute(
+      final InternalCache mockCache, final String diskStoreName) {
+    final GatewaySender mockGatewaySender = mock(GatewaySender.class, "GatewaySender");
+    when(mockCache.getGatewaySenders()).thenReturn(CollectionUtils.asSet(mockGatewaySender));
+    when(mockGatewaySender.getDiskStoreName()).thenReturn(diskStoreName);
+    when(mockGatewaySender.getId()).thenReturn("0123456789");
+    when(mockGatewaySender.isPersistenceEnabled()).thenReturn(true);
+
+    return CollectionUtils.asSet(createGatewayDetails("0123456789", true));
+  }
+
+  private Set<DiskStoreDetails.CacheServerDetails> setupCacheServersForTestExecute(
+      final InternalCache mockCache, final String diskStoreName) {
+    final CacheServer mockCacheServer1 = mock(CacheServer.class, "CacheServer1");
+    final CacheServer mockCacheServer2 = mock(CacheServer.class, "CacheServer2");
+    final CacheServer mockCacheServer3 = mock(CacheServer.class, "CacheServer3");
+    final ClientSubscriptionConfig cacheServer1ClientSubscriptionConfig =
+        mock(ClientSubscriptionConfig.class, "cacheServer1ClientSubscriptionConfig");
+    final ClientSubscriptionConfig cacheServer3ClientSubscriptionConfig =
+        mock(ClientSubscriptionConfig.class, "cacheServer3ClientSubscriptionConfig");
+
+    when(mockCache.getCacheServers())
+        .thenReturn(Arrays.asList(mockCacheServer1, mockCacheServer2, mockCacheServer3));
+    when(mockCacheServer1.getClientSubscriptionConfig())
+        .thenReturn(cacheServer1ClientSubscriptionConfig);
+    when(cacheServer1ClientSubscriptionConfig.getDiskStoreName()).thenReturn(diskStoreName);
+    when(mockCacheServer2.getClientSubscriptionConfig()).thenReturn(null);
+    when(mockCacheServer3.getClientSubscriptionConfig())
+        .thenReturn(cacheServer3ClientSubscriptionConfig);
+    when(cacheServer3ClientSubscriptionConfig.getDiskStoreName()).thenReturn("");
+    when(mockCacheServer1.getBindAddress()).thenReturn("10.127.0.1");
+    when(mockCacheServer1.getPort()).thenReturn(10123);
+    when(mockCacheServer1.getHostnameForClients()).thenReturn("rodan");
+
+    return CollectionUtils.asSet(createCacheServerDetails("10.127.0.1", 10123, "rodan"));
+  }
+
+  private Set<DiskStoreDetails.AsyncEventQueueDetails> setupAsyncEventQueuesForTestExecute(
+      final InternalCache mockCache, final String diskStoreName) {
+    final AsyncEventQueue mockAsyncEventQueue1 = mock(AsyncEventQueue.class, "AsyncEventQueue1");
+    final AsyncEventQueue mockAsyncEventQueue2 = mock(AsyncEventQueue.class, "AsyncEventQueue2");
+    final AsyncEventQueue mockAsyncEventQueue3 = mock(AsyncEventQueue.class, "AsyncEventQueue3");
+
+    when(mockCache.getAsyncEventQueues()).thenReturn(
+        CollectionUtils.asSet(mockAsyncEventQueue1, mockAsyncEventQueue2, mockAsyncEventQueue3));
+    when(mockAsyncEventQueue1.isPersistent()).thenReturn(true);
+    when(mockAsyncEventQueue1.getDiskStoreName()).thenReturn(diskStoreName);
+    when(mockAsyncEventQueue1.getId()).thenReturn("9876543210");
+    when(mockAsyncEventQueue2.isPersistent()).thenReturn(false);
+    when(mockAsyncEventQueue3.isPersistent()).thenReturn(true);
+    when(mockAsyncEventQueue3.getDiskStoreName()).thenReturn("memSto");
+
+    return CollectionUtils.asSet(createAsyncEventQueueDetails("9876543210"));
   }
 
   @Test
@@ -292,289 +342,84 @@ public class DescribeDiskStoreFunctionJUnitTest {
             .isInstanceOf(IllegalStateException.class).hasMessage("Expected (test) message!");
   }
 
-  private void setupEmptyRegionsPdxGatewaysCacheServersAndAsyncEventQueues(
-      final InternalCache mockCache) {
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockCache).rootRegions();
-        will(returnValue(Collections.emptySet()));
-        oneOf(mockCache).getCacheServers();
-        will(returnValue(Collections.emptyList()));
-        oneOf(mockCache).getGatewaySenders();
-        will(returnValue(Collections.emptyList()));
-        will(returnValue(Collections.emptyList()));
-        oneOf(mockCache).getPdxPersistent();
-        will(returnValue(false));
-        oneOf(mockCache).getAsyncEventQueues();
-        will(returnValue(Collections.emptySet()));
-      }
-    });
-  }
-
-  private Set<DiskStoreDetails.RegionDetails> setupRegionsForTestExecute(
-      final InternalCache mockCache, final String diskStoreName) {
-    final Region mockUserRegion = mockContext.mock(Region.class, "/UserRegion");
-    final Region mockSessionRegion = mockContext.mock(Region.class, "/UserRegion/SessionRegion");
-    final Region mockGuestRegion = mockContext.mock(Region.class, "/GuestRegion");
-
-    final RegionAttributes mockUserRegionAttributes =
-        mockContext.mock(RegionAttributes.class, "UserRegionAttributes");
-    final RegionAttributes mockSessionRegionAttributes =
-        mockContext.mock(RegionAttributes.class, "SessionRegionAttributes");
-    final RegionAttributes mockGuestRegionAttributes =
-        mockContext.mock(RegionAttributes.class, "GuestRegionAttributes");
-
-    final EvictionAttributes mockUserEvictionAttributes =
-        mockContext.mock(EvictionAttributes.class, "UserEvictionAttributes");
-    final EvictionAttributes mockSessionEvictionAttributes =
-        mockContext.mock(EvictionAttributes.class, "SessionEvictionAttributes");
-    final EvictionAttributes mockGuestEvictionAttributes =
-        mockContext.mock(EvictionAttributes.class, "GuestEvictionAttributes");
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockCache).rootRegions();
-        will(returnValue(CollectionUtils.asSet(mockUserRegion, mockGuestRegion)));
-        exactly(5).of(mockUserRegion).getAttributes();
-        will(returnValue(mockUserRegionAttributes));
-        oneOf(mockUserRegion).getFullPath();
-        will(returnValue("/UserRegion"));
-        oneOf(mockUserRegion).getName();
-        will(returnValue("UserRegion"));
-        oneOf(mockUserRegion).subregions(false);
-        will(returnValue(CollectionUtils.asSet(mockSessionRegion)));
-        exactly(2).of(mockUserRegionAttributes).getDataPolicy();
-        will(returnValue(DataPolicy.PERSISTENT_PARTITION));
-        oneOf(mockUserRegionAttributes).getDiskStoreName();
-        will(returnValue(diskStoreName));
-        exactly(2).of(mockUserRegionAttributes).getEvictionAttributes();
-        will(returnValue(mockUserEvictionAttributes));
-        oneOf(mockUserEvictionAttributes).getAction();
-        will(returnValue(EvictionAction.LOCAL_DESTROY));
-        exactly(7).of(mockSessionRegion).getAttributes();
-        will(returnValue(mockSessionRegionAttributes));
-        oneOf(mockSessionRegion).getFullPath();
-        will(returnValue("/UserRegion/SessionRegion"));
-        oneOf(mockSessionRegion).getName();
-        will(returnValue("SessionRegion"));
-        oneOf(mockSessionRegion).subregions(false);
-        will(returnValue(Collections.emptySet()));
-        exactly(2).of(mockSessionRegionAttributes).getDataPolicy();
-        will(returnValue(DataPolicy.REPLICATE));
-        oneOf(mockSessionRegionAttributes).getDiskStoreName();
-        will(returnValue(diskStoreName));
-        exactly(4).of(mockSessionRegionAttributes).getEvictionAttributes();
-        will(returnValue(mockSessionEvictionAttributes));
-        exactly(2).of(mockSessionEvictionAttributes).getAction();
-        will(returnValue(EvictionAction.OVERFLOW_TO_DISK));
-        exactly(4).of(mockGuestRegion).getAttributes();
-        will(returnValue(mockGuestRegionAttributes));
-        oneOf(mockGuestRegion).subregions(false);
-        will(returnValue(Collections.emptySet()));
-        oneOf(mockGuestRegionAttributes).getDataPolicy();
-        will(returnValue(DataPolicy.REPLICATE));
-        oneOf(mockGuestRegionAttributes).getDiskStoreName();
-        will(returnValue(DiskStoreDetails.DEFAULT_DISK_STORE_NAME));
-        exactly(2).of(mockGuestRegionAttributes).getEvictionAttributes();
-        will(returnValue(mockGuestEvictionAttributes));
-        oneOf(mockGuestEvictionAttributes).getAction();
-        will(returnValue(EvictionAction.OVERFLOW_TO_DISK));
-      }
-    });
-
-    return CollectionUtils.asSet(createRegionDetails("/UserRegion", "UserRegion", true, false),
-        createRegionDetails("/UserRegion/SessionRegion", "SessionRegion", false, true));
-  }
-
-  private Set<DiskStoreDetails.GatewayDetails> setupGatewaysForTestExecute(
-      final InternalCache mockCache, final String diskStoreName) {
-    final GatewaySender mockGatewaySender = mockContext.mock(GatewaySender.class, "GatewaySender");
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockCache).getGatewaySenders();
-        will(returnValue(CollectionUtils.asSet(mockGatewaySender)));
-        oneOf(mockGatewaySender).getDiskStoreName();
-        will(returnValue(diskStoreName));
-        oneOf(mockGatewaySender).getId();
-        will(returnValue("0123456789"));
-        oneOf(mockGatewaySender).isPersistenceEnabled();
-        will(returnValue(true));
-      }
-    });
-
-    return CollectionUtils.asSet(createGatewayDetails("0123456789", true));
-  }
-
-  private Set<DiskStoreDetails.CacheServerDetails> setupCacheServersForTestExecute(
-      final InternalCache mockCache, final String diskStoreName) {
-    final CacheServer mockCacheServer1 = mockContext.mock(CacheServer.class, "CacheServer1");
-    final CacheServer mockCacheServer2 = mockContext.mock(CacheServer.class, "CacheServer2");
-    final CacheServer mockCacheServer3 = mockContext.mock(CacheServer.class, "CacheServer3");
-
-    final ClientSubscriptionConfig cacheServer1ClientSubscriptionConfig =
-        mockContext.mock(ClientSubscriptionConfig.class, "cacheServer1ClientSubscriptionConfig");
-    final ClientSubscriptionConfig cacheServer3ClientSubscriptionConfig =
-        mockContext.mock(ClientSubscriptionConfig.class, "cacheServer3ClientSubscriptionConfig");
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockCache).getCacheServers();
-        will(returnValue(Arrays.asList(mockCacheServer1, mockCacheServer2, mockCacheServer3)));
-        exactly(2).of(mockCacheServer1).getClientSubscriptionConfig();
-        will(returnValue(cacheServer1ClientSubscriptionConfig));
-        oneOf(cacheServer1ClientSubscriptionConfig).getDiskStoreName();
-        will(returnValue(diskStoreName));
-        oneOf(mockCacheServer2).getClientSubscriptionConfig();
-        will(returnValue(null));
-        exactly(2).of(mockCacheServer3).getClientSubscriptionConfig();
-        will(returnValue(cacheServer3ClientSubscriptionConfig));
-        oneOf(cacheServer3ClientSubscriptionConfig).getDiskStoreName();
-        will(returnValue(""));
-        oneOf(mockCacheServer1).getBindAddress();
-        will(returnValue("10.127.0.1"));
-        oneOf(mockCacheServer1).getPort();
-        will(returnValue(10123));
-        oneOf(mockCacheServer1).getHostnameForClients();
-        will(returnValue("rodan"));
-      }
-    });
-
-    return CollectionUtils.asSet(createCacheServerDetails("10.127.0.1", 10123, "rodan"));
-  }
-
-  private Set<DiskStoreDetails.AsyncEventQueueDetails> setupAsyncEventQueuesForTestExecute(
-      final InternalCache mockCache, final String diskStoreName) {
-    final AsyncEventQueue mockAsyncEventQueue1 =
-        mockContext.mock(AsyncEventQueue.class, "AsyncEventQueue1");
-    final AsyncEventQueue mockAsyncEventQueue2 =
-        mockContext.mock(AsyncEventQueue.class, "AsyncEventQueue2");
-    final AsyncEventQueue mockAsyncEventQueue3 =
-        mockContext.mock(AsyncEventQueue.class, "AsyncEventQueue3");
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockCache).getAsyncEventQueues();
-        will(returnValue(CollectionUtils.asSet(mockAsyncEventQueue1, mockAsyncEventQueue2,
-            mockAsyncEventQueue3)));
-        oneOf(mockAsyncEventQueue1).isPersistent();
-        will(returnValue(true));
-        oneOf(mockAsyncEventQueue1).getDiskStoreName();
-        will(returnValue(diskStoreName));
-        oneOf(mockAsyncEventQueue1).getId();
-        will(returnValue("9876543210"));
-        oneOf(mockAsyncEventQueue2).isPersistent();
-        will(returnValue(false));
-        oneOf(mockAsyncEventQueue3).isPersistent();
-        will(returnValue(true));
-        oneOf(mockAsyncEventQueue3).getDiskStoreName();
-        will(returnValue("memSto"));
-      }
-    });
-
-    return CollectionUtils.asSet(createAsyncEventQueueDetails("9876543210"));
-  }
-
   @Test
   public void testExecute() throws Throwable {
+    // Prepare Mocks
     final UUID diskStoreId = UUID.randomUUID();
-
     final String diskStoreName = "mockDiskStore";
     final String memberId = "mockMemberId";
     final String memberName = "mockMemberName";
-
     final InternalDistributedMember mockMember =
-        mockContext.mock(InternalDistributedMember.class, "DistributedMember");
-
+        mock(InternalDistributedMember.class, "DistributedMember");
     final FunctionContext mockFunctionContext =
-        mockContext.mock(FunctionContext.class, "testExecute$FunctionContext");
-
+        mock(FunctionContext.class, "testExecute$FunctionContext");
     final DiskStore mockDiskStore =
         createMockDiskStore(diskStoreId, diskStoreName, true, false,
             75, 8192l, 500, 120l, 10240, createFileArray("/export/disk/backup",
                 "/export/disk/overflow", "/export/disk/persistence"),
             createIntArray(10240, 204800, 4096000), 50, 75);
-
     final TestResultSender testResultSender = new TestResultSender();
+    when(mockCache.getMyId()).thenReturn(mockMember);
+    when(mockCache.findDiskStore(diskStoreName)).thenReturn(mockDiskStore);
+    when(mockCache.getPdxPersistent()).thenReturn(true);
+    when(mockCache.getPdxDiskStore()).thenReturn("memoryStore");
+    when(mockMember.getId()).thenReturn(memberId);
+    when(mockMember.getName()).thenReturn(memberName);
+    when(mockFunctionContext.getCache()).thenReturn(mockCache);
+    when(mockFunctionContext.getArguments()).thenReturn(diskStoreName);
+    when(mockFunctionContext.getResultSender()).thenReturn(testResultSender);
 
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockCache).getMyId();
-        will(returnValue(mockMember));
-        oneOf(mockCache).findDiskStore(diskStoreName);
-        will(returnValue(mockDiskStore));
-        oneOf(mockCache).getPdxPersistent();
-        will(returnValue(true));
-        oneOf(mockCache).getPdxDiskStore();
-        will(returnValue("memoryStore"));
-        oneOf(mockMember).getId();
-        will(returnValue(memberId));
-        oneOf(mockMember).getName();
-        will(returnValue(memberName));
-        oneOf(mockFunctionContext).getCache();
-        will(returnValue(mockCache));
-        oneOf(mockFunctionContext).getArguments();
-        will(returnValue(diskStoreName));
-        oneOf(mockFunctionContext).getResultSender();
-        will(returnValue(testResultSender));
-      }
-    });
-
+    // Expected Results
     final Set<DiskStoreDetails.RegionDetails> expectedRegionDetails =
         setupRegionsForTestExecute(mockCache, diskStoreName);
-
     final Set<DiskStoreDetails.GatewayDetails> expectedGatewayDetails =
         setupGatewaysForTestExecute(mockCache, diskStoreName);
-
     final Set<DiskStoreDetails.CacheServerDetails> expectedCacheServerDetails =
         setupCacheServersForTestExecute(mockCache, diskStoreName);
-
     final Set<DiskStoreDetails.AsyncEventQueueDetails> expectedAsyncEventQueueDetails =
         setupAsyncEventQueuesForTestExecute(mockCache, diskStoreName);
 
+    // Execute Function and assert results
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-
     function.execute(mockFunctionContext);
 
     final List<?> results = testResultSender.getResults();
-
-    assertNotNull(results);
-    assertEquals(1, results.size());
+    assertThat(results).isNotNull();
+    assertThat(1).isEqualTo(results.size());
 
     final DiskStoreDetails diskStoreDetails = (DiskStoreDetails) results.get(0);
+    assertThat(diskStoreDetails != null).isTrue();
+    assertThat(diskStoreId).isEqualTo(diskStoreDetails.getId());
+    assertThat(diskStoreName).isEqualTo(diskStoreDetails.getName());
+    assertThat(memberId).isEqualTo(diskStoreDetails.getMemberId());
+    assertThat(memberName).isEqualTo(diskStoreDetails.getMemberName());
+    assertThat(diskStoreDetails.getAllowForceCompaction()).isTrue();
+    assertThat(diskStoreDetails.getAutoCompact()).isFalse();
+    assertThat(75).isEqualTo(diskStoreDetails.getCompactionThreshold().intValue());
+    assertThat(8192L).isEqualTo(diskStoreDetails.getMaxOplogSize().longValue());
+    assertThat(diskStoreDetails.isPdxSerializationMetaDataStored()).isFalse();
+    assertThat(500).isEqualTo(diskStoreDetails.getQueueSize().intValue());
+    assertThat(120L).isEqualTo(diskStoreDetails.getTimeInterval().longValue());
+    assertThat(10240).isEqualTo(diskStoreDetails.getWriteBufferSize().intValue());
+    assertThat(50.0f).isEqualTo(diskStoreDetails.getDiskUsageWarningPercentage());
+    assertThat(75.0f).isEqualTo(diskStoreDetails.getDiskUsageCriticalPercentage());
 
-    assertNotNull(diskStoreDetails);
-    assertEquals(diskStoreId, diskStoreDetails.getId());
-    assertEquals(diskStoreName, diskStoreDetails.getName());
-    assertEquals(memberId, diskStoreDetails.getMemberId());
-    assertEquals(memberName, diskStoreDetails.getMemberName());
-    assertTrue(diskStoreDetails.getAllowForceCompaction());
-    assertFalse(diskStoreDetails.getAutoCompact());
-    assertEquals(75, diskStoreDetails.getCompactionThreshold().intValue());
-    assertEquals(8192l, diskStoreDetails.getMaxOplogSize().longValue());
-    assertFalse(diskStoreDetails.isPdxSerializationMetaDataStored());
-    assertEquals(500, diskStoreDetails.getQueueSize().intValue());
-    assertEquals(120l, diskStoreDetails.getTimeInterval().longValue());
-    assertEquals(10240, diskStoreDetails.getWriteBufferSize().intValue());
-    assertEquals(50.0f, diskStoreDetails.getDiskUsageWarningPercentage().floatValue(), 0.0f);
-    assertEquals(75.0f, diskStoreDetails.getDiskUsageCriticalPercentage().floatValue(), 0.0f);
-
+    final List<Integer> expectdDiskDirSizes = Arrays.asList(10240, 204800, 4096000);
     final List<String> expectedDiskDirs =
         Arrays.asList(new File("/export/disk/backup").getAbsolutePath(),
             new File("/export/disk/overflow").getAbsolutePath(),
             new File("/export/disk/persistence").getAbsolutePath());
-
-    final List<Integer> expectdDiskDirSizes = Arrays.asList(10240, 204800, 4096000);
-
     int count = 0;
 
     for (final DiskStoreDetails.DiskDirDetails diskDirDetails : diskStoreDetails) {
-      assertTrue(expectedDiskDirs.contains(diskDirDetails.getAbsolutePath()));
-      assertTrue(expectdDiskDirSizes.contains(diskDirDetails.getSize()));
+      assertThat(expectdDiskDirSizes.contains(diskDirDetails.getSize())).isTrue();
+      assertThat(expectedDiskDirs.contains(diskDirDetails.getAbsolutePath())).isTrue();
       count++;
     }
 
-    assertEquals(expectedDiskDirs.size(), count);
+    verify(mockDiskStore, atLeastOnce()).getName();
+    verify(mockDiskStore, atLeastOnce()).getDiskStoreUUID();
+    assertThat(expectedDiskDirs.size()).isEqualTo(count);
     assertRegionDetails(expectedRegionDetails, diskStoreDetails);
     assertCacheServerDetails(expectedCacheServerDetails, diskStoreDetails);
     assertGatewayDetails(expectedGatewayDetails, diskStoreDetails);
@@ -583,1210 +428,750 @@ public class DescribeDiskStoreFunctionJUnitTest {
 
   @Test
   public void testExecuteOnMemberHavingANonGemFireCache() throws Throwable {
-    final Cache mockNonGemCache = mockContext.mock(Cache.class, "NonGemCache");
-
-    final FunctionContext mockFunctionContext =
-        mockContext.mock(FunctionContext.class, "FunctionContext");
-
+    final Cache mockNonGemCache = mock(Cache.class, "NonGemCache");
+    final FunctionContext mockFunctionContext = mock(FunctionContext.class, "FunctionContext");
     final TestResultSender testResultSender = new TestResultSender();
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockFunctionContext).getCache();
-        will(returnValue(mockNonGemCache));
-        exactly(0).of(mockFunctionContext).getResultSender();
-        will(returnValue(testResultSender));
-      }
-    });
+    when(mockFunctionContext.getCache()).thenReturn(mockNonGemCache);
+    when(mockFunctionContext.getResultSender()).thenReturn(testResultSender);
 
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-
     function.execute(mockFunctionContext);
 
     final List<?> results = testResultSender.getResults();
-
-    assertNotNull(results);
-    assertTrue(results.isEmpty());
+    assertThat(results).isNotNull();
+    assertThat(results.isEmpty()).isTrue();
   }
 
   @Test
-  public void testExecuteThrowingEntityNotFoundException() throws Exception {
-    final String diskStoreName = "testDiskStore";
+  public void testExecuteThrowingEntityNotFoundException() {
     final String memberId = "mockMemberId";
     final String memberName = "mockMemberName";
-
+    final String diskStoreName = "testDiskStore";
     final InternalDistributedMember mockMember =
-        mockContext.mock(InternalDistributedMember.class, "DistributedMember");
-
-    final FunctionContext mockFunctionContext =
-        mockContext.mock(FunctionContext.class, "FunctionContext");
-
+        mock(InternalDistributedMember.class, "DistributedMember");
+    final FunctionContext mockFunctionContext = mock(FunctionContext.class, "FunctionContext");
     final TestResultSender testResultSender = new TestResultSender();
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockCache).getMyId();
-        will(returnValue(mockMember));
-        oneOf(mockCache).findDiskStore(diskStoreName);
-        will(returnValue(null));
-        oneOf(mockMember).getId();
-        will(returnValue(memberId));
-        oneOf(mockMember).getName();
-        will(returnValue(memberName));
-        oneOf(mockFunctionContext).getCache();
-        will(returnValue(mockCache));
-        oneOf(mockFunctionContext).getArguments();
-        will(returnValue(diskStoreName));
-        oneOf(mockFunctionContext).getResultSender();
-        will(returnValue(testResultSender));
-      }
-    });
+    when(mockCache.getMyId()).thenReturn(mockMember);
+    when(mockCache.findDiskStore(diskStoreName)).thenReturn(null);
+    when(mockMember.getId()).thenReturn(memberId);
+    when(mockMember.getName()).thenReturn(memberName);
+    when(mockFunctionContext.getCache()).thenReturn(mockCache);
+    when(mockFunctionContext.getArguments()).thenReturn(diskStoreName);
+    when(mockFunctionContext.getResultSender()).thenReturn(testResultSender);
 
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-
     function.execute(mockFunctionContext);
-
     String expected = String.format("A disk store with name (%1$s) was not found on member (%2$s).",
         diskStoreName, memberName);
-    assertThatThrownBy(() -> testResultSender.getResults())
-        .isInstanceOf(EntityNotFoundException.class).hasMessage(expected);
+    assertThatThrownBy(testResultSender::getResults).isInstanceOf(EntityNotFoundException.class)
+        .hasMessage(expected);
   }
 
   @Test
-  public void testExecuteThrowingRuntimeException() throws Exception {
+  public void testExecuteThrowingRuntimeException() {
     final String diskStoreName = "testDiskStore";
     final String memberId = "mockMemberId";
     final String memberName = "mockMemberName";
-
+    final FunctionContext mockFunctionContext = mock(FunctionContext.class, "FunctionContext");
     final InternalDistributedMember mockMember =
-        mockContext.mock(InternalDistributedMember.class, "DistributedMember");
-
-    final FunctionContext mockFunctionContext =
-        mockContext.mock(FunctionContext.class, "FunctionContext");
-
+        mock(InternalDistributedMember.class, "DistributedMember");
     final TestResultSender testResultSender = new TestResultSender();
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockCache).getMyId();
-        will(returnValue(mockMember));
-        oneOf(mockCache).findDiskStore(diskStoreName);
-        will(throwException(new RuntimeException("ExpectedStrings")));
-        oneOf(mockMember).getId();
-        will(returnValue(memberId));
-        oneOf(mockMember).getName();
-        will(returnValue(memberName));
-        oneOf(mockFunctionContext).getCache();
-        will(returnValue(mockCache));
-        oneOf(mockFunctionContext).getArguments();
-        will(returnValue(diskStoreName));
-        oneOf(mockFunctionContext).getResultSender();
-        will(returnValue(testResultSender));
-      }
-    });
+    when(mockCache.getMyId()).thenReturn(mockMember);
+    when(mockCache.findDiskStore(diskStoreName)).thenThrow(new RuntimeException("ExpectedStrings"));
+    when(mockMember.getId()).thenReturn(memberId);
+    when(mockMember.getName()).thenReturn(memberName);
+    when(mockFunctionContext.getCache()).thenReturn(mockCache);
+    when(mockFunctionContext.getArguments()).thenReturn(diskStoreName);
+    when(mockFunctionContext.getResultSender()).thenReturn(testResultSender);
 
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-
     function.execute(mockFunctionContext);
-
-    assertThatThrownBy(() -> testResultSender.getResults()).isInstanceOf(RuntimeException.class)
+    assertThatThrownBy(testResultSender::getResults).isInstanceOf(RuntimeException.class)
         .hasMessage("ExpectedStrings");
   }
 
   @Test
-  public void testExecuteWithDiskDirsAndDiskSizesMismatch() throws Exception {
+  public void testExecuteWithDiskDirsAndDiskSizesMismatch() {
     final String diskStoreName = "mockDiskStore";
     final String memberId = "mockMemberId";
     final String memberName = "mockMemberName";
-
     final UUID diskStoreId = UUID.randomUUID();
-
+    final FunctionContext mockFunctionContext = mock(FunctionContext.class, "FunctionContext");
     final InternalDistributedMember mockMember =
-        mockContext.mock(InternalDistributedMember.class, "DistributedMember");
-
+        mock(InternalDistributedMember.class, "DistributedMember");
     final DiskStore mockDiskStore =
-        createMockDiskStore(diskStoreId, diskStoreName, false, true, 70, 8192000l, 1000, 300l, 8192,
+        createMockDiskStore(diskStoreId, diskStoreName, false, true, 70, 8192000L, 1000, 300L, 8192,
             createFileArray("/export/disk0/gemfire/backup"), new int[0], 50, 75);
-
-    final FunctionContext mockFunctionContext =
-        mockContext.mock(FunctionContext.class, "FunctionContext");
-
     final TestResultSender testResultSender = new TestResultSender();
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockCache).getMyId();
-        will(returnValue(mockMember));
-        oneOf(mockCache).findDiskStore(diskStoreName);
-        will(returnValue(mockDiskStore));
-        oneOf(mockMember).getId();
-        will(returnValue(memberId));
-        oneOf(mockMember).getName();
-        will(returnValue(memberName));
-        oneOf(mockFunctionContext).getCache();
-        will(returnValue(mockCache));
-        oneOf(mockFunctionContext).getArguments();
-        will(returnValue(diskStoreName));
-        oneOf(mockFunctionContext).getResultSender();
-        will(returnValue(testResultSender));
-      }
-    });
+    when(mockCache.getMyId()).thenReturn(mockMember);
+    when(mockCache.findDiskStore(diskStoreName)).thenReturn(mockDiskStore);
+    when(mockMember.getId()).thenReturn(memberId);
+    when(mockMember.getName()).thenReturn(memberName);
+    when(mockFunctionContext.getCache()).thenReturn(mockCache);
+    when(mockFunctionContext.getArguments()).thenReturn(diskStoreName);
+    when(mockFunctionContext.getResultSender()).thenReturn(testResultSender);
 
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-
     function.execute(mockFunctionContext);
-
     String expected =
         "The number of disk directories with a specified size (0) does not match the number of disk directories (1)!";
-    assertThatThrownBy(() -> testResultSender.getResults()).hasMessage(expected);
+    assertThatThrownBy(testResultSender::getResults).hasMessage(expected);
+    verify(mockDiskStore, atLeastOnce()).getName();
+    verify(mockDiskStore, atLeastOnce()).getDiskStoreUUID();
   }
 
   @Test
   public void testGetRegionDiskStoreName() {
     final String expectedDiskStoreName = "testDiskStore";
-
-    final Region mockRegion = mockContext.mock(Region.class, "Region");
-    final RegionAttributes mockRegionAttributes =
-        mockContext.mock(RegionAttributes.class, "RegionAttributes");
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockRegion).getAttributes();
-        will(returnValue(mockRegionAttributes));
-        oneOf(mockRegionAttributes).getDiskStoreName();
-        will(returnValue(expectedDiskStoreName));
-      }
-    });
+    final Region mockRegion = mock(Region.class, "Region");
+    final RegionAttributes mockRegionAttributes = mock(RegionAttributes.class, "RegionAttributes");
+    when(mockRegion.getAttributes()).thenReturn(mockRegionAttributes);
+    when(mockRegionAttributes.getDiskStoreName()).thenReturn(expectedDiskStoreName);
 
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-
-    assertEquals(expectedDiskStoreName, function.getDiskStoreName(mockRegion));
+    assertThat(expectedDiskStoreName).isEqualTo(function.getDiskStoreName(mockRegion));
   }
 
   @Test
   public void testGetRegionDiskStoreNameWhenUnspecified() {
-    final Region mockRegion = mockContext.mock(Region.class, "Region");
-    final RegionAttributes mockRegionAttributes =
-        mockContext.mock(RegionAttributes.class, "RegionAttributes");
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockRegion).getAttributes();
-        will(returnValue(mockRegionAttributes));
-        oneOf(mockRegionAttributes).getDiskStoreName();
-        will(returnValue(null));
-      }
-    });
+    final Region mockRegion = mock(Region.class, "Region");
+    final RegionAttributes mockRegionAttributes = mock(RegionAttributes.class, "RegionAttributes");
+    when(mockRegion.getAttributes()).thenReturn(mockRegionAttributes);
+    when(mockRegionAttributes.getDiskStoreName()).thenReturn(null);
 
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-
-    assertEquals(DiskStoreDetails.DEFAULT_DISK_STORE_NAME, function.getDiskStoreName(mockRegion));
+    assertThat(DiskStoreDetails.DEFAULT_DISK_STORE_NAME)
+        .isEqualTo(function.getDiskStoreName(mockRegion));
   }
 
   @Test
   public void testIsRegionOverflowToDiskWhenEvictionActionIsLocalDestroy() {
-    final Region mockRegion = mockContext.mock(Region.class, "Region");
-    final RegionAttributes mockRegionAttributes =
-        mockContext.mock(RegionAttributes.class, "RegionAttributes");
+    final Region mockRegion = mock(Region.class, "Region");
+    final RegionAttributes mockRegionAttributes = mock(RegionAttributes.class, "RegionAttributes");
     final EvictionAttributes mockEvictionAttributes =
-        mockContext.mock(EvictionAttributes.class, "EvictionAttributes");
-
-    mockContext.checking(new Expectations() {
-      {
-        exactly(2).of(mockRegion).getAttributes();
-        will(returnValue(mockRegionAttributes));
-        exactly(2).of(mockRegionAttributes).getEvictionAttributes();
-        will(returnValue(mockEvictionAttributes));
-        oneOf(mockEvictionAttributes).getAction();
-        will(returnValue(EvictionAction.LOCAL_DESTROY));
-      }
-    });
+        mock(EvictionAttributes.class, "EvictionAttributes");
+    when(mockRegion.getAttributes()).thenReturn(mockRegionAttributes);
+    when(mockRegionAttributes.getEvictionAttributes()).thenReturn(mockEvictionAttributes);
+    when(mockEvictionAttributes.getAction()).thenReturn(EvictionAction.LOCAL_DESTROY);
 
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-
-    assertFalse(function.isOverflowToDisk(mockRegion));
+    assertThat(function.isOverflowToDisk(mockRegion)).isFalse();
+    verify(mockRegion, times(2)).getAttributes();
+    verify(mockRegionAttributes, times(2)).getEvictionAttributes();
   }
 
   @Test
   public void testIsRegionOverflowToDiskWhenEvictionActionIsOverflowToDisk() {
-    final Region mockRegion = mockContext.mock(Region.class, "Region");
-    final RegionAttributes mockRegionAttributes =
-        mockContext.mock(RegionAttributes.class, "RegionAttributes");
+    final Region mockRegion = mock(Region.class, "Region");
+    final RegionAttributes mockRegionAttributes = mock(RegionAttributes.class, "RegionAttributes");
     final EvictionAttributes mockEvictionAttributes =
-        mockContext.mock(EvictionAttributes.class, "EvictionAttributes");
-
-    mockContext.checking(new Expectations() {
-      {
-        exactly(2).of(mockRegion).getAttributes();
-        will(returnValue(mockRegionAttributes));
-        exactly(2).of(mockRegionAttributes).getEvictionAttributes();
-        will(returnValue(mockEvictionAttributes));
-        oneOf(mockEvictionAttributes).getAction();
-        will(returnValue(EvictionAction.OVERFLOW_TO_DISK));
-      }
-    });
+        mock(EvictionAttributes.class, "EvictionAttributes");
+    when(mockRegion.getAttributes()).thenReturn(mockRegionAttributes);
+    when(mockRegionAttributes.getEvictionAttributes()).thenReturn(mockEvictionAttributes);
+    when(mockEvictionAttributes.getAction()).thenReturn(EvictionAction.OVERFLOW_TO_DISK);
 
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-
-    assertTrue(function.isOverflowToDisk(mockRegion));
+    assertThat(function.isOverflowToDisk(mockRegion)).isTrue();
+    verify(mockRegion, times(2)).getAttributes();
+    verify(mockRegionAttributes, times(2)).getEvictionAttributes();
   }
 
   @Test
   public void testIsRegionOverflowToDiskWithNullEvictionAttributes() {
-    final Region mockRegion = mockContext.mock(Region.class, "Region");
-    final RegionAttributes mockRegionAttributes =
-        mockContext.mock(RegionAttributes.class, "RegionAttributes");
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockRegion).getAttributes();
-        will(returnValue(mockRegionAttributes));
-        oneOf(mockRegionAttributes).getEvictionAttributes();
-        will(returnValue(null));
-      }
-    });
+    final Region mockRegion = mock(Region.class, "Region");
+    final RegionAttributes mockRegionAttributes = mock(RegionAttributes.class, "RegionAttributes");
+    when(mockRegion.getAttributes()).thenReturn(mockRegionAttributes);
+    when(mockRegionAttributes.getEvictionAttributes()).thenReturn(null);
 
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-
-    assertFalse(function.isOverflowToDisk(mockRegion));
+    assertThat(function.isOverflowToDisk(mockRegion)).isFalse();
   }
 
   @Test
   public void testIsRegionPersistentWhenDataPolicyIsPersistentPartition() {
-    final Region mockRegion = mockContext.mock(Region.class, "Region");
-    final RegionAttributes mockRegionAttributes =
-        mockContext.mock(RegionAttributes.class, "RegionAttributes");
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockRegion).getAttributes();
-        will(returnValue(mockRegionAttributes));
-        oneOf(mockRegionAttributes).getDataPolicy();
-        will(returnValue(DataPolicy.PERSISTENT_PARTITION));
-      }
-    });
+    final Region mockRegion = mock(Region.class, "Region");
+    final RegionAttributes mockRegionAttributes = mock(RegionAttributes.class, "RegionAttributes");
+    when(mockRegion.getAttributes()).thenReturn(mockRegionAttributes);
+    when(mockRegionAttributes.getDataPolicy()).thenReturn(DataPolicy.PERSISTENT_PARTITION);
 
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-
-    assertTrue(function.isPersistent(mockRegion));
+    assertThat(function.isPersistent(mockRegion)).isTrue();
   }
 
   @Test
   public void testIsRegionPersistentWhenDataPolicyIsPersistentReplicate() {
-    final Region mockRegion = mockContext.mock(Region.class, "Region");
-    final RegionAttributes mockRegionAttributes =
-        mockContext.mock(RegionAttributes.class, "RegionAttributes");
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockRegion).getAttributes();
-        will(returnValue(mockRegionAttributes));
-        oneOf(mockRegionAttributes).getDataPolicy();
-        will(returnValue(DataPolicy.PERSISTENT_REPLICATE));
-      }
-    });
+    final Region mockRegion = mock(Region.class, "Region");
+    final RegionAttributes mockRegionAttributes = mock(RegionAttributes.class, "RegionAttributes");
+    when(mockRegion.getAttributes()).thenReturn(mockRegionAttributes);
+    when(mockRegionAttributes.getDataPolicy()).thenReturn(DataPolicy.PERSISTENT_REPLICATE);
 
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-
-    assertTrue(function.isPersistent(mockRegion));
+    assertThat(function.isPersistent(mockRegion)).isTrue();
   }
 
   @Test
   public void testIsRegionPersistentWhenDataPolicyIsNormal() {
-    final Region mockRegion = mockContext.mock(Region.class, "Region");
-    final RegionAttributes mockRegionAttributes =
-        mockContext.mock(RegionAttributes.class, "RegionAttributes");
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockRegion).getAttributes();
-        will(returnValue(mockRegionAttributes));
-        oneOf(mockRegionAttributes).getDataPolicy();
-        will(returnValue(DataPolicy.NORMAL));
-      }
-    });
+    final Region mockRegion = mock(Region.class, "Region");
+    final RegionAttributes mockRegionAttributes = mock(RegionAttributes.class, "RegionAttributes");
+    when(mockRegion.getAttributes()).thenReturn(mockRegionAttributes);
+    when(mockRegionAttributes.getDataPolicy()).thenReturn(DataPolicy.NORMAL);
 
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-
-    assertFalse(function.isPersistent(mockRegion));
+    assertThat(function.isPersistent(mockRegion)).isFalse();
   }
 
   @Test
   public void testIsRegionPersistentWhenDataPolicyIsPartition() {
-    final Region mockRegion = mockContext.mock(Region.class, "Region");
-    final RegionAttributes mockRegionAttributes =
-        mockContext.mock(RegionAttributes.class, "RegionAttributes");
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockRegion).getAttributes();
-        will(returnValue(mockRegionAttributes));
-        oneOf(mockRegionAttributes).getDataPolicy();
-        will(returnValue(DataPolicy.PARTITION));
-      }
-    });
+    final Region mockRegion = mock(Region.class, "Region");
+    final RegionAttributes mockRegionAttributes = mock(RegionAttributes.class, "RegionAttributes");
+    when(mockRegion.getAttributes()).thenReturn(mockRegionAttributes);
+    when(mockRegionAttributes.getDataPolicy()).thenReturn(DataPolicy.PARTITION);
 
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-
-    assertFalse(function.isPersistent(mockRegion));
+    assertThat(function.isPersistent(mockRegion)).isFalse();
   }
 
   @Test
   public void testIsRegionPersistentWhenDataPolicyIsPreloaded() {
-    final Region mockRegion = mockContext.mock(Region.class, "Region");
-    final RegionAttributes mockRegionAttributes =
-        mockContext.mock(RegionAttributes.class, "RegionAttributes");
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockRegion).getAttributes();
-        will(returnValue(mockRegionAttributes));
-        oneOf(mockRegionAttributes).getDataPolicy();
-        will(returnValue(DataPolicy.PRELOADED));
-      }
-    });
+    final Region mockRegion = mock(Region.class, "Region");
+    final RegionAttributes mockRegionAttributes = mock(RegionAttributes.class, "RegionAttributes");
+    when(mockRegion.getAttributes()).thenReturn(mockRegionAttributes);
+    when(mockRegionAttributes.getDataPolicy()).thenReturn(DataPolicy.PRELOADED);
 
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-
-    assertFalse(function.isPersistent(mockRegion));
+    assertThat(function.isPersistent(mockRegion)).isFalse();
   }
 
   @Test
   public void testIsRegionPersistentWhenDataPolicyIsReplicate() {
-    final Region mockRegion = mockContext.mock(Region.class, "Region");
-    final RegionAttributes mockRegionAttributes =
-        mockContext.mock(RegionAttributes.class, "RegionAttributes");
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockRegion).getAttributes();
-        will(returnValue(mockRegionAttributes));
-        oneOf(mockRegionAttributes).getDataPolicy();
-        will(returnValue(DataPolicy.REPLICATE));
-      }
-    });
+    final Region mockRegion = mock(Region.class, "Region");
+    final RegionAttributes mockRegionAttributes = mock(RegionAttributes.class, "RegionAttributes");
+    when(mockRegion.getAttributes()).thenReturn(mockRegionAttributes);
+    when(mockRegionAttributes.getDataPolicy()).thenReturn(DataPolicy.REPLICATE);
 
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-
-    assertFalse(function.isPersistent(mockRegion));
+    assertThat(function.isPersistent(mockRegion)).isFalse();
   }
 
   @Test
   public void testIsRegionUsingDiskStoreWhenUsingDefaultDiskStore() {
-    final Region mockRegion = mockContext.mock(Region.class, "Region");
-    final RegionAttributes mockRegionAttributes =
-        mockContext.mock(RegionAttributes.class, "RegionAttributes");
-    final DiskStore mockDiskStore = mockContext.mock(DiskStore.class, "DiskStore");
-
-    mockContext.checking(new Expectations() {
-      {
-        atLeast(1).of(mockRegion).getAttributes();
-        will(returnValue(mockRegionAttributes));
-        oneOf(mockRegionAttributes).getDataPolicy();
-        will(returnValue(DataPolicy.PERSISTENT_REPLICATE));
-        oneOf(mockRegionAttributes).getDiskStoreName();
-        will(returnValue(null));
-        oneOf(mockDiskStore).getName();
-        will(returnValue(DiskStoreDetails.DEFAULT_DISK_STORE_NAME));
-      }
-    });
+    final Region mockRegion = mock(Region.class, "Region");
+    final DiskStore mockDiskStore = mock(DiskStore.class, "DiskStore");
+    final RegionAttributes mockRegionAttributes = mock(RegionAttributes.class, "RegionAttributes");
+    when(mockRegion.getAttributes()).thenReturn(mockRegionAttributes);
+    when(mockRegionAttributes.getDataPolicy()).thenReturn(DataPolicy.PERSISTENT_REPLICATE);
+    when(mockRegionAttributes.getDiskStoreName()).thenReturn(null);
+    when(mockDiskStore.getName()).thenReturn(DiskStoreDetails.DEFAULT_DISK_STORE_NAME);
 
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-
-    assertTrue(function.isUsingDiskStore(mockRegion, mockDiskStore));
+    assertThat(function.isUsingDiskStore(mockRegion, mockDiskStore)).isTrue();
+    verify(mockRegion, atLeastOnce()).getAttributes();
   }
 
   @Test
   public void testIsRegionUsingDiskStoreWhenPersistent() {
     final String diskStoreName = "testDiskStore";
-
-    final Region mockRegion = mockContext.mock(Region.class, "Region");
-    final RegionAttributes mockRegionAttributes =
-        mockContext.mock(RegionAttributes.class, "RegionAttributes");
-    final DiskStore mockDiskStore = mockContext.mock(DiskStore.class, "DiskStore");
-
-    mockContext.checking(new Expectations() {
-      {
-        atLeast(1).of(mockRegion).getAttributes();
-        will(returnValue(mockRegionAttributes));
-        oneOf(mockRegionAttributes).getDataPolicy();
-        will(returnValue(DataPolicy.PERSISTENT_PARTITION));
-        oneOf(mockRegionAttributes).getDiskStoreName();
-        will(returnValue(diskStoreName));
-        oneOf(mockDiskStore).getName();
-        will(returnValue(diskStoreName));
-      }
-    });
+    final Region mockRegion = mock(Region.class, "Region");
+    final DiskStore mockDiskStore = mock(DiskStore.class, "DiskStore");
+    final RegionAttributes mockRegionAttributes = mock(RegionAttributes.class, "RegionAttributes");
+    when(mockRegion.getAttributes()).thenReturn(mockRegionAttributes);
+    when(mockRegionAttributes.getDataPolicy()).thenReturn(DataPolicy.PERSISTENT_PARTITION);
+    when(mockRegionAttributes.getDiskStoreName()).thenReturn(diskStoreName);
+    when(mockDiskStore.getName()).thenReturn(diskStoreName);
 
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-
-    assertTrue(function.isUsingDiskStore(mockRegion, mockDiskStore));
+    assertThat(function.isUsingDiskStore(mockRegion, mockDiskStore)).isTrue();
+    verify(mockRegion, atLeastOnce()).getAttributes();
   }
 
   @Test
   public void testIsRegionUsingDiskStoreWhenOverflowing() {
     final String diskStoreName = "testDiskStore";
-
-    final Region mockRegion = mockContext.mock(Region.class, "Region");
-    final RegionAttributes mockRegionAttributes =
-        mockContext.mock(RegionAttributes.class, "RegionAttributes");
+    final Region mockRegion = mock(Region.class, "Region");
+    final DiskStore mockDiskStore = mock(DiskStore.class, "DiskStore");
+    final RegionAttributes mockRegionAttributes = mock(RegionAttributes.class, "RegionAttributes");
     final EvictionAttributes mockEvictionAttributes =
-        mockContext.mock(EvictionAttributes.class, "EvictionAttributes");
-    final DiskStore mockDiskStore = mockContext.mock(DiskStore.class, "DiskStore");
-
-    mockContext.checking(new Expectations() {
-      {
-        exactly(4).of(mockRegion).getAttributes();
-        will(returnValue(mockRegionAttributes));
-        oneOf(mockRegionAttributes).getDataPolicy();
-        will(returnValue(DataPolicy.PARTITION));
-        oneOf(mockRegionAttributes).getDiskStoreName();
-        will(returnValue(diskStoreName));
-        exactly(2).of(mockRegionAttributes).getEvictionAttributes();
-        will(returnValue(mockEvictionAttributes));
-        oneOf(mockEvictionAttributes).getAction();
-        will(returnValue(EvictionAction.OVERFLOW_TO_DISK));
-        oneOf(mockDiskStore).getName();
-        will(returnValue(diskStoreName));
-      }
-    });
+        mock(EvictionAttributes.class, "EvictionAttributes");
+    when(mockRegion.getAttributes()).thenReturn(mockRegionAttributes);
+    when(mockRegionAttributes.getDataPolicy()).thenReturn(DataPolicy.PARTITION);
+    when(mockRegionAttributes.getDiskStoreName()).thenReturn(diskStoreName);
+    when(mockRegionAttributes.getEvictionAttributes()).thenReturn(mockEvictionAttributes);
+    when(mockEvictionAttributes.getAction()).thenReturn(EvictionAction.OVERFLOW_TO_DISK);
+    when(mockDiskStore.getName()).thenReturn(diskStoreName);
 
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-
-    assertTrue(function.isUsingDiskStore(mockRegion, mockDiskStore));
+    assertThat(function.isUsingDiskStore(mockRegion, mockDiskStore)).isTrue();
+    verify(mockRegion, times(4)).getAttributes();
+    verify(mockRegionAttributes, times(2)).getEvictionAttributes();
   }
 
   @Test
   public void testIsRegionUsingDiskStoreWhenDiskStoresMismatch() {
-    final Region mockRegion = mockContext.mock(Region.class, "Region");
-    final RegionAttributes mockRegionAttributes =
-        mockContext.mock(RegionAttributes.class, "RegionAttributes");
-    final DiskStore mockDiskStore = mockContext.mock(DiskStore.class, "DiskStore");
-
-    mockContext.checking(new Expectations() {
-      {
-        atLeast(1).of(mockRegion).getAttributes();
-        will(returnValue(mockRegionAttributes));
-        oneOf(mockRegionAttributes).getDataPolicy();
-        will(returnValue(DataPolicy.PERSISTENT_PARTITION));
-        oneOf(mockRegionAttributes).getDiskStoreName();
-        will(returnValue("mockDiskStore"));
-        oneOf(mockDiskStore).getName();
-        will(returnValue("testDiskStore"));
-      }
-    });
+    final Region mockRegion = mock(Region.class, "Region");
+    final DiskStore mockDiskStore = mock(DiskStore.class, "DiskStore");
+    final RegionAttributes mockRegionAttributes = mock(RegionAttributes.class, "RegionAttributes");
+    when(mockRegion.getAttributes()).thenReturn(mockRegionAttributes);
+    when(mockRegionAttributes.getDataPolicy()).thenReturn(DataPolicy.PERSISTENT_PARTITION);
+    when(mockRegionAttributes.getDiskStoreName()).thenReturn("mockDiskStore");
+    when(mockDiskStore.getName()).thenReturn("testDiskStore");
 
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-
-    assertFalse(function.isUsingDiskStore(mockRegion, mockDiskStore));
+    assertThat(function.isUsingDiskStore(mockRegion, mockDiskStore)).isFalse();
   }
 
   @Test
   public void testSetRegionDetails() {
+    // Prepare Mocks
     final String diskStoreName = "companyDiskStore";
 
-    final Region mockCompanyRegion = mockContext.mock(Region.class, "/CompanyRegion");
-    final Region mockContractorsRegion =
-        mockContext.mock(Region.class, "/CompanyRegion/ContractorsRegion");
-    final Region mockEmployeeRegion =
-        mockContext.mock(Region.class, "/CompanyRegion/EmployeeRegion");
-    final Region mockRolesRegion =
-        mockContext.mock(Region.class, "/CompanyRegion/EmployeeRegion/RolesRegion");
-    final Region mockProductsRegion =
-        mockContext.mock(Region.class, "/CompanyRegion/ProductsRegion");
-    final Region mockServicesRegion =
-        mockContext.mock(Region.class, "/CompanyRegion/ServicesRegion");
-    final Region mockPartnersRegion = mockContext.mock(Region.class, "/PartnersRegion");
-    final Region mockCustomersRegion = mockContext.mock(Region.class, "/CustomersRegion");
-
+    final Region mockCompanyRegion = mock(Region.class, "/CompanyRegion");
     final RegionAttributes mockCompanyRegionAttributes =
-        mockContext.mock(RegionAttributes.class, "CompanyRegionAttributes");
-    final RegionAttributes mockContractorsRegionAttributes =
-        mockContext.mock(RegionAttributes.class, "ContractorsRegionAttributes");
-    final RegionAttributes mockProductsServicesRegionAttributes =
-        mockContext.mock(RegionAttributes.class, "ProductsServicesRegionAttributes");
-    final RegionAttributes mockPartnersRegionAttributes =
-        mockContext.mock(RegionAttributes.class, "PartnersRegionAttributes");
-    final RegionAttributes mockCustomersRegionAttributes =
-        mockContext.mock(RegionAttributes.class, "CustomersRegionAttributes");
-
+        mock(RegionAttributes.class, "CompanyRegionAttributes");
     final EvictionAttributes mockCompanyEvictionAttributes =
-        mockContext.mock(EvictionAttributes.class, "CompanyEvictionAttributes");
+        mock(EvictionAttributes.class, "CompanyEvictionAttributes");
+    when(mockCompanyRegion.getAttributes()).thenReturn(mockCompanyRegionAttributes);
+    when(mockCompanyRegion.getFullPath()).thenReturn("/CompanyRegion");
+    when(mockCompanyRegion.getName()).thenReturn("CompanyRegion");
+    when(mockCompanyRegionAttributes.getDataPolicy()).thenReturn(DataPolicy.PERSISTENT_PARTITION);
+    when(mockCompanyRegionAttributes.getDiskStoreName()).thenReturn(diskStoreName);
+    when(mockCompanyRegionAttributes.getEvictionAttributes())
+        .thenReturn(mockCompanyEvictionAttributes);
+    when(mockCompanyEvictionAttributes.getAction()).thenReturn(EvictionAction.LOCAL_DESTROY);
+
+    final Region mockEmployeeRegion = mock(Region.class, "/CompanyRegion/EmployeeRegion");
+    when(mockEmployeeRegion.getAttributes()).thenReturn(mockCompanyRegionAttributes);
+    when(mockEmployeeRegion.getFullPath()).thenReturn("/CompanyRegion/EmployeeRegion");
+    when(mockEmployeeRegion.getName()).thenReturn("EmployeeRegion");
+
+    final Region mockProductsRegion = mock(Region.class, "/CompanyRegion/ProductsRegion");
+    final RegionAttributes mockProductsServicesRegionAttributes =
+        mock(RegionAttributes.class, "ProductsServicesRegionAttributes");
+    when(mockProductsRegion.getAttributes()).thenReturn(mockProductsServicesRegionAttributes);
+    when(mockProductsRegion.subregions(false)).thenReturn(Collections.emptySet());
+    when(mockProductsServicesRegionAttributes.getDataPolicy())
+        .thenReturn(DataPolicy.PERSISTENT_REPLICATE);
+    when(mockProductsServicesRegionAttributes.getDiskStoreName())
+        .thenReturn("productsServicesDiskStore");
+
+    final Region mockServicesRegion = mock(Region.class, "/CompanyRegion/ServicesRegion");
+    when(mockServicesRegion.getAttributes()).thenReturn(mockProductsServicesRegionAttributes);
+    when(mockServicesRegion.subregions(false)).thenReturn(Collections.emptySet());
+
+    final Region mockContractorsRegion = mock(Region.class, "/CompanyRegion/ContractorsRegion");
+    final RegionAttributes mockContractorsRegionAttributes =
+        mock(RegionAttributes.class, "ContractorsRegionAttributes");
     final EvictionAttributes mockContractorsEvictionAttributes =
-        mockContext.mock(EvictionAttributes.class, "ContractorsEvictionAttributes");
+        mock(EvictionAttributes.class, "ContractorsEvictionAttributes");
+    when(mockContractorsRegion.getAttributes()).thenReturn(mockContractorsRegionAttributes);
+    when(mockContractorsRegion.getFullPath()).thenReturn("/CompanyRegion/ContractorsRegion");
+    when(mockContractorsRegion.getName()).thenReturn("ContractorsRegion");
+    when(mockContractorsRegionAttributes.getDataPolicy()).thenReturn(DataPolicy.REPLICATE);
+    when(mockContractorsRegionAttributes.getDiskStoreName()).thenReturn(diskStoreName);
+    when(mockContractorsRegionAttributes.getEvictionAttributes())
+        .thenReturn(mockContractorsEvictionAttributes);
+    when(mockContractorsEvictionAttributes.getAction()).thenReturn(EvictionAction.OVERFLOW_TO_DISK);
+
+    final Region mockRolesRegion = mock(Region.class, "/CompanyRegion/EmployeeRegion/RolesRegion");
+    when(mockRolesRegion.getAttributes()).thenReturn(mockCompanyRegionAttributes);
+    when(mockRolesRegion.getFullPath()).thenReturn("/CompanyRegion/EmployeeRegion/RolesRegion");
+    when(mockRolesRegion.getName()).thenReturn("RolesRegion");
+    when(mockRolesRegion.subregions(false)).thenReturn(Collections.emptySet());
+
+    final Region mockPartnersRegion = mock(Region.class, "/PartnersRegion");
+    final RegionAttributes mockPartnersRegionAttributes =
+        mock(RegionAttributes.class, "PartnersRegionAttributes");
+    when(mockPartnersRegion.getAttributes()).thenReturn(mockPartnersRegionAttributes);
+    when(mockPartnersRegion.subregions(false)).thenReturn(Collections.emptySet());
+    when(mockPartnersRegionAttributes.getDataPolicy()).thenReturn(DataPolicy.PERSISTENT_PARTITION);
+    when(mockPartnersRegionAttributes.getDiskStoreName()).thenReturn("");
+
+    final Region mockCustomersRegion = mock(Region.class, "/CustomersRegion");
+    final RegionAttributes mockCustomersRegionAttributes =
+        mock(RegionAttributes.class, "CustomersRegionAttributes");
     final EvictionAttributes mockCustomersEvictionAttributes =
-        mockContext.mock(EvictionAttributes.class, "CustomersEvictionAttributes");
+        mock(EvictionAttributes.class, "CustomersEvictionAttributes");
+    when(mockCustomersRegion.getAttributes()).thenReturn(mockCustomersRegionAttributes);
+    when(mockCustomersRegion.subregions(false)).thenReturn(Collections.emptySet());
+    when(mockCustomersRegionAttributes.getDataPolicy()).thenReturn(DataPolicy.REPLICATE);
+    when(mockCustomersRegionAttributes.getDiskStoreName()).thenReturn(null);
+    when(mockCustomersRegionAttributes.getEvictionAttributes())
+        .thenReturn(mockCustomersEvictionAttributes);
+    when(mockCustomersEvictionAttributes.getAction()).thenReturn(EvictionAction.OVERFLOW_TO_DISK);
 
-    final DiskStore mockDiskStore = mockContext.mock(DiskStore.class, "DiskStore");
+    final DiskStore mockDiskStore = mock(DiskStore.class, "DiskStore");
+    when(mockDiskStore.getName()).thenReturn(diskStoreName);
 
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockCache).rootRegions();
-        will(returnValue(
-            CollectionUtils.asSet(mockCompanyRegion, mockPartnersRegion, mockCustomersRegion)));
-        exactly(5).of(mockCompanyRegion).getAttributes();
-        will(returnValue(mockCompanyRegionAttributes));
-        oneOf(mockCompanyRegion).getFullPath();
-        will(returnValue("/CompanyRegion"));
-        oneOf(mockCompanyRegion).getName();
-        will(returnValue("CompanyRegion"));
-        oneOf(mockCompanyRegion).subregions(false);
-        will(returnValue(CollectionUtils.asSet(mockContractorsRegion, mockEmployeeRegion,
-            mockProductsRegion, mockServicesRegion)));
-        exactly(5).of(mockEmployeeRegion).getAttributes();
-        will(returnValue(mockCompanyRegionAttributes));
-        oneOf(mockEmployeeRegion).getFullPath();
-        will(returnValue("/CompanyRegion/EmployeeRegion"));
-        oneOf(mockEmployeeRegion).getName();
-        will(returnValue("EmployeeRegion"));
-        oneOf(mockEmployeeRegion).subregions(false);
-        will(returnValue(CollectionUtils.asSet(mockRolesRegion)));
-        exactly(5).of(mockRolesRegion).getAttributes();
-        will(returnValue(mockCompanyRegionAttributes));
-        oneOf(mockRolesRegion).getFullPath();
-        will(returnValue("/CompanyRegion/EmployeeRegion/RolesRegion"));
-        oneOf(mockRolesRegion).getName();
-        will(returnValue("RolesRegion"));
-        oneOf(mockRolesRegion).subregions(false);
-        will(returnValue(Collections.emptySet()));
-        exactly(6).of(mockCompanyRegionAttributes).getDataPolicy();
-        will(returnValue(DataPolicy.PERSISTENT_PARTITION));
-        exactly(3).of(mockCompanyRegionAttributes).getDiskStoreName();
-        will(returnValue(diskStoreName));
-        exactly(6).of(mockCompanyRegionAttributes).getEvictionAttributes();
-        will(returnValue(mockCompanyEvictionAttributes));
-        exactly(3).of(mockCompanyEvictionAttributes).getAction();
-        will(returnValue(EvictionAction.LOCAL_DESTROY));
+    when(mockCache.rootRegions()).thenReturn(
+        CollectionUtils.asSet(mockCompanyRegion, mockPartnersRegion, mockCustomersRegion));
+    when(mockCompanyRegion.subregions(false)).thenReturn(CollectionUtils
+        .asSet(mockContractorsRegion, mockEmployeeRegion, mockProductsRegion, mockServicesRegion));
+    when(mockEmployeeRegion.subregions(false)).thenReturn(CollectionUtils.asSet(mockRolesRegion));
+    when(mockContractorsRegion.subregions(false)).thenReturn(Collections.emptySet());
 
-        exactly(7).of(mockContractorsRegion).getAttributes();
-        will(returnValue(mockContractorsRegionAttributes));
-        oneOf(mockContractorsRegion).getFullPath();
-        will(returnValue("/CompanyRegion/ContractorsRegion"));
-        oneOf(mockContractorsRegion).getName();
-        will(returnValue("ContractorsRegion"));
-        oneOf(mockContractorsRegion).subregions(false);
-        will(returnValue(Collections.emptySet()));
-        exactly(2).of(mockContractorsRegionAttributes).getDataPolicy();
-        will(returnValue(DataPolicy.REPLICATE));
-        oneOf(mockContractorsRegionAttributes).getDiskStoreName();
-        will(returnValue(diskStoreName));
-        exactly(4).of(mockContractorsRegionAttributes).getEvictionAttributes();
-        will(returnValue(mockContractorsEvictionAttributes));
-        exactly(2).of(mockContractorsEvictionAttributes).getAction();
-        will(returnValue(EvictionAction.OVERFLOW_TO_DISK));
-
-        exactly(2).of(mockProductsRegion).getAttributes();
-        will(returnValue(mockProductsServicesRegionAttributes));
-        oneOf(mockProductsRegion).subregions(false);
-        will(returnValue(Collections.emptySet()));
-        exactly(2).of(mockServicesRegion).getAttributes();
-        will(returnValue(mockProductsServicesRegionAttributes));
-        oneOf(mockServicesRegion).subregions(false);
-        will(returnValue(Collections.emptySet()));
-        exactly(2).of(mockProductsServicesRegionAttributes).getDataPolicy();
-        will(returnValue(DataPolicy.PERSISTENT_REPLICATE));
-        exactly(2).of(mockProductsServicesRegionAttributes).getDiskStoreName();
-        will(returnValue("productsServicesDiskStore"));
-
-        exactly(2).of(mockPartnersRegion).getAttributes();
-        will(returnValue(mockPartnersRegionAttributes));
-        oneOf(mockPartnersRegion).subregions(false);
-        will(returnValue(Collections.emptySet()));
-        oneOf(mockPartnersRegionAttributes).getDataPolicy();
-        will(returnValue(DataPolicy.PERSISTENT_PARTITION));
-        oneOf(mockPartnersRegionAttributes).getDiskStoreName();
-        will(returnValue(""));
-
-        exactly(4).of(mockCustomersRegion).getAttributes();
-        will(returnValue(mockCustomersRegionAttributes));
-        oneOf(mockCustomersRegion).subregions(false);
-        will(returnValue(Collections.emptySet()));
-        oneOf(mockCustomersRegionAttributes).getDataPolicy();
-        will(returnValue(DataPolicy.REPLICATE));
-        oneOf(mockCustomersRegionAttributes).getDiskStoreName();
-        will(returnValue(null));
-        exactly(2).of(mockCustomersRegionAttributes).getEvictionAttributes();
-        will(returnValue(mockCustomersEvictionAttributes));
-        oneOf(mockCustomersEvictionAttributes).getAction();
-        will(returnValue(EvictionAction.OVERFLOW_TO_DISK));
-
-        atLeast(1).of(mockDiskStore).getName();
-        will(returnValue(diskStoreName));
-      }
-    });
-
+    // Execute Region and assert results
     final Set<DiskStoreDetails.RegionDetails> expectedRegionDetails = CollectionUtils.asSet(
         createRegionDetails("/CompanyRegion", "CompanyRegion", true, false),
         createRegionDetails("/CompanyRegion/EmployeeRegion", "EmployeeRegion", true, false),
         createRegionDetails("/CompanyRegion/EmployeeRegion/RolesRegion", "RolesRegion", true,
             false),
         createRegionDetails("/CompanyRegion/ContractorsRegion", "ContractorsRegion", false, true));
-
     final DiskStoreDetails diskStoreDetails = new DiskStoreDetails(diskStoreName, "memberOne");
-
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-
     function.setRegionDetails(mockCache, mockDiskStore, diskStoreDetails);
-
     assertRegionDetails(expectedRegionDetails, diskStoreDetails);
+    verify(mockCompanyRegion, times(5)).getAttributes();
+    verify(mockEmployeeRegion, times(5)).getAttributes();
+    verify(mockRolesRegion, times(5)).getAttributes();
+    verify(mockCompanyRegionAttributes, times(6)).getDataPolicy();
+    verify(mockCompanyRegionAttributes, times(3)).getDiskStoreName();
+    verify(mockCompanyRegionAttributes, times(6)).getEvictionAttributes();
+    verify(mockCompanyEvictionAttributes, times(3)).getAction();
+    verify(mockContractorsRegion, times(7)).getAttributes();
+    verify(mockContractorsRegionAttributes, times(2)).getDataPolicy();
+    verify(mockContractorsRegionAttributes, times(4)).getEvictionAttributes();
+    verify(mockContractorsEvictionAttributes, times(2)).getAction();
+    verify(mockProductsRegion, times(2)).getAttributes();
+    verify(mockServicesRegion, times(2)).getAttributes();
+    verify(mockProductsServicesRegionAttributes, times(2)).getDataPolicy();
+    verify(mockProductsServicesRegionAttributes, times(2)).getDiskStoreName();
+    verify(mockPartnersRegion, times(2)).getAttributes();
+    verify(mockCustomersRegion, times(4)).getAttributes();
+    verify(mockCustomersRegionAttributes, times(2)).getEvictionAttributes();
+    verify(mockDiskStore, atLeastOnce()).getName();
   }
 
   @Test
   public void testGetCacheServerDiskStoreName() {
     final String expectedDiskStoreName = "testDiskStore";
-
-    final CacheServer mockCacheServer = mockContext.mock(CacheServer.class, "CacheServer");
+    final CacheServer mockCacheServer = mock(CacheServer.class, "CacheServer");
     final ClientSubscriptionConfig mockClientSubscriptionConfig =
-        mockContext.mock(ClientSubscriptionConfig.class, "ClientSubscriptionConfig");
-
-    mockContext.checking(new Expectations() {
-      {
-        exactly(2).of(mockCacheServer).getClientSubscriptionConfig();
-        will(returnValue(mockClientSubscriptionConfig));
-        oneOf(mockClientSubscriptionConfig).getDiskStoreName();
-        will(returnValue(expectedDiskStoreName));
-      }
-    });
+        mock(ClientSubscriptionConfig.class, "ClientSubscriptionConfig");
+    when(mockCacheServer.getClientSubscriptionConfig()).thenReturn(mockClientSubscriptionConfig);
+    when(mockClientSubscriptionConfig.getDiskStoreName()).thenReturn(expectedDiskStoreName);
 
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-
-    assertEquals(expectedDiskStoreName, function.getDiskStoreName(mockCacheServer));
+    assertThat(expectedDiskStoreName).isEqualTo(function.getDiskStoreName(mockCacheServer));
+    verify(mockCacheServer, times(2)).getClientSubscriptionConfig();
   }
 
   @Test
   public void testGetCacheServerDiskStoreNameWhenUnspecified() {
-    final CacheServer mockCacheServer = mockContext.mock(CacheServer.class, "CacheServer");
+    final CacheServer mockCacheServer = mock(CacheServer.class, "CacheServer");
     final ClientSubscriptionConfig mockClientSubscriptionConfig =
-        mockContext.mock(ClientSubscriptionConfig.class, "ClientSubscriptionConfig");
-
-    mockContext.checking(new Expectations() {
-      {
-        exactly(2).of(mockCacheServer).getClientSubscriptionConfig();
-        will(returnValue(mockClientSubscriptionConfig));
-        oneOf(mockClientSubscriptionConfig).getDiskStoreName();
-        will(returnValue(null));
-      }
-    });
+        mock(ClientSubscriptionConfig.class, "ClientSubscriptionConfig");
+    when(mockCacheServer.getClientSubscriptionConfig()).thenReturn(mockClientSubscriptionConfig);
+    when(mockClientSubscriptionConfig.getDiskStoreName()).thenReturn(null);
 
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-
-    assertEquals(DiskStoreDetails.DEFAULT_DISK_STORE_NAME,
-        function.getDiskStoreName(mockCacheServer));
+    assertThat(DiskStoreDetails.DEFAULT_DISK_STORE_NAME)
+        .isEqualTo(function.getDiskStoreName(mockCacheServer));
+    verify(mockCacheServer, times(2)).getClientSubscriptionConfig();
   }
 
   @Test
   public void testGetCacheServerDiskStoreNameWithNullClientSubscriptionConfig() {
-    final CacheServer mockCacheServer = mockContext.mock(CacheServer.class, "CacheServer");
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockCacheServer).getClientSubscriptionConfig();
-        will(returnValue(null));
-      }
-    });
+    final CacheServer mockCacheServer = mock(CacheServer.class, "CacheServer");
+    when(mockCacheServer.getClientSubscriptionConfig()).thenReturn(null);
 
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-
-    assertNull(function.getDiskStoreName(mockCacheServer));
+    assertThat(function.getDiskStoreName(mockCacheServer)).isNull();
   }
 
   @Test
   public void testIsCacheServerUsingDiskStore() {
     final String diskStoreName = "testDiskStore";
-
-    final CacheServer mockCacheServer = mockContext.mock(CacheServer.class, "CacheServer");
+    final DiskStore mockDiskStore = mock(DiskStore.class, "DiskStore");
+    final CacheServer mockCacheServer = mock(CacheServer.class, "CacheServer");
     final ClientSubscriptionConfig mockClientSubscriptionConfig =
-        mockContext.mock(ClientSubscriptionConfig.class, "ClientSubscriptionConfig");
-    final DiskStore mockDiskStore = mockContext.mock(DiskStore.class, "DiskStore");
-
-    mockContext.checking(new Expectations() {
-      {
-        exactly(2).of(mockCacheServer).getClientSubscriptionConfig();
-        will(returnValue(mockClientSubscriptionConfig));
-        oneOf(mockClientSubscriptionConfig).getDiskStoreName();
-        will(returnValue(diskStoreName));
-        oneOf(mockDiskStore).getName();
-        will(returnValue(diskStoreName));
-      }
-    });
+        mock(ClientSubscriptionConfig.class, "ClientSubscriptionConfig");
+    when(mockCacheServer.getClientSubscriptionConfig()).thenReturn(mockClientSubscriptionConfig);
+    when(mockClientSubscriptionConfig.getDiskStoreName()).thenReturn(diskStoreName);
+    when(mockDiskStore.getName()).thenReturn(diskStoreName);
 
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
+    assertThat(function.isUsingDiskStore(mockCacheServer, mockDiskStore)).isTrue();
+    verify(mockCacheServer, times(2)).getClientSubscriptionConfig();
 
-    assertTrue(function.isUsingDiskStore(mockCacheServer, mockDiskStore));
   }
 
   @Test
   public void testIsCacheServerUsingDiskStoreWhenDiskStoresMismatch() {
-    final CacheServer mockCacheServer = mockContext.mock(CacheServer.class, "CacheServer");
+    final DiskStore mockDiskStore = mock(DiskStore.class, "DiskStore");
+    final CacheServer mockCacheServer = mock(CacheServer.class, "CacheServer");
     final ClientSubscriptionConfig mockClientSubscriptionConfig =
-        mockContext.mock(ClientSubscriptionConfig.class, "ClientSubscriptionConfig");
-    final DiskStore mockDiskStore = mockContext.mock(DiskStore.class, "DiskStore");
-
-    mockContext.checking(new Expectations() {
-      {
-        exactly(2).of(mockCacheServer).getClientSubscriptionConfig();
-        will(returnValue(mockClientSubscriptionConfig));
-        oneOf(mockClientSubscriptionConfig).getDiskStoreName();
-        will(returnValue(" "));
-        oneOf(mockDiskStore).getName();
-        will(returnValue("otherDiskStore"));
-      }
-    });
+        mock(ClientSubscriptionConfig.class, "ClientSubscriptionConfig");
+    when(mockCacheServer.getClientSubscriptionConfig()).thenReturn(mockClientSubscriptionConfig);
+    when(mockClientSubscriptionConfig.getDiskStoreName()).thenReturn(" ");
+    when(mockDiskStore.getName()).thenReturn("otherDiskStore");
 
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-
-    assertFalse(function.isUsingDiskStore(mockCacheServer, mockDiskStore));
+    assertThat(function.isUsingDiskStore(mockCacheServer, mockDiskStore)).isFalse();
+    verify(mockCacheServer, times(2)).getClientSubscriptionConfig();
   }
 
   @Test
   public void testIsCacheServerUsingDiskStoreWhenUsingDefaultDiskStore() {
-    final CacheServer mockCacheServer = mockContext.mock(CacheServer.class, "CacheServer");
+    final DiskStore mockDiskStore = mock(DiskStore.class, "DiskStore");
+    final CacheServer mockCacheServer = mock(CacheServer.class, "CacheServer");
     final ClientSubscriptionConfig mockClientSubscriptionConfig =
-        mockContext.mock(ClientSubscriptionConfig.class, "ClientSubscriptionConfig");
-    final DiskStore mockDiskStore = mockContext.mock(DiskStore.class, "DiskStore");
-
-    mockContext.checking(new Expectations() {
-      {
-        exactly(2).of(mockCacheServer).getClientSubscriptionConfig();
-        will(returnValue(mockClientSubscriptionConfig));
-        oneOf(mockClientSubscriptionConfig).getDiskStoreName();
-        will(returnValue(""));
-        oneOf(mockDiskStore).getName();
-        will(returnValue(DiskStoreDetails.DEFAULT_DISK_STORE_NAME));
-      }
-    });
+        mock(ClientSubscriptionConfig.class, "ClientSubscriptionConfig");
+    when(mockCacheServer.getClientSubscriptionConfig()).thenReturn(mockClientSubscriptionConfig);
+    when(mockClientSubscriptionConfig.getDiskStoreName()).thenReturn("");
+    when(mockDiskStore.getName()).thenReturn(DiskStoreDetails.DEFAULT_DISK_STORE_NAME);
 
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-
-    assertTrue(function.isUsingDiskStore(mockCacheServer, mockDiskStore));
+    assertThat(function.isUsingDiskStore(mockCacheServer, mockDiskStore)).isTrue();
+    verify(mockCacheServer, times(2)).getClientSubscriptionConfig();
   }
 
   @Test
   public void testSetCacheServerDetails() {
     final String diskStoreName = "testDiskStore";
-
-    final CacheServer mockCacheServer1 = mockContext.mock(CacheServer.class, "CacheServer1");
-    final CacheServer mockCacheServer2 = mockContext.mock(CacheServer.class, "CacheServer2");
-    final CacheServer mockCacheServer3 = mockContext.mock(CacheServer.class, "CacheServer3");
-
+    final DiskStore mockDiskStore = mock(DiskStore.class, "DiskStore");
+    final CacheServer mockCacheServer1 = mock(CacheServer.class, "CacheServer1");
+    final CacheServer mockCacheServer2 = mock(CacheServer.class, "CacheServer2");
+    final CacheServer mockCacheServer3 = mock(CacheServer.class, "CacheServer3");
     final ClientSubscriptionConfig mockCacheServer1ClientSubscriptionConfig =
-        mockContext.mock(ClientSubscriptionConfig.class, "cacheServer1ClientSubscriptionConfig");
+        mock(ClientSubscriptionConfig.class, "cacheServer1ClientSubscriptionConfig");
     final ClientSubscriptionConfig mockCacheServer2ClientSubscriptionConfig =
-        mockContext.mock(ClientSubscriptionConfig.class, "cacheServer2ClientSubscriptionConfig");
-
-    final DiskStore mockDiskStore = mockContext.mock(DiskStore.class, "DiskStore");
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockCache).getCacheServers();
-        will(returnValue(Arrays.asList(mockCacheServer1, mockCacheServer2, mockCacheServer3)));
-        exactly(2).of(mockCacheServer1).getClientSubscriptionConfig();
-        will(returnValue(mockCacheServer1ClientSubscriptionConfig));
-        oneOf(mockCacheServer1ClientSubscriptionConfig).getDiskStoreName();
-        will(returnValue(diskStoreName));
-        oneOf(mockCacheServer1).getBindAddress();
-        will(returnValue("10.127.255.1"));
-        oneOf(mockCacheServer1).getPort();
-        will(returnValue(65536));
-        oneOf(mockCacheServer1).getHostnameForClients();
-        will(returnValue("gemini"));
-        exactly(2).of(mockCacheServer2).getClientSubscriptionConfig();
-        will(returnValue(mockCacheServer2ClientSubscriptionConfig));
-        oneOf(mockCacheServer2ClientSubscriptionConfig).getDiskStoreName();
-        will(returnValue("  "));
-        oneOf(mockCacheServer3).getClientSubscriptionConfig();
-        will(returnValue(null));
-        exactly(3).of(mockDiskStore).getName();
-        will(returnValue(diskStoreName));
-      }
-    });
+        mock(ClientSubscriptionConfig.class, "cacheServer2ClientSubscriptionConfig");
+    when(mockCache.getCacheServers())
+        .thenReturn(Arrays.asList(mockCacheServer1, mockCacheServer2, mockCacheServer3));
+    when(mockCacheServer1.getClientSubscriptionConfig())
+        .thenReturn(mockCacheServer1ClientSubscriptionConfig);
+    when(mockCacheServer1ClientSubscriptionConfig.getDiskStoreName()).thenReturn(diskStoreName);
+    when(mockCacheServer1.getBindAddress()).thenReturn("10.127.255.1");
+    when(mockCacheServer1.getPort()).thenReturn(65536);
+    when(mockCacheServer1.getHostnameForClients()).thenReturn("gemini");
+    when(mockCacheServer2.getClientSubscriptionConfig())
+        .thenReturn(mockCacheServer2ClientSubscriptionConfig);
+    when(mockCacheServer2ClientSubscriptionConfig.getDiskStoreName()).thenReturn("  ");
+    when(mockCacheServer3.getClientSubscriptionConfig()).thenReturn(null);
+    when(mockDiskStore.getName()).thenReturn(diskStoreName);
 
     final Set<DiskStoreDetails.CacheServerDetails> expectedCacheServerDetails =
         CollectionUtils.asSet(createCacheServerDetails("10.127.255.1", 65536, "gemini"));
-
     final DiskStoreDetails diskStoreDetails = new DiskStoreDetails(diskStoreName, "memberOne");
-
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-
     function.setCacheServerDetails(mockCache, mockDiskStore, diskStoreDetails);
-
     assertCacheServerDetails(expectedCacheServerDetails, diskStoreDetails);
+    verify(mockCacheServer1, times(2)).getClientSubscriptionConfig();
+    verify(mockCacheServer2, times(2)).getClientSubscriptionConfig();
+    verify(mockDiskStore, times(3)).getName();
   }
 
   @Test
   public void testGetGatewaySenderDiskStoreName() {
     final String expectedDiskStoreName = "testDiskStore";
-
-    final GatewaySender mockGatewaySender = mockContext.mock(GatewaySender.class, "GatewaySender");
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockGatewaySender).getDiskStoreName();
-        will(returnValue(expectedDiskStoreName));
-      }
-    });
+    final GatewaySender mockGatewaySender = mock(GatewaySender.class, "GatewaySender");
+    when(mockGatewaySender.getDiskStoreName()).thenReturn(expectedDiskStoreName);
 
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-
-    assertEquals(expectedDiskStoreName, function.getDiskStoreName(mockGatewaySender));
+    assertThat(expectedDiskStoreName).isEqualTo(function.getDiskStoreName(mockGatewaySender));
   }
 
   @Test
   public void testGetGatewaySenderDiskStoreNameWhenUnspecified() {
-    final GatewaySender mockGatewaySender = mockContext.mock(GatewaySender.class, "GatewaySender");
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockGatewaySender).getDiskStoreName();
-        will(returnValue(" "));
-      }
-    });
+    final GatewaySender mockGatewaySender = mock(GatewaySender.class, "GatewaySender");
+    when(mockGatewaySender.getDiskStoreName()).thenReturn(" ");
 
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-
-    assertEquals(DiskStoreDetails.DEFAULT_DISK_STORE_NAME,
-        function.getDiskStoreName(mockGatewaySender));
+    assertThat(DiskStoreDetails.DEFAULT_DISK_STORE_NAME)
+        .isEqualTo(function.getDiskStoreName(mockGatewaySender));
   }
 
   @Test
   public void testIsGatewaySenderPersistent() {
-    final GatewaySender mockGatewaySender = mockContext.mock(GatewaySender.class, "GatewaySender");
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockGatewaySender).isPersistenceEnabled();
-        will(returnValue(true));
-      }
-    });
+    final GatewaySender mockGatewaySender = mock(GatewaySender.class, "GatewaySender");
+    when(mockGatewaySender.isPersistenceEnabled()).thenReturn(true);
 
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-
-    assertTrue(function.isPersistent(mockGatewaySender));
+    assertThat(function.isPersistent(mockGatewaySender)).isTrue();
   }
 
   @Test
   public void testIsGatewaySenderPersistentWhenPersistenceIsNotEnabled() {
-    final GatewaySender mockGatewaySender = mockContext.mock(GatewaySender.class, "GatewaySender");
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockGatewaySender).isPersistenceEnabled();
-        will(returnValue(true));
-      }
-    });
+    final GatewaySender mockGatewaySender = mock(GatewaySender.class, "GatewaySender");
+    when(mockGatewaySender.isPersistenceEnabled()).thenReturn(true);
 
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-
-    assertTrue(function.isPersistent(mockGatewaySender));
+    assertThat(function.isPersistent(mockGatewaySender)).isTrue();
   }
 
   @Test
   public void testIsGatewaySenderUsingDiskStore() {
     final String diskStoreName = "testDiskStore";
-
-    final GatewaySender mockGatewaySender = mockContext.mock(GatewaySender.class, "GatewaySender");
-
-    final DiskStore mockDiskStore = mockContext.mock(DiskStore.class, "DiskStore");
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockGatewaySender).getDiskStoreName();
-        will(returnValue(diskStoreName));
-        oneOf(mockDiskStore).getName();
-        will(returnValue(diskStoreName));
-      }
-    });
+    final DiskStore mockDiskStore = mock(DiskStore.class, "DiskStore");
+    final GatewaySender mockGatewaySender = mock(GatewaySender.class, "GatewaySender");
+    when(mockGatewaySender.getDiskStoreName()).thenReturn(diskStoreName);
+    when(mockDiskStore.getName()).thenReturn(diskStoreName);
 
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-
-    assertTrue(function.isUsingDiskStore(mockGatewaySender, mockDiskStore));
+    assertThat(function.isUsingDiskStore(mockGatewaySender, mockDiskStore)).isTrue();
   }
 
   @Test
   public void testIsGatewaySenderUsingDiskStoreWhenDiskStoresMismatch() {
-    final GatewaySender mockGatewaySender = mockContext.mock(GatewaySender.class, "GatewaySender");
-
-    final DiskStore mockDiskStore = mockContext.mock(DiskStore.class, "DiskStore");
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockGatewaySender).getDiskStoreName();
-        will(returnValue("mockDiskStore"));
-        oneOf(mockDiskStore).getName();
-        will(returnValue("testDiskStore"));
-      }
-    });
+    final DiskStore mockDiskStore = mock(DiskStore.class, "DiskStore");
+    final GatewaySender mockGatewaySender = mock(GatewaySender.class, "GatewaySender");
+    when(mockGatewaySender.getDiskStoreName()).thenReturn("mockDiskStore");
+    when(mockDiskStore.getName()).thenReturn("testDiskStore");
 
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-
-    assertFalse(function.isUsingDiskStore(mockGatewaySender, mockDiskStore));
+    assertThat(function.isUsingDiskStore(mockGatewaySender, mockDiskStore)).isFalse();
   }
 
   @Test
   public void testIsGatewaySenderUsingDiskStoreWhenUsingDefaultDiskStores() {
-    final GatewaySender mockGatewaySender = mockContext.mock(GatewaySender.class, "GatewaySender");
-
-    final DiskStore mockDiskStore = mockContext.mock(DiskStore.class, "DiskStore");
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockGatewaySender).getDiskStoreName();
-        will(returnValue(" "));
-        oneOf(mockDiskStore).getName();
-        will(returnValue(DiskStoreDetails.DEFAULT_DISK_STORE_NAME));
-      }
-    });
+    final DiskStore mockDiskStore = mock(DiskStore.class, "DiskStore");
+    final GatewaySender mockGatewaySender = mock(GatewaySender.class, "GatewaySender");
+    when(mockGatewaySender.getDiskStoreName()).thenReturn(" ");
+    when(mockDiskStore.getName()).thenReturn(DiskStoreDetails.DEFAULT_DISK_STORE_NAME);
 
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-
-    assertTrue(function.isUsingDiskStore(mockGatewaySender, mockDiskStore));
+    assertThat(function.isUsingDiskStore(mockGatewaySender, mockDiskStore)).isTrue();
   }
 
   @Test
   public void testSetPdxSerializationDetails() {
     final String diskStoreName = "testDiskStore";
-
-    final DiskStore mockDiskStore = mockContext.mock(DiskStore.class, "DiskStore");
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockCache).getPdxPersistent();
-        will(returnValue(true));
-        oneOf(mockCache).getPdxDiskStore();
-        will(returnValue(diskStoreName));
-        oneOf(mockDiskStore).getName();
-        will(returnValue(diskStoreName));
-      }
-    });
+    final DiskStore mockDiskStore = mock(DiskStore.class, "DiskStore");
+    when(mockCache.getPdxPersistent()).thenReturn(true);
+    when(mockCache.getPdxDiskStore()).thenReturn(diskStoreName);
+    when(mockDiskStore.getName()).thenReturn(diskStoreName);
 
     final DiskStoreDetails diskStoreDetails = new DiskStoreDetails(diskStoreName, "memberOne");
-
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-
     function.setPdxSerializationDetails(mockCache, mockDiskStore, diskStoreDetails);
-
-    assertTrue(diskStoreDetails.isPdxSerializationMetaDataStored());
+    assertThat(diskStoreDetails.isPdxSerializationMetaDataStored()).isTrue();
   }
 
   @Test
   public void testSetPdxSerializationDetailsWhenDiskStoreMismatch() {
-    final DiskStore mockDiskStore = mockContext.mock(DiskStore.class, "DiskStore");
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockCache).getPdxPersistent();
-        will(returnValue(true));
-        oneOf(mockCache).getPdxDiskStore();
-        will(returnValue("mockDiskStore"));
-        oneOf(mockDiskStore).getName();
-        will(returnValue("testDiskStore"));
-      }
-    });
+    final DiskStore mockDiskStore = mock(DiskStore.class, "DiskStore");
+    when(mockCache.getPdxPersistent()).thenReturn(true);
+    when(mockCache.getPdxDiskStore()).thenReturn("mockDiskStore");
+    when(mockDiskStore.getName()).thenReturn("testDiskStore");
 
     final DiskStoreDetails diskStoreDetails = new DiskStoreDetails("testDiskStore", "memberOne");
-
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-
     function.setPdxSerializationDetails(mockCache, mockDiskStore, diskStoreDetails);
-
-    assertFalse(diskStoreDetails.isPdxSerializationMetaDataStored());
+    assertThat(diskStoreDetails.isPdxSerializationMetaDataStored()).isFalse();
   }
 
   @Test
   public void testSetPdxSerializationDetailsWhenPdxIsNotPersistent() {
-    final DiskStore mockDiskStore = mockContext.mock(DiskStore.class, "DiskStore");
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockCache).getPdxPersistent();
-        will(returnValue(false));
-      }
-    });
+    final DiskStore mockDiskStore = mock(DiskStore.class, "DiskStore");
+    when(mockCache.getPdxPersistent()).thenReturn(false);
 
     final DiskStoreDetails diskStoreDetails = new DiskStoreDetails("testDiskStore", "memberOne");
-
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-
     function.setPdxSerializationDetails(mockCache, mockDiskStore, diskStoreDetails);
-
-    assertFalse(diskStoreDetails.isPdxSerializationMetaDataStored());
+    assertThat(diskStoreDetails.isPdxSerializationMetaDataStored()).isFalse();
   }
 
   @Test
   public void testGetAsyncEventQueueDiskStoreName() {
     final String expectedDiskStoreName = "testDiskStore";
-
-    final AsyncEventQueue mockQueue = mockContext.mock(AsyncEventQueue.class, "AsyncEventQueue");
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockQueue).getDiskStoreName();
-        will(returnValue(expectedDiskStoreName));
-      }
-    });
+    final AsyncEventQueue mockQueue = mock(AsyncEventQueue.class, "AsyncEventQueue");
+    when(mockQueue.getDiskStoreName()).thenReturn(expectedDiskStoreName);
 
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-
-    assertEquals(expectedDiskStoreName, function.getDiskStoreName(mockQueue));
+    assertThat(expectedDiskStoreName).isEqualTo(function.getDiskStoreName(mockQueue));
   }
 
   @Test
   public void testGetAsyncEventQueueDiskStoreNameUsingDefaultDiskStore() {
-    final AsyncEventQueue mockQueue = mockContext.mock(AsyncEventQueue.class, "AsyncEventQueue");
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockQueue).getDiskStoreName();
-        will(returnValue(null));
-      }
-    });
+    final AsyncEventQueue mockQueue = mock(AsyncEventQueue.class, "AsyncEventQueue");
+    when(mockQueue.getDiskStoreName()).thenReturn(null);
 
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-
-    assertEquals(DiskStoreDetails.DEFAULT_DISK_STORE_NAME, function.getDiskStoreName(mockQueue));
+    assertThat(DiskStoreDetails.DEFAULT_DISK_STORE_NAME)
+        .isEqualTo(function.getDiskStoreName(mockQueue));
   }
 
   @Test
   public void testIsAsyncEventQueueUsingDiskStore() {
     final String diskStoreName = "testDiskStore";
-
-    final AsyncEventQueue mockQueue = mockContext.mock(AsyncEventQueue.class, "AsyncEventQueue");
-
-    final DiskStore mockDiskStore = mockContext.mock(DiskStore.class, "DiskStore");
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockQueue).getDiskStoreName();
-        will(returnValue(diskStoreName));
-        oneOf(mockQueue).isPersistent();
-        will(returnValue(true));
-        oneOf(mockDiskStore).getName();
-        will(returnValue(diskStoreName));
-      }
-    });
+    final DiskStore mockDiskStore = mock(DiskStore.class, "DiskStore");
+    final AsyncEventQueue mockQueue = mock(AsyncEventQueue.class, "AsyncEventQueue");
+    when(mockQueue.getDiskStoreName()).thenReturn(diskStoreName);
+    when(mockQueue.isPersistent()).thenReturn(true);
+    when(mockDiskStore.getName()).thenReturn(diskStoreName);
 
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-
-    assertTrue(function.isUsingDiskStore(mockQueue, mockDiskStore));
+    assertThat(function.isUsingDiskStore(mockQueue, mockDiskStore)).isTrue();
   }
 
   @Test
   public void testIsAsyncEventQueueUsingDiskStoreWhenDiskStoresMismatch() {
-    final AsyncEventQueue mockQueue = mockContext.mock(AsyncEventQueue.class, "AsyncEventQueue");
-
-    final DiskStore mockDiskStore = mockContext.mock(DiskStore.class, "DiskStore");
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockQueue).getDiskStoreName();
-        will(returnValue("mockDiskStore"));
-        oneOf(mockQueue).isPersistent();
-        will(returnValue(true));
-        oneOf(mockDiskStore).getName();
-        will(returnValue(DiskStoreDetails.DEFAULT_DISK_STORE_NAME));
-      }
-    });
+    final DiskStore mockDiskStore = mock(DiskStore.class, "DiskStore");
+    final AsyncEventQueue mockQueue = mock(AsyncEventQueue.class, "AsyncEventQueue");
+    when(mockQueue.getDiskStoreName()).thenReturn("mockDiskStore");
+    when(mockQueue.isPersistent()).thenReturn(true);
+    when(mockDiskStore.getName()).thenReturn(DiskStoreDetails.DEFAULT_DISK_STORE_NAME);
 
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-
-    assertFalse(function.isUsingDiskStore(mockQueue, mockDiskStore));
+    assertThat(function.isUsingDiskStore(mockQueue, mockDiskStore)).isFalse();
   }
 
   @Test
   public void testIsAsyncEventQueueUsingDiskStoreWhenQueueIsNotPersistent() {
-    final String diskStoreName = "testDiskStore";
-
-    final AsyncEventQueue mockQueue = mockContext.mock(AsyncEventQueue.class, "AsyncEventQueue");
-
-    final DiskStore mockDiskStore = mockContext.mock(DiskStore.class, "DiskStore");
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockQueue).isPersistent();
-        will(returnValue(false));
-      }
-    });
+    final DiskStore mockDiskStore = mock(DiskStore.class, "DiskStore");
+    final AsyncEventQueue mockQueue = mock(AsyncEventQueue.class, "AsyncEventQueue");
+    when(mockQueue.isPersistent()).thenReturn(false);
 
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-
-    assertFalse(function.isUsingDiskStore(mockQueue, mockDiskStore));
+    assertThat(function.isUsingDiskStore(mockQueue, mockDiskStore)).isFalse();
   }
 
   @Test
   public void testIsAsyncEventQueueUsingDiskStoreWhenUsingDefaultDiskStore() {
-    final AsyncEventQueue mockQueue = mockContext.mock(AsyncEventQueue.class, "AsyncEventQueue");
-
-    final DiskStore mockDiskStore = mockContext.mock(DiskStore.class, "DiskStore");
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockQueue).getDiskStoreName();
-        will(returnValue(" "));
-        oneOf(mockQueue).isPersistent();
-        will(returnValue(true));
-        oneOf(mockDiskStore).getName();
-        will(returnValue(DiskStoreDetails.DEFAULT_DISK_STORE_NAME));
-      }
-    });
+    final DiskStore mockDiskStore = mock(DiskStore.class, "DiskStore");
+    final AsyncEventQueue mockQueue = mock(AsyncEventQueue.class, "AsyncEventQueue");
+    when(mockQueue.getDiskStoreName()).thenReturn(" ");
+    when(mockQueue.isPersistent()).thenReturn(true);
+    when(mockDiskStore.getName()).thenReturn(DiskStoreDetails.DEFAULT_DISK_STORE_NAME);
 
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-
-    assertTrue(function.isUsingDiskStore(mockQueue, mockDiskStore));
+    assertThat(function.isUsingDiskStore(mockQueue, mockDiskStore)).isTrue();
   }
 
   @Test
   public void testSetAsyncEventQueueDetails() {
     final String diskStoreName = "testDiskStore";
-
-    final AsyncEventQueue mockQueue1 = mockContext.mock(AsyncEventQueue.class, "AsyncEvenQueue1");
-    final AsyncEventQueue mockQueue2 = mockContext.mock(AsyncEventQueue.class, "AsyncEvenQueue2");
-    final AsyncEventQueue mockQueue3 = mockContext.mock(AsyncEventQueue.class, "AsyncEvenQueue3");
-
-    final DiskStore mockDiskStore = mockContext.mock(DiskStore.class, "DiskStore");
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockCache).getAsyncEventQueues();
-        will(returnValue(CollectionUtils.asSet(mockQueue1, mockQueue2, mockQueue3)));
-        oneOf(mockQueue1).isPersistent();
-        will(returnValue(true));
-        oneOf(mockQueue1).getDiskStoreName();
-        will(returnValue(diskStoreName));
-        oneOf(mockQueue1).getId();
-        will(returnValue("q1"));
-        oneOf(mockQueue2).isPersistent();
-        will(returnValue(true));
-        oneOf(mockQueue2).getDiskStoreName();
-        will(returnValue(null));
-        oneOf(mockQueue3).isPersistent();
-        will(returnValue(false));
-        atLeast(1).of(mockDiskStore).getName();
-        will(returnValue(diskStoreName));
-      }
-    });
+    final DiskStore mockDiskStore = mock(DiskStore.class, "DiskStore");
+    final AsyncEventQueue mockQueue1 = mock(AsyncEventQueue.class, "AsyncEvenQueue1");
+    final AsyncEventQueue mockQueue2 = mock(AsyncEventQueue.class, "AsyncEvenQueue2");
+    final AsyncEventQueue mockQueue3 = mock(AsyncEventQueue.class, "AsyncEvenQueue3");
+    when(mockCache.getAsyncEventQueues())
+        .thenReturn(CollectionUtils.asSet(mockQueue1, mockQueue2, mockQueue3));
+    when(mockQueue1.isPersistent()).thenReturn(true);
+    when(mockQueue1.getDiskStoreName()).thenReturn(diskStoreName);
+    when(mockQueue1.getId()).thenReturn("q1");
+    when(mockQueue2.isPersistent()).thenReturn(true);
+    when(mockQueue2.getDiskStoreName()).thenReturn(null);
+    when(mockQueue3.isPersistent()).thenReturn(false);
+    when(mockDiskStore.getName()).thenReturn(diskStoreName);
 
     final Set<DiskStoreDetails.AsyncEventQueueDetails> expectedAsyncEventQueueDetails =
         CollectionUtils.asSet(createAsyncEventQueueDetails("q1"));
-
     final DiskStoreDetails diskStoreDetails = new DiskStoreDetails(diskStoreName, "memberOne");
-
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-
     function.setAsyncEventQueueDetails(mockCache, mockDiskStore, diskStoreDetails);
-
     assertAsyncEventQueueDetails(expectedAsyncEventQueueDetails, diskStoreDetails);
+    verify(mockDiskStore, atLeastOnce()).getName();
   }
 
   private static class TestResultSender implements ResultSender {
-
-    private final List<Object> results = new LinkedList<>();
-
     private Throwable t;
+    private final List<Object> results = new LinkedList<>();
 
     protected List<Object> getResults() throws Throwable {
       if (t != null) {
         throw t;
       }
+
       return Collections.unmodifiableList(results);
     }
 
@@ -1805,5 +1190,4 @@ public class DescribeDiskStoreFunctionJUnitTest {
       this.t = t;
     }
   }
-
 }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/functions/DescribeDiskStoreFunctionJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/functions/DescribeDiskStoreFunctionJUnitTest.java
@@ -25,12 +25,14 @@ import static org.mockito.Mockito.when;
 import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
 import edu.umd.cs.findbugs.annotations.SuppressWarnings;
+import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -64,7 +66,6 @@ import org.apache.geode.management.internal.cli.exceptions.EntityNotFoundExcepti
  * @see org.junit.Test
  * @since GemFire 7.0
  */
-@SuppressWarnings({"null", "unused"})
 public class DescribeDiskStoreFunctionJUnitTest {
   private InternalCache mockCache;
 
@@ -83,11 +84,12 @@ public class DescribeDiskStoreFunctionJUnitTest {
       final DiskStoreDetails.AsyncEventQueueDetails expectedAsyncEventQueueDetails = CollectionUtils
           .findBy(expectedAsyncEventQueueDetailsSet, asyncEventQueueDetails -> ObjectUtils
               .equals(asyncEventQueueDetails.getId(), actualAsyncEventQueueDetails.getId()));
+
       assertThat(expectedAsyncEventQueueDetails).isNotNull();
       actualCount++;
     }
 
-    assertThat(expectedAsyncEventQueueDetailsSet.size()).isEqualTo(actualCount);
+    assertThat(actualCount).isEqualTo(expectedAsyncEventQueueDetailsSet.size());
   }
 
   private void assertCacheServerDetails(
@@ -103,13 +105,14 @@ public class DescribeDiskStoreFunctionJUnitTest {
                   actualCacheServerDetails.getBindAddress())
                   && ObjectUtils.equals(cacheServerDetails.getPort(),
                       actualCacheServerDetails.getPort()));
+
       assertThat(expectedCacheServerDetails).isNotNull();
-      assertThat(expectedCacheServerDetails.getHostName())
-          .isEqualTo(actualCacheServerDetails.getHostName());
+      assertThat(actualCacheServerDetails.getHostName())
+          .isEqualTo(expectedCacheServerDetails.getHostName());
       actualCount++;
     }
 
-    assertThat(expectedCacheServerDetailsSet.size()).isEqualTo(actualCount);
+    assertThat(actualCount).isEqualTo(expectedCacheServerDetailsSet.size());
   }
 
   private void assertGatewayDetails(
@@ -122,13 +125,14 @@ public class DescribeDiskStoreFunctionJUnitTest {
       DiskStoreDetails.GatewayDetails expectedGatewayDetails =
           CollectionUtils.findBy(expectedGatewayDetailsSet, gatewayDetails -> ObjectUtils
               .equals(gatewayDetails.getId(), actualGatewayDetails.getId()));
+
       assertThat(expectedGatewayDetails).isNotNull();
-      assertThat(expectedGatewayDetails.isPersistent())
-          .isEqualTo(actualGatewayDetails.isPersistent());
+      assertThat(actualGatewayDetails.isPersistent())
+          .isEqualTo(expectedGatewayDetails.isPersistent());
       actualCount++;
     }
 
-    assertThat(expectedGatewayDetailsSet.size()).isEqualTo(actualCount);
+    assertThat(actualCount).isEqualTo(expectedGatewayDetailsSet.size());
   }
 
   private void assertRegionDetails(
@@ -143,15 +147,15 @@ public class DescribeDiskStoreFunctionJUnitTest {
               .equals(regionDetails.getFullPath(), actualRegionDetails.getFullPath()));
 
       assertThat(expectedRegionDetails).isNotNull();
-      assertThat(expectedRegionDetails.getName()).isEqualTo(actualRegionDetails.getName());
-      assertThat(expectedRegionDetails.isOverflowToDisk())
-          .isEqualTo(actualRegionDetails.isOverflowToDisk());
-      assertThat(expectedRegionDetails.isPersistent())
-          .isEqualTo(actualRegionDetails.isPersistent());
+      assertThat(actualRegionDetails.getName()).isEqualTo(expectedRegionDetails.getName());
+      assertThat(actualRegionDetails.isPersistent())
+          .isEqualTo(expectedRegionDetails.isPersistent());
+      assertThat(actualRegionDetails.isOverflowToDisk())
+          .isEqualTo(expectedRegionDetails.isOverflowToDisk());
       actualCount++;
     }
 
-    assertThat(expectedRegionDetailsSet.size()).isEqualTo(actualCount);
+    assertThat(actualCount).isEqualTo(expectedRegionDetailsSet.size());
   }
 
   private DiskStoreDetails.AsyncEventQueueDetails createAsyncEventQueueDetails(final String id) {
@@ -355,7 +359,7 @@ public class DescribeDiskStoreFunctionJUnitTest {
         mock(FunctionContext.class, "testExecute$FunctionContext");
     final DiskStore mockDiskStore =
         createMockDiskStore(diskStoreId, diskStoreName, true, false,
-            75, 8192l, 500, 120l, 10240, createFileArray("/export/disk/backup",
+            75, 8192L, 500, 120L, 10240, createFileArray("/export/disk/backup",
                 "/export/disk/overflow", "/export/disk/persistence"),
             createIntArray(10240, 204800, 4096000), 50, 75);
     final TestResultSender testResultSender = new TestResultSender();
@@ -385,26 +389,26 @@ public class DescribeDiskStoreFunctionJUnitTest {
 
     final List<?> results = testResultSender.getResults();
     assertThat(results).isNotNull();
-    assertThat(1).isEqualTo(results.size());
+    assertThat(results.size()).isEqualTo(1);
 
     final DiskStoreDetails diskStoreDetails = (DiskStoreDetails) results.get(0);
-    assertThat(diskStoreDetails != null).isTrue();
-    assertThat(diskStoreId).isEqualTo(diskStoreDetails.getId());
-    assertThat(diskStoreName).isEqualTo(diskStoreDetails.getName());
-    assertThat(memberId).isEqualTo(diskStoreDetails.getMemberId());
-    assertThat(memberName).isEqualTo(diskStoreDetails.getMemberName());
+    AssertionsForClassTypes.assertThat(diskStoreDetails).isNotNull();
+    assertThat(diskStoreDetails.getId()).isEqualTo(diskStoreId);
+    assertThat(diskStoreDetails.getName()).isEqualTo(diskStoreName);
+    assertThat(diskStoreDetails.getMemberId()).isEqualTo(memberId);
+    assertThat(diskStoreDetails.getMemberName()).isEqualTo(memberName);
     assertThat(diskStoreDetails.getAllowForceCompaction()).isTrue();
     assertThat(diskStoreDetails.getAutoCompact()).isFalse();
-    assertThat(75).isEqualTo(diskStoreDetails.getCompactionThreshold().intValue());
-    assertThat(8192L).isEqualTo(diskStoreDetails.getMaxOplogSize().longValue());
+    assertThat(diskStoreDetails.getCompactionThreshold().intValue()).isEqualTo(75);
+    assertThat(diskStoreDetails.getMaxOplogSize().longValue()).isEqualTo(8192L);
     assertThat(diskStoreDetails.isPdxSerializationMetaDataStored()).isFalse();
-    assertThat(500).isEqualTo(diskStoreDetails.getQueueSize().intValue());
-    assertThat(120L).isEqualTo(diskStoreDetails.getTimeInterval().longValue());
-    assertThat(10240).isEqualTo(diskStoreDetails.getWriteBufferSize().intValue());
-    assertThat(50.0f).isEqualTo(diskStoreDetails.getDiskUsageWarningPercentage());
-    assertThat(75.0f).isEqualTo(diskStoreDetails.getDiskUsageCriticalPercentage());
+    assertThat(diskStoreDetails.getQueueSize().intValue()).isEqualTo(500);
+    assertThat(diskStoreDetails.getTimeInterval().longValue()).isEqualTo(120L);
+    assertThat(diskStoreDetails.getWriteBufferSize().intValue()).isEqualTo(10240);
+    assertThat(diskStoreDetails.getDiskUsageWarningPercentage()).isEqualTo(50.0f);
+    assertThat(diskStoreDetails.getDiskUsageCriticalPercentage()).isEqualTo(75.0f);
 
-    final List<Integer> expectdDiskDirSizes = Arrays.asList(10240, 204800, 4096000);
+    final List<Integer> expectedDiskDirSizes = Arrays.asList(10240, 204800, 4096000);
     final List<String> expectedDiskDirs =
         Arrays.asList(new File("/export/disk/backup").getAbsolutePath(),
             new File("/export/disk/overflow").getAbsolutePath(),
@@ -412,14 +416,14 @@ public class DescribeDiskStoreFunctionJUnitTest {
     int count = 0;
 
     for (final DiskStoreDetails.DiskDirDetails diskDirDetails : diskStoreDetails) {
-      assertThat(expectdDiskDirSizes.contains(diskDirDetails.getSize())).isTrue();
+      assertThat(expectedDiskDirSizes.contains(diskDirDetails.getSize())).isTrue();
       assertThat(expectedDiskDirs.contains(diskDirDetails.getAbsolutePath())).isTrue();
       count++;
     }
 
     verify(mockDiskStore, atLeastOnce()).getName();
     verify(mockDiskStore, atLeastOnce()).getDiskStoreUUID();
-    assertThat(expectedDiskDirs.size()).isEqualTo(count);
+    assertThat(count).isEqualTo(expectedDiskDirs.size());
     assertRegionDetails(expectedRegionDetails, diskStoreDetails);
     assertCacheServerDetails(expectedCacheServerDetails, diskStoreDetails);
     assertGatewayDetails(expectedGatewayDetails, diskStoreDetails);
@@ -529,7 +533,7 @@ public class DescribeDiskStoreFunctionJUnitTest {
     when(mockRegionAttributes.getDiskStoreName()).thenReturn(expectedDiskStoreName);
 
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-    assertThat(expectedDiskStoreName).isEqualTo(function.getDiskStoreName(mockRegion));
+    assertThat(function.getDiskStoreName(mockRegion)).isEqualTo(expectedDiskStoreName);
   }
 
   @Test
@@ -540,8 +544,8 @@ public class DescribeDiskStoreFunctionJUnitTest {
     when(mockRegionAttributes.getDiskStoreName()).thenReturn(null);
 
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-    assertThat(DiskStoreDetails.DEFAULT_DISK_STORE_NAME)
-        .isEqualTo(function.getDiskStoreName(mockRegion));
+    assertThat(function.getDiskStoreName(mockRegion))
+        .isEqualTo(DiskStoreDetails.DEFAULT_DISK_STORE_NAME);
   }
 
   @Test
@@ -801,8 +805,11 @@ public class DescribeDiskStoreFunctionJUnitTest {
     final DiskStore mockDiskStore = mock(DiskStore.class, "DiskStore");
     when(mockDiskStore.getName()).thenReturn(diskStoreName);
 
-    when(mockCache.rootRegions()).thenReturn(
-        CollectionUtils.asSet(mockCompanyRegion, mockPartnersRegion, mockCustomersRegion));
+    Set<Region<?, ?>> mockRootRegions = new HashSet<>();
+    mockRootRegions.add(mockCompanyRegion);
+    mockRootRegions.add(mockPartnersRegion);
+    mockRootRegions.add(mockCustomersRegion);
+    when(mockCache.rootRegions()).thenReturn(mockRootRegions);
     when(mockCompanyRegion.subregions(false)).thenReturn(CollectionUtils
         .asSet(mockContractorsRegion, mockEmployeeRegion, mockProductsRegion, mockServicesRegion));
     when(mockEmployeeRegion.subregions(false)).thenReturn(CollectionUtils.asSet(mockRolesRegion));
@@ -850,7 +857,7 @@ public class DescribeDiskStoreFunctionJUnitTest {
     when(mockClientSubscriptionConfig.getDiskStoreName()).thenReturn(expectedDiskStoreName);
 
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-    assertThat(expectedDiskStoreName).isEqualTo(function.getDiskStoreName(mockCacheServer));
+    assertThat(function.getDiskStoreName(mockCacheServer)).isEqualTo(expectedDiskStoreName);
     verify(mockCacheServer, times(2)).getClientSubscriptionConfig();
   }
 
@@ -863,8 +870,8 @@ public class DescribeDiskStoreFunctionJUnitTest {
     when(mockClientSubscriptionConfig.getDiskStoreName()).thenReturn(null);
 
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-    assertThat(DiskStoreDetails.DEFAULT_DISK_STORE_NAME)
-        .isEqualTo(function.getDiskStoreName(mockCacheServer));
+    assertThat(function.getDiskStoreName(mockCacheServer))
+        .isEqualTo(DiskStoreDetails.DEFAULT_DISK_STORE_NAME);
     verify(mockCacheServer, times(2)).getClientSubscriptionConfig();
   }
 
@@ -967,7 +974,7 @@ public class DescribeDiskStoreFunctionJUnitTest {
     when(mockGatewaySender.getDiskStoreName()).thenReturn(expectedDiskStoreName);
 
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-    assertThat(expectedDiskStoreName).isEqualTo(function.getDiskStoreName(mockGatewaySender));
+    assertThat(function.getDiskStoreName(mockGatewaySender)).isEqualTo(expectedDiskStoreName);
   }
 
   @Test
@@ -976,8 +983,8 @@ public class DescribeDiskStoreFunctionJUnitTest {
     when(mockGatewaySender.getDiskStoreName()).thenReturn(" ");
 
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-    assertThat(DiskStoreDetails.DEFAULT_DISK_STORE_NAME)
-        .isEqualTo(function.getDiskStoreName(mockGatewaySender));
+    assertThat(function.getDiskStoreName(mockGatewaySender))
+        .isEqualTo(DiskStoreDetails.DEFAULT_DISK_STORE_NAME);
   }
 
   @Test
@@ -1077,7 +1084,7 @@ public class DescribeDiskStoreFunctionJUnitTest {
     when(mockQueue.getDiskStoreName()).thenReturn(expectedDiskStoreName);
 
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-    assertThat(expectedDiskStoreName).isEqualTo(function.getDiskStoreName(mockQueue));
+    assertThat(function.getDiskStoreName(mockQueue)).isEqualTo(expectedDiskStoreName);
   }
 
   @Test
@@ -1086,8 +1093,8 @@ public class DescribeDiskStoreFunctionJUnitTest {
     when(mockQueue.getDiskStoreName()).thenReturn(null);
 
     final DescribeDiskStoreFunction function = new DescribeDiskStoreFunction();
-    assertThat(DiskStoreDetails.DEFAULT_DISK_STORE_NAME)
-        .isEqualTo(function.getDiskStoreName(mockQueue));
+    assertThat(function.getDiskStoreName(mockQueue))
+        .isEqualTo(DiskStoreDetails.DEFAULT_DISK_STORE_NAME);
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/functions/ListDiskStoresFunctionJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/functions/ListDiskStoresFunctionJUnitTest.java
@@ -63,11 +63,6 @@ public class ListDiskStoresFunctionJUnitTest {
     mockFunctionContext = mock(FunctionContext.class, "FunctionContext");
   }
 
-  private DiskStoreDetails createDiskStoreDetails(final UUID id, final String name,
-      final String memberName, final String memberId) {
-    return new DiskStoreDetails(id, name, memberId, memberName);
-  }
-
   @Test
   @SuppressWarnings("unchecked")
   public void testExecute() throws Throwable {
@@ -102,17 +97,17 @@ public class ListDiskStoresFunctionJUnitTest {
 
     final List<?> results = testResultSender.getResults();
     assertThat(results).isNotNull();
-    assertThat(1).isEqualTo(results.size());
+    assertThat(results.size()).isEqualTo(1);
 
     final Set<DiskStoreDetails> diskStoreDetails = (Set<DiskStoreDetails>) results.get(0);
     assertThat(diskStoreDetails).isNotNull();
-    assertThat(3).isEqualTo(diskStoreDetails.size());
+    assertThat(diskStoreDetails.size()).isEqualTo(3);
     verify(mockMember, times(3)).getId();
     verify(mockMember, times(3)).getName();
     diskStoreDetails.containsAll(
-        Arrays.asList(createDiskStoreDetails(mockDiskStoreOneId, "ds-backup", memberId, memberName),
-            createDiskStoreDetails(mockDiskStoreTwoId, "ds-overflow", memberId, memberName),
-            createDiskStoreDetails(mockDiskStoreThreeId, "ds-persistence", memberId, memberName)));
+        Arrays.asList(new DiskStoreDetails(mockDiskStoreOneId, "ds-backup", memberId, memberName),
+            new DiskStoreDetails(mockDiskStoreTwoId, "ds-overflow", memberId, memberName),
+            new DiskStoreDetails(mockDiskStoreThreeId, "ds-persistence", memberId, memberName)));
   }
 
   @Test
@@ -144,7 +139,7 @@ public class ListDiskStoresFunctionJUnitTest {
 
     final List<?> results = testResultSender.getResults();
     assertThat(results).isNotNull();
-    assertThat(1).isEqualTo(results.size());
+    assertThat(results.size()).isEqualTo(1);
 
     final Set<DiskStoreDetails> diskStoreDetails = (Set<DiskStoreDetails>) results.get(0);
     assertThat(diskStoreDetails).isNotNull();
@@ -164,7 +159,7 @@ public class ListDiskStoresFunctionJUnitTest {
 
     final List<?> results = testResultSender.getResults();
     assertThat(results).isNotNull();
-    assertThat(1).isEqualTo(results.size());
+    assertThat(results.size()).isEqualTo(1);
 
     final Set<DiskStoreDetails> diskStoreDetails = (Set<DiskStoreDetails>) results.get(0);
     assertThat(diskStoreDetails).isNotNull();

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/functions/ListDiskStoresFunctionJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/functions/ListDiskStoresFunctionJUnitTest.java
@@ -14,11 +14,13 @@
  */
 package org.apache.geode.management.internal.cli.functions;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -27,16 +29,12 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
-import org.jmock.Expectations;
-import org.jmock.Mockery;
-import org.jmock.lib.concurrent.Synchroniser;
-import org.jmock.lib.legacy.ClassImposteriser;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.CacheClosedException;
+import org.apache.geode.cache.DiskStore;
 import org.apache.geode.cache.execute.FunctionContext;
 import org.apache.geode.cache.execute.ResultSender;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -52,37 +50,17 @@ import org.apache.geode.management.internal.cli.domain.DiskStoreDetails;
  * @see org.apache.geode.internal.cache.DiskStoreImpl
  * @see org.apache.geode.management.internal.cli.domain.DiskStoreDetails
  * @see org.apache.geode.management.internal.cli.functions.ListDiskStoresFunction
- * @see org.jmock.Expectations
- * @see org.jmock.Mockery
- * @see org.junit.Assert
  * @see org.junit.Test
  * @since GemFire 7.0
  */
 public class ListDiskStoresFunctionJUnitTest {
-
-  private Mockery mockContext;
   private InternalCache mockCache;
   private FunctionContext mockFunctionContext;
 
-
-
   @Before
   public void setup() {
-    mockContext = new Mockery() {
-      {
-        setImposteriser(ClassImposteriser.INSTANCE);
-        setThreadingPolicy(new Synchroniser());
-      }
-    };
-
-    mockCache = mockContext.mock(InternalCache.class, "Cache");
-    mockFunctionContext = mockContext.mock(FunctionContext.class, "FunctionContext");
-  }
-
-  @After
-  public void tearDown() {
-    mockContext.assertIsSatisfied();
-    mockContext = null;
+    mockCache = mock(InternalCache.class, "Cache");
+    mockFunctionContext = mock(FunctionContext.class, "FunctionContext");
   }
 
   private DiskStoreDetails createDiskStoreDetails(final UUID id, final String name,
@@ -93,210 +71,127 @@ public class ListDiskStoresFunctionJUnitTest {
   @Test
   @SuppressWarnings("unchecked")
   public void testExecute() throws Throwable {
+    final String memberId = "mockMemberId";
+    final String memberName = "mockMemberName";
     final UUID mockDiskStoreOneId = UUID.randomUUID();
     final UUID mockDiskStoreTwoId = UUID.randomUUID();
     final UUID mockDiskStoreThreeId = UUID.randomUUID();
-
-    final String memberId = "mockMemberId";
-    final String memberName = "mockMemberName";
-
+    final DiskStoreImpl mockDiskStoreOne = mock(DiskStoreImpl.class, "DiskStoreOne");
+    final DiskStoreImpl mockDiskStoreTwo = mock(DiskStoreImpl.class, "DiskStoreTwo");
+    final DiskStoreImpl mockDiskStoreThree = mock(DiskStoreImpl.class, "DiskStoreThree");
     final InternalDistributedMember mockMember =
-        mockContext.mock(InternalDistributedMember.class, "DistributedMember");
-
-    final DiskStoreImpl mockDiskStoreOne = mockContext.mock(DiskStoreImpl.class, "DiskStoreOne");
-    final DiskStoreImpl mockDiskStoreTwo = mockContext.mock(DiskStoreImpl.class, "DiskStoreTwo");
-    final DiskStoreImpl mockDiskStoreThree =
-        mockContext.mock(DiskStoreImpl.class, "DiskStoreThree");
-
-    final Collection<DiskStoreImpl> mockDiskStores = new ArrayList<DiskStoreImpl>();
-
-    mockDiskStores.add(mockDiskStoreOne);
-    mockDiskStores.add(mockDiskStoreTwo);
-    mockDiskStores.add(mockDiskStoreThree);
-
+        mock(InternalDistributedMember.class, "DistributedMember");
+    final Collection<DiskStore> mockDiskStores =
+        Arrays.asList(mockDiskStoreOne, mockDiskStoreTwo, mockDiskStoreThree);
     final TestResultSender testResultSender = new TestResultSender();
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockCache).getMyId();
-        will(returnValue(mockMember));
-        oneOf(mockCache).listDiskStoresIncludingRegionOwned();
-        will(returnValue(mockDiskStores));
-        exactly(3).of(mockMember).getId();
-        will(returnValue(memberId));
-        exactly(3).of(mockMember).getName();
-        will(returnValue(memberName));
-        oneOf(mockDiskStoreOne).getDiskStoreUUID();
-        will(returnValue(mockDiskStoreOneId));
-        oneOf(mockDiskStoreOne).getName();
-        will(returnValue("ds-backup"));
-        oneOf(mockDiskStoreTwo).getDiskStoreUUID();
-        will(returnValue(mockDiskStoreTwoId));
-        oneOf(mockDiskStoreTwo).getName();
-        will(returnValue("ds-overflow"));
-        oneOf(mockDiskStoreThree).getDiskStoreUUID();
-        will(returnValue(mockDiskStoreThreeId));
-        oneOf(mockDiskStoreThree).getName();
-        will(returnValue("ds-persistence"));
-        oneOf(mockFunctionContext).getCache();
-        will(returnValue(mockCache));
-        oneOf(mockFunctionContext).getResultSender();
-        will(returnValue(testResultSender));
-      }
-    });
+    when(mockCache.getMyId()).thenReturn(mockMember);
+    when(mockCache.listDiskStoresIncludingRegionOwned()).thenReturn(mockDiskStores);
+    when(mockMember.getId()).thenReturn(memberId);
+    when(mockMember.getName()).thenReturn(memberName);
+    when(mockDiskStoreOne.getDiskStoreUUID()).thenReturn(mockDiskStoreOneId);
+    when(mockDiskStoreOne.getName()).thenReturn("ds-backup");
+    when(mockDiskStoreTwo.getDiskStoreUUID()).thenReturn(mockDiskStoreTwoId);
+    when(mockDiskStoreTwo.getName()).thenReturn("ds-overflow");
+    when(mockDiskStoreThree.getDiskStoreUUID()).thenReturn(mockDiskStoreThreeId);
+    when(mockDiskStoreThree.getName()).thenReturn("ds-persistence");
+    when(mockFunctionContext.getCache()).thenReturn(mockCache);
+    when(mockFunctionContext.getResultSender()).thenReturn(testResultSender);
 
     final ListDiskStoresFunction function = new ListDiskStoresFunction();
-
     function.execute(mockFunctionContext);
 
     final List<?> results = testResultSender.getResults();
-
-    assertNotNull(results);
-    assertEquals(1, results.size());
+    assertThat(results).isNotNull();
+    assertThat(1).isEqualTo(results.size());
 
     final Set<DiskStoreDetails> diskStoreDetails = (Set<DiskStoreDetails>) results.get(0);
-
-    assertNotNull(diskStoreDetails);
-    assertEquals(3, diskStoreDetails.size());
+    assertThat(diskStoreDetails).isNotNull();
+    assertThat(3).isEqualTo(diskStoreDetails.size());
+    verify(mockMember, times(3)).getId();
+    verify(mockMember, times(3)).getName();
     diskStoreDetails.containsAll(
         Arrays.asList(createDiskStoreDetails(mockDiskStoreOneId, "ds-backup", memberId, memberName),
             createDiskStoreDetails(mockDiskStoreTwoId, "ds-overflow", memberId, memberName),
             createDiskStoreDetails(mockDiskStoreThreeId, "ds-persistence", memberId, memberName)));
   }
 
-  @Test(expected = CacheClosedException.class)
-  public void testExecuteOnMemberWithNoCache() throws Throwable {
-    final FunctionContext mockFunctionContext =
-        mockContext.mock(FunctionContext.class, "MockFunctionContext");
-
+  @Test
+  public void testExecuteOnMemberWithNoCache() {
     final ListDiskStoresFunction testListDiskStoresFunction = new ListDiskStoresFunction();
-
     final TestResultSender testResultSender = new TestResultSender();
 
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockFunctionContext).getCache();
-        will(throwException(new CacheClosedException("Expected")));
-        oneOf(mockFunctionContext).getResultSender();
-        will(returnValue(testResultSender));
-      }
-    });
-
+    when(mockFunctionContext.getCache())
+        .thenThrow(new CacheClosedException("Mocked CacheClosedException"));
+    when(mockFunctionContext.getResultSender()).thenReturn(testResultSender);
     testListDiskStoresFunction.execute(mockFunctionContext);
-
-    try {
-      testResultSender.getResults();
-    } catch (CacheClosedException expected) {
-      assertEquals("Expected", expected.getMessage());
-      throw expected;
-    }
+    assertThatThrownBy(testResultSender::getResults).isInstanceOf(CacheClosedException.class)
+        .hasMessage("Mocked CacheClosedException");
   }
 
   @Test
   @SuppressWarnings("unchecked")
   public void testExecuteOnMemberHavingNoDiskStores() throws Throwable {
     final InternalDistributedMember mockMember =
-        mockContext.mock(InternalDistributedMember.class, "DistributedMember");
-
+        mock(InternalDistributedMember.class, "DistributedMember");
     final TestResultSender testResultSender = new TestResultSender();
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockCache).getMyId();
-        will(returnValue(mockMember));
-        oneOf(mockCache).listDiskStoresIncludingRegionOwned();
-        will(returnValue(Collections.emptyList()));
-        oneOf(mockFunctionContext).getCache();
-        will(returnValue(mockCache));
-        oneOf(mockFunctionContext).getResultSender();
-        will(returnValue(testResultSender));
-      }
-    });
+    when(mockCache.getMyId()).thenReturn(mockMember);
+    when(mockCache.listDiskStoresIncludingRegionOwned()).thenReturn(Collections.emptyList());
+    when(mockFunctionContext.getCache()).thenReturn(mockCache);
+    when(mockFunctionContext.getResultSender()).thenReturn(testResultSender);
 
     final ListDiskStoresFunction function = new ListDiskStoresFunction();
-
     function.execute(mockFunctionContext);
 
     final List<?> results = testResultSender.getResults();
-
-    assertNotNull(results);
-    assertEquals(1, results.size());
+    assertThat(results).isNotNull();
+    assertThat(1).isEqualTo(results.size());
 
     final Set<DiskStoreDetails> diskStoreDetails = (Set<DiskStoreDetails>) results.get(0);
-
-    assertNotNull(diskStoreDetails);
-    assertTrue(diskStoreDetails.isEmpty());
+    assertThat(diskStoreDetails).isNotNull();
+    assertThat(diskStoreDetails.isEmpty()).isTrue();
   }
 
   @Test
   @SuppressWarnings("unchecked")
   public void testExecuteOnMemberWithANonGemFireCache() throws Throwable {
     final TestResultSender testResultSender = new TestResultSender();
-
-    final Cache mockNonGemCache = mockContext.mock(Cache.class, "NonGemCache");
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockFunctionContext).getCache();
-        will(returnValue(mockNonGemCache));
-        oneOf(mockFunctionContext).getResultSender();
-        will(returnValue(testResultSender));
-      }
-    });
+    final Cache mockNonGemCache = mock(Cache.class, "NonGemCache");
+    when(mockFunctionContext.getCache()).thenReturn(mockNonGemCache);
+    when(mockFunctionContext.getResultSender()).thenReturn(testResultSender);
 
     final ListDiskStoresFunction function = new ListDiskStoresFunction();
-
     function.execute(mockFunctionContext);
 
     final List<?> results = testResultSender.getResults();
-
-    assertNotNull(results);
-    assertEquals(1, results.size());
+    assertThat(results).isNotNull();
+    assertThat(1).isEqualTo(results.size());
 
     final Set<DiskStoreDetails> diskStoreDetails = (Set<DiskStoreDetails>) results.get(0);
-
-    assertNotNull(diskStoreDetails);
-    assertTrue(diskStoreDetails.isEmpty());
+    assertThat(diskStoreDetails).isNotNull();
+    assertThat(diskStoreDetails.isEmpty()).isTrue();
   }
 
-  @Test(expected = RuntimeException.class)
-  public void testExecuteThrowsRuntimeException() throws Throwable {
+  @Test
+  public void testExecuteThrowsRuntimeException() {
     final InternalDistributedMember mockMember =
-        mockContext.mock(InternalDistributedMember.class, "DistributedMember");
-
+        mock(InternalDistributedMember.class, "DistributedMember");
     final TestResultSender testResultSender = new TestResultSender();
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockCache).getMyId();
-        will(returnValue(mockMember));
-        oneOf(mockCache).listDiskStoresIncludingRegionOwned();
-        will(throwException(new RuntimeException("expected")));
-        oneOf(mockFunctionContext).getCache();
-        will(returnValue(mockCache));
-        oneOf(mockFunctionContext).getResultSender();
-        will(returnValue(testResultSender));
-      }
-    });
+    when(mockCache.getMyId()).thenReturn(mockMember);
+    when(mockCache.listDiskStoresIncludingRegionOwned())
+        .thenThrow(new RuntimeException("Mock RuntimeException"));
+    when(mockFunctionContext.getCache()).thenReturn(mockCache);
+    when(mockFunctionContext.getResultSender()).thenReturn(testResultSender);
 
     final ListDiskStoresFunction function = new ListDiskStoresFunction();
-
     function.execute(mockFunctionContext);
-
-    try {
-      testResultSender.getResults();
-    } catch (Throwable throwable) {
-      assertTrue(throwable instanceof RuntimeException);
-      assertEquals("expected", throwable.getMessage());
-      throw throwable;
-    }
+    assertThatThrownBy(testResultSender::getResults).isInstanceOf(RuntimeException.class)
+        .hasMessage("Mock RuntimeException");
   }
 
   private static class TestResultSender implements ResultSender {
-
-    private final List<Object> results = new LinkedList<Object>();
-
     private Throwable t;
+    private final List<Object> results = new LinkedList<>();
+
 
     protected List<Object> getResults() throws Throwable {
       if (t != null) {
@@ -320,5 +215,4 @@ public class ListDiskStoresFunctionJUnitTest {
       this.t = t;
     }
   }
-
 }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/functions/ListIndexFunctionJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/functions/ListIndexFunctionJUnitTest.java
@@ -106,6 +106,7 @@ public class ListIndexFunctionJUnitTest {
 
   private void assertIndexDetailsEquals(final IndexDetails actualIndexDetails,
       final IndexDetails expectedIndexDetails) {
+    assertThat(actualIndexDetails).isNotNull();
     assertThat(actualIndexDetails.getFromClause()).isEqualTo(expectedIndexDetails.getFromClause());
     assertThat(actualIndexDetails.getIndexedExpression())
         .isEqualTo(expectedIndexDetails.getIndexedExpression());
@@ -227,7 +228,6 @@ public class ListIndexFunctionJUnitTest {
     for (final IndexDetails expectedIndexDetails : expectedIndexDetailsSet) {
       final IndexDetails actualIndexDetails = CollectionUtils.findBy(actualIndexDetailsSet,
           indexDetails -> ObjectUtils.equals(expectedIndexDetails, indexDetails));
-      assertThat(actualIndexDetails).isNotNull();
       assertIndexDetailsEquals(actualIndexDetails, expectedIndexDetails);
     }
   }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/functions/ListIndexFunctionJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/functions/ListIndexFunctionJUnitTest.java
@@ -84,41 +84,41 @@ public class ListIndexFunctionJUnitTest {
     when(mockFunctionContext.getResultSender()).thenReturn(testResultSender);
   }
 
-  private void assertIndexDetailsEquals(final IndexDetails expectedIndexDetails,
-      final IndexDetails actualIndexDetails) {
-    assertThat(expectedIndexDetails.getFromClause()).isEqualTo(actualIndexDetails.getFromClause());
-    assertThat(expectedIndexDetails.getIndexedExpression())
-        .isEqualTo(actualIndexDetails.getIndexedExpression());
-    assertThat(expectedIndexDetails.getIndexName()).isEqualTo(actualIndexDetails.getIndexName());
-    assertIndexStatisticsDetailsEquals(expectedIndexDetails.getIndexStatisticsDetails(),
-        actualIndexDetails.getIndexStatisticsDetails());
-    assertThat(expectedIndexDetails.getIndexType()).isEqualTo(actualIndexDetails.getIndexType());
-    assertThat(expectedIndexDetails.getMemberId()).isEqualTo(actualIndexDetails.getMemberId());
-    assertThat(expectedIndexDetails.getMemberName()).isEqualTo(actualIndexDetails.getMemberName());
-    assertThat(expectedIndexDetails.getProjectionAttributes())
-        .isEqualTo(actualIndexDetails.getProjectionAttributes());
-    assertThat(expectedIndexDetails.getRegionName()).isEqualTo(actualIndexDetails.getRegionName());
-    assertThat(expectedIndexDetails.getRegionPath()).isEqualTo(actualIndexDetails.getRegionPath());
-  }
-
   private void assertIndexStatisticsDetailsEquals(
-      final IndexStatisticsDetails expectedIndexStatisticsDetails,
-      final IndexStatisticsDetails actualIndexStatisticsDetails) {
+      final IndexStatisticsDetails actualIndexStatisticsDetails,
+      final IndexStatisticsDetails expectedIndexStatisticsDetails) {
     if (expectedIndexStatisticsDetails != null) {
       assertThat(actualIndexStatisticsDetails).isNotNull();
-      assertThat(expectedIndexStatisticsDetails.getNumberOfKeys())
-          .isEqualTo(actualIndexStatisticsDetails.getNumberOfKeys());
-      assertThat(expectedIndexStatisticsDetails.getNumberOfUpdates())
-          .isEqualTo(actualIndexStatisticsDetails.getNumberOfUpdates());
-      assertThat(expectedIndexStatisticsDetails.getNumberOfValues())
-          .isEqualTo(actualIndexStatisticsDetails.getNumberOfValues());
-      assertThat(expectedIndexStatisticsDetails.getTotalUpdateTime())
-          .isEqualTo(actualIndexStatisticsDetails.getTotalUpdateTime());
-      assertThat(expectedIndexStatisticsDetails.getTotalUses())
-          .isEqualTo(actualIndexStatisticsDetails.getTotalUses());
+      assertThat(actualIndexStatisticsDetails.getNumberOfKeys())
+          .isEqualTo(expectedIndexStatisticsDetails.getNumberOfKeys());
+      assertThat(actualIndexStatisticsDetails.getNumberOfUpdates())
+          .isEqualTo(expectedIndexStatisticsDetails.getNumberOfUpdates());
+      assertThat(actualIndexStatisticsDetails.getNumberOfValues())
+          .isEqualTo(expectedIndexStatisticsDetails.getNumberOfValues());
+      assertThat(actualIndexStatisticsDetails.getTotalUpdateTime())
+          .isEqualTo(expectedIndexStatisticsDetails.getTotalUpdateTime());
+      assertThat(actualIndexStatisticsDetails.getTotalUses())
+          .isEqualTo(expectedIndexStatisticsDetails.getTotalUses());
     } else {
       assertThat(actualIndexStatisticsDetails).isNull();
     }
+  }
+
+  private void assertIndexDetailsEquals(final IndexDetails actualIndexDetails,
+      final IndexDetails expectedIndexDetails) {
+    assertThat(actualIndexDetails.getFromClause()).isEqualTo(expectedIndexDetails.getFromClause());
+    assertThat(actualIndexDetails.getIndexedExpression())
+        .isEqualTo(expectedIndexDetails.getIndexedExpression());
+    assertThat(actualIndexDetails.getIndexName()).isEqualTo(expectedIndexDetails.getIndexName());
+    assertThat(actualIndexDetails.getIndexType()).isEqualTo(expectedIndexDetails.getIndexType());
+    assertThat(actualIndexDetails.getMemberId()).isEqualTo(expectedIndexDetails.getMemberId());
+    assertThat(actualIndexDetails.getMemberName()).isEqualTo(expectedIndexDetails.getMemberName());
+    assertThat(actualIndexDetails.getProjectionAttributes())
+        .isEqualTo(expectedIndexDetails.getProjectionAttributes());
+    assertThat(actualIndexDetails.getRegionName()).isEqualTo(expectedIndexDetails.getRegionName());
+    assertThat(actualIndexDetails.getRegionPath()).isEqualTo(expectedIndexDetails.getRegionPath());
+    assertIndexStatisticsDetailsEquals(actualIndexDetails.getIndexStatisticsDetails(),
+        expectedIndexDetails.getIndexStatisticsDetails());
   }
 
   private IndexDetails createIndexDetails(final String regionPath, final String indexName,
@@ -218,17 +218,17 @@ public class ListIndexFunctionJUnitTest {
 
     final List<?> results = testResultSender.getResults();
     assertThat(results).isNotNull();
-    assertThat(1).isEqualTo(results.size());
+    assertThat(results.size()).isEqualTo(1);
 
     final Set<IndexDetails> actualIndexDetailsSet = (Set<IndexDetails>) results.get(0);
     assertThat(actualIndexDetailsSet).isNotNull();
-    assertThat(expectedIndexDetailsSet.size()).isEqualTo(actualIndexDetailsSet.size());
+    assertThat(actualIndexDetailsSet.size()).isEqualTo(expectedIndexDetailsSet.size());
 
     for (final IndexDetails expectedIndexDetails : expectedIndexDetailsSet) {
       final IndexDetails actualIndexDetails = CollectionUtils.findBy(actualIndexDetailsSet,
           indexDetails -> ObjectUtils.equals(expectedIndexDetails, indexDetails));
       assertThat(actualIndexDetails).isNotNull();
-      assertIndexDetailsEquals(expectedIndexDetails, actualIndexDetails);
+      assertIndexDetailsEquals(actualIndexDetails, expectedIndexDetails);
     }
   }
 
@@ -244,7 +244,7 @@ public class ListIndexFunctionJUnitTest {
 
     final List<?> results = testResultSender.getResults();
     assertThat(results).isNotNull();
-    assertThat(1).isEqualTo(results.size());
+    assertThat(results.size()).isEqualTo(1);
 
     final Set<IndexDetails> actualIndexDetailsSet = (Set<IndexDetails>) results.get(0);
     assertThat(actualIndexDetailsSet).isNotNull();

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/functions/ListIndexFunctionJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/functions/ListIndexFunctionJUnitTest.java
@@ -14,10 +14,10 @@
  */
 package org.apache.geode.management.internal.cli.functions;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -27,11 +27,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.jmock.Expectations;
-import org.jmock.Mockery;
-import org.jmock.lib.concurrent.Synchroniser;
-import org.jmock.lib.legacy.ClassImposteriser;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -45,7 +40,6 @@ import org.apache.geode.cache.query.IndexType;
 import org.apache.geode.cache.query.QueryService;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.DistributedSystem;
-import org.apache.geode.internal.lang.Filter;
 import org.apache.geode.internal.lang.ObjectUtils;
 import org.apache.geode.internal.util.CollectionUtils;
 import org.apache.geode.management.internal.cli.domain.IndexDetails;
@@ -58,83 +52,83 @@ import org.apache.geode.management.internal.cli.domain.IndexDetails.IndexStatist
  * </p>
  *
  * @see org.apache.geode.management.internal.cli.functions.ListIndexFunction
- * @see org.jmock.Expectations
- * @see org.jmock.Mockery
- * @see org.jmock.lib.legacy.ClassImposteriser
- * @see org.junit.Assert
  * @see org.junit.Test
  * @since GemFire 7.0
  */
 public class ListIndexFunctionJUnitTest {
-
-  private Mockery mockContext;
-  private AtomicLong mockCounter;
+  private AtomicLong counter;
+  private QueryService mockQueryService;
+  private TestResultSender testResultSender;
+  private FunctionContext mockFunctionContext;
+  private final String mockMemberId = "mockMemberId";
+  private final String mockMemberName = "mockMemberName";
 
   @Before
   public void setup() {
-    mockContext = new Mockery() {
-      {
-        setImposteriser(ClassImposteriser.INSTANCE);
-        setThreadingPolicy(new Synchroniser());
-      }
-    };
-    mockCounter = new AtomicLong(0l);
-  }
+    counter = new AtomicLong(0L);
+    testResultSender = new TestResultSender();
+    mockQueryService = mock(QueryService.class, "QueryService");
+    mockFunctionContext = mock(FunctionContext.class, "FunctionContext");
 
-  @After
-  public void tearDown() {
-    mockContext.assertIsSatisfied();
-    mockContext = null;
+    final Cache mockCache = mock(Cache.class, "Cache");
+    final DistributedSystem mockDistributedSystem =
+        mock(DistributedSystem.class, "DistributedSystem");
+    final DistributedMember mockDistributedMember =
+        mock(DistributedMember.class, "DistributedMember");
+    when(mockCache.getQueryService()).thenReturn(mockQueryService);
+    when(mockCache.getDistributedSystem()).thenReturn(mockDistributedSystem);
+    when(mockDistributedSystem.getDistributedMember()).thenReturn(mockDistributedMember);
+    when(mockDistributedMember.getId()).thenReturn(mockMemberId);
+    when(mockDistributedMember.getName()).thenReturn(mockMemberName);
+    when(mockFunctionContext.getCache()).thenReturn(mockCache);
+    when(mockFunctionContext.getResultSender()).thenReturn(testResultSender);
   }
 
   private void assertIndexDetailsEquals(final IndexDetails expectedIndexDetails,
       final IndexDetails actualIndexDetails) {
-    assertEquals(expectedIndexDetails.getFromClause(), actualIndexDetails.getFromClause());
-    assertEquals(expectedIndexDetails.getIndexedExpression(),
-        actualIndexDetails.getIndexedExpression());
-    assertEquals(expectedIndexDetails.getIndexName(), actualIndexDetails.getIndexName());
+    assertThat(expectedIndexDetails.getFromClause()).isEqualTo(actualIndexDetails.getFromClause());
+    assertThat(expectedIndexDetails.getIndexedExpression())
+        .isEqualTo(actualIndexDetails.getIndexedExpression());
+    assertThat(expectedIndexDetails.getIndexName()).isEqualTo(actualIndexDetails.getIndexName());
     assertIndexStatisticsDetailsEquals(expectedIndexDetails.getIndexStatisticsDetails(),
         actualIndexDetails.getIndexStatisticsDetails());
-    assertEquals(expectedIndexDetails.getIndexType(), actualIndexDetails.getIndexType());
-    assertEquals(expectedIndexDetails.getMemberId(), actualIndexDetails.getMemberId());
-    assertEquals(expectedIndexDetails.getMemberName(), actualIndexDetails.getMemberName());
-    assertEquals(expectedIndexDetails.getProjectionAttributes(),
-        actualIndexDetails.getProjectionAttributes());
-    assertEquals(expectedIndexDetails.getRegionName(), actualIndexDetails.getRegionName());
-    assertEquals(expectedIndexDetails.getRegionPath(), actualIndexDetails.getRegionPath());
+    assertThat(expectedIndexDetails.getIndexType()).isEqualTo(actualIndexDetails.getIndexType());
+    assertThat(expectedIndexDetails.getMemberId()).isEqualTo(actualIndexDetails.getMemberId());
+    assertThat(expectedIndexDetails.getMemberName()).isEqualTo(actualIndexDetails.getMemberName());
+    assertThat(expectedIndexDetails.getProjectionAttributes())
+        .isEqualTo(actualIndexDetails.getProjectionAttributes());
+    assertThat(expectedIndexDetails.getRegionName()).isEqualTo(actualIndexDetails.getRegionName());
+    assertThat(expectedIndexDetails.getRegionPath()).isEqualTo(actualIndexDetails.getRegionPath());
   }
 
   private void assertIndexStatisticsDetailsEquals(
       final IndexStatisticsDetails expectedIndexStatisticsDetails,
       final IndexStatisticsDetails actualIndexStatisticsDetails) {
     if (expectedIndexStatisticsDetails != null) {
-      assertNotNull(actualIndexStatisticsDetails);
-      assertEquals(expectedIndexStatisticsDetails.getNumberOfKeys(),
-          actualIndexStatisticsDetails.getNumberOfKeys());
-      assertEquals(expectedIndexStatisticsDetails.getNumberOfUpdates(),
-          actualIndexStatisticsDetails.getNumberOfUpdates());
-      assertEquals(expectedIndexStatisticsDetails.getNumberOfValues(),
-          actualIndexStatisticsDetails.getNumberOfValues());
-      assertEquals(expectedIndexStatisticsDetails.getTotalUpdateTime(),
-          actualIndexStatisticsDetails.getTotalUpdateTime());
-      assertEquals(expectedIndexStatisticsDetails.getTotalUses(),
-          actualIndexStatisticsDetails.getTotalUses());
-
+      assertThat(actualIndexStatisticsDetails).isNotNull();
+      assertThat(expectedIndexStatisticsDetails.getNumberOfKeys())
+          .isEqualTo(actualIndexStatisticsDetails.getNumberOfKeys());
+      assertThat(expectedIndexStatisticsDetails.getNumberOfUpdates())
+          .isEqualTo(actualIndexStatisticsDetails.getNumberOfUpdates());
+      assertThat(expectedIndexStatisticsDetails.getNumberOfValues())
+          .isEqualTo(actualIndexStatisticsDetails.getNumberOfValues());
+      assertThat(expectedIndexStatisticsDetails.getTotalUpdateTime())
+          .isEqualTo(actualIndexStatisticsDetails.getTotalUpdateTime());
+      assertThat(expectedIndexStatisticsDetails.getTotalUses())
+          .isEqualTo(actualIndexStatisticsDetails.getTotalUses());
     } else {
-      assertNull(actualIndexStatisticsDetails);
+      assertThat(actualIndexStatisticsDetails).isNull();
     }
   }
 
-  private IndexDetails createIndexDetails(final String memberId, final String regionPath,
-      final String indexName, final IndexType indexType, final String fromClause,
-      final String indexedExpression, final String memberName, final String projectionAttributes,
-      final String regionName) {
-    final IndexDetails indexDetails = new IndexDetails(memberId, regionPath, indexName);
-
+  private IndexDetails createIndexDetails(final String regionPath, final String indexName,
+      final IndexType indexType, final String fromClause, final String indexedExpression,
+      final String projectionAttributes, final String regionName) {
+    final IndexDetails indexDetails = new IndexDetails(mockMemberId, regionPath, indexName);
     indexDetails.setFromClause(fromClause);
     indexDetails.setIndexedExpression(indexedExpression);
     indexDetails.setIndexType(indexType);
-    indexDetails.setMemberName(memberName);
+    indexDetails.setMemberName(mockMemberName);
     indexDetails.setProjectionAttributes(projectionAttributes);
     indexDetails.setRegionName(regionName);
 
@@ -145,7 +139,6 @@ public class ListIndexFunctionJUnitTest {
       final Long numberOfUpdates, final Long numberOfValues, final Long totalUpdateTime,
       final Long totalUses) {
     final IndexStatisticsDetails indexStatisticsDetails = new IndexStatisticsDetails();
-
     indexStatisticsDetails.setNumberOfKeys(numberOfKeys);
     indexStatisticsDetails.setNumberOfUpdates(numberOfUpdates);
     indexStatisticsDetails.setNumberOfValues(numberOfValues);
@@ -155,62 +148,40 @@ public class ListIndexFunctionJUnitTest {
     return indexStatisticsDetails;
   }
 
+  @SuppressWarnings("unchecked")
   private Index createMockIndex(final IndexDetails indexDetails) {
-    final Index mockIndex = mockContext.mock(Index.class,
-        "Index " + indexDetails.getIndexName() + " " + mockCounter.getAndIncrement());
+    final Region mockRegion =
+        mock(Region.class, "Region " + indexDetails.getRegionPath() + " " + counter
+            .getAndIncrement());
+    when(mockRegion.getName()).thenReturn(indexDetails.getRegionName());
+    when(mockRegion.getFullPath()).thenReturn(indexDetails.getRegionPath());
 
-    final Region mockRegion = mockContext.mock(Region.class,
-        "Region " + indexDetails.getRegionPath() + " " + mockCounter.getAndIncrement());
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockIndex).getFromClause();
-        will(returnValue(indexDetails.getFromClause()));
-        oneOf(mockIndex).getIndexedExpression();
-        will(returnValue(indexDetails.getIndexedExpression()));
-        oneOf(mockIndex).getName();
-        will(returnValue(indexDetails.getIndexName()));
-        oneOf(mockIndex).getProjectionAttributes();
-        will(returnValue(indexDetails.getProjectionAttributes()));
-        exactly(2).of(mockIndex).getRegion();
-        will(returnValue(mockRegion));
-        oneOf(mockIndex).getType();
-        will(returnValue(indexDetails.getIndexType()));
-        oneOf(mockRegion).getName();
-        will(returnValue(indexDetails.getRegionName()));
-        oneOf(mockRegion).getFullPath();
-        will(returnValue(indexDetails.getRegionPath()));
-      }
-    });
+    final Index mockIndex = mock(Index.class, "Index " + indexDetails.getIndexName() + " " + counter
+        .getAndIncrement());
+    when(mockIndex.getRegion()).thenReturn(mockRegion);
+    when(mockIndex.getType()).thenReturn(indexDetails.getIndexType());
+    when(mockIndex.getName()).thenReturn(indexDetails.getIndexName());
+    when(mockIndex.getFromClause()).thenReturn(indexDetails.getFromClause());
+    when(mockIndex.getIndexedExpression()).thenReturn(indexDetails.getIndexedExpression());
+    when(mockIndex.getProjectionAttributes()).thenReturn(indexDetails.getProjectionAttributes());
 
     if (indexDetails.getIndexStatisticsDetails() != null) {
-      final IndexStatistics mockIndexStatistics = mockContext.mock(IndexStatistics.class,
-          "IndexStatistics " + indexDetails.getIndexName() + " " + mockCounter.getAndIncrement());
-
-      mockContext.checking(new Expectations() {
-        {
-          exactly(2).of(mockIndex).getStatistics();
-          will(returnValue(mockIndexStatistics));
-          oneOf(mockIndexStatistics).getNumUpdates();
-          will(returnValue(indexDetails.getIndexStatisticsDetails().getNumberOfUpdates()));
-          oneOf(mockIndexStatistics).getNumberOfKeys();
-          will(returnValue(indexDetails.getIndexStatisticsDetails().getNumberOfKeys()));
-          oneOf(mockIndexStatistics).getNumberOfValues();
-          will(returnValue(indexDetails.getIndexStatisticsDetails().getNumberOfValues()));
-          oneOf(mockIndexStatistics).getTotalUpdateTime();
-          will(returnValue(indexDetails.getIndexStatisticsDetails().getTotalUpdateTime()));
-          oneOf(mockIndexStatistics).getTotalUses();
-          will(returnValue(indexDetails.getIndexStatisticsDetails().getTotalUses()));
-        }
-      });
-
+      final IndexStatistics mockIndexStatistics = mock(IndexStatistics.class,
+          "IndexStatistics " + indexDetails.getIndexName() + " " + counter
+              .getAndIncrement());
+      when(mockIndex.getStatistics()).thenReturn(mockIndexStatistics);
+      when(mockIndexStatistics.getNumUpdates())
+          .thenReturn(indexDetails.getIndexStatisticsDetails().getNumberOfUpdates());
+      when(mockIndexStatistics.getNumberOfKeys())
+          .thenReturn(indexDetails.getIndexStatisticsDetails().getNumberOfKeys());
+      when(mockIndexStatistics.getNumberOfValues())
+          .thenReturn(indexDetails.getIndexStatisticsDetails().getNumberOfValues());
+      when(mockIndexStatistics.getTotalUpdateTime())
+          .thenReturn(indexDetails.getIndexStatisticsDetails().getTotalUpdateTime());
+      when(mockIndexStatistics.getTotalUses())
+          .thenReturn(indexDetails.getIndexStatisticsDetails().getTotalUses());
     } else {
-      mockContext.checking(new Expectations() {
-        {
-          oneOf(mockIndex).getStatistics();
-          will(returnValue(null));
-        }
-      });
+      when(mockIndex.getStatistics()).thenReturn(null);
     }
 
     return mockIndex;
@@ -219,98 +190,44 @@ public class ListIndexFunctionJUnitTest {
   @Test
   @SuppressWarnings("unchecked")
   public void testExecute() throws Throwable {
-    final String memberId = "mockMemberId";
-    final String memberName = "mockMemberName";
-
-    final Cache mockCache = mockContext.mock(Cache.class, "Cache");
-
-    final DistributedSystem mockDistributedSystem =
-        mockContext.mock(DistributedSystem.class, "DistributedSystem");
-    final DistributedMember mockDistributedMember =
-        mockContext.mock(DistributedMember.class, "DistributedMember");
-
-    final IndexDetails indexDetailsOne =
-        createIndexDetails(memberId, "/Employees", "empIdIdx", IndexType.PRIMARY_KEY, "/Employees",
-            "id", memberName, "id, firstName, lastName", "Employees");
-
+    // Expected Results
+    final IndexDetails indexDetailsOne = createIndexDetails("/Employees", "empIdIdx",
+        IndexType.PRIMARY_KEY, "/Employees", "id", "id, firstName, lastName", "Employees");
     indexDetailsOne.setIndexStatisticsDetails(
-        createIndexStatisticsDetails(10124l, 4096l, 10124l, 1284100l, 280120l));
-
-    final IndexDetails indexDetailsTwo =
-        createIndexDetails(memberId, "/Employees", "empGivenNameIdx", IndexType.FUNCTIONAL,
-            "/Employees", "lastName", memberName, "id, firstName, lastName", "Employees");
-
-    final IndexDetails indexDetailsThree =
-        createIndexDetails(memberId, "/Contractors", "empIdIdx", IndexType.PRIMARY_KEY,
-            "/Contrators", "id", memberName, "id, firstName, lastName", "Contractors");
-
+        createIndexStatisticsDetails(10124L, 4096L, 10124L, 1284100L, 280120L));
+    final IndexDetails indexDetailsTwo = createIndexDetails("/Employees", "empGivenNameIdx",
+        IndexType.FUNCTIONAL, "/Employees", "lastName", "id, firstName, lastName", "Employees");
+    final IndexDetails indexDetailsThree = createIndexDetails("/Contractors", "empIdIdx",
+        IndexType.PRIMARY_KEY, "/Contrators", "id", "id, firstName, lastName", "Contractors");
     indexDetailsThree.setIndexStatisticsDetails(
-        createIndexStatisticsDetails(1024l, 256l, 20248l, 768001l, 24480l));
+        createIndexStatisticsDetails(1024L, 256L, 20248L, 768001L, 24480L));
+    final IndexDetails indexDetailsFour = createIndexDetails("/Employees", "empIdIdx",
+        IndexType.FUNCTIONAL, "/Employees", "emp_id", "id, surname, givenname", "Employees");
+    final Set<IndexDetails> expectedIndexDetailsSet =
+        new HashSet<>(Arrays.asList(indexDetailsOne, indexDetailsTwo, indexDetailsThree));
 
-    final IndexDetails indexDetailsFour =
-        createIndexDetails(memberId, "/Employees", "empIdIdx", IndexType.FUNCTIONAL, "/Employees",
-            "emp_id", memberName, "id, surname, givenname", "Employees");
+    // Prepare Mocks
+    List<Index> indexes =
+        Arrays.asList(createMockIndex(indexDetailsOne), createMockIndex(indexDetailsTwo),
+            createMockIndex(indexDetailsThree), createMockIndex(indexDetailsFour));
+    when(mockQueryService.getIndexes()).thenReturn(indexes);
 
-    final Set<IndexDetails> expectedIndexDetailsSet = new HashSet<IndexDetails>(3);
-
-    expectedIndexDetailsSet.add(indexDetailsOne);
-    expectedIndexDetailsSet.add(indexDetailsTwo);
-    expectedIndexDetailsSet.add(indexDetailsThree);
-
-    final QueryService mockQueryService = mockContext.mock(QueryService.class, "QueryService");
-
-    final FunctionContext mockFunctionContext =
-        mockContext.mock(FunctionContext.class, "FunctionContext");
-
-    final TestResultSender testResultSender = new TestResultSender();
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockCache).getDistributedSystem();
-        will(returnValue(mockDistributedSystem));
-        oneOf(mockCache).getQueryService();
-        will(returnValue(mockQueryService));
-        oneOf(mockDistributedSystem).getDistributedMember();
-        will(returnValue(mockDistributedMember));
-        exactly(4).of(mockDistributedMember).getId();
-        will(returnValue(memberId));
-        exactly(4).of(mockDistributedMember).getName();
-        will(returnValue(memberName));
-        oneOf(mockQueryService).getIndexes();
-        will(returnValue(
-            Arrays.asList(createMockIndex(indexDetailsOne), createMockIndex(indexDetailsTwo),
-                createMockIndex(indexDetailsThree), createMockIndex(indexDetailsFour))));
-        oneOf(mockFunctionContext).getCache();
-        will(returnValue(mockCache));
-        oneOf(mockFunctionContext).getResultSender();
-        will(returnValue(testResultSender));
-      }
-    });
-
+    // Execute Function and Assert Results
     final ListIndexFunction function = new ListIndexFunction();
-
     function.execute(mockFunctionContext);
 
     final List<?> results = testResultSender.getResults();
-
-    assertNotNull(results);
-    assertEquals(1, results.size());
+    assertThat(results).isNotNull();
+    assertThat(1).isEqualTo(results.size());
 
     final Set<IndexDetails> actualIndexDetailsSet = (Set<IndexDetails>) results.get(0);
-
-    assertNotNull(actualIndexDetailsSet);
-    assertEquals(expectedIndexDetailsSet.size(), actualIndexDetailsSet.size());
+    assertThat(actualIndexDetailsSet).isNotNull();
+    assertThat(expectedIndexDetailsSet.size()).isEqualTo(actualIndexDetailsSet.size());
 
     for (final IndexDetails expectedIndexDetails : expectedIndexDetailsSet) {
-      final IndexDetails actualIndexDetails =
-          CollectionUtils.findBy(actualIndexDetailsSet, new Filter<IndexDetails>() {
-            @Override
-            public boolean accept(final IndexDetails indexDetails) {
-              return ObjectUtils.equals(expectedIndexDetails, indexDetails);
-            }
-          });
-
-      assertNotNull(actualIndexDetails);
+      final IndexDetails actualIndexDetails = CollectionUtils.findBy(actualIndexDetailsSet,
+          indexDetails -> ObjectUtils.equals(expectedIndexDetails, indexDetails));
+      assertThat(actualIndexDetails).isNotNull();
       assertIndexDetailsEquals(expectedIndexDetails, actualIndexDetails);
     }
   }
@@ -318,108 +235,43 @@ public class ListIndexFunctionJUnitTest {
   @Test
   @SuppressWarnings("unchecked")
   public void testExecuteWithNoIndexes() throws Throwable {
-    final Cache mockCache = mockContext.mock(Cache.class, "Cache");
+    // Prepare Mocks
+    when(mockQueryService.getIndexes()).thenReturn(Collections.emptyList());
 
-    final DistributedSystem mockDistributedSystem =
-        mockContext.mock(DistributedSystem.class, "DistributedSystem");
-    final DistributedMember mockDistributedMember =
-        mockContext.mock(DistributedMember.class, "DistributedMember");
-
-    final QueryService mockQueryService = mockContext.mock(QueryService.class, "QueryService");
-
-    final FunctionContext mockFunctionContext =
-        mockContext.mock(FunctionContext.class, "FunctionContext");
-
-    final TestResultSender testResultSender = new TestResultSender();
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockCache).getDistributedSystem();
-        will(returnValue(mockDistributedSystem));
-        oneOf(mockCache).getQueryService();
-        will(returnValue(mockQueryService));
-        oneOf(mockDistributedSystem).getDistributedMember();
-        will(returnValue(mockDistributedMember));
-        oneOf(mockQueryService).getIndexes();
-        will(returnValue(Collections.emptyList()));
-        oneOf(mockFunctionContext).getCache();
-        will(returnValue(mockCache));
-        oneOf(mockFunctionContext).getResultSender();
-        will(returnValue(testResultSender));
-      }
-    });
-
+    // Execute Function and assert results
     final ListIndexFunction function = new ListIndexFunction();
-
     function.execute(mockFunctionContext);
 
     final List<?> results = testResultSender.getResults();
-
-    assertNotNull(results);
-    assertEquals(1, results.size());
+    assertThat(results).isNotNull();
+    assertThat(1).isEqualTo(results.size());
 
     final Set<IndexDetails> actualIndexDetailsSet = (Set<IndexDetails>) results.get(0);
-
-    assertNotNull(actualIndexDetailsSet);
-    assertTrue(actualIndexDetailsSet.isEmpty());
+    assertThat(actualIndexDetailsSet).isNotNull();
+    assertThat(actualIndexDetailsSet.isEmpty()).isTrue();
   }
 
-  @Test(expected = RuntimeException.class)
-  public void testExecuteThrowsException() throws Throwable {
-    final Cache mockCache = mockContext.mock(Cache.class, "Cache");
+  @Test
+  public void testExecuteThrowsException() {
+    // Prepare Mocks
+    when(mockQueryService.getIndexes()).thenThrow(new RuntimeException("Mocked Exception"));
 
-    final DistributedSystem mockDistributedSystem =
-        mockContext.mock(DistributedSystem.class, "DistributedSystem");
-    final DistributedMember mockDistributedMember =
-        mockContext.mock(DistributedMember.class, "DistributedMember");
-
-    final QueryService mockQueryService = mockContext.mock(QueryService.class, "QueryService");
-
-    final FunctionContext mockFunctionContext =
-        mockContext.mock(FunctionContext.class, "FunctionContext");
-
-    final TestResultSender testResultSender = new TestResultSender();
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockCache).getDistributedSystem();
-        will(returnValue(mockDistributedSystem));
-        oneOf(mockCache).getQueryService();
-        will(returnValue(mockQueryService));
-        oneOf(mockDistributedSystem).getDistributedMember();
-        will(returnValue(mockDistributedMember));
-        oneOf(mockQueryService).getIndexes();
-        will(throwException(new RuntimeException("expected")));
-        oneOf(mockFunctionContext).getCache();
-        will(returnValue(mockCache));
-        oneOf(mockFunctionContext).getResultSender();
-        will(returnValue(testResultSender));
-      }
-    });
-
+    // Execute Function and assert results
     final ListIndexFunction function = new ListIndexFunction();
-
     function.execute(mockFunctionContext);
-
-    try {
-      testResultSender.getResults();
-    } catch (Throwable t) {
-      assertTrue(t instanceof RuntimeException);
-      assertEquals("expected", t.getMessage());
-      throw t;
-    }
+    assertThatThrownBy(() -> testResultSender.getResults()).isInstanceOf(RuntimeException.class)
+        .hasMessage("Mocked Exception");
   }
 
   private static class TestResultSender implements ResultSender {
-
-    private final List<Object> results = new LinkedList<Object>();
-
     private Throwable t;
+    private final List<Object> results = new LinkedList<>();
 
     protected List<Object> getResults() throws Throwable {
       if (t != null) {
         throw t;
       }
+
       return Collections.unmodifiableList(results);
     }
 
@@ -438,5 +290,4 @@ public class ListIndexFunctionJUnitTest {
       this.t = t;
     }
   }
-
 }

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexCommandsJUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexCommandsJUnitTest.java
@@ -16,8 +16,8 @@ package org.apache.geode.cache.lucene.internal.cli;
 
 import static org.apache.commons.lang.SystemUtils.LINE_SEPARATOR;
 import static org.apache.geode.management.internal.cli.result.ResultData.TYPE_TABULAR;
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.isA;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doReturn;
@@ -42,7 +42,6 @@ import junitparams.Parameters;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.core.KeywordAnalyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -82,27 +81,23 @@ import org.apache.geode.test.junit.categories.LuceneTest;
  * @see LuceneIndexCommands
  * @see LuceneIndexDetails
  * @see LuceneListIndexFunction
- * @see org.jmock.Expectations
- * @see org.jmock.Mockery
- * @see org.jmock.lib.legacy.ClassImposteriser
- * @see org.junit.Assert
  * @see org.junit.Test
  * @since GemFire 7.0
  */
-@Category({LuceneTest.class})
+@Category(LuceneTest.class)
 @RunWith(JUnitParamsRunner.class)
 public class LuceneIndexCommandsJUnitTest {
 
   private InternalCache mockCache;
 
   @Before
-  public void before() throws Exception {
+  public void before() {
     this.mockCache = mock(InternalCache.class, "InternalCache");
     when(this.mockCache.getSecurityService()).thenReturn(mock(SecurityService.class));
   }
 
   @Test
-  public void testListIndexWithoutStats() throws Exception {
+  public void testListIndexWithoutStats() {
     final String serverName = "mockServer";
     final AbstractExecution mockFunctionExecutor =
         mock(AbstractExecution.class, "Function Executor");
@@ -126,7 +121,7 @@ public class LuceneIndexCommandsJUnitTest {
 
     results.add(CollectionUtils.asSet(indexDetails2, indexDetails1, indexDetails3));
 
-    when(mockFunctionExecutor.execute(isA(LuceneListIndexFunction.class)))
+    when(mockFunctionExecutor.execute(any(LuceneListIndexFunction.class)))
         .thenReturn(mockResultCollector);
     when(mockResultCollector.getResult()).thenReturn(results);
 
@@ -134,23 +129,22 @@ public class LuceneIndexCommandsJUnitTest {
 
     CommandResult result = (CommandResult) commands.listIndex(false);
     TabularResultData data = (TabularResultData) result.getResultData();
-    assertEquals(Arrays.asList("memberFive", "memberSix", "memberTen"),
-        data.retrieveAllValues("Index Name"));
-    assertEquals(Arrays.asList("/Employees", "/Employees", "/Employees"),
-        data.retrieveAllValues("Region Path"));
-    assertEquals(Arrays.asList("[field1, field2, field3]", "[field1, field2, field3]",
-        "[field1, field2, field3]"), data.retrieveAllValues("Indexed Fields"));
-    assertEquals(
-        Arrays.asList("{field1=StandardAnalyzer, field2=KeywordAnalyzer}",
-            "{field1=StandardAnalyzer, field2=KeywordAnalyzer}",
-            "{field1=StandardAnalyzer, field2=KeywordAnalyzer}"),
-        data.retrieveAllValues("Field Analyzer"));
-    assertEquals(Arrays.asList("INITIALIZED", "NOT_INITIALIZED", "INITIALIZED"),
-        data.retrieveAllValues("Status"));
+    assertThat(Arrays.asList("memberFive", "memberSix", "memberTen"))
+        .isEqualTo(data.retrieveAllValues("Index Name"));
+    assertThat(Arrays.asList("/Employees", "/Employees", "/Employees"))
+        .isEqualTo(data.retrieveAllValues("Region Path"));
+    assertThat(Arrays.asList("[field1, field2, field3]", "[field1, field2, field3]",
+        "[field1, field2, field3]")).isEqualTo(data.retrieveAllValues("Indexed Fields"));
+    assertThat(Arrays.asList("{field1=StandardAnalyzer, field2=KeywordAnalyzer}",
+        "{field1=StandardAnalyzer, field2=KeywordAnalyzer}",
+        "{field1=StandardAnalyzer, field2=KeywordAnalyzer}"))
+            .isEqualTo(data.retrieveAllValues("Field Analyzer"));
+    assertThat(Arrays.asList("INITIALIZED", "NOT_INITIALIZED", "INITIALIZED"))
+        .isEqualTo(data.retrieveAllValues("Status"));
   }
 
   @Test
-  public void testListIndexWithStats() throws Exception {
+  public void testListIndexWithStats() {
     final String serverName = "mockServer";
     final AbstractExecution mockFunctionExecutor =
         mock(AbstractExecution.class, "Function Executor");
@@ -178,7 +172,7 @@ public class LuceneIndexCommandsJUnitTest {
 
     results.add(CollectionUtils.asSet(indexDetails2, indexDetails1, indexDetails3));
 
-    when(mockFunctionExecutor.execute(isA(LuceneListIndexFunction.class)))
+    when(mockFunctionExecutor.execute(any(LuceneListIndexFunction.class)))
         .thenReturn(mockResultCollector);
     when(mockResultCollector.getResult()).thenReturn(results);
 
@@ -186,26 +180,24 @@ public class LuceneIndexCommandsJUnitTest {
 
     CommandResult result = (CommandResult) commands.listIndex(true);
     TabularResultData data = (TabularResultData) result.getResultData();
-    assertEquals(Arrays.asList("memberFive", "memberSix", "memberTen"),
-        data.retrieveAllValues("Index Name"));
-    assertEquals(Arrays.asList("/Employees", "/Employees", "/Employees"),
-        data.retrieveAllValues("Region Path"));
-    assertEquals(Arrays.asList("[field1, field2, field3]", "[field1, field2, field3]",
-        "[field1, field2, field3]"), data.retrieveAllValues("Indexed Fields"));
-    assertEquals(
-        Arrays.asList("{field1=StandardAnalyzer, field2=KeywordAnalyzer}",
-            "{field1=StandardAnalyzer, field2=KeywordAnalyzer}",
-            "{field1=StandardAnalyzer, field2=KeywordAnalyzer}"),
-        data.retrieveAllValues("Field Analyzer"));
-    assertEquals(Arrays.asList("1", "2", "3"), data.retrieveAllValues("Query Executions"));
-    assertEquals(Arrays.asList("10", "20", "30"), data.retrieveAllValues("Commits"));
-    assertEquals(Arrays.asList("5", "10", "15"), data.retrieveAllValues("Updates"));
-    assertEquals(Arrays.asList("1", "2", "3"), data.retrieveAllValues("Documents"));
-    assertEquals(
-        Arrays.asList(HeterogeneousLuceneSerializer.class.getSimpleName(),
-            HeterogeneousLuceneSerializer.class.getSimpleName(),
-            HeterogeneousLuceneSerializer.class.getSimpleName()),
-        data.retrieveAllValues("Serializer"));
+    assertThat(Arrays.asList("memberFive", "memberSix", "memberTen"))
+        .isEqualTo(data.retrieveAllValues("Index Name"));
+    assertThat(Arrays.asList("/Employees", "/Employees", "/Employees"))
+        .isEqualTo(data.retrieveAllValues("Region Path"));
+    assertThat(Arrays.asList("[field1, field2, field3]", "[field1, field2, field3]",
+        "[field1, field2, field3]")).isEqualTo(data.retrieveAllValues("Indexed Fields"));
+    assertThat(Arrays.asList("{field1=StandardAnalyzer, field2=KeywordAnalyzer}",
+        "{field1=StandardAnalyzer, field2=KeywordAnalyzer}",
+        "{field1=StandardAnalyzer, field2=KeywordAnalyzer}"))
+            .isEqualTo(data.retrieveAllValues("Field Analyzer"));
+    assertThat(Arrays.asList("1", "2", "3")).isEqualTo(data.retrieveAllValues("Query Executions"));
+    assertThat(Arrays.asList("10", "20", "30")).isEqualTo(data.retrieveAllValues("Commits"));
+    assertThat(Arrays.asList("5", "10", "15")).isEqualTo(data.retrieveAllValues("Updates"));
+    assertThat(Arrays.asList("1", "2", "3")).isEqualTo(data.retrieveAllValues("Documents"));
+    assertThat(Arrays.asList(HeterogeneousLuceneSerializer.class.getSimpleName(),
+        HeterogeneousLuceneSerializer.class.getSimpleName(),
+        HeterogeneousLuceneSerializer.class.getSimpleName()))
+            .isEqualTo(data.retrieveAllValues("Serializer"));
   }
 
   @Test
@@ -214,12 +206,15 @@ public class LuceneIndexCommandsJUnitTest {
     final LuceneIndexCommands commands = spy(createIndexCommands(this.mockCache, null));
 
     final List<CliFunctionResult> cliFunctionResults = new ArrayList<>();
-    cliFunctionResults.add(new CliFunctionResult("member1", true, "Index Created"));
-    cliFunctionResults.add(new CliFunctionResult("member2", false, "Index creation failed"));
-    cliFunctionResults.add(new CliFunctionResult("member3", true, "Index Created"));
+    cliFunctionResults
+        .add(new CliFunctionResult("member1", CliFunctionResult.StatusState.OK, "Index Created"));
+    cliFunctionResults.add(new CliFunctionResult("member2", CliFunctionResult.StatusState.ERROR,
+        "Index creation failed"));
+    cliFunctionResults
+        .add(new CliFunctionResult("member3", CliFunctionResult.StatusState.OK, "Index Created"));
 
     doReturn(mockResultCollector).when(commands).executeFunctionOnAllMembers(
-        isA(LuceneCreateIndexFunction.class), any(LuceneIndexInfo.class));
+        any(LuceneCreateIndexFunction.class), any(LuceneIndexInfo.class));
     doReturn(cliFunctionResults).when(mockResultCollector).getResult();
 
     String indexName = "index";
@@ -232,11 +227,12 @@ public class LuceneIndexCommandsJUnitTest {
 
     CommandResult result = (CommandResult) commands.createIndex(indexName, regionPath,
         searchableFields, fieldAnalyzers, serializer);
-    assertEquals(Status.OK, result.getStatus());
+    assertThat(Status.OK).isEqualTo(result.getStatus());
     TabularResultData data = (TabularResultData) result.getResultData();
-    assertEquals(Arrays.asList("member1", "member2", "member3"), data.retrieveAllValues("Member"));
-    assertEquals(Arrays.asList("Successfully created lucene index", "Failed: Index creation failed",
-        "Successfully created lucene index"), data.retrieveAllValues("Status"));
+    assertThat(Arrays.asList("member1", "member2", "member3"))
+        .isEqualTo(data.retrieveAllValues("Member"));
+    assertThat(Arrays.asList("Successfully created lucene index", "Failed: Index creation failed",
+        "Successfully created lucene index")).isEqualTo(data.retrieveAllValues("Status"));
   }
 
   @Test
@@ -257,23 +253,27 @@ public class LuceneIndexCommandsJUnitTest {
         fieldAnalyzers, mockIndexStats, LuceneIndexStatus.INITIALIZED, serverName, serializer));
 
     doReturn(mockResultCollector).when(commands).executeFunctionOnRegion(
-        isA(LuceneDescribeIndexFunction.class), any(LuceneIndexInfo.class), eq(true));
+        any(LuceneDescribeIndexFunction.class), any(LuceneIndexInfo.class), eq(true));
     doReturn(indexDetails).when(mockResultCollector).getResult();
 
     CommandResult result = (CommandResult) commands.describeIndex("memberFive", "/Employees");
 
     TabularResultData data = (TabularResultData) result.getResultData();
-    assertEquals(Collections.singletonList("memberFive"), data.retrieveAllValues("Index Name"));
-    assertEquals(Collections.singletonList("/Employees"), data.retrieveAllValues("Region Path"));
-    assertEquals(Collections.singletonList("[field1, field2, field3]"),
-        data.retrieveAllValues("Indexed Fields"));
-    assertEquals(Collections.singletonList("{field1=StandardAnalyzer, field2=KeywordAnalyzer}"),
-        data.retrieveAllValues("Field Analyzer"));
-    assertEquals(Collections.singletonList("INITIALIZED"), data.retrieveAllValues("Status"));
-    assertEquals(Collections.singletonList("1"), data.retrieveAllValues("Query Executions"));
-    assertEquals(Collections.singletonList("10"), data.retrieveAllValues("Commits"));
-    assertEquals(Collections.singletonList("5"), data.retrieveAllValues("Updates"));
-    assertEquals(Collections.singletonList("1"), data.retrieveAllValues("Documents"));
+    assertThat(Collections.singletonList("memberFive"))
+        .isEqualTo(data.retrieveAllValues("Index Name"));
+    assertThat(Collections.singletonList("/Employees"))
+        .isEqualTo(data.retrieveAllValues("Region Path"));
+    assertThat(Collections.singletonList("[field1, field2, field3]"))
+        .isEqualTo(data.retrieveAllValues("Indexed Fields"));
+    assertThat(Collections.singletonList("{field1=StandardAnalyzer, field2=KeywordAnalyzer}"))
+        .isEqualTo(data.retrieveAllValues("Field Analyzer"));
+    assertThat(Collections.singletonList("INITIALIZED"))
+        .isEqualTo(data.retrieveAllValues("Status"));
+    assertThat(Collections.singletonList("1"))
+        .isEqualTo(data.retrieveAllValues("Query Executions"));
+    assertThat(Collections.singletonList("10")).isEqualTo(data.retrieveAllValues("Commits"));
+    assertThat(Collections.singletonList("5")).isEqualTo(data.retrieveAllValues("Updates"));
+    assertThat(Collections.singletonList("1")).isEqualTo(data.retrieveAllValues("Documents"));
   }
 
   @Test
@@ -287,17 +287,16 @@ public class LuceneIndexCommandsJUnitTest {
     queryResults.add(createQueryResults("B", "Result1", Float.valueOf("1.2")));
     queryResults.add(createQueryResults("C", "Result1", Float.valueOf("1.1")));
     queryResultsList.add(queryResults);
-    doReturn(mockResultCollector).when(commands).executeSearch(isA(LuceneQueryInfo.class));
+    doReturn(mockResultCollector).when(commands).executeSearch(any(LuceneQueryInfo.class));
     doReturn(queryResultsList).when(mockResultCollector).getResult();
 
     CommandResult result =
         (CommandResult) commands.searchIndex("index", "region", "Result1", "field1", -1, false);
-
     TabularResultData data = (TabularResultData) result.getResultData();
-
-    assertEquals(Arrays.asList("A", "B", "C"), data.retrieveAllValues("key"));
-    assertEquals(Arrays.asList("Result1", "Result1", "Result1"), data.retrieveAllValues("value"));
-    assertEquals(Arrays.asList("1.3", "1.2", "1.1"), data.retrieveAllValues("score"));
+    assertThat(Arrays.asList("A", "B", "C")).isEqualTo(data.retrieveAllValues("key"));
+    assertThat(Arrays.asList("Result1", "Result1", "Result1"))
+        .isEqualTo(data.retrieveAllValues("value"));
+    assertThat(Arrays.asList("1.3", "1.2", "1.1")).isEqualTo(data.retrieveAllValues("score"));
   }
 
   @Ignore
@@ -335,36 +334,36 @@ public class LuceneIndexCommandsJUnitTest {
     verify(mockGfsh, times(20)).printAsInfo(resultCaptor.capture());
     List<String> actualPageResults = resultCaptor.getAllValues();
 
-    assertEquals(expectedPage1, actualPageResults.get(0));
-    assertEquals("\t\tPage 1 of 4", actualPageResults.get(1));
+    assertThat(expectedPage1).isEqualTo(actualPageResults.get(0));
+    assertThat("\t\tPage 1 of 4").isEqualTo(actualPageResults.get(1));
 
-    assertEquals(expectedPage2, actualPageResults.get(2));
-    assertEquals("\t\tPage 2 of 4", actualPageResults.get(3));
+    assertThat(expectedPage2).isEqualTo(actualPageResults.get(2));
+    assertThat("\t\tPage 2 of 4").isEqualTo(actualPageResults.get(3));
 
-    assertEquals(expectedPage3, actualPageResults.get(4));
-    assertEquals("\t\tPage 3 of 4", actualPageResults.get(5));
+    assertThat(expectedPage3).isEqualTo(actualPageResults.get(4));
+    assertThat("\t\tPage 3 of 4").isEqualTo(actualPageResults.get(5));
 
-    assertEquals(expectedPage4, actualPageResults.get(6));
-    assertEquals("\t\tPage 4 of 4", actualPageResults.get(7));
+    assertThat(expectedPage4).isEqualTo(actualPageResults.get(6));
+    assertThat("\t\tPage 4 of 4").isEqualTo(actualPageResults.get(7));
 
-    assertEquals("No more results to display.", actualPageResults.get(8));
+    assertThat("No more results to display.").isEqualTo(actualPageResults.get(8));
 
-    assertEquals(expectedPage4, actualPageResults.get(9));
-    assertEquals("\t\tPage 4 of 4", actualPageResults.get(10));
+    assertThat(expectedPage4).isEqualTo(actualPageResults.get(9));
+    assertThat("\t\tPage 4 of 4").isEqualTo(actualPageResults.get(10));
 
-    assertEquals(expectedPage3, actualPageResults.get(11));
-    assertEquals("\t\tPage 3 of 4", actualPageResults.get(12));
+    assertThat(expectedPage3).isEqualTo(actualPageResults.get(11));
+    assertThat("\t\tPage 3 of 4").isEqualTo(actualPageResults.get(12));
 
-    assertEquals(expectedPage2, actualPageResults.get(13));
-    assertEquals("\t\tPage 2 of 4", actualPageResults.get(14));
+    assertThat(expectedPage2).isEqualTo(actualPageResults.get(13));
+    assertThat("\t\tPage 2 of 4").isEqualTo(actualPageResults.get(14));
 
-    assertEquals(expectedPage1, actualPageResults.get(15));
-    assertEquals("\t\tPage 1 of 4", actualPageResults.get(16));
+    assertThat(expectedPage1).isEqualTo(actualPageResults.get(15));
+    assertThat("\t\tPage 1 of 4").isEqualTo(actualPageResults.get(16));
 
-    assertEquals("At the top of the search results.", actualPageResults.get(17));
+    assertThat("At the top of the search results.").isEqualTo(actualPageResults.get(17));
 
-    assertEquals(expectedPage1, actualPageResults.get(18));
-    assertEquals("\t\tPage 1 of 4", actualPageResults.get(19));
+    assertThat(expectedPage1).isEqualTo(actualPageResults.get(18));
+    assertThat("\t\tPage 1 of 4").isEqualTo(actualPageResults.get(19));
   }
 
   @Test
@@ -378,7 +377,7 @@ public class LuceneIndexCommandsJUnitTest {
     queryResults.add(createQueryResults("B", "Result1", Float.valueOf("1.2")));
     queryResults.add(createQueryResults("C", "Result1", Float.valueOf("1.1")));
     queryResultsList.add(queryResults);
-    doReturn(mockResultCollector).when(commands).executeSearch(isA(LuceneQueryInfo.class));
+    doReturn(mockResultCollector).when(commands).executeSearch(any(LuceneQueryInfo.class));
     doReturn(queryResultsList).when(mockResultCollector).getResult();
 
     CommandResult result =
@@ -386,7 +385,7 @@ public class LuceneIndexCommandsJUnitTest {
 
     TabularResultData data = (TabularResultData) result.getResultData();
 
-    assertEquals(Arrays.asList("A", "B", "C"), data.retrieveAllValues("key"));
+    assertThat(Arrays.asList("A", "B", "C")).isEqualTo(data.retrieveAllValues("key"));
   }
 
   @Test
@@ -417,7 +416,7 @@ public class LuceneIndexCommandsJUnitTest {
     queryResults.add(createQueryResults("T", "Result1", 1));
     queryResultsList.add(queryResults);
 
-    doReturn(mockResultCollector).when(commands).executeSearch(isA(LuceneQueryInfo.class));
+    doReturn(mockResultCollector).when(commands).executeSearch(any(LuceneQueryInfo.class));
     doReturn(queryResultsList).when(mockResultCollector).getResult();
 
     CommandResult result =
@@ -425,17 +424,17 @@ public class LuceneIndexCommandsJUnitTest {
 
     TabularResultData data = (TabularResultData) result.getResultData();
 
-    assertEquals(queryResults.size(), data.retrieveAllValues("key").size());
+    assertThat(queryResults.size()).isEqualTo(data.retrieveAllValues("key").size());
   }
 
   @Test
-  public void testDestroySingleIndexNoRegionMembers() throws Exception {
+  public void testDestroySingleIndexNoRegionMembers() {
     LuceneIndexCommands commands = createTestLuceneIndexCommandsForDestroyIndex();
     final List<CliFunctionResult> cliFunctionResults = new ArrayList<>();
     String expectedStatus = CliStrings.format(
         LuceneCliStrings.LUCENE_DESTROY_INDEX__MSG__COULD_NOT_FIND__MEMBERS_GREATER_THAN_VERSION_0,
         new Object[] {Version.GEODE_180}) + LINE_SEPARATOR;
-    cliFunctionResults.add(new CliFunctionResult("member0"));
+    cliFunctionResults.add(new CliFunctionResult("member0", CliFunctionResult.StatusState.OK));
     doReturn(Collections.emptySet()).when(commands).getNormalMembersWithSameOrNewerVersion(any());
     CommandResult result = (CommandResult) commands.destroyIndex("index", "regionPath");
     verifyDestroyIndexCommandResult(result, cliFunctionResults, expectedStatus);
@@ -443,7 +442,7 @@ public class LuceneIndexCommandsJUnitTest {
 
   @Test
   @Parameters({"true", "false"})
-  public void testDestroySingleIndexWithRegionMembers(boolean expectedToSucceed) throws Exception {
+  public void testDestroySingleIndexWithRegionMembers(boolean expectedToSucceed) {
     LuceneIndexCommands commands = createTestLuceneIndexCommandsForDestroyIndex();
     String indexName = "index";
     String regionPath = "regionPath";
@@ -459,8 +458,9 @@ public class LuceneIndexCommandsJUnitTest {
     if (expectedToSucceed) {
       expectedStatus = CliStrings.format(
           LuceneCliStrings.LUCENE_DESTROY_INDEX__MSG__SUCCESSFULLY_DESTROYED_INDEX_0_FROM_REGION_1,
-          new Object[] {indexName, regionPath});
-      cliFunctionResults.add(new CliFunctionResult(mockMember.getId()));
+          indexName, regionPath);
+      cliFunctionResults
+          .add(new CliFunctionResult(mockMember.getId(), CliFunctionResult.StatusState.OK));
     } else {
       Exception e = new IllegalStateException("failed");
       expectedStatus = e.getMessage();
@@ -468,7 +468,7 @@ public class LuceneIndexCommandsJUnitTest {
     }
 
     doReturn(mockResultCollector).when(commands).executeFunction(
-        isA(LuceneDestroyIndexFunction.class), any(LuceneDestroyIndexInfo.class), any(Set.class));
+        any(LuceneDestroyIndexFunction.class), any(LuceneDestroyIndexInfo.class), anySet());
     doReturn(cliFunctionResults).when(mockResultCollector).getResult();
 
     doReturn(members).when(commands).getNormalMembersWithSameOrNewerVersion(any());
@@ -478,21 +478,21 @@ public class LuceneIndexCommandsJUnitTest {
   }
 
   @Test
-  public void testDestroyAllIndexesNoRegionMembers() throws Exception {
+  public void testDestroyAllIndexesNoRegionMembers() {
     LuceneIndexCommands commands = createTestLuceneIndexCommandsForDestroyIndex();
     doReturn(Collections.emptySet()).when(commands).getNormalMembersWithSameOrNewerVersion(any());
     final List<CliFunctionResult> cliFunctionResults = new ArrayList<>();
     String expectedStatus = CliStrings.format(
         LuceneCliStrings.LUCENE_DESTROY_INDEX__MSG__COULD_NOT_FIND__MEMBERS_GREATER_THAN_VERSION_0,
         new Object[] {Version.GEODE_180}) + LINE_SEPARATOR;
-    cliFunctionResults.add(new CliFunctionResult("member0"));
+    cliFunctionResults.add(new CliFunctionResult("member0", CliFunctionResult.StatusState.OK));
     CommandResult result = (CommandResult) commands.destroyIndex(null, "regionPath");
     verifyDestroyIndexCommandResult(result, cliFunctionResults, expectedStatus);
   }
 
   @Test
   @Parameters({"true", "false"})
-  public void testDestroyAllIndexesWithRegionMembers(boolean expectedToSucceed) throws Exception {
+  public void testDestroyAllIndexesWithRegionMembers(boolean expectedToSucceed) {
     LuceneIndexCommands commands = createTestLuceneIndexCommandsForDestroyIndex();
     String indexName = null;
     String regionPath = "regionPath";
@@ -509,7 +509,8 @@ public class LuceneIndexCommandsJUnitTest {
       expectedStatus = CliStrings.format(
           LuceneCliStrings.LUCENE_DESTROY_INDEX__MSG__SUCCESSFULLY_DESTROYED_INDEXES_FROM_REGION_0,
           new Object[] {regionPath});
-      cliFunctionResults.add(new CliFunctionResult(mockMember.getId()));
+      cliFunctionResults
+          .add(new CliFunctionResult(mockMember.getId(), CliFunctionResult.StatusState.OK));
     } else {
       Exception e = new IllegalStateException("failed");
       expectedStatus = e.getMessage();
@@ -517,7 +518,7 @@ public class LuceneIndexCommandsJUnitTest {
     }
 
     doReturn(mockResultCollector).when(commands).executeFunction(
-        isA(LuceneDestroyIndexFunction.class), any(LuceneDestroyIndexInfo.class), any(Set.class));
+        any(LuceneDestroyIndexFunction.class), any(LuceneDestroyIndexInfo.class), anySet());
     doReturn(cliFunctionResults).when(mockResultCollector).getResult();
 
     doReturn(members).when(commands).getNormalMembersWithSameOrNewerVersion(any());
@@ -531,33 +532,34 @@ public class LuceneIndexCommandsJUnitTest {
     final LuceneIndexCommands commands = spy(createIndexCommands(this.mockCache, null));
 
     final List<CliFunctionResult> cliFunctionResults = new ArrayList<>();
-    cliFunctionResults.add(new CliFunctionResult("member", true, "Index Destroyed"));
+    cliFunctionResults
+        .add(new CliFunctionResult("member", CliFunctionResult.StatusState.OK, "Index Destroyed"));
 
     doReturn(mockResultCollector).when(commands).executeFunctionOnRegion(
-        isA(LuceneDestroyIndexFunction.class), any(LuceneIndexInfo.class), eq(false));
+        any(LuceneDestroyIndexFunction.class), any(LuceneIndexInfo.class), eq(false));
     doReturn(cliFunctionResults).when(mockResultCollector).getResult();
     return commands;
   }
 
   private void verifyDestroyIndexCommandResult(CommandResult result,
       List<CliFunctionResult> cliFunctionResults, String expectedStatus) {
-    assertEquals(Status.OK, result.getStatus());
+    assertThat(Status.OK).isEqualTo(result.getStatus());
     if (result.getType().equals(TYPE_TABULAR)) {
       TabularResultData data = (TabularResultData) result.getResultData();
       List<String> members = data.retrieveAllValues("Member");
-      assertEquals(cliFunctionResults.size(), members.size());
+      assertThat(cliFunctionResults.size()).isEqualTo(members.size());
       // Verify each member
       for (int i = 0; i < members.size(); i++) {
-        assertEquals("member" + i, members.get(i));
+        assertThat("member" + i).isEqualTo(members.get(i));
       }
       // Verify each status
       List<String> status = data.retrieveAllValues("Status");
       for (String statu : status) {
-        assertEquals(expectedStatus, statu);
+        assertThat(expectedStatus).isEqualTo(statu);
       }
     } else {
       // Info result. Verify next lines are equal.
-      assertEquals(result.nextLine(), expectedStatus);
+      assertThat(result.nextLine()).isEqualTo(expectedStatus);
     }
   }
 
@@ -568,7 +570,7 @@ public class LuceneIndexCommandsJUnitTest {
       data.accumulate("value", expectedResults[i].getValue());
       data.accumulate("score", expectedResults[i].getScore());
     }
-    CommandResult commandResult = (CommandResult) ResultBuilder.buildResult(data);
+    CommandResult commandResult = ResultBuilder.buildResult(data);
     StringBuilder buffer = new StringBuilder();
     while (commandResult.hasNextLine()) {
       buffer.append(commandResult.nextLine());
@@ -622,7 +624,7 @@ public class LuceneIndexCommandsJUnitTest {
 
     private final Execution functionExecutor;
 
-    protected LuceneTestIndexCommands(final InternalCache cache, final Execution functionExecutor) {
+    LuceneTestIndexCommands(final InternalCache cache, final Execution functionExecutor) {
       assert cache != null : "The InternalCache cannot be null!";
       setCache(cache);
       this.functionExecutor = functionExecutor;
@@ -635,7 +637,7 @@ public class LuceneIndexCommandsJUnitTest {
 
     @Override
     public Execution getMembersFunctionExecutor(final Set<DistributedMember> members) {
-      Assert.assertNotNull(members);
+      assertThat(members).isNotNull();
       return this.functionExecutor;
     }
   }

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexCommandsJUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexCommandsJUnitTest.java
@@ -129,18 +129,18 @@ public class LuceneIndexCommandsJUnitTest {
 
     CommandResult result = (CommandResult) commands.listIndex(false);
     TabularResultData data = (TabularResultData) result.getResultData();
-    assertThat(Arrays.asList("memberFive", "memberSix", "memberTen"))
-        .isEqualTo(data.retrieveAllValues("Index Name"));
-    assertThat(Arrays.asList("/Employees", "/Employees", "/Employees"))
-        .isEqualTo(data.retrieveAllValues("Region Path"));
-    assertThat(Arrays.asList("[field1, field2, field3]", "[field1, field2, field3]",
-        "[field1, field2, field3]")).isEqualTo(data.retrieveAllValues("Indexed Fields"));
-    assertThat(Arrays.asList("{field1=StandardAnalyzer, field2=KeywordAnalyzer}",
-        "{field1=StandardAnalyzer, field2=KeywordAnalyzer}",
-        "{field1=StandardAnalyzer, field2=KeywordAnalyzer}"))
-            .isEqualTo(data.retrieveAllValues("Field Analyzer"));
-    assertThat(Arrays.asList("INITIALIZED", "NOT_INITIALIZED", "INITIALIZED"))
-        .isEqualTo(data.retrieveAllValues("Status"));
+    assertThat(data.retrieveAllValues("Index Name"))
+        .isEqualTo(Arrays.asList("memberFive", "memberSix", "memberTen"));
+    assertThat(data.retrieveAllValues("Region Path"))
+        .isEqualTo(Arrays.asList("/Employees", "/Employees", "/Employees"));
+    assertThat(data.retrieveAllValues("Indexed Fields")).isEqualTo(Arrays.asList(
+        "[field1, field2, field3]", "[field1, field2, field3]", "[field1, field2, field3]"));
+    assertThat(data.retrieveAllValues("Field Analyzer"))
+        .isEqualTo(Arrays.asList("{field1=StandardAnalyzer, field2=KeywordAnalyzer}",
+            "{field1=StandardAnalyzer, field2=KeywordAnalyzer}",
+            "{field1=StandardAnalyzer, field2=KeywordAnalyzer}"));
+    assertThat(data.retrieveAllValues("Status"))
+        .isEqualTo(Arrays.asList("INITIALIZED", "NOT_INITIALIZED", "INITIALIZED"));
   }
 
   @Test
@@ -180,24 +180,24 @@ public class LuceneIndexCommandsJUnitTest {
 
     CommandResult result = (CommandResult) commands.listIndex(true);
     TabularResultData data = (TabularResultData) result.getResultData();
-    assertThat(Arrays.asList("memberFive", "memberSix", "memberTen"))
-        .isEqualTo(data.retrieveAllValues("Index Name"));
-    assertThat(Arrays.asList("/Employees", "/Employees", "/Employees"))
-        .isEqualTo(data.retrieveAllValues("Region Path"));
-    assertThat(Arrays.asList("[field1, field2, field3]", "[field1, field2, field3]",
-        "[field1, field2, field3]")).isEqualTo(data.retrieveAllValues("Indexed Fields"));
-    assertThat(Arrays.asList("{field1=StandardAnalyzer, field2=KeywordAnalyzer}",
-        "{field1=StandardAnalyzer, field2=KeywordAnalyzer}",
-        "{field1=StandardAnalyzer, field2=KeywordAnalyzer}"))
-            .isEqualTo(data.retrieveAllValues("Field Analyzer"));
-    assertThat(Arrays.asList("1", "2", "3")).isEqualTo(data.retrieveAllValues("Query Executions"));
-    assertThat(Arrays.asList("10", "20", "30")).isEqualTo(data.retrieveAllValues("Commits"));
-    assertThat(Arrays.asList("5", "10", "15")).isEqualTo(data.retrieveAllValues("Updates"));
-    assertThat(Arrays.asList("1", "2", "3")).isEqualTo(data.retrieveAllValues("Documents"));
-    assertThat(Arrays.asList(HeterogeneousLuceneSerializer.class.getSimpleName(),
-        HeterogeneousLuceneSerializer.class.getSimpleName(),
-        HeterogeneousLuceneSerializer.class.getSimpleName()))
-            .isEqualTo(data.retrieveAllValues("Serializer"));
+    assertThat(data.retrieveAllValues("Index Name"))
+        .isEqualTo(Arrays.asList("memberFive", "memberSix", "memberTen"));
+    assertThat(data.retrieveAllValues("Region Path"))
+        .isEqualTo(Arrays.asList("/Employees", "/Employees", "/Employees"));
+    assertThat(data.retrieveAllValues("Indexed Fields")).isEqualTo(Arrays.asList(
+        "[field1, field2, field3]", "[field1, field2, field3]", "[field1, field2, field3]"));
+    assertThat(data.retrieveAllValues("Field Analyzer"))
+        .isEqualTo(Arrays.asList("{field1=StandardAnalyzer, field2=KeywordAnalyzer}",
+            "{field1=StandardAnalyzer, field2=KeywordAnalyzer}",
+            "{field1=StandardAnalyzer, field2=KeywordAnalyzer}"));
+    assertThat(data.retrieveAllValues("Query Executions")).isEqualTo(Arrays.asList("1", "2", "3"));
+    assertThat(data.retrieveAllValues("Commits")).isEqualTo(Arrays.asList("10", "20", "30"));
+    assertThat(data.retrieveAllValues("Updates")).isEqualTo(Arrays.asList("5", "10", "15"));
+    assertThat(data.retrieveAllValues("Documents")).isEqualTo(Arrays.asList("1", "2", "3"));
+    assertThat(data.retrieveAllValues("Serializer"))
+        .isEqualTo(Arrays.asList(HeterogeneousLuceneSerializer.class.getSimpleName(),
+            HeterogeneousLuceneSerializer.class.getSimpleName(),
+            HeterogeneousLuceneSerializer.class.getSimpleName()));
   }
 
   @Test
@@ -227,12 +227,13 @@ public class LuceneIndexCommandsJUnitTest {
 
     CommandResult result = (CommandResult) commands.createIndex(indexName, regionPath,
         searchableFields, fieldAnalyzers, serializer);
-    assertThat(Status.OK).isEqualTo(result.getStatus());
+    assertThat(result.getStatus()).isEqualTo(Status.OK);
     TabularResultData data = (TabularResultData) result.getResultData();
-    assertThat(Arrays.asList("member1", "member2", "member3"))
-        .isEqualTo(data.retrieveAllValues("Member"));
-    assertThat(Arrays.asList("Successfully created lucene index", "Failed: Index creation failed",
-        "Successfully created lucene index")).isEqualTo(data.retrieveAllValues("Status"));
+    assertThat(data.retrieveAllValues("Member"))
+        .isEqualTo(Arrays.asList("member1", "member2", "member3"));
+    assertThat(data.retrieveAllValues("Status"))
+        .isEqualTo(Arrays.asList("Successfully created lucene index",
+            "Failed: Index creation failed", "Successfully created lucene index"));
   }
 
   @Test
@@ -259,21 +260,21 @@ public class LuceneIndexCommandsJUnitTest {
     CommandResult result = (CommandResult) commands.describeIndex("memberFive", "/Employees");
 
     TabularResultData data = (TabularResultData) result.getResultData();
-    assertThat(Collections.singletonList("memberFive"))
-        .isEqualTo(data.retrieveAllValues("Index Name"));
-    assertThat(Collections.singletonList("/Employees"))
-        .isEqualTo(data.retrieveAllValues("Region Path"));
-    assertThat(Collections.singletonList("[field1, field2, field3]"))
-        .isEqualTo(data.retrieveAllValues("Indexed Fields"));
-    assertThat(Collections.singletonList("{field1=StandardAnalyzer, field2=KeywordAnalyzer}"))
-        .isEqualTo(data.retrieveAllValues("Field Analyzer"));
-    assertThat(Collections.singletonList("INITIALIZED"))
-        .isEqualTo(data.retrieveAllValues("Status"));
-    assertThat(Collections.singletonList("1"))
-        .isEqualTo(data.retrieveAllValues("Query Executions"));
-    assertThat(Collections.singletonList("10")).isEqualTo(data.retrieveAllValues("Commits"));
-    assertThat(Collections.singletonList("5")).isEqualTo(data.retrieveAllValues("Updates"));
-    assertThat(Collections.singletonList("1")).isEqualTo(data.retrieveAllValues("Documents"));
+    assertThat(data.retrieveAllValues("Index Name"))
+        .isEqualTo(Collections.singletonList("memberFive"));
+    assertThat(data.retrieveAllValues("Region Path"))
+        .isEqualTo(Collections.singletonList("/Employees"));
+    assertThat(data.retrieveAllValues("Indexed Fields"))
+        .isEqualTo(Collections.singletonList("[field1, field2, field3]"));
+    assertThat(data.retrieveAllValues("Field Analyzer"))
+        .isEqualTo(Collections.singletonList("{field1=StandardAnalyzer, field2=KeywordAnalyzer}"));
+    assertThat(data.retrieveAllValues("Status"))
+        .isEqualTo(Collections.singletonList("INITIALIZED"));
+    assertThat(data.retrieveAllValues("Query Executions"))
+        .isEqualTo(Collections.singletonList("1"));
+    assertThat(data.retrieveAllValues("Commits")).isEqualTo(Collections.singletonList("10"));
+    assertThat(data.retrieveAllValues("Updates")).isEqualTo(Collections.singletonList("5"));
+    assertThat(data.retrieveAllValues("Documents")).isEqualTo(Collections.singletonList("1"));
   }
 
   @Test
@@ -293,10 +294,10 @@ public class LuceneIndexCommandsJUnitTest {
     CommandResult result =
         (CommandResult) commands.searchIndex("index", "region", "Result1", "field1", -1, false);
     TabularResultData data = (TabularResultData) result.getResultData();
-    assertThat(Arrays.asList("A", "B", "C")).isEqualTo(data.retrieveAllValues("key"));
-    assertThat(Arrays.asList("Result1", "Result1", "Result1"))
-        .isEqualTo(data.retrieveAllValues("value"));
-    assertThat(Arrays.asList("1.3", "1.2", "1.1")).isEqualTo(data.retrieveAllValues("score"));
+    assertThat(data.retrieveAllValues("key")).isEqualTo(Arrays.asList("A", "B", "C"));
+    assertThat(data.retrieveAllValues("value"))
+        .isEqualTo(Arrays.asList("Result1", "Result1", "Result1"));
+    assertThat(data.retrieveAllValues("score")).isEqualTo(Arrays.asList("1.3", "1.2", "1.1"));
   }
 
   @Ignore
@@ -334,36 +335,36 @@ public class LuceneIndexCommandsJUnitTest {
     verify(mockGfsh, times(20)).printAsInfo(resultCaptor.capture());
     List<String> actualPageResults = resultCaptor.getAllValues();
 
-    assertThat(expectedPage1).isEqualTo(actualPageResults.get(0));
-    assertThat("\t\tPage 1 of 4").isEqualTo(actualPageResults.get(1));
+    assertThat(actualPageResults.get(0)).isEqualTo(expectedPage1);
+    assertThat(actualPageResults.get(1)).isEqualTo("\t\tPage 1 of 4");
 
-    assertThat(expectedPage2).isEqualTo(actualPageResults.get(2));
-    assertThat("\t\tPage 2 of 4").isEqualTo(actualPageResults.get(3));
+    assertThat(actualPageResults.get(2)).isEqualTo(expectedPage2);
+    assertThat(actualPageResults.get(3)).isEqualTo("\t\tPage 2 of 4");
 
-    assertThat(expectedPage3).isEqualTo(actualPageResults.get(4));
-    assertThat("\t\tPage 3 of 4").isEqualTo(actualPageResults.get(5));
+    assertThat(actualPageResults.get(4)).isEqualTo(expectedPage3);
+    assertThat(actualPageResults.get(5)).isEqualTo("\t\tPage 3 of 4");
 
-    assertThat(expectedPage4).isEqualTo(actualPageResults.get(6));
-    assertThat("\t\tPage 4 of 4").isEqualTo(actualPageResults.get(7));
+    assertThat(actualPageResults.get(6)).isEqualTo(expectedPage4);
+    assertThat(actualPageResults.get(7)).isEqualTo("\t\tPage 4 of 4");
 
-    assertThat("No more results to display.").isEqualTo(actualPageResults.get(8));
+    assertThat(actualPageResults.get(8)).isEqualTo("No more results to display.");
 
-    assertThat(expectedPage4).isEqualTo(actualPageResults.get(9));
-    assertThat("\t\tPage 4 of 4").isEqualTo(actualPageResults.get(10));
+    assertThat(actualPageResults.get(9)).isEqualTo(expectedPage4);
+    assertThat(actualPageResults.get(10)).isEqualTo("\t\tPage 4 of 4");
 
-    assertThat(expectedPage3).isEqualTo(actualPageResults.get(11));
-    assertThat("\t\tPage 3 of 4").isEqualTo(actualPageResults.get(12));
+    assertThat(actualPageResults.get(11)).isEqualTo(expectedPage3);
+    assertThat(actualPageResults.get(12)).isEqualTo("\t\tPage 3 of 4");
 
-    assertThat(expectedPage2).isEqualTo(actualPageResults.get(13));
-    assertThat("\t\tPage 2 of 4").isEqualTo(actualPageResults.get(14));
+    assertThat(actualPageResults.get(13)).isEqualTo(expectedPage2);
+    assertThat(actualPageResults.get(14)).isEqualTo("\t\tPage 2 of 4");
 
-    assertThat(expectedPage1).isEqualTo(actualPageResults.get(15));
-    assertThat("\t\tPage 1 of 4").isEqualTo(actualPageResults.get(16));
+    assertThat(actualPageResults.get(15)).isEqualTo(expectedPage1);
+    assertThat(actualPageResults.get(16)).isEqualTo("\t\tPage 1 of 4");
 
-    assertThat("At the top of the search results.").isEqualTo(actualPageResults.get(17));
+    assertThat(actualPageResults.get(17)).isEqualTo("At the top of the search results.");
 
-    assertThat(expectedPage1).isEqualTo(actualPageResults.get(18));
-    assertThat("\t\tPage 1 of 4").isEqualTo(actualPageResults.get(19));
+    assertThat(actualPageResults.get(18)).isEqualTo(expectedPage1);
+    assertThat(actualPageResults.get(19)).isEqualTo("\t\tPage 1 of 4");
   }
 
   @Test
@@ -382,10 +383,8 @@ public class LuceneIndexCommandsJUnitTest {
 
     CommandResult result =
         (CommandResult) commands.searchIndex("index", "region", "Result1", "field1", -1, true);
-
     TabularResultData data = (TabularResultData) result.getResultData();
-
-    assertThat(Arrays.asList("A", "B", "C")).isEqualTo(data.retrieveAllValues("key"));
+    assertThat(data.retrieveAllValues("key")).isEqualTo(Arrays.asList("A", "B", "C"));
   }
 
   @Test
@@ -421,10 +420,8 @@ public class LuceneIndexCommandsJUnitTest {
 
     CommandResult result =
         (CommandResult) commands.searchIndex("index", "region", "Result1", "field1", -1, true);
-
     TabularResultData data = (TabularResultData) result.getResultData();
-
-    assertThat(queryResults.size()).isEqualTo(data.retrieveAllValues("key").size());
+    assertThat(data.retrieveAllValues("key").size()).isEqualTo(queryResults.size());
   }
 
   @Test
@@ -543,19 +540,19 @@ public class LuceneIndexCommandsJUnitTest {
 
   private void verifyDestroyIndexCommandResult(CommandResult result,
       List<CliFunctionResult> cliFunctionResults, String expectedStatus) {
-    assertThat(Status.OK).isEqualTo(result.getStatus());
+    assertThat(result.getStatus()).isEqualTo(Status.OK);
     if (result.getType().equals(TYPE_TABULAR)) {
       TabularResultData data = (TabularResultData) result.getResultData();
       List<String> members = data.retrieveAllValues("Member");
       assertThat(cliFunctionResults.size()).isEqualTo(members.size());
       // Verify each member
       for (int i = 0; i < members.size(); i++) {
-        assertThat("member" + i).isEqualTo(members.get(i));
+        assertThat(members.get(i)).isEqualTo("member" + i);
       }
       // Verify each status
       List<String> status = data.retrieveAllValues("Status");
       for (String statu : status) {
-        assertThat(expectedStatus).isEqualTo(statu);
+        assertThat(statu).isEqualTo(expectedStatus);
       }
     } else {
       // Info result. Verify next lines are equal.

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/distributed/TopEntriesJUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/distributed/TopEntriesJUnitTest.java
@@ -41,7 +41,7 @@ public class TopEntriesJUnitTest {
     hits.addHit(r1_2);
     hits.addHit(r2_2);
 
-    assertThat(4).isEqualTo(hits.size());
+    assertThat(hits.size()).isEqualTo(4);
     LuceneTestUtilities.verifyResultOrder(hits.getHits(), r1_1, r2_1, r1_2, r2_2);
   }
 
@@ -54,17 +54,17 @@ public class TopEntriesJUnitTest {
     hits.addHit(r1);
     hits.addHit(r2);
 
-    assertThat(2).isEqualTo(hits.size());
+    assertThat(hits.size()).isEqualTo(2);
     LuceneTestUtilities.verifyResultOrder(hits.getHits(), r1, r2);
   }
 
   @Test
   public void testInitialization() {
     TopEntries<String> hits = new TopEntries<>();
-    assertThat(LuceneQueryFactory.DEFAULT_LIMIT).isEqualTo(hits.getLimit());
+    assertThat(hits.getLimit()).isEqualTo(LuceneQueryFactory.DEFAULT_LIMIT);
 
     hits = new TopEntries<>(123);
-    assertThat(123).isEqualTo(hits.getLimit());
+    assertThat(hits.getLimit()).isEqualTo(123);
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -81,7 +81,7 @@ public class TopEntriesJUnitTest {
     hits.addHit(r1_2);
     hits.addHit(r2_2);
 
-    assertThat(3).isEqualTo(hits.size());
+    assertThat(hits.size()).isEqualTo(3);
     LuceneTestUtilities.verifyResultOrder(hits.getHits(), r1_1, r2_1, r1_2);
   }
 
@@ -92,8 +92,9 @@ public class TopEntriesJUnitTest {
     TopEntries<String> hits = new TopEntries<>(3);
 
     TopEntries<String> copy = CopyHelper.deepCopy(hits);
-    assertThat(3).isEqualTo(copy.getLimit());
-    assertThat(0).isEqualTo(copy.getHits().size());
+    assertThat(copy).isNotNull();
+    assertThat(copy.getLimit()).isEqualTo(3);
+    assertThat(copy.getHits().size()).isEqualTo(0);
 
     hits = new TopEntries<>(3);
     hits.addHit(r1_1);
@@ -101,7 +102,8 @@ public class TopEntriesJUnitTest {
     hits.addHit(r1_2);
 
     copy = CopyHelper.deepCopy(hits);
-    assertThat(3).isEqualTo(copy.size());
+    assertThat(copy).isNotNull();
+    assertThat(copy.size()).isEqualTo(3);
     LuceneTestUtilities.verifyResultOrder(copy.getHits(), r1_1, r2_1, r1_2);
   }
 }

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/distributed/TopEntriesJUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/distributed/TopEntriesJUnitTest.java
@@ -14,13 +14,8 @@
  */
 package org.apache.geode.cache.lucene.internal.distributed;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.jmock.Mockery;
-import org.jmock.lib.concurrent.Synchroniser;
-import org.jmock.lib.legacy.ClassImposteriser;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -30,17 +25,15 @@ import org.apache.geode.cache.lucene.internal.LuceneServiceImpl;
 import org.apache.geode.cache.lucene.test.LuceneTestUtilities;
 import org.apache.geode.test.junit.categories.LuceneTest;
 
-@Category({LuceneTest.class})
+@Category(LuceneTest.class)
 public class TopEntriesJUnitTest {
-
-  private Mockery mockContext;
-
-  private EntryScore<String> r1_1 = new EntryScore("3", .9f);
-  private EntryScore<String> r1_2 = new EntryScore("1", .8f);
-  private EntryScore<String> r2_1 = new EntryScore("2", 0.85f);
-  private EntryScore<String> r2_2 = new EntryScore("4", 0.1f);
+  private EntryScore<String> r1_1 = new EntryScore<>("3", .9f);
+  private EntryScore<String> r1_2 = new EntryScore<>("1", .8f);
+  private EntryScore<String> r2_1 = new EntryScore<>("2", 0.85f);
+  private EntryScore<String> r2_2 = new EntryScore<>("4", 0.1f);
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testPopulateTopEntries() {
     TopEntries<String> hits = new TopEntries<>();
     hits.addHit(r1_1);
@@ -48,11 +41,12 @@ public class TopEntriesJUnitTest {
     hits.addHit(r1_2);
     hits.addHit(r2_2);
 
-    assertEquals(4, hits.size());
+    assertThat(4).isEqualTo(hits.size());
     LuceneTestUtilities.verifyResultOrder(hits.getHits(), r1_1, r2_1, r1_2, r2_2);
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void putSameScoreEntries() {
     TopEntries<String> hits = new TopEntries<>();
     EntryScore<String> r1 = new EntryScore<>("1", .8f);
@@ -60,17 +54,17 @@ public class TopEntriesJUnitTest {
     hits.addHit(r1);
     hits.addHit(r2);
 
-    assertEquals(2, hits.size());
+    assertThat(2).isEqualTo(hits.size());
     LuceneTestUtilities.verifyResultOrder(hits.getHits(), r1, r2);
   }
 
   @Test
   public void testInitialization() {
     TopEntries<String> hits = new TopEntries<>();
-    assertEquals(LuceneQueryFactory.DEFAULT_LIMIT, hits.getLimit());
+    assertThat(LuceneQueryFactory.DEFAULT_LIMIT).isEqualTo(hits.getLimit());
 
     hits = new TopEntries<>(123);
-    assertEquals(123, hits.getLimit());
+    assertThat(123).isEqualTo(hits.getLimit());
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -79,25 +73,27 @@ public class TopEntriesJUnitTest {
   }
 
   @Test
-  public void enforceLimit() throws Exception {
+  @SuppressWarnings("unchecked")
+  public void enforceLimit() {
     TopEntries<String> hits = new TopEntries<>(3);
     hits.addHit(r1_1);
     hits.addHit(r2_1);
     hits.addHit(r1_2);
     hits.addHit(r2_2);
 
-    assertEquals(3, hits.size());
+    assertThat(3).isEqualTo(hits.size());
     LuceneTestUtilities.verifyResultOrder(hits.getHits(), r1_1, r2_1, r1_2);
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testSerialization() {
     LuceneServiceImpl.registerDataSerializables();
     TopEntries<String> hits = new TopEntries<>(3);
 
     TopEntries<String> copy = CopyHelper.deepCopy(hits);
-    assertEquals(3, copy.getLimit());
-    assertEquals(0, copy.getHits().size());
+    assertThat(3).isEqualTo(copy.getLimit());
+    assertThat(0).isEqualTo(copy.getHits().size());
 
     hits = new TopEntries<>(3);
     hits.addHit(r1_1);
@@ -105,23 +101,7 @@ public class TopEntriesJUnitTest {
     hits.addHit(r1_2);
 
     copy = CopyHelper.deepCopy(hits);
-    assertEquals(3, copy.size());
+    assertThat(3).isEqualTo(copy.size());
     LuceneTestUtilities.verifyResultOrder(copy.getHits(), r1_1, r2_1, r1_2);
-  }
-
-  @Before
-  public void setupMock() {
-    mockContext = new Mockery() {
-      {
-        setImposteriser(ClassImposteriser.INSTANCE);
-        setThreadingPolicy(new Synchroniser());
-      }
-    };
-  }
-
-  @After
-  public void validateMock() {
-    mockContext.assertIsSatisfied();
-    mockContext = null;
   }
 }

--- a/geode-rebalancer/src/test/java/org/apache/geode/cache/util/AutoBalancerJUnitTest.java
+++ b/geode-rebalancer/src/test/java/org/apache/geode/cache/util/AutoBalancerJUnitTest.java
@@ -225,8 +225,8 @@ public class AutoBalancerJUnitTest {
     AutoBalancer balancer = new AutoBalancer();
     balancer.initialize(null, getBasicConfig());
     SizeBasedOOBAuditor auditor = (SizeBasedOOBAuditor) balancer.getOOBAuditor();
-    assertThat(AutoBalancer.DEFAULT_SIZE_THRESHOLD_PERCENT).isEqualTo(auditor.getSizeThreshold());
-    assertThat(AutoBalancer.DEFAULT_MINIMUM_SIZE).isEqualTo(auditor.getSizeMinimum());
+    assertThat(auditor.getSizeThreshold()).isEqualTo(AutoBalancer.DEFAULT_SIZE_THRESHOLD_PERCENT);
+    assertThat(auditor.getSizeMinimum()).isEqualTo(AutoBalancer.DEFAULT_MINIMUM_SIZE);
 
     Properties props = getBasicConfig();
     props.put(AutoBalancer.SIZE_THRESHOLD_PERCENT, "17");
@@ -234,8 +234,8 @@ public class AutoBalancerJUnitTest {
     balancer = new AutoBalancer();
     balancer.initialize(null, props);
     auditor = (SizeBasedOOBAuditor) balancer.getOOBAuditor();
-    assertThat(17).isEqualTo(auditor.getSizeThreshold());
-    assertThat(10).isEqualTo(auditor.getSizeMinimum());
+    assertThat(auditor.getSizeThreshold()).isEqualTo(17);
+    assertThat(auditor.getSizeMinimum()).isEqualTo(10);
   }
 
   @Test
@@ -299,7 +299,7 @@ public class AutoBalancerJUnitTest {
 
   @Test
   public void testFacadeTotalTransferSize() throws Exception {
-    assertThat(12345).isEqualTo(getFacadeForResourceManagerOps(true).getTotalTransferSize());
+    assertThat(getFacadeForResourceManagerOps(true).getTotalTransferSize()).isEqualTo(12345);
   }
 
   @Test
@@ -312,7 +312,7 @@ public class AutoBalancerJUnitTest {
   public void testFacadeTotalBytesNoRegion() {
     CacheOperationFacade facade = new AutoBalancer().getCacheOperationFacade();
 
-    assertThat(0).isEqualTo(facade.getTotalDataSize(new HashMap<>()));
+    assertThat(facade.getTotalDataSize(new HashMap<>())).isEqualTo(0);
   }
 
   @Test
@@ -322,7 +322,7 @@ public class AutoBalancerJUnitTest {
     when(mockCache.getPartitionedRegions()).thenReturn(Collections.emptySet());
     GeodeCacheFacade facade = new GeodeCacheFacade(mockCache);
 
-    assertThat(0).isEqualTo(facade.getRegionMemberDetails().size());
+    assertThat(facade.getRegionMemberDetails().size()).isEqualTo(0);
   }
 
   @Test
@@ -357,7 +357,7 @@ public class AutoBalancerJUnitTest {
     GeodeCacheFacade facade = new GeodeCacheFacade(mockCache);
     Map<PartitionedRegion, InternalPRInfo> map = facade.getRegionMemberDetails();
     assertThat(map).isNotNull();
-    assertThat(2).isEqualTo(map.size());
+    assertThat(map.size()).isEqualTo(2);
     assertThat(map.get(mockR1)).isEqualTo(mockR1PRInfo);
     assertThat(map.get(mockR2)).isEqualTo(mockR2PRInfo);
   }
@@ -394,7 +394,7 @@ public class AutoBalancerJUnitTest {
       }
     };
 
-    assertThat(123 + 74 + 3475).isEqualTo(facade.getTotalDataSize(details));
+    assertThat(facade.getTotalDataSize(details)).isEqualTo(123 + 74 + 3475);
     verify(mockR1M1Info, atLeastOnce()).getSize();
     verify(mockR1M2Info, atLeastOnce()).getSize();
     verify(mockR2M1Info, atLeastOnce()).getSize();
@@ -410,7 +410,7 @@ public class AutoBalancerJUnitTest {
     });
 
     Properties props = AutoBalancerJUnitTest.getBasicConfig();
-    assertThat(3).isEqualTo(latch.getCount());
+    assertThat(latch.getCount()).isEqualTo(3);
     AutoBalancer autoR = new AutoBalancer(null, mockAuditor, mockClock, null);
     autoR.initialize(null, props);
 
@@ -436,7 +436,7 @@ public class AutoBalancerJUnitTest {
     });
 
     Properties props = AutoBalancerJUnitTest.getBasicConfig();
-    assertThat(2).isEqualTo(latch.getCount());
+    assertThat(latch.getCount()).isEqualTo(2);
     AutoBalancer autoR = new AutoBalancer(null, mockAuditor, mockClock, null);
     autoR.initialize(null, props);
     assertThat(latch.await(1, TimeUnit.MINUTES)).isTrue();

--- a/geode-rebalancer/src/test/java/org/apache/geode/cache/util/AutoBalancerJUnitTest.java
+++ b/geode-rebalancer/src/test/java/org/apache/geode/cache/util/AutoBalancerJUnitTest.java
@@ -14,12 +14,19 @@
  */
 package org.apache.geode.cache.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -27,17 +34,10 @@ import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.jmock.Expectations;
-import org.jmock.Mockery;
-import org.jmock.Sequence;
-import org.jmock.api.Invocation;
-import org.jmock.lib.action.CustomAction;
-import org.jmock.lib.concurrent.Synchroniser;
-import org.jmock.lib.legacy.ClassImposteriser;
-import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
 
 import org.apache.geode.GemFireConfigException;
 import org.apache.geode.cache.control.RebalanceFactory;
@@ -61,261 +61,217 @@ import org.apache.geode.internal.cache.partitioned.LoadProbe;
  * UnitTests for AutoBalancer. All collaborators should be mocked.
  */
 public class AutoBalancerJUnitTest {
-  Mockery mockContext;
-
-  CacheOperationFacade mockCacheFacade;
-  OOBAuditor mockAuditor;
-  AuditScheduler mockScheduler;
-  TimeProvider mockClock;
+  private TimeProvider mockClock;
+  private OOBAuditor mockAuditor;
+  private AuditScheduler mockScheduler;
+  private CacheOperationFacade mockCacheFacade;
 
   @Before
   public void setupMock() {
-    mockContext = new Mockery() {
-      {
-        setImposteriser(ClassImposteriser.INSTANCE);
-        setThreadingPolicy(new Synchroniser());
-      }
-    };
-
-    mockCacheFacade = mockContext.mock(CacheOperationFacade.class);
-    mockAuditor = mockContext.mock(OOBAuditor.class);
-    mockScheduler = mockContext.mock(AuditScheduler.class);
-    mockClock = mockContext.mock(TimeProvider.class);
+    mockClock = mock(TimeProvider.class);
+    mockAuditor = mock(OOBAuditor.class);
+    mockScheduler = mock(AuditScheduler.class);
+    mockCacheFacade = mock(CacheOperationFacade.class);
   }
 
-  @After
-  public void validateMock() {
-    mockContext.assertIsSatisfied();
-    mockContext = null;
+  private static Properties getBasicConfig() {
+    Properties props = new Properties();
+    // every second schedule
+    props.put(AutoBalancer.SCHEDULE, "* 0/30 * * * ?");
+    return props;
+  }
+
+  private GeodeCacheFacade getFacadeForResourceManagerOps(final boolean simulate) throws Exception {
+    final GemFireCacheImpl mockCache = mock(GemFireCacheImpl.class);
+    final InternalResourceManager mockRM = mock(InternalResourceManager.class);
+    final RebalanceFactory mockRebalanceFactory = mock(RebalanceFactory.class);
+    final RebalanceOperation mockRebalanceOperation = mock(RebalanceOperation.class);
+    final RebalanceResults mockRebalanceResults = mock(RebalanceResults.class);
+
+    when(mockCache.isClosed()).thenReturn(false);
+    when(mockCache.getResourceManager()).thenReturn(mockRM);
+    when(mockRM.createRebalanceFactory()).thenReturn(mockRebalanceFactory);
+    when(mockRebalanceFactory.start()).thenReturn(mockRebalanceOperation);
+    when(mockRebalanceFactory.simulate()).thenReturn(mockRebalanceOperation);
+    when(mockRebalanceOperation.getResults()).thenReturn(mockRebalanceResults);
+    if (simulate)
+      when(mockRebalanceResults.getTotalBucketTransferBytes()).thenReturn(12345L);
+
+    return new GeodeCacheFacade(mockCache);
   }
 
   @Test
-  public void testLockStatExecuteInSequence() throws InterruptedException {
-    final Sequence sequence = mockContext.sequence("sequence");
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockCacheFacade).acquireAutoBalanceLock();
-        inSequence(sequence);
-        will(returnValue(true));
-        oneOf(mockCacheFacade).incrementAttemptCounter();
-        inSequence(sequence);
-        oneOf(mockCacheFacade).getTotalTransferSize();
-        inSequence(sequence);
-        will(returnValue(0L));
-      }
-    });
+  public void testLockStatExecuteInSequence() {
+    when(mockCacheFacade.acquireAutoBalanceLock()).thenReturn(true);
+    when(mockCacheFacade.getTotalTransferSize()).thenReturn(0L);
 
     AutoBalancer balancer = new AutoBalancer(null, null, null, mockCacheFacade);
     balancer.getOOBAuditor().execute();
+    InOrder inOrder = Mockito.inOrder(mockCacheFacade);
+    inOrder.verify(mockCacheFacade, times(1)).acquireAutoBalanceLock();
+    inOrder.verify(mockCacheFacade, times(1)).incrementAttemptCounter();
+    inOrder.verify(mockCacheFacade, times(1)).getTotalTransferSize();
   }
 
   @Test
-  public void testAcquireLockAfterReleasedRemotely() throws InterruptedException {
-    final Sequence sequence = mockContext.sequence("sequence");
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockCacheFacade).acquireAutoBalanceLock();
-        inSequence(sequence);
-        will(returnValue(false));
-        oneOf(mockCacheFacade).acquireAutoBalanceLock();
-        inSequence(sequence);
-        will(returnValue(true));
-        oneOf(mockCacheFacade).incrementAttemptCounter();
-        oneOf(mockCacheFacade).getTotalTransferSize();
-        will(returnValue(0L));
-      }
-    });
+  public void testAcquireLockAfterReleasedRemotely() {
+    when(mockCacheFacade.getTotalTransferSize()).thenReturn(0L);
+    when(mockCacheFacade.acquireAutoBalanceLock()).thenReturn(false, true);
 
     AutoBalancer balancer = new AutoBalancer(null, null, null, mockCacheFacade);
     balancer.getOOBAuditor().execute();
     balancer.getOOBAuditor().execute();
+    InOrder inOrder = Mockito.inOrder(mockCacheFacade);
+    inOrder.verify(mockCacheFacade, times(2)).acquireAutoBalanceLock();
+    inOrder.verify(mockCacheFacade, times(1)).incrementAttemptCounter();
+    inOrder.verify(mockCacheFacade, times(1)).getTotalTransferSize();
   }
 
   @Test
-  public void testFailExecuteIfLockedElsewhere() throws InterruptedException {
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockCacheFacade).acquireAutoBalanceLock();
-        will(returnValue(false));
-        // no other methods, rebalance, will be called
-      }
-    });
+  public void testFailExecuteIfLockedElsewhere() {
+    when(mockCacheFacade.acquireAutoBalanceLock()).thenReturn(false);
 
     AutoBalancer balancer = new AutoBalancer(null, null, null, mockCacheFacade);
     balancer.getOOBAuditor().execute();
+    verify(mockCacheFacade, times(1)).acquireAutoBalanceLock();
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testNoCacheError() {
     AutoBalancer balancer = new AutoBalancer();
     OOBAuditor auditor = balancer.getOOBAuditor();
-    auditor.execute();
+    assertThatThrownBy(auditor::execute).isInstanceOf(IllegalStateException.class);
   }
 
   @Test
   public void testOOBWhenBelowSizeThreshold() {
     final long totalSize = 1000L;
-
     final Map<PartitionedRegion, InternalPRInfo> details = new HashMap<>();
-    mockContext.checking(new Expectations() {
-      {
-        allowing(mockCacheFacade).getRegionMemberDetails();
-        will(returnValue(details));
-        // first run
-        oneOf(mockCacheFacade).getTotalDataSize(details);
-        will(returnValue(totalSize));
-        oneOf(mockCacheFacade).getTotalTransferSize();
-        // half of threshold limit
-        will(returnValue((AutoBalancer.DEFAULT_SIZE_THRESHOLD_PERCENT * totalSize / 100) / 2));
-
-        // second run
-        oneOf(mockCacheFacade).getTotalTransferSize();
-        // nothing to transfer
-        will(returnValue(0L));
-      }
-    });
+    when(mockCacheFacade.getRegionMemberDetails()).thenReturn(details);
+    when(mockCacheFacade.getTotalDataSize(details)).thenReturn(totalSize);
+    // First Run: half of threshold limit. Second Run: nothing to transfer.
+    when(mockCacheFacade.getTotalTransferSize())
+        .thenReturn((AutoBalancer.DEFAULT_SIZE_THRESHOLD_PERCENT * totalSize / 100) / 2, 0L);
 
     AutoBalancer balancer = new AutoBalancer(null, null, null, mockCacheFacade);
     Properties config = getBasicConfig();
     config.put(AutoBalancer.MINIMUM_SIZE, "10");
-    balancer.init(config);
+    balancer.initialize(null, config);
     SizeBasedOOBAuditor auditor = (SizeBasedOOBAuditor) balancer.getOOBAuditor();
 
-    // first run
-    assertFalse(auditor.needsRebalancing());
+    // First run
+    assertThat(auditor.needsRebalancing()).isFalse();
 
-    // second run
-    assertFalse(auditor.needsRebalancing());
+    // Second run
+    assertThat(auditor.needsRebalancing()).isFalse();
   }
 
   @Test
   public void testOOBWhenAboveThresholdButBelowMin() {
     final long totalSize = 1000L;
-
-    mockContext.checking(new Expectations() {
-      {
-        // first run
-        oneOf(mockCacheFacade).getTotalTransferSize();
-        // twice threshold
-        will(returnValue((AutoBalancer.DEFAULT_SIZE_THRESHOLD_PERCENT * totalSize / 100) * 2));
-
-        // second run
-        oneOf(mockCacheFacade).getTotalTransferSize();
-        // more than total size
-        will(returnValue(2 * totalSize));
-      }
-    });
+    // First Run: twice threshold. Second Run: more than total size.
+    when(mockCacheFacade.getTotalTransferSize()).thenReturn(
+        (AutoBalancer.DEFAULT_SIZE_THRESHOLD_PERCENT * totalSize / 100) / 2, 2 * totalSize);
 
     AutoBalancer balancer = new AutoBalancer(null, null, null, mockCacheFacade);
     Properties config = getBasicConfig();
     config.put(AutoBalancer.MINIMUM_SIZE, "" + (totalSize * 5));
-    balancer.init(config);
+    balancer.initialize(null, config);
     SizeBasedOOBAuditor auditor = (SizeBasedOOBAuditor) balancer.getOOBAuditor();
 
-    // first run
-    assertFalse(auditor.needsRebalancing());
+    // First run
+    assertThat(auditor.needsRebalancing()).isFalse();
 
-    // second run
-    assertFalse(auditor.needsRebalancing());
+    // Second run
+    assertThat(auditor.needsRebalancing()).isFalse();
   }
 
   @Test
   public void testOOBWhenAboveThresholdAndMin() {
     final long totalSize = 1000L;
-
     final Map<PartitionedRegion, InternalPRInfo> details = new HashMap<>();
-    mockContext.checking(new Expectations() {
-      {
-        allowing(mockCacheFacade).getRegionMemberDetails();
-        will(returnValue(details));
-
-        // first run
-        oneOf(mockCacheFacade).getTotalDataSize(details);
-        will(returnValue(totalSize));
-        oneOf(mockCacheFacade).getTotalTransferSize();
-        // twice threshold
-        will(returnValue((AutoBalancer.DEFAULT_SIZE_THRESHOLD_PERCENT * totalSize / 100) * 2));
-
-        // second run
-        oneOf(mockCacheFacade).getTotalDataSize(details);
-        will(returnValue(totalSize));
-        oneOf(mockCacheFacade).getTotalTransferSize();
-        // more than total size
-        will(returnValue(2 * totalSize));
-      }
-    });
+    when(mockCacheFacade.getRegionMemberDetails()).thenReturn(details);
+    when(mockCacheFacade.getTotalDataSize(details)).thenReturn(totalSize);
+    // First Run: twice threshold. Second Run: more than total size.
+    when(mockCacheFacade.getTotalTransferSize()).thenReturn(
+        (AutoBalancer.DEFAULT_SIZE_THRESHOLD_PERCENT * totalSize / 100) * 2, 2 * totalSize);
 
     AutoBalancer balancer = new AutoBalancer(null, null, null, mockCacheFacade);
     Properties config = getBasicConfig();
     config.put(AutoBalancer.MINIMUM_SIZE, "10");
-    balancer.init(config);
+    balancer.initialize(null, config);
     SizeBasedOOBAuditor auditor = (SizeBasedOOBAuditor) balancer.getOOBAuditor();
 
-    // first run
-    assertTrue(auditor.needsRebalancing());
+    // First run
+    assertThat(auditor.needsRebalancing()).isTrue();
 
-    // second run
-    assertTrue(auditor.needsRebalancing());
+    // Second run
+    assertThat(auditor.needsRebalancing()).isTrue();
   }
 
-  @Test(expected = GemFireConfigException.class)
+  @Test
   public void testInvalidSchedule() {
     String someSchedule = "X Y * * * *";
     Properties props = new Properties();
     props.put(AutoBalancer.SCHEDULE, someSchedule);
 
     AutoBalancer autoR = new AutoBalancer();
-    autoR.init(props);
+    assertThatThrownBy(() -> autoR.initialize(null, props))
+        .isInstanceOf(GemFireConfigException.class);
   }
 
   @Test
   public void testOOBAuditorInit() {
     AutoBalancer balancer = new AutoBalancer();
-    balancer.init(getBasicConfig());
+    balancer.initialize(null, getBasicConfig());
     SizeBasedOOBAuditor auditor = (SizeBasedOOBAuditor) balancer.getOOBAuditor();
-    assertEquals(AutoBalancer.DEFAULT_SIZE_THRESHOLD_PERCENT, auditor.getSizeThreshold());
-    assertEquals(AutoBalancer.DEFAULT_MINIMUM_SIZE, auditor.getSizeMinimum());
+    assertThat(AutoBalancer.DEFAULT_SIZE_THRESHOLD_PERCENT).isEqualTo(auditor.getSizeThreshold());
+    assertThat(AutoBalancer.DEFAULT_MINIMUM_SIZE).isEqualTo(auditor.getSizeMinimum());
 
     Properties props = getBasicConfig();
     props.put(AutoBalancer.SIZE_THRESHOLD_PERCENT, "17");
     props.put(AutoBalancer.MINIMUM_SIZE, "10");
     balancer = new AutoBalancer();
-    balancer.init(props);
+    balancer.initialize(null, props);
     auditor = (SizeBasedOOBAuditor) balancer.getOOBAuditor();
-    assertEquals(17, auditor.getSizeThreshold());
-    assertEquals(10, auditor.getSizeMinimum());
+    assertThat(17).isEqualTo(auditor.getSizeThreshold());
+    assertThat(10).isEqualTo(auditor.getSizeMinimum());
   }
 
-  @Test(expected = GemFireConfigException.class)
+  @Test
   public void testConfigTransferThresholdNegative() {
     AutoBalancer balancer = new AutoBalancer();
     Properties props = getBasicConfig();
     props.put(AutoBalancer.SIZE_THRESHOLD_PERCENT, "-1");
-    balancer.initialize(null, props);
+    assertThatThrownBy(() -> balancer.initialize(null, props))
+        .isInstanceOf(GemFireConfigException.class);
   }
 
-  @Test(expected = GemFireConfigException.class)
+  @Test
   public void testConfigSizeMinNegative() {
     AutoBalancer balancer = new AutoBalancer();
     Properties props = getBasicConfig();
     props.put(AutoBalancer.MINIMUM_SIZE, "-1");
-    balancer.initialize(null, props);
+    assertThatThrownBy(() -> balancer.initialize(null, props))
+        .isInstanceOf(GemFireConfigException.class);
   }
 
-  @Test(expected = GemFireConfigException.class)
+  @Test
   public void testConfigTransferThresholdZero() {
     AutoBalancer balancer = new AutoBalancer();
     Properties props = getBasicConfig();
     props.put(AutoBalancer.SIZE_THRESHOLD_PERCENT, "0");
-    balancer.initialize(null, props);
+    assertThatThrownBy(() -> balancer.initialize(null, props))
+        .isInstanceOf(GemFireConfigException.class);
   }
 
-  @Test(expected = GemFireConfigException.class)
+  @Test
   public void testConfigTransferThresholdTooHigh() {
     AutoBalancer balancer = new AutoBalancer();
     Properties props = getBasicConfig();
     props.put(AutoBalancer.SIZE_THRESHOLD_PERCENT, "100");
-    balancer.initialize(null, props);
+    assertThatThrownBy(() -> balancer.initialize(null, props))
+        .isInstanceOf(GemFireConfigException.class);
   }
 
   @Test
@@ -325,204 +281,111 @@ public class AutoBalancerJUnitTest {
     props.put(AutoBalancer.SCHEDULE, someSchedule);
     props.put(AutoBalancer.SIZE_THRESHOLD_PERCENT, 17);
 
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockScheduler).init(someSchedule);
-        oneOf(mockAuditor).init(props);
-      }
-    });
-
     AutoBalancer autoR = new AutoBalancer(mockScheduler, mockAuditor, null, null);
     autoR.initialize(null, props);
+    verify(mockAuditor, times(1)).init(props);
+    verify(mockScheduler, times(1)).init(someSchedule);
   }
 
   @Test
   public void testMinimalConfiguration() {
     AutoBalancer autoR = new AutoBalancer();
-    try {
-      autoR.init(null);
-      fail();
-    } catch (GemFireConfigException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> autoR.initialize(null, null))
+        .isInstanceOf(GemFireConfigException.class);
 
     Properties props = getBasicConfig();
-    autoR.init(props);
+    assertThatCode(() -> autoR.initialize(null, props)).doesNotThrowAnyException();
   }
 
   @Test
-  @Ignore("GEODE-2789: need to rewrite this test")
   public void testFacadeTotalTransferSize() throws Exception {
-    assertEquals(12345, getFacadeForResourceManagerOps(true).getTotalTransferSize());
+    assertThat(12345).isEqualTo(getFacadeForResourceManagerOps(true).getTotalTransferSize());
   }
 
   @Test
-  @Ignore("GEODE-2789: need to rewrite this test")
-  public void testFacadeRebalance() throws Exception {
-    getFacadeForResourceManagerOps(false).rebalance();
-  }
-
-  private GeodeCacheFacade getFacadeForResourceManagerOps(final boolean simulate) throws Exception {
-    final GemFireCacheImpl mockCache = mockContext.mock(GemFireCacheImpl.class);
-    final InternalResourceManager mockRM = mockContext.mock(InternalResourceManager.class);
-    final RebalanceFactory mockRebalanceFactory = mockContext.mock(RebalanceFactory.class);
-    final RebalanceOperation mockRebalanceOperation = mockContext.mock(RebalanceOperation.class);
-    final RebalanceResults mockRebalanceResults = mockContext.mock(RebalanceResults.class);
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockCache).isClosed();
-        will(returnValue(false));
-        oneOf(mockCache).getResourceManager();
-        will(returnValue(mockRM));
-        oneOf(mockRM).createRebalanceFactory();
-        will(returnValue(mockRebalanceFactory));
-        if (simulate) {
-          oneOf(mockRebalanceFactory).simulate();
-        } else {
-          oneOf(mockRebalanceFactory).start();
-        }
-        will(returnValue(mockRebalanceOperation));
-        oneOf(mockRebalanceOperation).getResults();
-        will(returnValue(mockRebalanceResults));
-        if (simulate) {
-          atLeast(1).of(mockRebalanceResults).getTotalBucketTransferBytes();
-          will(returnValue(12345L));
-        }
-        allowing(mockRebalanceResults);
-      }
-    });
-
-    GeodeCacheFacade facade = new GeodeCacheFacade(mockCache);
-
-    return facade;
+  public void testFacadeRebalance() {
+    assertThatCode(() -> getFacadeForResourceManagerOps(false).rebalance())
+        .doesNotThrowAnyException();
   }
 
   @Test
   public void testFacadeTotalBytesNoRegion() {
     CacheOperationFacade facade = new AutoBalancer().getCacheOperationFacade();
 
-    assertEquals(0, facade.getTotalDataSize(new HashMap<PartitionedRegion, InternalPRInfo>()));
+    assertThat(0).isEqualTo(facade.getTotalDataSize(new HashMap<>()));
   }
 
   @Test
-  @Ignore("GEODE-2789: need to rewrite this test")
   public void testFacadeCollectMemberDetailsNoRegion() {
-    final GemFireCacheImpl mockCache = mockContext.mock(GemFireCacheImpl.class);
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockCache).isClosed();
-        will(returnValue(false));
-        oneOf(mockCache).getPartitionedRegions();
-        will(returnValue(new HashSet<PartitionedRegion>()));
-      }
-    });
-
+    final GemFireCacheImpl mockCache = mock(GemFireCacheImpl.class);
+    when(mockCache.isClosed()).thenReturn(false);
+    when(mockCache.getPartitionedRegions()).thenReturn(Collections.emptySet());
     GeodeCacheFacade facade = new GeodeCacheFacade(mockCache);
 
-    assertEquals(0, facade.getRegionMemberDetails().size());
+    assertThat(0).isEqualTo(facade.getRegionMemberDetails().size());
   }
 
   @Test
-  @Ignore("GEODE-2789: need to rewrite this test")
   public void testFacadeCollectMemberDetails2Regions() {
-    final GemFireCacheImpl mockCache = mockContext.mock(GemFireCacheImpl.class);
-    final InternalResourceManager mockRM = mockContext.mock(InternalResourceManager.class);
-    final LoadProbe mockProbe = mockContext.mock(LoadProbe.class);
-
-    final PartitionedRegion mockR1 = mockContext.mock(PartitionedRegion.class, "r1");
-    final PartitionedRegion mockR2 = mockContext.mock(PartitionedRegion.class, "r2");
+    final LoadProbe mockProbe = mock(LoadProbe.class);
+    final GemFireCacheImpl mockCache = mock(GemFireCacheImpl.class);
+    final InternalResourceManager mockRM = mock(InternalResourceManager.class);
+    final PartitionedRegion mockR1 = mock(PartitionedRegion.class, "r1");
+    final PartitionedRegion mockR2 = mock(PartitionedRegion.class, "r2");
+    final PRHARedundancyProvider mockRedundancyProviderR1 =
+        mock(PRHARedundancyProvider.class, "prhaR1");
+    final InternalPRInfo mockR1PRInfo = mock(InternalPRInfo.class, "prInforR1");
+    final PRHARedundancyProvider mockRedundancyProviderR2 =
+        mock(PRHARedundancyProvider.class, "prhaR2");
+    final InternalPRInfo mockR2PRInfo = mock(InternalPRInfo.class, "prInforR2");
     final HashSet<PartitionedRegion> regions = new HashSet<>();
     regions.add(mockR1);
     regions.add(mockR2);
 
-    final PRHARedundancyProvider mockRedundancyProviderR1 =
-        mockContext.mock(PRHARedundancyProvider.class, "prhaR1");
-    final InternalPRInfo mockR1PRInfo = mockContext.mock(InternalPRInfo.class, "prInforR1");
-
-    final PRHARedundancyProvider mockRedundancyProviderR2 =
-        mockContext.mock(PRHARedundancyProvider.class, "prhaR2");
-    final InternalPRInfo mockR2PRInfo = mockContext.mock(InternalPRInfo.class, "prInforR2");
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockCache).isClosed();
-        will(returnValue(false));
-        oneOf(mockCache).getPartitionedRegions();
-        will(returnValue(regions));
-        exactly(2).of(mockCache).getResourceManager();
-        will(returnValue(mockRM));
-        exactly(2).of(mockRM).getLoadProbe();
-        will(returnValue(mockProbe));
-        allowing(mockR1).getFullPath();
-        oneOf(mockR1).getRedundancyProvider();
-        will(returnValue(mockRedundancyProviderR1));
-        allowing(mockR2).getFullPath();
-        oneOf(mockR2).getRedundancyProvider();
-        will(returnValue(mockRedundancyProviderR2));
-
-        oneOf(mockRedundancyProviderR1).buildPartitionedRegionInfo(with(true),
-            with(any(LoadProbe.class)));
-        will(returnValue(mockR1PRInfo));
-
-        oneOf(mockRedundancyProviderR2).buildPartitionedRegionInfo(with(true),
-            with(any(LoadProbe.class)));
-        will(returnValue(mockR2PRInfo));
-      }
-    });
+    when(mockCache.isClosed()).thenReturn(false);
+    when(mockCache.getPartitionedRegions()).thenReturn(regions);
+    when(mockCache.getResourceManager()).thenReturn(mockRM);
+    when(mockCache.getInternalResourceManager()).thenReturn(mockRM);
+    when(mockRM.getLoadProbe()).thenReturn(mockProbe);
+    when(mockR1.getRedundancyProvider()).thenReturn(mockRedundancyProviderR1);
+    when(mockR2.getRedundancyProvider()).thenReturn(mockRedundancyProviderR2);
+    when(mockRedundancyProviderR1.buildPartitionedRegionInfo(eq(true), any(LoadProbe.class)))
+        .thenReturn(mockR1PRInfo);
+    when(mockRedundancyProviderR2.buildPartitionedRegionInfo(eq(true), any(LoadProbe.class)))
+        .thenReturn(mockR2PRInfo);
 
     GeodeCacheFacade facade = new GeodeCacheFacade(mockCache);
-
     Map<PartitionedRegion, InternalPRInfo> map = facade.getRegionMemberDetails();
-    assertNotNull(map);
-    assertEquals(2, map.size());
-    assertEquals(map.get(mockR1), mockR1PRInfo);
-    assertEquals(map.get(mockR2), mockR2PRInfo);
+    assertThat(map).isNotNull();
+    assertThat(2).isEqualTo(map.size());
+    assertThat(map.get(mockR1)).isEqualTo(mockR1PRInfo);
+    assertThat(map.get(mockR2)).isEqualTo(mockR2PRInfo);
   }
 
   @Test
-  @Ignore("GEODE-2789: need to rewrite this test")
   public void testFacadeTotalBytes2Regions() {
-    final PartitionedRegion mockR1 = mockContext.mock(PartitionedRegion.class, "r1");
-    final PartitionedRegion mockR2 = mockContext.mock(PartitionedRegion.class, "r2");
-    final HashSet<PartitionedRegion> regions = new HashSet<>();
-    regions.add(mockR1);
-    regions.add(mockR2);
-
-    final InternalPRInfo mockR1PRInfo = mockContext.mock(InternalPRInfo.class, "prInforR1");
-    final PartitionMemberInfo mockR1M1Info = mockContext.mock(PartitionMemberInfo.class, "r1M1");
-    final PartitionMemberInfo mockR1M2Info = mockContext.mock(PartitionMemberInfo.class, "r1M2");
+    final PartitionedRegion mockR1 = mock(PartitionedRegion.class, "r1");
+    final InternalPRInfo mockR1PRInfo = mock(InternalPRInfo.class, "prInforR1");
+    final PartitionMemberInfo mockR1M1Info = mock(PartitionMemberInfo.class, "r1M1");
+    final PartitionMemberInfo mockR1M2Info = mock(PartitionMemberInfo.class, "r1M2");
     final HashSet<PartitionMemberInfo> r1Members = new HashSet<>();
     r1Members.add(mockR1M1Info);
     r1Members.add(mockR1M2Info);
+    when(mockR1PRInfo.getPartitionMemberInfo()).thenReturn(r1Members);
+    when(mockR1M1Info.getSize()).thenReturn(123L);
+    when(mockR1M2Info.getSize()).thenReturn(74L);
 
-    final InternalPRInfo mockR2PRInfo = mockContext.mock(InternalPRInfo.class, "prInforR2");
-    final PartitionMemberInfo mockR2M1Info = mockContext.mock(PartitionMemberInfo.class, "r2M1");
+    final PartitionedRegion mockR2 = mock(PartitionedRegion.class, "r2");
+    final InternalPRInfo mockR2PRInfo = mock(InternalPRInfo.class, "prInforR2");
+    final PartitionMemberInfo mockR2M1Info = mock(PartitionMemberInfo.class, "r2M1");
     final HashSet<PartitionMemberInfo> r2Members = new HashSet<>();
     r2Members.add(mockR2M1Info);
+    when(mockR2PRInfo.getPartitionMemberInfo()).thenReturn(r2Members);
+    when(mockR2M1Info.getSize()).thenReturn(3475L);
 
     final Map<PartitionedRegion, InternalPRInfo> details = new HashMap<>();
     details.put(mockR1, mockR1PRInfo);
     details.put(mockR2, mockR2PRInfo);
-
-    mockContext.checking(new Expectations() {
-      {
-        allowing(mockR1).getFullPath();
-        allowing(mockR2).getFullPath();
-
-        oneOf(mockR1PRInfo).getPartitionMemberInfo();
-        will(returnValue(r1Members));
-        atLeast(1).of(mockR1M1Info).getSize();
-        will(returnValue(123L));
-        atLeast(1).of(mockR1M2Info).getSize();
-        will(returnValue(74L));
-
-        oneOf(mockR2PRInfo).getPartitionMemberInfo();
-        will(returnValue(r2Members));
-        atLeast(1).of(mockR2M1Info).getSize();
-        will(returnValue(3475L));
-      }
-    });
 
     GeodeCacheFacade facade = new GeodeCacheFacade() {
       @Override
@@ -531,79 +394,57 @@ public class AutoBalancerJUnitTest {
       }
     };
 
-    assertEquals(123 + 74 + 3475, facade.getTotalDataSize(details));
+    assertThat(123 + 74 + 3475).isEqualTo(facade.getTotalDataSize(details));
+    verify(mockR1M1Info, atLeastOnce()).getSize();
+    verify(mockR1M2Info, atLeastOnce()).getSize();
+    verify(mockR2M1Info, atLeastOnce()).getSize();
   }
 
   @Test
   public void testAuditorInvocation() throws InterruptedException {
     final CountDownLatch latch = new CountDownLatch(3);
 
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockAuditor).init(with(any(Properties.class)));
-        atLeast(2).of(mockAuditor).execute();
-        allowing(mockClock).currentTimeMillis();
-        will(new CustomAction("returnTime") {
-          @Override
-          public Object invoke(Invocation invocation) throws Throwable {
-            latch.countDown();
-            return 990L;
-          }
-        });
-      }
+    when(mockClock.currentTimeMillis()).then((invocation) -> {
+      latch.countDown();
+      return 990L;
     });
 
     Properties props = AutoBalancerJUnitTest.getBasicConfig();
-
-    assertEquals(3, latch.getCount());
+    assertThat(3).isEqualTo(latch.getCount());
     AutoBalancer autoR = new AutoBalancer(null, mockAuditor, mockClock, null);
     autoR.initialize(null, props);
-    assertTrue(latch.await(1, TimeUnit.MINUTES));
+
+    assertThat(latch.await(1, TimeUnit.MINUTES)).isTrue();
+    verify(mockAuditor, atLeast(2)).execute();
+    verify(mockAuditor, times(1)).init(any(Properties.class));
   }
 
   @Test
   public void destroyAutoBalancer() throws InterruptedException {
+    final int timer = 20; // simulate 20 milliseconds
     final CountDownLatch latch = new CountDownLatch(2);
     final CountDownLatch timerLatch = new CountDownLatch(1);
-    final int timer = 20; // simulate 20 milliseconds
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockAuditor).init(with(any(Properties.class)));
-        allowing(mockAuditor).execute();
-        allowing(mockClock).currentTimeMillis();
-        will(new CustomAction("returnTime") {
-          @Override
-          public Object invoke(Invocation invocation) throws Throwable {
-            latch.countDown();
-            if (latch.getCount() == 0) {
-              assertTrue(timerLatch.await(1, TimeUnit.SECONDS));
-              // scheduler is destroyed before wait is over
-              fail();
-            }
-            return 1000L - timer;
-          }
-        });
+    when(mockClock.currentTimeMillis()).then((invocation) -> {
+      latch.countDown();
+      if (latch.getCount() == 0) {
+        assertThat(timerLatch.await(1, TimeUnit.SECONDS)).isTrue();
+        // scheduler is destroyed before wait is over
+        // fail();
+        throw new AssertionError();
       }
+      return 1000L - timer;
     });
 
     Properties props = AutoBalancerJUnitTest.getBasicConfig();
-
-    assertEquals(2, latch.getCount());
+    assertThat(2).isEqualTo(latch.getCount());
     AutoBalancer autoR = new AutoBalancer(null, mockAuditor, mockClock, null);
     autoR.initialize(null, props);
-    assertTrue(latch.await(1, TimeUnit.MINUTES));
+    assertThat(latch.await(1, TimeUnit.MINUTES)).isTrue();
+    verify(mockAuditor, times(1)).init(any(Properties.class));
 
     // after destroy no more execute will be called.
     autoR.destroy();
     timerLatch.countDown();
     TimeUnit.MILLISECONDS.sleep(2 * timer);
-  }
-
-  static Properties getBasicConfig() {
-    Properties props = new Properties();
-    // every second schedule
-    props.put(AutoBalancer.SCHEDULE, "* 0/30 * * * ?");
-    return props;
   }
 }

--- a/geode-web/src/test/java/org/apache/geode/management/internal/web/controllers/support/LoginHandlerInterceptorJUnitTest.java
+++ b/geode-web/src/test/java/org/apache/geode/management/internal/web/controllers/support/LoginHandlerInterceptorJUnitTest.java
@@ -100,10 +100,10 @@ public class LoginHandlerInterceptorJUnitTest {
     assertThat(handlerInterceptor.preHandle(mockHttpRequest, null, null)).isTrue();
     Map<String, String> environmentAfterPreHandle = LoginHandlerInterceptor.getEnvironment();
     assertThat(environmentAfterPreHandle).isNotNull();
-    assertThat(environmentBeforePreHandle).isNotSameAs(environmentAfterPreHandle);
-    assertThat(1).isEqualTo(environmentAfterPreHandle.size());
+    assertThat(environmentAfterPreHandle).isNotSameAs(environmentBeforePreHandle);
+    assertThat(environmentAfterPreHandle.size()).isEqualTo(1);
     assertThat(environmentAfterPreHandle.containsKey("variable")).isTrue();
-    assertThat("two").isEqualTo(environmentAfterPreHandle.get("variable"));
+    assertThat(environmentAfterPreHandle.get("variable")).isEqualTo("two");
     Properties expectedLoginProperties = new Properties();
     expectedLoginProperties.put(USER_NAME, "admin");
     expectedLoginProperties.put(PASSWORD, "password");
@@ -126,9 +126,9 @@ public class LoginHandlerInterceptorJUnitTest {
     assertThat(handlerInterceptor.preHandle(mockHttpRequest, null, null)).isTrue();
     Map<String, String> environmentAfterPreHandle = LoginHandlerInterceptor.getEnvironment();
     assertThat(environmentAfterPreHandle).isNotNull();
-    assertThat(1).isEqualTo(environmentAfterPreHandle.size());
+    assertThat(environmentAfterPreHandle.size()).isEqualTo(1);
     assertThat(environmentAfterPreHandle.containsKey("variable")).isTrue();
-    assertThat("two").isEqualTo(environmentAfterPreHandle.get("variable"));
+    assertThat(environmentAfterPreHandle.get("variable")).isEqualTo("two");
     Properties expectedLoginProperties = new Properties();
     expectedLoginProperties.put(USER_NAME, "admin");
     expectedLoginProperties.put(PASSWORD, "password");
@@ -205,38 +205,38 @@ public class LoginHandlerInterceptorJUnitTest {
 
       env = LoginHandlerInterceptor.getEnvironment();
       assertThat(env).isNotNull();
-      assertThat(2).isEqualTo(env.size());
+      assertThat(env.size()).isEqualTo(2);
       assertThat(env.containsKey("param")).isFalse();
       assertThat(env.containsKey("parameter")).isFalse();
       assertThat(env.containsKey("HOST")).isFalse();
       assertThat(env.containsKey("security-username")).isFalse();
       assertThat(env.containsKey("security-password")).isFalse();
-      assertThat("test").isEqualTo(env.get("STAGE"));
-      assertThat("/path/to/geode").isEqualTo(env.get("GEODE_HOME"));
+      assertThat(env.get("STAGE")).isEqualTo("test");
+      assertThat(env.get("GEODE_HOME")).isEqualTo("/path/to/geode");
 
       waitForTick(2);
       env = LoginHandlerInterceptor.getEnvironment();
       assertThat(env).isNotNull();
-      assertThat(2).isEqualTo(env.size());
+      assertThat(env.size()).isEqualTo(2);
       assertThat(env.containsKey("param")).isFalse();
       assertThat(env.containsKey("parameter")).isFalse();
       assertThat(env.containsKey("HOST")).isFalse();
       assertThat(env.containsKey("security-username")).isFalse();
       assertThat(env.containsKey("security-password")).isFalse();
-      assertThat("test").isEqualTo(env.get("STAGE"));
-      assertThat("/path/to/geode").isEqualTo(env.get("GEODE_HOME"));
+      assertThat(env.get("STAGE")).isEqualTo("test");
+      assertThat(env.get("GEODE_HOME")).isEqualTo("/path/to/geode");
 
       waitForTick(4);
       env = LoginHandlerInterceptor.getEnvironment();
       assertThat(env).isNotNull();
-      assertThat(2).isEqualTo(env.size());
+      assertThat(env.size()).isEqualTo(2);
       assertThat(env.containsKey("param")).isFalse();
       assertThat(env.containsKey("parameter")).isFalse();
       assertThat(env.containsKey("HOST")).isFalse();
       assertThat(env.containsKey("security-username")).isFalse();
       assertThat(env.containsKey("security-password")).isFalse();
-      assertThat("test").isEqualTo(env.get("STAGE"));
-      assertThat("/path/to/geode").isEqualTo(env.get("GEODE_HOME"));
+      assertThat(env.get("STAGE")).isEqualTo("test");
+      assertThat(env.get("GEODE_HOME")).isEqualTo("/path/to/geode");
 
       handlerInterceptor.afterCompletion(mockHttpRequestOne, null, null, null);
       env = LoginHandlerInterceptor.getEnvironment();
@@ -257,14 +257,14 @@ public class LoginHandlerInterceptorJUnitTest {
 
       env = LoginHandlerInterceptor.getEnvironment();
       assertThat(env).isNotNull();
-      assertThat(2).isEqualTo(env.size());
+      assertThat(env.size()).isEqualTo(2);
       assertThat(env.containsKey("parameter")).isFalse();
       assertThat(env.containsKey("param")).isFalse();
       assertThat(env.containsKey("STAGE")).isFalse();
       assertThat(env.containsKey("security-username")).isFalse();
       assertThat(env.containsKey("security-password")).isFalse();
-      assertThat("localhost").isEqualTo(env.get("HOST"));
-      assertThat("/path/to/geode/180").isEqualTo(env.get("GEODE_HOME"));
+      assertThat(env.get("HOST")).isEqualTo("localhost");
+      assertThat(env.get("GEODE_HOME")).isEqualTo("/path/to/geode/180");
 
       waitForTick(3);
       handlerInterceptor.afterCompletion(mockHttpRequestTwo, null, null, null);

--- a/geode-web/src/test/java/org/apache/geode/management/internal/web/controllers/support/LoginHandlerInterceptorJUnitTest.java
+++ b/geode-web/src/test/java/org/apache/geode/management/internal/web/controllers/support/LoginHandlerInterceptorJUnitTest.java
@@ -14,10 +14,14 @@
  */
 package org.apache.geode.management.internal.web.controllers.support;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertTrue;
+import static org.apache.geode.management.internal.security.ResourceConstants.PASSWORD;
+import static org.apache.geode.management.internal.security.ResourceConstants.USER_NAME;
+import static org.apache.geode.management.internal.web.controllers.support.LoginHandlerInterceptor.ENVIRONMENT_VARIABLE_REQUEST_PARAMETER_PREFIX;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -29,13 +33,11 @@ import javax.servlet.http.HttpServletRequest;
 
 import edu.umd.cs.mtc.MultithreadedTestCase;
 import edu.umd.cs.mtc.TestFramework;
-import org.jmock.Expectations;
-import org.jmock.Mockery;
-import org.jmock.lib.concurrent.Synchroniser;
-import org.jmock.lib.legacy.ClassImposteriser;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
 
 import org.apache.geode.internal.security.SecurityService;
 import org.apache.geode.management.internal.security.ResourceConstants;
@@ -44,36 +46,24 @@ import org.apache.geode.management.internal.security.ResourceConstants;
  * The LoginHandlerInterceptorJUnitTest class is a test suite of test cases to test the contract and
  * functionality of the Spring HandlerInterceptor, LoginHandlerInterceptor class.
  *
- * @see org.jmock.Mockery
- * @see org.junit.Assert
  * @see org.junit.Test
  * @since GemFire 8.0
  */
 public class LoginHandlerInterceptorJUnitTest {
-
-  private Mockery mockContext;
-
   private SecurityService securityService;
+
+  @Rule
+  public TestName name = new TestName();
 
   @Before
   public void setUp() {
-    mockContext = new Mockery();
-    mockContext.setImposteriser(ClassImposteriser.INSTANCE);
-    mockContext.setThreadingPolicy(new Synchroniser());
     LoginHandlerInterceptor.getEnvironment().clear();
-
-    securityService = mockContext.mock(SecurityService.class);
+    securityService = mock(SecurityService.class);
   }
 
   @After
   public void tearDown() {
-    mockContext.assertIsSatisfied();
-    mockContext = null;
     LoginHandlerInterceptor.getEnvironment().clear();
-  }
-
-  private String createEnvironmentVariable(final String name) {
-    return (LoginHandlerInterceptor.ENVIRONMENT_VARIABLE_REQUEST_PARAMETER_PREFIX + name);
   }
 
   private <T> Enumeration<T> enumeration(final Iterator<T> iterator) {
@@ -89,52 +79,66 @@ public class LoginHandlerInterceptorJUnitTest {
   }
 
   @Test
-  public void testPreHandleAfterCompletion() throws Exception {
+  public void preHandleShouldSetEnvironmentVariablesFromSpecificRequestParameters()
+      throws Exception {
     final Map<String, String> requestParameters = new HashMap<>(2);
-
     requestParameters.put("parameter", "one");
-    requestParameters.put(createEnvironmentVariable("variable"), "two");
-
-    final HttpServletRequest mockHttpRequest = mockContext.mock(HttpServletRequest.class,
-        "testPreHandleAfterCompletion.HttpServletRequest");
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockHttpRequest).getParameterNames();
-        will(returnValue(enumeration(requestParameters.keySet().iterator())));
-        oneOf(mockHttpRequest).getHeader(ResourceConstants.USER_NAME);
-        will(returnValue("admin"));
-        oneOf(mockHttpRequest).getHeader(ResourceConstants.PASSWORD);
-        will(returnValue("password"));
-        oneOf(mockHttpRequest).getParameter(with(equal(createEnvironmentVariable("variable"))));
-        will(returnValue(requestParameters.get(createEnvironmentVariable("variable"))));
-        oneOf(securityService).login(with(aNonNull(Properties.class)));
-        oneOf(securityService).logout();
-      }
-    });
+    requestParameters.put(ENVIRONMENT_VARIABLE_REQUEST_PARAMETER_PREFIX + "variable", "two");
+    final HttpServletRequest mockHttpRequest = mock(HttpServletRequest.class, name.getMethodName());
+    when(mockHttpRequest.getParameterNames())
+        .thenReturn(enumeration(requestParameters.keySet().iterator()));
+    when(mockHttpRequest.getHeader(USER_NAME)).thenReturn("admin");
+    when(mockHttpRequest.getHeader(PASSWORD)).thenReturn("password");
+    when(mockHttpRequest.getParameter(ENVIRONMENT_VARIABLE_REQUEST_PARAMETER_PREFIX + "variable"))
+        .thenReturn("two");
 
     LoginHandlerInterceptor handlerInterceptor = new LoginHandlerInterceptor(securityService);
+    Map<String, String> environmentBeforePreHandle = LoginHandlerInterceptor.getEnvironment();
+    assertThat(environmentBeforePreHandle).isNotNull();
+    assertThat(environmentBeforePreHandle.isEmpty()).isTrue();
 
-    Map<String, String> envBefore = LoginHandlerInterceptor.getEnvironment();
+    assertThat(handlerInterceptor.preHandle(mockHttpRequest, null, null)).isTrue();
+    Map<String, String> environmentAfterPreHandle = LoginHandlerInterceptor.getEnvironment();
+    assertThat(environmentAfterPreHandle).isNotNull();
+    assertThat(environmentBeforePreHandle).isNotSameAs(environmentAfterPreHandle);
+    assertThat(1).isEqualTo(environmentAfterPreHandle.size());
+    assertThat(environmentAfterPreHandle.containsKey("variable")).isTrue();
+    assertThat("two").isEqualTo(environmentAfterPreHandle.get("variable"));
+    Properties expectedLoginProperties = new Properties();
+    expectedLoginProperties.put(USER_NAME, "admin");
+    expectedLoginProperties.put(PASSWORD, "password");
+    verify(securityService, times(1)).login(expectedLoginProperties);
+  }
 
-    assertNotNull(envBefore);
-    assertTrue(envBefore.isEmpty());
-    assertTrue(handlerInterceptor.preHandle(mockHttpRequest, null, null));
+  @Test
+  public void afterCompletionShouldCleanTheEnvironment() throws Exception {
+    final Map<String, String> requestParameters = new HashMap<>(2);
+    requestParameters.put(ENVIRONMENT_VARIABLE_REQUEST_PARAMETER_PREFIX + "variable", "two");
+    final HttpServletRequest mockHttpRequest = mock(HttpServletRequest.class, name.getMethodName());
+    when(mockHttpRequest.getParameterNames())
+        .thenReturn(enumeration(requestParameters.keySet().iterator()));
+    when(mockHttpRequest.getHeader(USER_NAME)).thenReturn("admin");
+    when(mockHttpRequest.getHeader(PASSWORD)).thenReturn("password");
+    when(mockHttpRequest.getParameter(ENVIRONMENT_VARIABLE_REQUEST_PARAMETER_PREFIX + "variable"))
+        .thenReturn("two");
 
-    Map<String, String> envSet = LoginHandlerInterceptor.getEnvironment();
-
-    assertNotNull(envSet);
-    assertNotSame(envBefore, envSet);
-    assertEquals(1, envSet.size());
-    assertTrue(envSet.containsKey("variable"));
-    assertEquals("two", envSet.get("variable"));
+    LoginHandlerInterceptor handlerInterceptor = new LoginHandlerInterceptor(securityService);
+    assertThat(handlerInterceptor.preHandle(mockHttpRequest, null, null)).isTrue();
+    Map<String, String> environmentAfterPreHandle = LoginHandlerInterceptor.getEnvironment();
+    assertThat(environmentAfterPreHandle).isNotNull();
+    assertThat(1).isEqualTo(environmentAfterPreHandle.size());
+    assertThat(environmentAfterPreHandle.containsKey("variable")).isTrue();
+    assertThat("two").isEqualTo(environmentAfterPreHandle.get("variable"));
+    Properties expectedLoginProperties = new Properties();
+    expectedLoginProperties.put(USER_NAME, "admin");
+    expectedLoginProperties.put(PASSWORD, "password");
+    verify(securityService, times(1)).login(expectedLoginProperties);
 
     handlerInterceptor.afterCompletion(mockHttpRequest, null, null, null);
-
-    Map<String, String> envAfter = LoginHandlerInterceptor.getEnvironment();
-
-    assertNotNull(envAfter);
-    assertTrue(envAfter.isEmpty());
+    Map<String, String> environmentAfterCompletion = LoginHandlerInterceptor.getEnvironment();
+    assertThat(environmentAfterCompletion).isNotNull();
+    assertThat(environmentAfterCompletion.isEmpty()).isTrue();
+    verify(securityService, times(1)).logout();
   }
 
   @Test
@@ -143,162 +147,130 @@ public class LoginHandlerInterceptorJUnitTest {
   }
 
   private class HandlerInterceptorThreadSafetyMultiThreadedTestCase extends MultithreadedTestCase {
-
-    private LoginHandlerInterceptor handlerInterceptor;
-
     private HttpServletRequest mockHttpRequestOne;
     private HttpServletRequest mockHttpRequestTwo;
+    private LoginHandlerInterceptor handlerInterceptor;
 
     @Override
     public void initialize() {
       super.initialize();
 
       final Map<String, String> requestParametersOne = new HashMap<>(3);
-
       requestParametersOne.put("param", "one");
-      requestParametersOne.put(createEnvironmentVariable("STAGE"), "test");
-      requestParametersOne.put(createEnvironmentVariable("GEODE_HOME"), "/path/to/gemfire/700");
+      requestParametersOne.put(ENVIRONMENT_VARIABLE_REQUEST_PARAMETER_PREFIX + "STAGE", "test");
+      requestParametersOne.put(ENVIRONMENT_VARIABLE_REQUEST_PARAMETER_PREFIX + "GEODE_HOME",
+          "/path/to/geode");
 
-      mockHttpRequestOne = mockContext.mock(HttpServletRequest.class,
-          "testHandlerInterceptorThreadSafety.HttpServletRequest.1");
+      mockHttpRequestOne =
+          mock(HttpServletRequest.class, "testHandlerInterceptorThreadSafety.HttpServletRequest.1");
+      when(mockHttpRequestOne.getParameterNames())
+          .thenReturn(enumeration(requestParametersOne.keySet().iterator()));
+      when(mockHttpRequestOne.getHeader(ResourceConstants.USER_NAME)).thenReturn("admin");
+      when(mockHttpRequestOne.getHeader(ResourceConstants.PASSWORD)).thenReturn("password");
+      when(mockHttpRequestOne.getParameter(ENVIRONMENT_VARIABLE_REQUEST_PARAMETER_PREFIX + "STAGE"))
+          .thenReturn("test");
+      when(mockHttpRequestOne
+          .getParameter(ENVIRONMENT_VARIABLE_REQUEST_PARAMETER_PREFIX + "GEODE_HOME"))
+              .thenReturn("/path/to/geode");
 
-      mockContext.checking(new Expectations() {
-        {
-          oneOf(mockHttpRequestOne).getParameterNames();
-          will(returnValue(enumeration(requestParametersOne.keySet().iterator())));
-          oneOf(mockHttpRequestOne).getHeader(ResourceConstants.USER_NAME);
-          will(returnValue("admin"));
-          oneOf(mockHttpRequestOne).getHeader(ResourceConstants.PASSWORD);
-          will(returnValue("password"));
-          oneOf(mockHttpRequestOne).getParameter(with(equal(createEnvironmentVariable("STAGE"))));
-          will(returnValue(requestParametersOne.get(createEnvironmentVariable("STAGE"))));
-          oneOf(mockHttpRequestOne)
-              .getParameter(with(equal(createEnvironmentVariable("GEODE_HOME"))));
-          will(returnValue(requestParametersOne.get(createEnvironmentVariable("GEODE_HOME"))));
-          oneOf(securityService).login(with(aNonNull(Properties.class)));
-          oneOf(securityService).logout();
-        }
-      });
-
-      mockHttpRequestTwo = mockContext.mock(HttpServletRequest.class,
-          "testHandlerInterceptorThreadSafety.HttpServletRequest.2");
-
+      mockHttpRequestTwo =
+          mock(HttpServletRequest.class, "testHandlerInterceptorThreadSafety.HttpServletRequest.2");
       final Map<String, String> requestParametersTwo = new HashMap<>(3);
-
       requestParametersTwo.put("parameter", "two");
-      requestParametersTwo.put(createEnvironmentVariable("HOST"), "localhost");
-      requestParametersTwo.put(createEnvironmentVariable("GEODE_HOME"), "/path/to/gemfire/75");
-
-      mockContext.checking(new Expectations() {
-        {
-          oneOf(mockHttpRequestTwo).getParameterNames();
-          will(returnValue(enumeration(requestParametersTwo.keySet().iterator())));
-          oneOf(mockHttpRequestTwo).getHeader(ResourceConstants.USER_NAME);
-          will(returnValue("admin"));
-          oneOf(mockHttpRequestTwo).getHeader(ResourceConstants.PASSWORD);
-          will(returnValue("password"));
-          oneOf(mockHttpRequestTwo).getParameter(with(equal(createEnvironmentVariable("HOST"))));
-          will(returnValue(requestParametersTwo.get(createEnvironmentVariable("HOST"))));
-          oneOf(mockHttpRequestTwo)
-              .getParameter(with(equal(createEnvironmentVariable("GEODE_HOME"))));
-          will(returnValue(requestParametersTwo.get(createEnvironmentVariable("GEODE_HOME"))));
-          oneOf(securityService).login(with(aNonNull(Properties.class)));
-          oneOf(securityService).logout();
-        }
-      });
+      requestParametersTwo.put(ENVIRONMENT_VARIABLE_REQUEST_PARAMETER_PREFIX + "HOST", "localhost");
+      requestParametersTwo.put(ENVIRONMENT_VARIABLE_REQUEST_PARAMETER_PREFIX + "GEODE_HOME",
+          "/path/to/geode/180");
+      when(mockHttpRequestTwo.getParameterNames())
+          .thenReturn(enumeration(requestParametersTwo.keySet().iterator()));
+      when(mockHttpRequestTwo.getHeader(ResourceConstants.USER_NAME)).thenReturn("admin");
+      when(mockHttpRequestTwo.getHeader(ResourceConstants.PASSWORD)).thenReturn("password");
+      when(mockHttpRequestTwo.getParameter(ENVIRONMENT_VARIABLE_REQUEST_PARAMETER_PREFIX + "HOST"))
+          .thenReturn("localhost");
+      when(mockHttpRequestTwo
+          .getParameter(ENVIRONMENT_VARIABLE_REQUEST_PARAMETER_PREFIX + "GEODE_HOME"))
+              .thenReturn("/path/to/geode/180");
 
       handlerInterceptor = new LoginHandlerInterceptor(securityService);
     }
 
+    @SuppressWarnings("unused")
     public void thread1() throws Exception {
       assertTick(0);
       Thread.currentThread().setName("HTTP Request Processing Thread 1");
 
       Map<String, String> env = LoginHandlerInterceptor.getEnvironment();
-
-      assertNotNull(env);
-      assertTrue(env.isEmpty());
-      assertTrue(handlerInterceptor.preHandle(mockHttpRequestOne, null, null));
+      assertThat(env).isNotNull();
+      assertThat(env.isEmpty()).isTrue();
+      assertThat(handlerInterceptor.preHandle(mockHttpRequestOne, null, null)).isTrue();
 
       env = LoginHandlerInterceptor.getEnvironment();
-
-      assertNotNull(env);
-      assertEquals(2, env.size());
-      assertFalse(env.containsKey("param"));
-      assertFalse(env.containsKey("parameter"));
-      assertFalse(env.containsKey("HOST"));
-      assertFalse(env.containsKey("security-username"));
-      assertFalse(env.containsKey("security-password"));
-      assertEquals("test", env.get("STAGE"));
-      assertEquals("/path/to/gemfire/700", env.get("GEODE_HOME"));
+      assertThat(env).isNotNull();
+      assertThat(2).isEqualTo(env.size());
+      assertThat(env.containsKey("param")).isFalse();
+      assertThat(env.containsKey("parameter")).isFalse();
+      assertThat(env.containsKey("HOST")).isFalse();
+      assertThat(env.containsKey("security-username")).isFalse();
+      assertThat(env.containsKey("security-password")).isFalse();
+      assertThat("test").isEqualTo(env.get("STAGE"));
+      assertThat("/path/to/geode").isEqualTo(env.get("GEODE_HOME"));
 
       waitForTick(2);
-
       env = LoginHandlerInterceptor.getEnvironment();
-
-      assertNotNull(env);
-      assertEquals(2, env.size());
-      assertFalse(env.containsKey("param"));
-      assertFalse(env.containsKey("parameter"));
-      assertFalse(env.containsKey("HOST"));
-      assertFalse(env.containsKey("security-username"));
-      assertFalse(env.containsKey("security-password"));
-      assertEquals("test", env.get("STAGE"));
-      assertEquals("/path/to/gemfire/700", env.get("GEODE_HOME"));
+      assertThat(env).isNotNull();
+      assertThat(2).isEqualTo(env.size());
+      assertThat(env.containsKey("param")).isFalse();
+      assertThat(env.containsKey("parameter")).isFalse();
+      assertThat(env.containsKey("HOST")).isFalse();
+      assertThat(env.containsKey("security-username")).isFalse();
+      assertThat(env.containsKey("security-password")).isFalse();
+      assertThat("test").isEqualTo(env.get("STAGE"));
+      assertThat("/path/to/geode").isEqualTo(env.get("GEODE_HOME"));
 
       waitForTick(4);
-
       env = LoginHandlerInterceptor.getEnvironment();
-
-      assertNotNull(env);
-      assertEquals(2, env.size());
-      assertFalse(env.containsKey("param"));
-      assertFalse(env.containsKey("parameter"));
-      assertFalse(env.containsKey("HOST"));
-      assertFalse(env.containsKey("security-username"));
-      assertFalse(env.containsKey("security-password"));
-      assertEquals("test", env.get("STAGE"));
-      assertEquals("/path/to/gemfire/700", env.get("GEODE_HOME"));
+      assertThat(env).isNotNull();
+      assertThat(2).isEqualTo(env.size());
+      assertThat(env.containsKey("param")).isFalse();
+      assertThat(env.containsKey("parameter")).isFalse();
+      assertThat(env.containsKey("HOST")).isFalse();
+      assertThat(env.containsKey("security-username")).isFalse();
+      assertThat(env.containsKey("security-password")).isFalse();
+      assertThat("test").isEqualTo(env.get("STAGE"));
+      assertThat("/path/to/geode").isEqualTo(env.get("GEODE_HOME"));
 
       handlerInterceptor.afterCompletion(mockHttpRequestOne, null, null, null);
-
       env = LoginHandlerInterceptor.getEnvironment();
-
       assertNotNull(env);
       assertTrue(env.isEmpty());
     }
 
+    @SuppressWarnings("unused")
     public void thread2() throws Exception {
       assertTick(0);
       Thread.currentThread().setName("HTTP Request Processing Thread 2");
+
       waitForTick(1);
-
       Map<String, String> env = LoginHandlerInterceptor.getEnvironment();
-
-      assertNotNull(env);
-      assertTrue(env.isEmpty());
-      assertTrue(handlerInterceptor.preHandle(mockHttpRequestTwo, null, null));
+      assertThat(env).isNotNull();
+      assertThat(env.isEmpty()).isTrue();
+      assertThat(handlerInterceptor.preHandle(mockHttpRequestTwo, null, null)).isTrue();
 
       env = LoginHandlerInterceptor.getEnvironment();
-
-      assertNotNull(env);
-      assertEquals(2, env.size());
-      assertFalse(env.containsKey("parameter"));
-      assertFalse(env.containsKey("param"));
-      assertFalse(env.containsKey("STAGE"));
-      assertFalse(env.containsKey("security-username"));
-      assertFalse(env.containsKey("security-password"));
-      assertEquals("localhost", env.get("HOST"));
-      assertEquals("/path/to/gemfire/75", env.get("GEODE_HOME"));
+      assertThat(env).isNotNull();
+      assertThat(2).isEqualTo(env.size());
+      assertThat(env.containsKey("parameter")).isFalse();
+      assertThat(env.containsKey("param")).isFalse();
+      assertThat(env.containsKey("STAGE")).isFalse();
+      assertThat(env.containsKey("security-username")).isFalse();
+      assertThat(env.containsKey("security-password")).isFalse();
+      assertThat("localhost").isEqualTo(env.get("HOST"));
+      assertThat("/path/to/geode/180").isEqualTo(env.get("GEODE_HOME"));
 
       waitForTick(3);
-
       handlerInterceptor.afterCompletion(mockHttpRequestTwo, null, null, null);
-
       env = LoginHandlerInterceptor.getEnvironment();
-
-      assertNotNull(env);
-      assertTrue(env.isEmpty());
+      assertThat(env).isNotNull();
+      assertThat(env.isEmpty()).isTrue();
     }
 
     @Override
@@ -307,5 +279,4 @@ public class LoginHandlerInterceptorJUnitTest {
       handlerInterceptor = null;
     }
   }
-
 }

--- a/geode-web/src/test/java/org/apache/geode/management/internal/web/http/converter/SerializableObjectHttpMessageConverterJUnitTest.java
+++ b/geode-web/src/test/java/org/apache/geode/management/internal/web/http/converter/SerializableObjectHttpMessageConverterJUnitTest.java
@@ -80,7 +80,7 @@ public class SerializableObjectHttpMessageConverterJUnitTest {
 
     final Serializable obj = converter.readInternal(String.class, mockInputMessage);
     assertThat(obj).isInstanceOf(String.class);
-    assertThat(expectedInputMessageBody).isEqualTo(obj);
+    assertThat(obj).isEqualTo(expectedInputMessageBody);
   }
 
   @Test
@@ -91,7 +91,7 @@ public class SerializableObjectHttpMessageConverterJUnitTest {
     when(mockOutputMessage.getHeaders()).thenReturn(headers);
 
     converter.setContentLength(mockOutputMessage, bytes);
-    assertThat(bytes.length).isEqualTo(headers.getContentLength());
+    assertThat(headers.getContentLength()).isEqualTo(bytes.length);
   }
 
   @Test
@@ -108,13 +108,9 @@ public class SerializableObjectHttpMessageConverterJUnitTest {
 
     converter.writeInternal(expectedOutputMessageBody, mockOutputMessage);
     final byte[] actualOutputMessageBodyBytes = out.toByteArray();
-    assertThat(expectedOutputMessageBodyBytes.length).isEqualTo(headers.getContentLength());
-    assertThat(expectedOutputMessageBodyBytes.length)
-        .isEqualTo(actualOutputMessageBodyBytes.length);
-
-    for (int index = 0; index < actualOutputMessageBodyBytes.length; index++) {
-      assertThat(expectedOutputMessageBodyBytes[index])
-          .isEqualTo(actualOutputMessageBodyBytes[index]);
-    }
+    assertThat(headers.getContentLength()).isEqualTo(expectedOutputMessageBodyBytes.length);
+    assertThat(actualOutputMessageBodyBytes.length)
+        .isEqualTo(expectedOutputMessageBodyBytes.length);
+    assertThat(actualOutputMessageBodyBytes).isEqualTo(expectedOutputMessageBodyBytes);
   }
 }

--- a/geode-web/src/test/java/org/apache/geode/management/internal/web/http/converter/SerializableObjectHttpMessageConverterJUnitTest.java
+++ b/geode-web/src/test/java/org/apache/geode/management/internal/web/http/converter/SerializableObjectHttpMessageConverterJUnitTest.java
@@ -14,10 +14,9 @@
  */
 package org.apache.geode.management.internal.web.http.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -25,11 +24,6 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.Calendar;
 
-import org.jmock.Expectations;
-import org.jmock.Mockery;
-import org.jmock.lib.concurrent.Synchroniser;
-import org.jmock.lib.legacy.ClassImposteriser;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.http.HttpHeaders;
@@ -45,139 +39,82 @@ import org.apache.geode.internal.util.IOUtils;
  * <p/>
  *
  * @see org.apache.geode.management.internal.web.http.converter.SerializableObjectHttpMessageConverter
- * @see org.jmock.Mockery
- * @see org.junit.Assert
  * @see org.junit.Test
  * @since GemFire 8.0
  */
 public class SerializableObjectHttpMessageConverterJUnitTest {
-
-  private Mockery mockContext;
+  private SerializableObjectHttpMessageConverter converter;
 
   @Before
   public void setUp() {
-    mockContext = new Mockery();
-    mockContext.setImposteriser(ClassImposteriser.INSTANCE);
-    mockContext.setThreadingPolicy(new Synchroniser());
-  }
-
-  @After
-  public void tearDown() {
-    mockContext.assertIsSatisfied();
-    mockContext = null;
+    converter = new SerializableObjectHttpMessageConverter();
   }
 
   @Test
   public void testCreateSerializableObjectHttpMessageConverter() {
-    final SerializableObjectHttpMessageConverter converter =
-        new SerializableObjectHttpMessageConverter();
-
-    assertNotNull(converter);
-    assertTrue(converter.getSupportedMediaTypes().contains(MediaType.APPLICATION_OCTET_STREAM));
-    assertTrue(converter.getSupportedMediaTypes().contains(MediaType.ALL));
+    assertThat(converter).isNotNull();
+    assertThat(converter.getSupportedMediaTypes().contains(MediaType.ALL)).isTrue();
+    assertThat(converter.getSupportedMediaTypes().contains(MediaType.APPLICATION_OCTET_STREAM))
+        .isTrue();
   }
 
   @Test
   public void testSupport() {
-    final SerializableObjectHttpMessageConverter converter =
-        new SerializableObjectHttpMessageConverter();
-
-    assertTrue(converter.supports(Boolean.class));
-    assertTrue(converter.supports(Calendar.class));
-    assertTrue(converter.supports(Character.class));
-    assertTrue(converter.supports(Integer.class));
-    assertTrue(converter.supports(Double.class));
-    assertTrue(converter.supports(String.class));
-    assertTrue(converter.supports(Serializable.class));
-    assertFalse(converter.supports(Object.class));
-    assertFalse(converter.supports(null));
+    assertThat(converter.supports(Boolean.class)).isTrue();
+    assertThat(converter.supports(Calendar.class)).isTrue();
+    assertThat(converter.supports(Character.class)).isTrue();
+    assertThat(converter.supports(Integer.class)).isTrue();
+    assertThat(converter.supports(Double.class)).isTrue();
+    assertThat(converter.supports(String.class)).isTrue();
+    assertThat(converter.supports(Serializable.class)).isTrue();
+    assertThat(converter.supports(Object.class)).isFalse();
+    assertThat(converter.supports(null)).isFalse();
   }
 
   @Test
   public void testReadInternal() throws IOException {
     final String expectedInputMessageBody = "Expected content of the HTTP input message body!";
-
-    final HttpInputMessage mockInputMessage =
-        mockContext.mock(HttpInputMessage.class, "HttpInputMessage");
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockInputMessage).getBody();
-        will(returnValue(
-            new ByteArrayInputStream(IOUtils.serializeObject(expectedInputMessageBody))));
-      }
-    });
-
-    final SerializableObjectHttpMessageConverter converter =
-        new SerializableObjectHttpMessageConverter();
+    final HttpInputMessage mockInputMessage = mock(HttpInputMessage.class, "HttpInputMessage");
+    when(mockInputMessage.getBody())
+        .thenReturn(new ByteArrayInputStream(IOUtils.serializeObject(expectedInputMessageBody)));
 
     final Serializable obj = converter.readInternal(String.class, mockInputMessage);
-
-    assertTrue(obj instanceof String);
-    assertEquals(expectedInputMessageBody, obj);
+    assertThat(obj).isInstanceOf(String.class);
+    assertThat(expectedInputMessageBody).isEqualTo(obj);
   }
 
   @Test
   public void testSetContentLength() {
-    final byte[] bytes = {(byte) 0xCA, (byte) 0xFE, (byte) 0xBA, (byte) 0xBE};
-
     final HttpHeaders headers = new HttpHeaders();
-
-    final HttpOutputMessage mockOutputMessage =
-        mockContext.mock(HttpOutputMessage.class, "HttpOutputMessage");
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockOutputMessage).getHeaders();
-        will(returnValue(headers));
-      }
-    });
-
-    final SerializableObjectHttpMessageConverter converter =
-        new SerializableObjectHttpMessageConverter();
+    final byte[] bytes = {(byte) 0xCA, (byte) 0xFE, (byte) 0xBA, (byte) 0xBE};
+    final HttpOutputMessage mockOutputMessage = mock(HttpOutputMessage.class, "HttpOutputMessage");
+    when(mockOutputMessage.getHeaders()).thenReturn(headers);
 
     converter.setContentLength(mockOutputMessage, bytes);
-
-    assertEquals(bytes.length, headers.getContentLength());
+    assertThat(bytes.length).isEqualTo(headers.getContentLength());
   }
 
   @Test
   public void testWriteInternal() throws IOException {
+    final HttpHeaders headers = new HttpHeaders();
     final String expectedOutputMessageBody = "Expected media of the HTTP output message body!";
-
     final byte[] expectedOutputMessageBodyBytes =
         IOUtils.serializeObject(expectedOutputMessageBody);
-
     final ByteArrayOutputStream out =
         new ByteArrayOutputStream(expectedOutputMessageBodyBytes.length);
-
-    final HttpHeaders headers = new HttpHeaders();
-
-    final HttpOutputMessage mockOutputMessage =
-        mockContext.mock(HttpOutputMessage.class, "HttpOutputMessage");
-
-    mockContext.checking(new Expectations() {
-      {
-        oneOf(mockOutputMessage).getHeaders();
-        will(returnValue(headers));
-        oneOf(mockOutputMessage).getBody();
-        will(returnValue(out));
-      }
-    });
-
-    final SerializableObjectHttpMessageConverter converter =
-        new SerializableObjectHttpMessageConverter();
+    final HttpOutputMessage mockOutputMessage = mock(HttpOutputMessage.class, "HttpOutputMessage");
+    when(mockOutputMessage.getBody()).thenReturn(out);
+    when(mockOutputMessage.getHeaders()).thenReturn(headers);
 
     converter.writeInternal(expectedOutputMessageBody, mockOutputMessage);
-
     final byte[] actualOutputMessageBodyBytes = out.toByteArray();
-
-    assertEquals(expectedOutputMessageBodyBytes.length, headers.getContentLength());
-    assertEquals(expectedOutputMessageBodyBytes.length, actualOutputMessageBodyBytes.length);
+    assertThat(expectedOutputMessageBodyBytes.length).isEqualTo(headers.getContentLength());
+    assertThat(expectedOutputMessageBodyBytes.length)
+        .isEqualTo(actualOutputMessageBodyBytes.length);
 
     for (int index = 0; index < actualOutputMessageBodyBytes.length; index++) {
-      assertEquals(expectedOutputMessageBodyBytes[index], actualOutputMessageBodyBytes[index]);
+      assertThat(expectedOutputMessageBodyBytes[index])
+          .isEqualTo(actualOutputMessageBodyBytes[index]);
     }
   }
-
 }

--- a/gradle/dependency-versions.properties
+++ b/gradle/dependency-versions.properties
@@ -58,7 +58,6 @@ jedis.version = 2.9.0
 # at o.a.g.sessions.tests.GenericAppServerInstall.java
 jetty.version = 9.4.8.v20171121
 jgroups.version = 3.6.14.Final
-jmock.version = 2.8.4
 jna.version = 4.1.0
 jopt-simple.version = 5.0.4
 json-path.version = 2.4.0

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -45,8 +45,6 @@ subprojects {
     testCompile 'junit:junit:' + project.'junit.version'
     testCompile 'org.assertj:assertj-core:' + project.'assertj-core.version'
     testCompile 'org.hamcrest:hamcrest-all:' + project.'hamcrest-all.version'
-    testCompile 'org.jmock:jmock-junit4:' + project.'jmock.version'
-    testCompile 'org.jmock:jmock-legacy:' + project.'jmock.version'
 
     testCompile 'org.mockito:mockito-core:' + project.'mockito-core.version'
     testCompile 'org.powermock:powermock-core:' + project.'powermock.version'
@@ -140,9 +138,6 @@ subprojects {
   }
 
   dependencies {
-    integrationTestCompile 'org.jmock:jmock-junit4:' + project.'jmock.version'
-    integrationTestCompile 'org.jmock:jmock-legacy:' + project.'jmock.version'
-
     integrationTestCompile 'org.mockito:mockito-core:' + project.'mockito-core.version'
 
     integrationTestCompile 'org.powermock:powermock-core:' + project.'powermock.version'


### PR DESCRIPTION
GEODE-5607: Replace Jmock with Mockito

- Removed dependency to `org.jmock`.
- Migrated several test classes to use `Mockito` instead `Jmock`.
- Changed same classes to use `assertj` instead of `junit.Assert`.
- Changed same classes to use `Awaitility` instead of `WaitCriterion`.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
