### PR TITLE
GEODE-5704: use untilAsserted to avoid early failure

### DIFF
--- a/geode-dunit/src/main/java/org/apache/geode/cache30/MultiVMRegionTestCase.java
+++ b/geode-dunit/src/main/java/org/apache/geode/cache30/MultiVMRegionTestCase.java
@@ -8284,45 +8284,46 @@ public abstract class MultiVMRegionTestCase extends RegionTestCase {
       fail("neither member saw event conflation - check stats for " + name);
     }
 
-    // Wait for the members to eventually be consistent
     // For no-ack regions, messages may still be in flight between replicas at this point
-    waitAtMost(5, MINUTES).until(() -> {
+    await("Wait for the members to eventually be consistent").atMost(5, MINUTES)
+        .untilAsserted(() -> {
 
-      // check consistency of the regions
-      Map r1Contents = vm1.invoke(MultiVMRegionTestCase::getCCRegionContents);
-      Map r2Contents = vm2.invoke(MultiVMRegionTestCase::getCCRegionContents);
-      Map r3Contents = vm3.invoke(MultiVMRegionTestCase::getCCRegionContents);
+          // check consistency of the regions
+          Map r1Contents = vm1.invoke(MultiVMRegionTestCase::getCCRegionContents);
+          Map r2Contents = vm2.invoke(MultiVMRegionTestCase::getCCRegionContents);
+          Map r3Contents = vm3.invoke(MultiVMRegionTestCase::getCCRegionContents);
 
-      try {
-        for (int i = 0; i < 10; i++) {
-          String key = "cckey" + i;
-          assertThat(r2Contents.get(key)).describedAs(
-              "1 region contents are not consistent for i " + key).isEqualTo(r1Contents.get(key));
-          assertThat(r3Contents.get(key)).describedAs(
-              "2 region contents are not consistent for i " + key).isEqualTo(r2Contents.get(key));
-          for (int subi = 1; subi < 3; subi++) {
-            String subkey = key + "-" + subi;
-            if (r1Contents.containsKey(subkey)) {
-              assertThat(r2Contents.get(subkey)).describedAs(
-                  "3 region contents are not consistent for " + subkey).isEqualTo(
-                      r1Contents.get(subkey));
-              assertThat(r3Contents.get(subkey)).describedAs(
-                  "4 region contents are not consistent for " + subkey).isEqualTo(
-                      r2Contents.get(subkey));
-            } else {
-              boolean condition1 = !r2Contents.containsKey(subkey);
-              assertThat(condition1).describedAs("5 r2contents").isTrue();
-              boolean condition = !r3Contents.containsKey(subkey);
-              assertThat(condition).describedAs("6 r3contents").isTrue();
+          try {
+            for (int i = 0; i < 10; i++) {
+              String key = "cckey" + i;
+              assertThat(r2Contents.get(key)).describedAs(
+                  "r2 contents are not consistent with r1 for " + key)
+                  .isEqualTo(r1Contents.get(key));
+              assertThat(r3Contents.get(key)).describedAs(
+                  "r3 contents are not consistent with r2 for " + key)
+                  .isEqualTo(r2Contents.get(key));
+              for (int subi = 1; subi < 3; subi++) {
+                String subkey = key + "-" + subi;
+                if (r1Contents.containsKey(subkey)) {
+                  assertThat(r2Contents.get(subkey)).describedAs(
+                      "r2 contents are not consistent with r1 for subkey " + subkey).isEqualTo(
+                          r1Contents.get(subkey));
+                  assertThat(r3Contents.get(subkey)).describedAs(
+                      "r3 contents are not consistent with r2 for subkey " + subkey).isEqualTo(
+                          r2Contents.get(subkey));
+                } else {
+                  assertThat(r2Contents.containsKey(subkey))
+                      .describedAs("r2 contains subkey " + subkey + " that r1 does not").isFalse();
+                  assertThat(r3Contents.containsKey(subkey))
+                      .describedAs("r3 contains subkey " + subkey + " that r1 does not").isFalse();
+                }
+              }
             }
+          } catch (Exception e) {
+            e.printStackTrace();
+            throw (e);
           }
-        }
-      } catch (Exception e) {
-        e.printStackTrace();
-        throw (e);
-      }
-      return true;
-    });
+        });
 
   }
 

--- a/geode-dunit/src/main/java/org/apache/geode/cache30/MultiVMRegionTestCase.java
+++ b/geode-dunit/src/main/java/org/apache/geode/cache30/MultiVMRegionTestCase.java
@@ -8293,35 +8293,30 @@ public abstract class MultiVMRegionTestCase extends RegionTestCase {
           Map r2Contents = vm2.invoke(MultiVMRegionTestCase::getCCRegionContents);
           Map r3Contents = vm3.invoke(MultiVMRegionTestCase::getCCRegionContents);
 
-          try {
-            for (int i = 0; i < 10; i++) {
-              String key = "cckey" + i;
-              assertThat(r2Contents.get(key)).describedAs(
-                  "r2 contents are not consistent with r1 for " + key)
-                  .isEqualTo(r1Contents.get(key));
-              assertThat(r3Contents.get(key)).describedAs(
-                  "r3 contents are not consistent with r2 for " + key)
-                  .isEqualTo(r2Contents.get(key));
-              for (int subi = 1; subi < 3; subi++) {
-                String subkey = key + "-" + subi;
-                if (r1Contents.containsKey(subkey)) {
-                  assertThat(r2Contents.get(subkey)).describedAs(
-                      "r2 contents are not consistent with r1 for subkey " + subkey).isEqualTo(
-                          r1Contents.get(subkey));
-                  assertThat(r3Contents.get(subkey)).describedAs(
-                      "r3 contents are not consistent with r2 for subkey " + subkey).isEqualTo(
-                          r2Contents.get(subkey));
-                } else {
-                  assertThat(r2Contents.containsKey(subkey))
-                      .describedAs("r2 contains subkey " + subkey + " that r1 does not").isFalse();
-                  assertThat(r3Contents.containsKey(subkey))
-                      .describedAs("r3 contains subkey " + subkey + " that r1 does not").isFalse();
-                }
+          for (int i = 0; i < 10; i++) {
+            String key = "cckey" + i;
+            assertThat(r2Contents.get(key)).describedAs(
+                "r2 contents are not consistent with r1 for " + key)
+                .isEqualTo(r1Contents.get(key));
+            assertThat(r3Contents.get(key)).describedAs(
+                "r3 contents are not consistent with r2 for " + key)
+                .isEqualTo(r2Contents.get(key));
+            for (int subi = 1; subi < 3; subi++) {
+              String subkey = key + "-" + subi;
+              if (r1Contents.containsKey(subkey)) {
+                assertThat(r2Contents.get(subkey)).describedAs(
+                    "r2 contents are not consistent with r1 for subkey " + subkey).isEqualTo(
+                        r1Contents.get(subkey));
+                assertThat(r3Contents.get(subkey)).describedAs(
+                    "r3 contents are not consistent with r2 for subkey " + subkey).isEqualTo(
+                        r2Contents.get(subkey));
+              } else {
+                assertThat(r2Contents.containsKey(subkey))
+                    .describedAs("r2 contains subkey " + subkey + " that r1 does not").isFalse();
+                assertThat(r3Contents.containsKey(subkey))
+                    .describedAs("r3 contains subkey " + subkey + " that r1 does not").isFalse();
               }
             }
-          } catch (Exception e) {
-            e.printStackTrace();
-            throw (e);
           }
         });
 


### PR DESCRIPTION
There was an awaitility that intended to loop until data was consistent
but instead failed on the first pass if any keys weren't consistent.

Signed-off-by: khowe@pivotal.io

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
