### PR TITLE
GEODE-5501: add logging in test base for debug

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/NetSearchMessagingDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/NetSearchMessagingDUnitTest.java
@@ -34,7 +34,6 @@ import org.apache.geode.distributed.internal.ClusterDistributionManager;
 import org.apache.geode.distributed.internal.DistributionMessage;
 import org.apache.geode.distributed.internal.DistributionMessageObserver;
 import org.apache.geode.internal.cache.SearchLoadAndWriteProcessor.NetSearchRequestMessage;
-import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.test.dunit.Host;
 import org.apache.geode.test.dunit.LogWriterUtils;
 import org.apache.geode.test.dunit.SerializableCallable;
@@ -400,7 +399,7 @@ public class NetSearchMessagingDUnitTest extends JUnit4CacheTestCase {
   }
 
   private void createReplicate(VM vm) {
-    LogService.getLogger().info("START SETUP createReplicate in vm " + vm.getId() + " for test "
+    System.out.println("START SETUP createReplicate in vm " + vm.getId() + " for test "
         + getTestClass().getSimpleName() + "." + getTestMethodName());
 
     vm.invoke(new SerializableRunnable() {
@@ -415,7 +414,7 @@ public class NetSearchMessagingDUnitTest extends JUnit4CacheTestCase {
       }
     });
 
-    LogService.getLogger().info("END SETUP createReplicate in vm " + vm.getId() + " for test "
+    System.out.println("END SETUP createReplicate in vm " + vm.getId() + " for test "
         + getTestClass().getSimpleName() + "." + getTestMethodName());
 
   }

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/NetSearchMessagingDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/NetSearchMessagingDUnitTest.java
@@ -60,48 +60,41 @@ public class NetSearchMessagingDUnitTest extends JUnit4CacheTestCase {
     createEmpty(vm3);
 
     // Test with a null value
-    {
-      long vm0Count = getReceivedMessages(vm0);
-      long vm1Count = getReceivedMessages(vm1);
-      long vm2Count = getReceivedMessages(vm2);
-      long vm3Count = getReceivedMessages(vm3);
+    long vm0Count = getReceivedMessages(vm0);
+    long vm1Count = getReceivedMessages(vm1);
+    long vm2Count = getReceivedMessages(vm2);
+    long vm3Count = getReceivedMessages(vm3);
 
-      assertEquals(null, get(vm3, "a"));
+    assertEquals(null, get(vm3, "a"));
 
-      // Make sure we only processed one message
-      assertEquals(vm3Count + 1, getReceivedMessages(vm3));
+    // Make sure we only processed one message
+    assertEquals(vm3Count + 1, getReceivedMessages(vm3));
 
-      // Make sure the replicates only saw one message between them
+    // Make sure the replicates only saw one message between them
+    assertEquals(vm0Count + vm1Count + 1, getReceivedMessages(vm0) + getReceivedMessages(vm1));
 
-      assertEquals(vm0Count + vm1Count + 1, getReceivedMessages(vm0) + getReceivedMessages(vm1));
-
-      // Make sure the normal vm didn't see any messages
-      assertEquals(vm2Count, getReceivedMessages(vm2));
-    }
+    // Make sure the normal vm didn't see any messages
+    assertEquals(vm2Count, getReceivedMessages(vm2));
 
     // Test with a real value value
-    {
+    put(vm3, "a", "b");
 
-      put(vm3, "a", "b");
+    vm0Count = getReceivedMessages(vm0);
+    vm1Count = getReceivedMessages(vm1);
+    vm2Count = getReceivedMessages(vm2);
+    vm3Count = getReceivedMessages(vm3);
 
-      long vm0Count = getReceivedMessages(vm0);
-      long vm1Count = getReceivedMessages(vm1);
-      long vm2Count = getReceivedMessages(vm2);
-      long vm3Count = getReceivedMessages(vm3);
+    assertEquals("b", get(vm3, "a"));
 
-      assertEquals("b", get(vm3, "a"));
+    // Make sure we only processed one message
+    assertEquals(vm3Count + 1, getReceivedMessages(vm3));
 
-      // Make sure we only processed one message
-      assertEquals(vm3Count + 1, getReceivedMessages(vm3));
+    // Make sure the replicates only saw one message between them
 
-      // Make sure the replicates only saw one message between them
+    assertEquals(vm0Count + vm1Count + 1, getReceivedMessages(vm0) + getReceivedMessages(vm1));
 
-      assertEquals(vm0Count + vm1Count + 1, getReceivedMessages(vm0) + getReceivedMessages(vm1));
-
-      // Make sure the normal vm didn't see any messages
-      assertEquals(vm2Count, getReceivedMessages(vm2));
-    }
-
+    // Make sure the normal vm didn't see any messages
+    assertEquals(vm2Count, getReceivedMessages(vm2));
   }
 
   @Test
@@ -118,44 +111,38 @@ public class NetSearchMessagingDUnitTest extends JUnit4CacheTestCase {
     createEmpty(vm3);
 
     // Test with a null value
-    {
-      long vm0Count = getReceivedMessages(vm0);
-      long vm1Count = getReceivedMessages(vm1);
-      long vm2Count = getReceivedMessages(vm2);
-      long vm3Count = getReceivedMessages(vm3);
+    long vm0Count = getReceivedMessages(vm0);
+    long vm1Count = getReceivedMessages(vm1);
+    long vm2Count = getReceivedMessages(vm2);
+    long vm3Count = getReceivedMessages(vm3);
 
-      assertEquals(null, get(vm3, "a"));
+    assertEquals(null, get(vm3, "a"));
 
-      // Make sure we only processed one message
-      waitForReceivedMessages(vm3, vm3Count + 3);
+    // Make sure we only processed one message
+    waitForReceivedMessages(vm3, vm3Count + 3);
 
-      // Make sure the normal vms each saw 1 query message.
-      assertEquals(vm0Count + vm1Count + vm2Count + 3,
-          getReceivedMessages(vm0) + getReceivedMessages(vm1) + getReceivedMessages(vm2));
-    }
+    // Make sure the normal vms each saw 1 query message.
+    assertEquals(vm0Count + vm1Count + vm2Count + 3,
+        getReceivedMessages(vm0) + getReceivedMessages(vm1) + getReceivedMessages(vm2));
 
     // Test with a real value value
-    {
+    put(vm3, "a", "b");
 
-      put(vm3, "a", "b");
+    vm0Count = getReceivedMessages(vm0);
+    vm1Count = getReceivedMessages(vm1);
+    vm2Count = getReceivedMessages(vm2);
+    vm3Count = getReceivedMessages(vm3);
 
-      long vm0Count = getReceivedMessages(vm0);
-      long vm1Count = getReceivedMessages(vm1);
-      long vm2Count = getReceivedMessages(vm2);
-      final long vm3Count = getReceivedMessages(vm3);
+    assertEquals("b", get(vm3, "a"));
 
-      assertEquals("b", get(vm3, "a"));
+    // Make sure we only processed one message
+    waitForReceivedMessages(vm2, vm2Count + 1);
 
-      // Make sure we only processed one message
-      waitForReceivedMessages(vm2, vm2Count + 1);
+    waitForReceivedMessages(vm3, vm3Count + 3);
 
-      waitForReceivedMessages(vm3, vm3Count + 3);
-
-      // Make sure the normal vms each saw 1 query message.
-      assertEquals(vm0Count + vm1Count + vm2Count + 3,
-          getReceivedMessages(vm0) + getReceivedMessages(vm1) + getReceivedMessages(vm2));
-    }
-
+    // Make sure the normal vms each saw 1 query message.
+    assertEquals(vm0Count + vm1Count + vm2Count + 3,
+        getReceivedMessages(vm0) + getReceivedMessages(vm1) + getReceivedMessages(vm2));
   }
 
   /**
@@ -172,53 +159,49 @@ public class NetSearchMessagingDUnitTest extends JUnit4CacheTestCase {
     createOverflow(vm2, 5);
     createEmpty(vm1);
 
-
-
     // Test with a null value
-    {
-      put(vm2, "a", "1");
-      put(vm2, "b", "2");
-      put(vm2, "c", "3");
-      put(vm2, "d", "4");
-      put(vm2, "e", "5");
-      // the cache in vm0 is now full and LRU will occur on this next put()
-      put(vm2, "f", "6");
+    put(vm2, "a", "1");
+    put(vm2, "b", "2");
+    put(vm2, "c", "3");
+    put(vm2, "d", "4");
+    put(vm2, "e", "5");
+    // the cache in vm0 is now full and LRU will occur on this next put()
+    put(vm2, "f", "6");
 
-      SerializableCallable verifyEvicted = new SerializableCallable("verify eviction of 'a'") {
-        public Object call() {
-          Cache cache = getCache();
-          LocalRegion region = (LocalRegion) cache.getRegion("region");
-          RegionEntry re = region.getRegionEntry("a");
+    SerializableCallable verifyEvicted = new SerializableCallable("verify eviction of 'a'") {
+      public Object call() {
+        Cache cache = getCache();
+        LocalRegion region = (LocalRegion) cache.getRegion("region");
+        RegionEntry re = region.getRegionEntry("a");
+        Object o = re.getValueInVM(region);
+        LogWriterUtils.getLogWriter().info("key a=" + o);;
+        return o == null || o == Token.NOT_AVAILABLE;
+      }
+    };
+
+    boolean evicted = (Boolean) vm2.invoke(verifyEvicted);
+    assertTrue("expected 'a' to be evicted", evicted);
+
+    // now netsearch for 'a' from the other VM and verify again
+    Object value = get(vm1, "a");
+    assertEquals("expected to find '1' result from netSearch", "1", value);
+
+    evicted = (Boolean) vm2.invoke(verifyEvicted);
+    assertTrue("expected 'a' to still be evicted", evicted);
+    vm2.invoke(new SerializableRunnable("verify other entries are not evicted") {
+      public void run() {
+        Cache cache = getCache();
+        LocalRegion region = (LocalRegion) cache.getRegion("region");
+        String[] keys = new String[] {"b", "c", "d", "e", "f"};
+        for (String key : keys) {
+          RegionEntry re = region.getRegionEntry(key);
           Object o = re.getValueInVM(region);
-          LogWriterUtils.getLogWriter().info("key a=" + o);;
-          return o == null || o == Token.NOT_AVAILABLE;
+          LogWriterUtils.getLogWriter().info("key " + key + "=" + o);
+          assertTrue("expected key " + key + " to not be evicted",
+              (o != null) && (o != Token.NOT_AVAILABLE));
         }
-      };
-
-      boolean evicted = (Boolean) vm2.invoke(verifyEvicted);
-      assertTrue("expected 'a' to be evicted", evicted);
-
-      // now netsearch for 'a' from the other VM and verify again
-      Object value = get(vm1, "a");
-      assertEquals("expected to find '1' result from netSearch", "1", value);
-
-      evicted = (Boolean) vm2.invoke(verifyEvicted);
-      assertTrue("expected 'a' to still be evicted", evicted);
-      vm2.invoke(new SerializableRunnable("verify other entries are not evicted") {
-        public void run() {
-          Cache cache = getCache();
-          LocalRegion region = (LocalRegion) cache.getRegion("region");
-          String[] keys = new String[] {"b", "c", "d", "e", "f"};
-          for (String key : keys) {
-            RegionEntry re = region.getRegionEntry(key);
-            Object o = re.getValueInVM(region);
-            LogWriterUtils.getLogWriter().info("key " + key + "=" + o);
-            assertTrue("expected key " + key + " to not be evicted",
-                (o != null) && (o != Token.NOT_AVAILABLE));
-          }
-        }
-      });
-    }
+      }
+    });
   }
 
   /**
@@ -256,25 +239,22 @@ public class NetSearchMessagingDUnitTest extends JUnit4CacheTestCase {
     createEmpty(vm3);
 
     // Test with a real value value
-    {
-      put(vm3, "a", "b");
+    put(vm3, "a", "b");
 
-      long vm0Count = getReceivedMessages(vm0);
-      long vm1Count = getReceivedMessages(vm1);
-      long vm2Count = getReceivedMessages(vm2);
-      long vm3Count = getReceivedMessages(vm3);
+    long vm0Count = getReceivedMessages(vm0);
+    long vm1Count = getReceivedMessages(vm1);
+    long vm2Count = getReceivedMessages(vm2);
+    long vm3Count = getReceivedMessages(vm3);
 
-      assertEquals("b", get(vm3, "a"));
+    assertEquals("b", get(vm3, "a"));
 
-      // Make sure we were disconnected in vm0
-      vm0.invoke(new SerializableRunnable("check disconnected") {
+    // Make sure we were disconnected in vm0
+    vm0.invoke(new SerializableRunnable("check disconnected") {
 
-        public void run() {
-          assertNull(GemFireCacheImpl.getInstance());
-        }
-      });
-    }
-
+      public void run() {
+        assertNull(GemFireCacheImpl.getInstance());
+      }
+    });
   }
 
   @Test
@@ -307,23 +287,20 @@ public class NetSearchMessagingDUnitTest extends JUnit4CacheTestCase {
     createEmpty(vm3);
 
     // Test with a real value value
-    {
-      put(vm3, "a", "b");
+    put(vm3, "a", "b");
 
-      boolean disconnected = false;
-      while (!disconnected) {
-        assertEquals("b", get(vm3, "a"));
+    boolean disconnected = false;
+    while (!disconnected) {
+      assertEquals("b", get(vm3, "a"));
 
-        // Make sure we were disconnected in vm0
-        disconnected = (Boolean) vm0.invoke(new SerializableCallable("check disconnected") {
+      // Make sure we were disconnected in vm0
+      disconnected = (Boolean) vm0.invoke(new SerializableCallable("check disconnected") {
 
-          public Object call() {
-            return GemFireCacheImpl.getInstance() == null;
-          }
-        });
-      }
+        public Object call() {
+          return GemFireCacheImpl.getInstance() == null;
+        }
+      });
     }
-
   }
 
   private Object put(VM vm, final String key, final String value) {

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/NetSearchMessagingDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/NetSearchMessagingDUnitTest.java
@@ -34,6 +34,7 @@ import org.apache.geode.distributed.internal.ClusterDistributionManager;
 import org.apache.geode.distributed.internal.DistributionMessage;
 import org.apache.geode.distributed.internal.DistributionMessageObserver;
 import org.apache.geode.internal.cache.SearchLoadAndWriteProcessor.NetSearchRequestMessage;
+import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.test.dunit.Host;
 import org.apache.geode.test.dunit.LogWriterUtils;
 import org.apache.geode.test.dunit.SerializableCallable;
@@ -399,6 +400,9 @@ public class NetSearchMessagingDUnitTest extends JUnit4CacheTestCase {
   }
 
   private void createReplicate(VM vm) {
+    LogService.getLogger().info("START SETUP createReplicate in vm " + vm.getId() + " for test "
+        + getTestClass().getSimpleName() + "." + getTestMethodName());
+
     vm.invoke(new SerializableRunnable() {
 
       public void run() {
@@ -410,6 +414,9 @@ public class NetSearchMessagingDUnitTest extends JUnit4CacheTestCase {
         rf.create("region");
       }
     });
+
+    LogService.getLogger().info("END SETUP createReplicate in vm " + vm.getId() + " for test "
+        + getTestClass().getSimpleName() + "." + getTestMethodName());
 
   }
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/PartitionedRegionMultipleDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/PartitionedRegionMultipleDUnitTest.java
@@ -72,14 +72,14 @@ public class PartitionedRegionMultipleDUnitTest extends CacheTestCase {
    */
   @Test
   public void testPartitionedRegionDestroyAndContainsAPI() throws Exception {
-    vm0.invoke(() -> createPartitionRegion());
-    vm1.invoke(() -> createPartitionRegion());
+    vm0.invoke(this::createPartitionRegion);
+    vm1.invoke(this::createPartitionRegion);
 
     vm0.invoke(() -> putInPartitionRegion(startIndexForKey, endIndexForKey));
-    vm0.invoke(() -> destroyInPartitionedRegion());
+    vm0.invoke(this::destroyInPartitionedRegion);
 
-    vm0.invoke(() -> validateContainsAPIForPartitionRegion());
-    vm1.invoke(() -> validateContainsAPIForPartitionRegion());
+    vm0.invoke(this::validateContainsAPIForPartitionRegion);
+    vm1.invoke(this::validateContainsAPIForPartitionRegion);
   }
 
   private void putInPartitionRegion(int startIndexForKey, int endIndexForKey) {

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/versions/TombstoneDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/versions/TombstoneDUnitTest.java
@@ -38,9 +38,9 @@ public class TombstoneDUnitTest extends JUnit4CacheTestCase {
 
     vm0.invoke(() -> {
       createRegion("TestRegion", true);
-      Region r = getCache().getRegion("TestRegion");
-      r.put("K1", "V1");
-      r.put("K2", "V2");
+      Region<String, String> region = getCache().getRegion("TestRegion");
+      region.put("K1", "V1");
+      region.put("K2", "V2");
     });
 
     vm1.invoke(() -> {
@@ -49,10 +49,10 @@ public class TombstoneDUnitTest extends JUnit4CacheTestCase {
 
     vm0.invoke(() -> {
       // Send tombstone gc message to vm1.
-      Region r = getCache().getRegion("TestRegion");
-      r.destroy("K1");
+      Region<String, String> region = getCache().getRegion("TestRegion");
+      region.destroy("K1");
       assertEquals(1, getGemfireCache().getCachePerfStats().getTombstoneCount());
-      performGC(r);
+      performGC(region);
     });
 
     vm1.invoke(() -> {
@@ -61,9 +61,9 @@ public class TombstoneDUnitTest extends JUnit4CacheTestCase {
       assertEquals(0, getGemfireCache().getCachePerfStats().getTombstoneCount());
 
       // Send tombstone gc message to vm0.
-      Region r = getCache().getRegion("TestRegion");
-      r.destroy("K2");
-      performGC(r);
+      Region<String, String> region = getCache().getRegion("TestRegion");
+      region.destroy("K2");
+      performGC(region);
     });
 
     vm0.invoke(() -> {
@@ -91,7 +91,7 @@ public class TombstoneDUnitTest extends JUnit4CacheTestCase {
     }
   }
 
-  private void performGC(Region r) throws Exception {
+  private void performGC(Region region) throws Exception {
     getGemfireCache().getTombstoneService().forceBatchExpirationForTests(1);
   }
 

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/JUnit4DistributedTestCase.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/JUnit4DistributedTestCase.java
@@ -473,8 +473,8 @@ public abstract class JUnit4DistributedTestCase implements DistributedTestFixtur
    * out if a previous test may have caused problems
    */
   private final void logTestHistory() {
-    String classname = getTestClass().getSimpleName();
-    testHistory.add(classname);
+    String name = getTestClass().getSimpleName() + "." + getTestMethodName();
+    testHistory.add(name);
     System.out.println("Previously run tests: " + testHistory);
   }
 
@@ -498,6 +498,9 @@ public abstract class JUnit4DistributedTestCase implements DistributedTestFixtur
     } finally {
       postTearDown();
       postTearDownAssertions();
+
+      System.out.println(
+          "\n\n[setup] END TEST " + getTestClass().getSimpleName() + "." + testMethodName + "\n\n");
     }
   }
 


### PR DESCRIPTION
* Add logging to the JUnit4DistributedTestCase for test lifecycle. The
GEODE-5501 bug may be due to tests' @After executing after the next
test has started. Extra logging as to when tests are starting and ending
will help with diagnosing this failure when it occurs.
* Touch the failing test, NetSearchMessagingDUnitTest, so it runs in
StressNewTest CI job
* Touch other tests that extend JUnit4DistributedTestCase so that they
run in StressNewTest CI job

Signed-off-by: Dale Emery <demery@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
