### PR TITLE
GEODE-5734: allow extensibility of Docker build mounts.

### DIFF
--- a/gradle/docker.gradle
+++ b/gradle/docker.gradle
@@ -39,7 +39,7 @@
  */
 
 
-if (project.hasProperty('parallelDunit')) {
+if (project.hasProperty('parallelDunit') && !project.hasProperty('dunitDockerVolumes')) {
   def pwd = System.getenv('PWD')
   def geodeDir = new File(pwd).getCanonicalPath()
   ext.dunitDockerVolumes = ["${geodeDir}":geodeDir]


### PR DESCRIPTION
If a user wants to extend Gradle's Docker plugin with their own tests,
setting dunitDockerVolumes to some value, then that value will be
overridden in docker.gradle. For better extensibility, do not set this
property if it is already set.
