### PR TITLE
GEODE-5094: Replace flaky expiration with prexisting better one

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/RegionExpirationIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/RegionExpirationIntegrationTest.java
@@ -35,13 +35,24 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.mockito.InOrder;
 
+import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactory;
 
-/**
- * Extracted from {@link RegionExpirationDistributedTest}.
- */
+
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
 public class RegionExpirationIntegrationTest {
+
+  @Parameterized.Parameter(0)
+  public DataPolicy dataPolicy;
+
+  @Parameterized.Parameters(name = "{0}")
+  public static Object[] data() {
+    return new Object[] {DataPolicy.NORMAL, DataPolicy.EMPTY};
+  }
 
   private Cache cache;
   private String regionName;
@@ -66,6 +77,7 @@ public class RegionExpirationIntegrationTest {
 
     RegionFactory<String, String> regionFactory = cache.createRegionFactory(LOCAL);
     regionFactory.setRegionTimeToLive(new ExpirationAttributes(firstTtlSeconds, DESTROY));
+    regionFactory.setDataPolicy(dataPolicy);
     Region<String, String> region = regionFactory.create(regionName);
 
     region.getAttributesMutator()
@@ -84,6 +96,7 @@ public class RegionExpirationIntegrationTest {
 
     RegionFactory<String, String> regionFactory = cache.createRegionFactory(LOCAL);
     regionFactory.setRegionTimeToLive(new ExpirationAttributes(firstTtlSeconds, DESTROY));
+    regionFactory.setDataPolicy(dataPolicy);
     Region<String, String> region = regionFactory.create(regionName);
 
     region.getAttributesMutator()
@@ -101,6 +114,7 @@ public class RegionExpirationIntegrationTest {
     RegionFactory<String, String> regionFactory = cache.createRegionFactory(LOCAL);
     regionFactory.setRegionTimeToLive(new ExpirationAttributes(ttlSeconds, DESTROY));
     regionFactory.setRegionIdleTimeout(new ExpirationAttributes(idleSeconds, INVALIDATE));
+    regionFactory.setDataPolicy(dataPolicy);
     regionFactory.addCacheListener(spyCacheListener);
     Region<String, String> region = regionFactory.create(regionName);
 


### PR DESCRIPTION
ProxyJUnitTest.testExpiration used small timeouts and was flaky. It
looks like it was probably a near duplicate of a test that was already
refactored into RegionExpirationIntegrationTest. Removing the test and
parameterizing RegionExpirationIntegrationTest instead.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
