### PR TITLE
GEODE-3: do not use Assert in production code. use explicit exception.

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/offheap/OffHeapRegionEntryHelper.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/offheap/OffHeapRegionEntryHelper.java
@@ -276,7 +276,9 @@ public class OffHeapRegionEntryHelper {
   }
 
   static int decodeAddressToDataSize(long addr) {
-    assert (addr & ENCODED_BIT) != 0;
+    if ((addr & ENCODED_BIT) == 0) {
+      throw new AssertionError("Invalid address: " + addr);
+    }
     boolean isLong = (addr & LONG_BIT) != 0;
     if (isLong) {
       return 9;
@@ -291,7 +293,9 @@ public class OffHeapRegionEntryHelper {
    * @throws UnsupportedOperationException if the address has compressed data
    */
   static byte[] decodeUncompressedAddressToBytes(long addr) {
-    assert (addr & COMPRESSED_BIT) == 0 : "Did not expect encoded address to be compressed";
+    if ((addr & COMPRESSED_BIT) != 0) {
+      throw new AssertionError("Did not expect encoded address to be compressed");
+    }
     return decodeAddressToRawBytes(addr);
   }
 
@@ -300,7 +304,9 @@ public class OffHeapRegionEntryHelper {
    * compressed then the raw bytes are the compressed bytes.
    */
   static byte[] decodeAddressToRawBytes(long addr) {
-    assert (addr & ENCODED_BIT) != 0;
+    if ((addr & ENCODED_BIT) == 0) {
+      throw new AssertionError("Invalid address: " + addr);
+    }
     int size = (int) ((addr & SIZE_MASK) >> SIZE_SHIFT);
     boolean isLong = (addr & LONG_BIT) != 0;
     byte[] bytes;

--- a/geode-core/src/test/java/org/apache/geode/internal/offheap/OffHeapRegionEntryHelperJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/offheap/OffHeapRegionEntryHelperJUnitTest.java
@@ -25,9 +25,7 @@ import static org.mockito.Mockito.when;
 import java.nio.ByteBuffer;
 
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
@@ -54,25 +52,6 @@ import org.apache.geode.internal.cache.entries.VersionedStatsDiskRegionEntryOffH
 public class OffHeapRegionEntryHelperJUnitTest {
 
   private static final Long VALUE_IS_NOT_ENCODABLE = 0L;
-
-  private static Boolean assertionsEnabled;
-
-  @BeforeClass
-  public static void setUpOnce() {
-    try {
-      assert false;
-      assertionsEnabled = false;
-    } catch (AssertionError e) {
-      assertionsEnabled = true;
-    }
-    ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
-    System.out.println("assertionsEnabled = " + assertionsEnabled);
-  }
-
-  @AfterClass
-  public static void tearDownOnce() {
-    ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(assertionsEnabled);
-  }
 
   private MemoryAllocator ma;
 


### PR DESCRIPTION
* turning on assertion in classloader would not play nicely in jdk9 and later.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
