### PR TITLE
GEODE-5722 - Improve concourse deployment experience for releases

### DIFF
--- a/ci/pipelines/geode-build/deploy_pipeline.sh
+++ b/ci/pipelines/geode-build/deploy_pipeline.sh
@@ -84,4 +84,7 @@ pushd ${SCRIPTDIR} 2>&1 > /dev/null
     --var docker-image-prefix=${DOCKER_IMAGE_PREFIX} \
     --config ${SCRIPTDIR}/generated-pipeline.yml
 
+  if [[ "${SANITIZED_GEODE_FORK}" == "apache" ]]; then
+    fly -t ${TARGET} expose-pipeline -p ${PIPELINE_NAME}
+  fi
 popd 2>&1 > /dev/null

--- a/ci/pipelines/meta/deploy_meta.sh
+++ b/ci/pipelines/meta/deploy_meta.sh
@@ -77,15 +77,29 @@ fi
 
 if [[ "${GEODE_FORK}" != "apache" ]]; then
   echo "Disabling unnecessary jobs for forks."
-  set -x
   for job in set set-images set-reaper; do
+    set -x
     fly -t ${TARGET} pause-job \
         -j ${META_PIPELINE}/${job}-pipeline
+    set +x
   done
-
-  fly -t ${TARGET} trigger-job \
-      -j ${META_PIPELINE}/build-meta-mini-docker-image
-  fly -t ${TARGET} unpause-pipeline \
-      -p ${META_PIPELINE}
-  set +x
+else
+  echo "Disabling unnecessary jobs for release branches."
+  echo "*** DO NOT RE-ENABLE THESE META-JOBS ***"
+  for job in set set-pr set-images set-reaper set-metrics set-examples; do
+    set -x
+    fly -t ${TARGET} pause-job \
+        -j ${META_PIPELINE}/${job}-pipeline
+    set +x
+  done
 fi
+
+set -x
+fly -t ${TARGET} trigger-job \
+    -j ${META_PIPELINE}/build-meta-mini-docker-image
+fly -t ${TARGET} unpause-pipeline \
+    -p ${META_PIPELINE}
+
+set +x
+
+echo "When 'build-meta-mini-docker-image' job is complete, manually unpause and trigger 'set-pipeline'."

--- a/ci/pipelines/shared/utilities.sh
+++ b/ci/pipelines/shared/utilities.sh
@@ -17,10 +17,14 @@
 # limitations under the License.
 
 
+sanitizeName() {
+  echo ${1} | tr "._/" "-" | tr '[:upper:]' '[:lower:]'
+}
+
 getSanitizedBranch () {
-  echo ${1} | tr "_/" "-" | tr '[:upper:]' '[:lower:]' | cut -c 1-20
+  echo $(sanitizeName ${1}) | cut -c 1-20
 }
 
 getSanitizedFork () {
-  echo ${1} | tr "_/" "-" | tr '[:upper:]' '[:lower:]' | cut -c 1-16
+  echo $(sanitizeName ${1}) | cut -c 1-16
 }

--- a/ci/scripts/start_instance.sh
+++ b/ci/scripts/start_instance.sh
@@ -44,15 +44,13 @@ if [[ -z "${GEODE_BRANCH}" ]]; then
 fi
 
 
-
-
 . ${SCRIPTDIR}/../pipelines/shared/utilities.sh
 SANITIZED_GEODE_BRANCH=$(getSanitizedBranch ${GEODE_BRANCH})
 SANITIZED_GEODE_FORK=$(getSanitizedFork ${GEODE_FORK})
 
-SANITIZED_BUILD_PIPELINE_NAME=$(echo ${BUILD_PIPELINE_NAME} | tr "/" "-" | tr '[:upper:]' '[:lower:]')
-SANITIZED_BUILD_JOB_NAME=$(echo ${BUILD_JOB_NAME} | tr "/" "-" | tr '[:upper:]' '[:lower:]')
-SANITIZED_BUILD_NAME=$(echo ${BUILD_NAME} | tr "/" "-" | tr '[:upper:]' '[:lower:]')
+SANITIZED_BUILD_PIPELINE_NAME=$(sanitizeName ${BUILD_PIPELINE_NAME})
+SANITIZED_BUILD_JOB_NAME=$(sanitizeName ${BUILD_JOB_NAME})
+SANITIZED_BUILD_NAME=$(sanitizeName ${BUILD_NAME})
 IMAGE_FAMILY_PREFIX=""
 WINDOWS_PREFIX=""
 
@@ -64,7 +62,7 @@ if [[ "${SANITIZED_BUILD_JOB_NAME}" =~ [Ww]indows ]]; then
   WINDOWS_PREFIX="windows-"
 fi
 
-INSTANCE_NAME="$(echo "${BUILD_PIPELINE_NAME}-${BUILD_JOB_NAME}-${BUILD_NAME}" | tr '[:upper:]' '[:lower:]')"
+INSTANCE_NAME=$(sanitizeName "${BUILD_PIPELINE_NAME}-${BUILD_JOB_NAME}-${BUILD_NAME}")
 PROJECT=apachegeode-ci
 ZONE=us-central1-f
 echo "${INSTANCE_NAME}" > "instance-data/instance-name"


### PR DESCRIPTION
Automatically start the meta-mini-image job on deployment
Disable/pause jobs that are unused in release
DRY the sanitization utility across scripts
Expose the main pipeline from a deployment from apache

Co-authored-by: Robert Houghton <rhoughton@pivotal.io>
Co-authored-by: Dick Cavender <dcavender@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
