### PR TITLE
GEODE-3: small java 9 compatibility fixes

### DIFF
--- a/extensions/geode-modules-session/src/integrationTest/java/org/apache/geode/modules/session/installer/InstallerJUnitTest.java
+++ b/extensions/geode-modules-session/src/integrationTest/java/org/apache/geode/modules/session/installer/InstallerJUnitTest.java
@@ -14,7 +14,7 @@
  */
 package org.apache.geode.modules.session.installer;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -55,7 +55,7 @@ public class InstallerJUnitTest {
         .replaceAll(IOUtils.LINE_SEPARATOR_WINDOWS, "").replaceAll(IOUtils.LINE_SEPARATOR_UNIX, "");
     String actual = output.toString().replaceAll(IOUtils.LINE_SEPARATOR_WINDOWS, "")
         .replaceAll(IOUtils.LINE_SEPARATOR_UNIX, "");
-    assertEquals(expected, actual);
+    assertThat(actual).isEqualToIgnoringWhitespace(expected);
   }
 
 }

--- a/geode-core/src/test/java/org/apache/geode/test/process/ProcessWrapper.java
+++ b/geode-core/src/test/java/org/apache/geode/test/process/ProcessWrapper.java
@@ -43,6 +43,7 @@ import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang.SystemUtils;
 import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.internal.logging.LogService;
@@ -388,6 +389,14 @@ public class ProcessWrapper {
     argumentList.add(javaExe.getPath());
     argumentList.add("-classpath");
     argumentList.add(manifestJar);
+
+    // -d64 is not a valid option for windows and results in failure
+    // -d64 is not a valid option for java 9 and above
+    final int bits = Integer.getInteger("sun.arch.data.model", 0).intValue();
+    if (bits == 64 && !(System.getProperty("os.name").toLowerCase().contains("windows"))
+        && !SystemUtils.isJavaVersionAtLeast(1.9f)) {
+      argumentList.add("-d64");
+    }
 
     argumentList.add("-Djava.library.path=" + System.getProperty("java.library.path"));
 

--- a/geode-core/src/test/java/org/apache/geode/test/process/ProcessWrapper.java
+++ b/geode-core/src/test/java/org/apache/geode/test/process/ProcessWrapper.java
@@ -389,12 +389,6 @@ public class ProcessWrapper {
     argumentList.add("-classpath");
     argumentList.add(manifestJar);
 
-    // -d64 is not a valid option for windows and results in failure
-    final int bits = Integer.getInteger("sun.arch.data.model", 0).intValue();
-    if (bits == 64 && !(System.getProperty("os.name").toLowerCase().contains("windows"))) {
-      argumentList.add("-d64");
-    }
-
     argumentList.add("-Djava.library.path=" + System.getProperty("java.library.path"));
 
     if (jvmArguments != null) {

--- a/geode-pulse/src/integrationTest/java/org/apache/geode/tools/pulse/controllers/PulseControllerJUnitTest.java
+++ b/geode-pulse/src/integrationTest/java/org/apache/geode/tools/pulse/controllers/PulseControllerJUnitTest.java
@@ -69,7 +69,7 @@ import org.apache.geode.tools.pulse.internal.data.Repository;
 @PowerMockRunnerDelegate(SpringJUnit4ClassRunner.class)
 @WebAppConfiguration
 @ContextConfiguration("classpath*:mvc-dispatcher-servlet.xml")
-@PowerMockIgnore("javax.management.*")
+@PowerMockIgnore({"javax.management.*", "javax.xml.*", "org.xml.*", "org.w3c.*"})
 public class PulseControllerJUnitTest {
 
   private static final String PRINCIPAL_USER = "test-user";


### PR DESCRIPTION
* fix InstallerJUnitTest
* remove -d64 option
* PowerMock needs to ignore more modules in PulseControllerJunitTest in java9

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
