### PR TITLE
GEODE-3: Use the correct DataSerializer for TimeUnit in java 9 and later

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/InternalDataSerializer.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/InternalDataSerializer.java
@@ -621,38 +621,53 @@ public abstract class InternalDataSerializer extends DataSerializer {
             return true;
           }
         });
-    classesToSerializers.put(TimeUnit.NANOSECONDS.getClass().getName(), new WellKnownDS() {
+
+    WellKnownDS TIME_UNIT_SERIALIZER = new WellKnownDS() {
       @Override
       public boolean toData(Object o, DataOutput out) throws IOException {
-        out.writeByte(DSCODE.TIME_UNIT.toByte());
-        out.writeByte(TIME_UNIT_NANOSECONDS);
+        TimeUnit timeUnit = (TimeUnit) o;
+        switch (timeUnit) {
+          case NANOSECONDS: {
+            out.writeByte(DSCODE.TIME_UNIT.toByte());
+            out.writeByte(TIME_UNIT_NANOSECONDS);
+            break;
+          }
+          case MICROSECONDS: {
+            out.writeByte(DSCODE.TIME_UNIT.toByte());
+            out.writeByte(TIME_UNIT_MICROSECONDS);
+            break;
+          }
+          case MILLISECONDS: {
+            out.writeByte(DSCODE.TIME_UNIT.toByte());
+            out.writeByte(TIME_UNIT_MILLISECONDS);
+            break;
+          }
+          case SECONDS: {
+            out.writeByte(DSCODE.TIME_UNIT.toByte());
+            out.writeByte(TIME_UNIT_SECONDS);
+            break;
+          }
+          // handles all other timeunits
+          default: {
+            writeGemFireEnum(timeUnit, out);
+          }
+        }
         return true;
       }
-    });
-    classesToSerializers.put(TimeUnit.MICROSECONDS.getClass().getName(), new WellKnownDS() {
-      @Override
-      public boolean toData(Object o, DataOutput out) throws IOException {
-        out.writeByte(DSCODE.TIME_UNIT.toByte());
-        out.writeByte(TIME_UNIT_MICROSECONDS);
-        return true;
-      }
-    });
-    classesToSerializers.put(TimeUnit.MILLISECONDS.getClass().getName(), new WellKnownDS() {
-      @Override
-      public boolean toData(Object o, DataOutput out) throws IOException {
-        out.writeByte(DSCODE.TIME_UNIT.toByte());
-        out.writeByte(TIME_UNIT_MILLISECONDS);
-        return true;
-      }
-    });
-    classesToSerializers.put(TimeUnit.SECONDS.getClass().getName(), new WellKnownDS() {
-      @Override
-      public boolean toData(Object o, DataOutput out) throws IOException {
-        out.writeByte(DSCODE.TIME_UNIT.toByte());
-        out.writeByte(TIME_UNIT_SECONDS);
-        return true;
-      }
-    });
+    };
+
+    // in java 9 and above, TimeUnit implementation changes. the class name of these units are the
+    // same now.
+    if (TimeUnit.NANOSECONDS.getClass().getName().equals(TimeUnit.SECONDS.getClass().getName())) {
+      classesToSerializers.put(TimeUnit.class.getName(), TIME_UNIT_SERIALIZER);
+    }
+    // in java 8 and below
+    else {
+      classesToSerializers.put(TimeUnit.NANOSECONDS.getClass().getName(), TIME_UNIT_SERIALIZER);
+      classesToSerializers.put(TimeUnit.MICROSECONDS.getClass().getName(), TIME_UNIT_SERIALIZER);
+      classesToSerializers.put(TimeUnit.MILLISECONDS.getClass().getName(), TIME_UNIT_SERIALIZER);
+      classesToSerializers.put(TimeUnit.SECONDS.getClass().getName(), TIME_UNIT_SERIALIZER);
+    }
     classesToSerializers.put("java.util.Date", new WellKnownPdxDS() {
       @Override
       public boolean toData(Object o, DataOutput out) throws IOException {


### PR DESCRIPTION
this code change is covered by analyzeDataSerializable test already.
this should not impact runs on jdk8,  but the test was failing using jdk9 and later without this fix.

Port the fix to develop to make sure this does not interfere with jdk8.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
