### PR TITLE
GEODE-5605: After removeAll/PutAll messages are processed on replicas, check for cache close is done.

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/BucketRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/BucketRegion.java
@@ -1558,7 +1558,7 @@ public class BucketRegion extends DistributedRegion implements Bucket {
     // No need to close advisor, assume its already closed
     // However we need to remove our listener from the advisor (see bug 43950).
     this.distAdvisor.removeMembershipListener(this.advisorListener);
-    super.distributedRegionCleanup(event);
+    waitForCurrentOperations();
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/BucketRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/BucketRegion.java
@@ -1558,6 +1558,7 @@ public class BucketRegion extends DistributedRegion implements Bucket {
     // No need to close advisor, assume its already closed
     // However we need to remove our listener from the advisor (see bug 43950).
     this.distAdvisor.removeMembershipListener(this.advisorListener);
+    super.distributedRegionCleanup(event);
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/BucketRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/BucketRegion.java
@@ -1558,7 +1558,6 @@ public class BucketRegion extends DistributedRegion implements Bucket {
     // No need to close advisor, assume its already closed
     // However we need to remove our listener from the advisor (see bug 43950).
     this.distAdvisor.removeMembershipListener(this.advisorListener);
-    waitForCurrentOperations();
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
@@ -2478,7 +2478,6 @@ public class DistributedRegion extends LocalRegion implements InternalDistribute
       }
     }
     waitForCurrentOperations();
-
   }
 
   protected void waitForCurrentOperations() {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
@@ -2477,6 +2477,11 @@ public class DistributedRegion extends LocalRegion implements InternalDistribute
             this.getFullPath()), ex);
       }
     }
+    waitForCurrentOperations();
+
+  }
+
+  protected void waitForCurrentOperations() {
     // Fix for #48066 - make sure that region operations are completely
     // distributed to peers before destroying the region.
     Boolean flushOnClose =

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
@@ -5307,6 +5307,18 @@ public class PartitionedRegion extends LocalRegion
           retryTime = new RetryTimeKeeper(this.retryTimeout);
         }
         currentTarget = getOrCreateNodeForBucketWrite(bucketId, retryTime);
