### PR TITLE
GEODE-5499: move awaitility into invoked runnable

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/cache30/DistributedNoAckRegionCCEDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache30/DistributedNoAckRegionCCEDUnitTest.java
@@ -85,18 +85,18 @@ public class DistributedNoAckRegionCCEDUnitTest extends DistributedNoAckRegionDU
 
   @Override
   @Test
-  public void testLocalDestroy() throws InterruptedException {
+  public void testLocalDestroy() {
     // replicates don't allow local destroy
   }
 
   @Override
   @Test
-  public void testEntryTtlLocalDestroy() throws InterruptedException {
+  public void testEntryTtlLocalDestroy() {
     // replicates don't allow local destroy
   }
 
   @Test
-  public void testClearWithManyEventsInFlight() throws Exception {
+  public void testClearWithManyEventsInFlight() {
     Host host = Host.getHost(0);
     VM vm0 = host.getVM(0);
     VM vm1 = host.getVM(1);
@@ -131,10 +131,10 @@ public class DistributedNoAckRegionCCEDUnitTest extends DistributedNoAckRegionDU
 
     Wait.pause(2000);// this test has with noack, thus we should wait before validating entries
     // check consistency of the regions
-    Map r0Contents = (Map) vm0.invoke(() -> this.getCCRegionContents());
-    Map r1Contents = (Map) vm1.invoke(() -> this.getCCRegionContents());
-    Map r2Contents = (Map) vm2.invoke(() -> this.getCCRegionContents());
-    Map r3Contents = (Map) vm3.invoke(() -> this.getCCRegionContents());
+    Map r0Contents = vm0.invoke(() -> getCCRegionContents());
+    Map r1Contents = vm1.invoke(() -> getCCRegionContents());
+    Map r2Contents = vm2.invoke(() -> getCCRegionContents());
+    Map r3Contents = vm3.invoke(() -> getCCRegionContents());
 
     for (int i = 0; i < 10; i++) {
       String key = "cckey" + i;
@@ -234,7 +234,7 @@ public class DistributedNoAckRegionCCEDUnitTest extends DistributedNoAckRegionDU
    */
 
   @Test
-  public void testGIISendsTombstones() throws Exception {
+  public void testGIISendsTombstones() {
     versionTestGIISendsTombstones();
   }
 
@@ -255,23 +255,23 @@ public class DistributedNoAckRegionCCEDUnitTest extends DistributedNoAckRegionDU
 
 
   @Test
-  public void testClearWithConcurrentEvents() throws Exception {
+  public void testClearWithConcurrentEvents() {
     // need to figure out how to flush clear() ops for verification steps
   }
 
   @Test
-  public void testClearWithConcurrentEventsAsync() throws Exception {
+  public void testClearWithConcurrentEventsAsync() {
     // need to figure out how to flush clear() ops for verification steps
   }
 
   @Test
-  public void testClearOnNonReplicateWithConcurrentEvents() throws Exception {
+  public void testClearOnNonReplicateWithConcurrentEvents() {
     // need to figure out how to flush clear() ops for verification steps
   }
 
 
   @Test
-  public void testTombstones() throws Exception {
+  public void testTombstones() {
     versionTestTombstones();
   }
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache30/DistributedNoAckRegionCCEOffHeapDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache30/DistributedNoAckRegionCCEOffHeapDUnitTest.java
@@ -36,7 +36,6 @@ public class DistributedNoAckRegionCCEOffHeapDUnitTest extends DistributedNoAckR
   @Override
   public final void preTearDownAssertions() throws Exception {
     SerializableRunnable checkOrphans = new SerializableRunnable() {
-
       @Override
       public void run() {
         if (hasCache()) {
@@ -44,6 +43,7 @@ public class DistributedNoAckRegionCCEOffHeapDUnitTest extends DistributedNoAckR
         }
       }
     };
+
     Invoke.invokeInEveryVM(checkOrphans);
     checkOrphans.run();
   }

--- a/geode-dunit/src/main/java/org/apache/geode/cache30/RegionTestCase.java
+++ b/geode-dunit/src/main/java/org/apache/geode/cache30/RegionTestCase.java
@@ -70,6 +70,7 @@ import org.apache.geode.internal.cache.EntrySnapshot;
 import org.apache.geode.internal.cache.ExpiryTask;
 import org.apache.geode.internal.cache.ExpiryTask.ExpiryTaskListener;
 import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.test.dunit.Host;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.Wait;
@@ -1776,7 +1777,7 @@ public abstract class RegionTestCase extends JUnit4CacheTestCase {
   @Test
   public void testValues() throws CacheException {
     String name = this.getUniqueName();
-    System.err.println("testValues region name is " + name);
+    LogService.getLogger().info("testValues region name is " + name);
     Region region = createRegion(name);
     assertEquals(0, region.values().size());
 


### PR DESCRIPTION
Assertion errors within invoked runnables get wrapped in an
RMIException, so untilAsserted does not recognize them as failed
assertions. Since they are treated as unexpected errors, awaitility
does not loop.  Moving the awaitility inside the invocation gives us the
expected behavior.

Signed-off-by: Dale Emery<demery@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