+      } catch (EntryNotFoundException entryNotFoundException) {
+        if (!event.isPossibleDuplicate()) {
+          throw entryNotFoundException;
+        }
+        // EntryNotFoundException during retry attempt. The operation
+        // may have been applied during the initial attempt.
+        if (logger.isDebugEnabled()) {
+          logger.debug(
+              "EntryNotFoundException is ignored during retry attempt for destroy operation. "
+                  + event);
+        }
+        return;
       }
 
       // If we get here, the attempt failed.

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/RemoveAllPRMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/RemoveAllPRMessage.java
@@ -516,17 +516,7 @@ public class RemoveAllPRMessage extends PartitionMessageWithDirectReply {
             // encounter cacheWriter exception
             partialKeys.saveFailedKey(key, cwe);
           } finally {
-            try {
-              // Only RemoveAllPRMessage knows if the thread id is fake. Event has no idea.
-              // So we have to manually set useFakeEventId for this op
-              op.setUseFakeEventId(true);
-              r.checkReadiness();
-              bucketRegion.getDataView().postRemoveAll(op, this.versions, bucketRegion);
-            } finally {
-              if (lockedForPrimary) {
-                bucketRegion.doUnlockForPrimary();
-              }
-            }
+            doPostRemoveAll(r, op, bucketRegion, lockedForPrimary);
           }
           if (partialKeys.hasFailure()) {
             partialKeys.addKeysAndVersions(this.versions);
@@ -565,6 +555,22 @@ public class RemoveAllPRMessage extends PartitionMessageWithDirectReply {
     }
 
     return true;
+  }
+
+  void doPostRemoveAll(PartitionedRegion r, DistributedRemoveAllOperation op,
+      BucketRegion bucketRegion, boolean lockedForPrimary) {
+    try {
+      // Only RemoveAllPRMessage knows if the thread id is fake. Event has no idea.
+      // So we have to manually set useFakeEventId for this op
+      op.setUseFakeEventId(true);
+      r.checkReadiness();
+      bucketRegion.getDataView().postRemoveAll(op, this.versions, bucketRegion);
+      r.checkReadiness();
+    } finally {
+      if (lockedForPrimary) {
+        bucketRegion.doUnlockForPrimary();
+      }
+    }
   }
 
   public VersionedObjectList getVersions() {

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/BucketRegionJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/BucketRegionJUnitTest.java
@@ -31,11 +31,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-import org.junit.Test;
-
 import org.apache.geode.cache.RegionAttributes;
-import org.apache.geode.distributed.internal.DistributionManager;
-import org.apache.geode.distributed.internal.membership.MembershipManager;
 
 public class BucketRegionJUnitTest extends DistributedRegionJUnitTest {
 
@@ -128,24 +124,6 @@ public class BucketRegionJUnitTest extends DistributedRegionJUnitTest {
     } else {
       verify(br, never()).distributeUpdateEntryVersionOperation(eq(event));
     }
-  }
-
-  @Test
-  public void regionCleanupWaitsForCurrentOperationToBeCompleted() {
-    RegionEventImpl regionEventImpl = mock(RegionEventImpl.class);
-    CacheDistributionAdvisor cacheDistributionAdvisor = mock(CacheDistributionAdvisor.class);
-    DistributionManager distributionManager = mock(DistributionManager.class);
-    MembershipManager membershipManager = mock(MembershipManager.class);
-    when(membershipManager.isConnected()).thenReturn(true);
-    when(distributionManager.getMembershipManager()).thenReturn(membershipManager);
-    BucketRegion bucketRegion = (BucketRegion) prepare(true, false);
-    when(bucketRegion.getDistributionAdvisor()).thenReturn(cacheDistributionAdvisor);
-    when(bucketRegion.getDistributionManager()).thenReturn(distributionManager);
-
-    bucketRegion.distributedRegionCleanup(regionEventImpl);
-
-    verify(bucketRegion, times(1)).distributedRegionCleanup(eq(regionEventImpl));
-    verify(cacheDistributionAdvisor, times(1)).waitForCurrentOperations();
   }
 
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/BucketRegionJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/BucketRegionJUnitTest.java
@@ -31,7 +31,11 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
+import org.junit.Test;
+
 import org.apache.geode.cache.RegionAttributes;
+import org.apache.geode.distributed.internal.DistributionManager;
+import org.apache.geode.distributed.internal.membership.MembershipManager;
 
 public class BucketRegionJUnitTest extends DistributedRegionJUnitTest {
 
@@ -124,6 +128,24 @@ public class BucketRegionJUnitTest extends DistributedRegionJUnitTest {
     } else {
       verify(br, never()).distributeUpdateEntryVersionOperation(eq(event));
     }
+  }
+
+  @Test
+  public void regionCleanupWaitsForCurrentOperationToBeCompleted() {
+    RegionEventImpl regionEventImpl = mock(RegionEventImpl.class);
+    CacheDistributionAdvisor cacheDistributionAdvisor = mock(CacheDistributionAdvisor.class);
+    DistributionManager distributionManager = mock(DistributionManager.class);
+    MembershipManager membershipManager = mock(MembershipManager.class);
+    when(membershipManager.isConnected()).thenReturn(true);
+    when(distributionManager.getMembershipManager()).thenReturn(membershipManager);
+    BucketRegion bucketRegion = (BucketRegion) prepare(true, false);
+    when(bucketRegion.getDistributionAdvisor()).thenReturn(cacheDistributionAdvisor);
+    when(bucketRegion.getDistributionManager()).thenReturn(distributionManager);
+
+    bucketRegion.distributedRegionCleanup(regionEventImpl);
+
+    verify(bucketRegion, times(1)).distributedRegionCleanup(eq(regionEventImpl));
+    verify(cacheDistributionAdvisor, times(1)).waitForCurrentOperations();
   }
 
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionedRegionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionedRegionTest.java
@@ -15,12 +15,14 @@
 package org.apache.geode.internal.cache;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.ThrowableAssert.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -37,6 +39,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import org.apache.geode.cache.AttributesFactory;
+import org.apache.geode.cache.EntryNotFoundException;
 import org.apache.geode.cache.Operation;
 import org.apache.geode.cache.PartitionAttributesFactory;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -175,4 +178,45 @@ public class PartitionedRegionTest {
     verify(spyPR, times(1)).getNodeForBucketWrite(anyInt(), isNull());
   }
 
+  @Test
+  public void remoteAttemptOfDestroyInBucketThrowsEntryNotFoundException() throws Exception {
+    int bucketId = 0;
+    Object expectedOldValue = "expectedOldValue";
+    KeyInfo keyInfo = mock(KeyInfo.class);
+    when(keyInfo.getBucketId()).thenReturn(bucketId);
+    EntryEventImpl entryEventImpl = mock(EntryEventImpl.class);
+    when(entryEventImpl.getKeyInfo()).thenReturn(keyInfo);
+    InternalDistributedMember primaryMember = mock(InternalDistributedMember.class);
+    PartitionedRegion spyPR = spy(partitionedRegion);
+    doReturn(primaryMember).when(spyPR).getOrCreateNodeForBucketWrite(eq(bucketId), isNull());
+    doThrow(EntryNotFoundException.class).when(spyPR).destroyRemotely(eq(primaryMember),
+        eq(bucketId), eq(entryEventImpl), eq(expectedOldValue));
+
+    Throwable thrown = catchThrowable(() -> {
+      spyPR.destroyInBucket(entryEventImpl, expectedOldValue);
+    });
+
+    assertThat(thrown).isInstanceOf(EntryNotFoundException.class);
+    verify(spyPR, times(1)).getOrCreateNodeForBucketWrite(eq(bucketId), isNull());
+  }
+
+  @Test
+  public void remoteAttemptOfDestroyInBucketForPosDupEventIgnoresEntryNotFoundException()
+      throws Exception {
+    int bucketId = 0;
+    Object expectedOldValue = "expectedOldValue";
+    EntryEventImpl entryEventImpl = mock(EntryEventImpl.class);
+    when(entryEventImpl.isPossibleDuplicate()).thenReturn(true);
+    KeyInfo keyInfo = mock(KeyInfo.class);
+    when(keyInfo.getBucketId()).thenReturn(bucketId);
+    when(entryEventImpl.getKeyInfo()).thenReturn(keyInfo);
+    InternalDistributedMember primaryMember = mock(InternalDistributedMember.class);
+    PartitionedRegion spyPR = spy(partitionedRegion);
+    doReturn(primaryMember).when(spyPR).getOrCreateNodeForBucketWrite(eq(bucketId), isNull());
+    doThrow(EntryNotFoundException.class).when(spyPR).destroyRemotely(eq(primaryMember),
+        eq(bucketId), eq(entryEventImpl), eq(expectedOldValue));
+
+    spyPR.destroyInBucket(entryEventImpl, expectedOldValue);
+    verify(spyPR, times(1)).getOrCreateNodeForBucketWrite(eq(bucketId), isNull());
+  }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionedRegionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionedRegionTest.java
@@ -179,7 +179,7 @@ public class PartitionedRegionTest {
   }
 
   @Test
-  public void remoteAttemptOfDestroyInBucketThrowsEntryNotFoundException() throws Exception {
+  public void destroyInBucketRemoteOperationThrowsEntryNotFoundException() throws Exception {
     int bucketId = 0;
     Object expectedOldValue = "expectedOldValue";
     KeyInfo keyInfo = mock(KeyInfo.class);
@@ -201,7 +201,7 @@ public class PartitionedRegionTest {
   }
 
   @Test
-  public void remoteAttemptOfDestroyInBucketForPosDupEventIgnoresEntryNotFoundException()
+  public void destroyInBucketRemoteOperationDoesNotThrowEntryNotFoundExceptionForPossibleDuplicateEvent()
       throws Exception {
     int bucketId = 0;
     Object expectedOldValue = "expectedOldValue";
@@ -217,6 +217,7 @@ public class PartitionedRegionTest {
         eq(bucketId), eq(entryEventImpl), eq(expectedOldValue));
 
     spyPR.destroyInBucket(entryEventImpl, expectedOldValue);
+
     verify(spyPR, times(1)).getOrCreateNodeForBucketWrite(eq(bucketId), isNull());
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/PutAllPRMessageTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/PutAllPRMessageTest.java
@@ -14,50 +14,36 @@
  */
 package org.apache.geode.internal.cache.partitioned;
 
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.junit.Test;
 import org.mockito.InOrder;
 
 import org.apache.geode.internal.cache.BucketRegion;
-import org.apache.geode.internal.cache.DistributedRemoveAllOperation;
+import org.apache.geode.internal.cache.DistributedPutAllOperation;
 import org.apache.geode.internal.cache.InternalDataView;
 import org.apache.geode.internal.cache.PartitionedRegion;
 
-public class RemoveAllPRMessageTest {
+public class PutAllPRMessageTest {
 
   @Test
-  public void shouldBeMockable() throws Exception {
-    RemoveAllPRMessage mockRemoveAllPRMessage = mock(RemoveAllPRMessage.class);
-    StringBuilder stringBuilder = new StringBuilder();
-
-    mockRemoveAllPRMessage.appendFields(stringBuilder);
-
-    verify(mockRemoveAllPRMessage, times(1)).appendFields(stringBuilder);
-  }
-
-
-  @Test
-  public void doPostRemoveAllCallsCheckReadinessBeforeAndAfter() throws Exception {
+  public void doPostPutAllCallsCheckReadinessBeforeAndAfter() throws Exception {
     PartitionedRegion partitionedRegion = mock(PartitionedRegion.class);
-    DistributedRemoveAllOperation distributedRemoveAllOperation =
-        mock(DistributedRemoveAllOperation.class);
+    DistributedPutAllOperation distributedPutAllOperation = mock(DistributedPutAllOperation.class);
     BucketRegion bucketRegion = mock(BucketRegion.class);
     InternalDataView internalDataView = mock(InternalDataView.class);
     when(bucketRegion.getDataView()).thenReturn(internalDataView);
-    RemoveAllPRMessage removeAllPRMessage = new RemoveAllPRMessage();
+    PutAllPRMessage putAllPRMessage = new PutAllPRMessage();
 
-    removeAllPRMessage.doPostRemoveAll(partitionedRegion, distributedRemoveAllOperation,
-        bucketRegion, true);
+    putAllPRMessage.doPostPutAll(partitionedRegion, distributedPutAllOperation, bucketRegion, true);
 
     InOrder inOrder = inOrder(partitionedRegion, internalDataView);
     inOrder.verify(partitionedRegion).checkReadiness();
-    inOrder.verify(internalDataView).postRemoveAll(any(), any(), any());
+    inOrder.verify(internalDataView).postPutAll(any(), any(), any());
     inOrder.verify(partitionedRegion).checkReadiness();
   }
 }


### PR DESCRIPTION
Co-authored-by: @boglesby 

GEODE-5605: 
- After removeAll/PutAll messages are processed on replicas, check for cache close is done.
   This results in retrying the operation from accessor node; which will take care of partial 
   distribution due to cache close.

### For all changes:
- [Yes] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [No ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [Yes] Is your initial contribution a single, squashed commit?

- [Yes ] Does `gradlew build` run cleanly?

- [Yes] Have you written or updated unit tests to verify your changes?

- [NA ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
