### PR TITLE
GEODE-3: more memory usage beans are available in java9. GemFireStatS…

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/statistics/GemFireStatSamplerIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/statistics/GemFireStatSamplerIntegrationTest.java
@@ -478,29 +478,16 @@ public class GemFireStatSamplerIntegrationTest extends StatSamplerTestCase {
     final String tenuredPoolName = HeapMemoryMonitor.getTenuredMemoryPoolMXBean().getName();
     logger.info("TenuredPoolName: {}", tenuredPoolName);
 
-    final List<Statistics> list = ((StatisticsManager) this.system).getStatsList();
-    assertFalse(list.isEmpty());
-
     boolean done = false;
     try {
       for (StopWatch time = new StopWatch(true); !done && time.elapsedTimeMillis() < 5000;) {
         Thread.sleep(10);
-        int i = 0;
-        synchronized (list) {
-          for (Object obj : list) {
-            ++i;
-            logger.info("List:{}:{}", i, obj);
-            if (obj instanceof StatisticsImpl) {
-              StatisticsImpl si = (StatisticsImpl) obj;
-              logger.info("stat:{}", si.getTextId());
-              if (si.getTextId().contains(tenuredPoolName)) {
-                statSampler.addLocalStatListener(listener, si, "currentUsedMemory");
-                done = true;
-              }
-            }
-          }
+        Statistics si =
+            HeapMemoryMonitor.getTenuredPoolStatistics((StatisticsManager) this.system);
+        if (si != null) {
+          statSampler.addLocalStatListener(listener, si, "currentUsedMemory");
+          done = true;
         }
-        // done = false;
       }
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/control/HeapMemoryMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/control/HeapMemoryMonitor.java
@@ -322,8 +322,8 @@ public class HeapMemoryMonitor implements NotificationListener, MemoryMonitor {
       Statistics si = getTenuredPoolStatistics(this.cache.getInternalDistributedSystem());
       if (si != null) {
         sampler.addLocalStatListener(this.statListener, si, "currentUsedMemory");
-        if (this.cache.getLoggerI18n().fineEnabled()) {
-          this.cache.getLoggerI18n().fine("Registered stat listener for " + si.getTextId());
+        if (this.cache.getLogger().fineEnabled()) {
+          this.cache.getLogger().fine("Registered stat listener for " + si.getTextId());
         }
 
         return true;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/control/HeapMemoryMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/control/HeapMemoryMonitor.java
@@ -279,11 +279,13 @@ public class HeapMemoryMonitor implements NotificationListener, MemoryMonitor {
       NotificationEmitter emitter = (NotificationEmitter) ManagementFactory.getMemoryMXBean();
       try {
         emitter.removeNotificationListener(this, null, null);
-        if (logger.isTraceEnabled()) {
-          logger.trace("Removed Memory MXBean notification listener" + this);
+        if (logger.isDebugEnabled()) {
+          logger.debug("Removed Memory MXBean notification listener" + this);
         }
       } catch (ListenerNotFoundException ignore) {
-        logger.debug("This instance '{}' was not registered as a Memory MXBean listener", this);
+        if (logger.isDebugEnabled()) {
+          logger.debug("This instance '{}' was not registered as a Memory MXBean listener", this);
+        }
       }
 
       // Stop the stats listener
@@ -324,8 +326,8 @@ public class HeapMemoryMonitor implements NotificationListener, MemoryMonitor {
       Statistics si = getTenuredPoolStatistics(this.cache.getInternalDistributedSystem());
       if (si != null) {
         sampler.addLocalStatListener(this.statListener, si, "currentUsedMemory");
-        if (logger.isTraceEnabled()) {
-          logger.trace("Registered stat listener for " + si.getTextId());
+        if (logger.isDebugEnabled()) {
+          logger.debug("Registered stat listener for " + si.getTextId());
         }
 
         return true;
@@ -360,8 +362,8 @@ public class HeapMemoryMonitor implements NotificationListener, MemoryMonitor {
     this.pollerExecutor.scheduleAtFixedRate(new HeapPoller(), POLLER_INTERVAL, POLLER_INTERVAL,
         TimeUnit.MILLISECONDS);
 
-    if (logger.isTraceEnabled()) {
-      logger.trace(
+    if (logger.isDebugEnabled()) {
+      logger.debug(
           "Started GemfireHeapPoller to poll the heap every " + POLLER_INTERVAL + " milliseconds");
     }
   }
@@ -609,8 +611,8 @@ public class HeapMemoryMonitor implements NotificationListener, MemoryMonitor {
       this.evictionToleranceCounter++;
       this.criticalToleranceCounter = 0;
       if (this.evictionToleranceCounter <= memoryStateChangeTolerance) {
-        if (logger.isTraceEnabled()) {
-          logger.trace("State " + newState + " ignored. toleranceCounter:"
+        if (logger.isDebugEnabled()) {
+          logger.debug("State " + newState + " ignored. toleranceCounter:"
               + this.evictionToleranceCounter + " MEMORY_EVENT_TOLERANCE:"
               + memoryStateChangeTolerance);
         }
@@ -620,8 +622,8 @@ public class HeapMemoryMonitor implements NotificationListener, MemoryMonitor {
       this.criticalToleranceCounter++;
       this.evictionToleranceCounter = 0;
       if (this.criticalToleranceCounter <= memoryStateChangeTolerance) {
-        if (logger.isTraceEnabled()) {
-          logger.trace("State " + newState + " ignored. toleranceCounter:"
+        if (logger.isDebugEnabled()) {
+          logger.debug("State " + newState + " ignored. toleranceCounter:"
               + this.criticalToleranceCounter + " MEMORY_EVENT_TOLERANCE:"
               + memoryStateChangeTolerance);
         }
@@ -630,8 +632,8 @@ public class HeapMemoryMonitor implements NotificationListener, MemoryMonitor {
     } else {
       this.criticalToleranceCounter = 0;
       this.evictionToleranceCounter = 0;
-      if (logger.isTraceEnabled()) {
-        logger.trace("TOLERANCE counters reset");
+      if (logger.isDebugEnabled()) {
+        logger.debug("TOLERANCE counters reset");
       }
     }
     return false;
@@ -661,8 +663,8 @@ public class HeapMemoryMonitor implements NotificationListener, MemoryMonitor {
   synchronized void processLocalEvent(MemoryEvent event) {
     assert event.isLocal();
 
-    if (logger.isTraceEnabled()) {
-      logger.trace("Handling new local event " + event);
+    if (logger.isDebugEnabled()) {
+      logger.debug("Handling new local event " + event);
     }
 
     if (event.getState().isCritical() && !event.getPreviousState().isCritical()) {
@@ -691,8 +693,8 @@ public class HeapMemoryMonitor implements NotificationListener, MemoryMonitor {
           new Object[] {event.getMember(), "heap"});
     }
 
-    if (logger.isTraceEnabled()) {
-      logger.trace("Informing remote members of event " + event);
+    if (logger.isDebugEnabled()) {
+      logger.debug("Informing remote members of event " + event);
     }
 
     this.resourceAdvisor.updateRemoteProfile();
@@ -834,8 +836,8 @@ public class HeapMemoryMonitor implements NotificationListener, MemoryMonitor {
             }
           }
         });
-        if (HeapMemoryMonitor.logger.isTraceEnabled()) {
-          HeapMemoryMonitor.logger.trace(
+        if (HeapMemoryMonitor.logger.isDebugEnabled()) {
+          HeapMemoryMonitor.logger.debug(
               "StatSampler scheduled a " + "handleNotification call with " + usedBytes + " bytes");
         }
       } catch (RejectedExecutionException ignore) {
@@ -896,7 +898,7 @@ public class HeapMemoryMonitor implements NotificationListener, MemoryMonitor {
       builder.append(" maxMemoryBytes:").append(newThresholds.getMaxMemoryBytes());
       builder.append(" criticalThresholdBytes:").append(newThresholds.getCriticalThresholdBytes());
       builder.append(" evictionThresholdBytes:").append(newThresholds.getEvictionThresholdBytes());
-      logger.trace(builder.toString());
+      logger.debug(builder.toString());
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/control/HeapMemoryMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/control/HeapMemoryMonitor.java
@@ -279,7 +279,9 @@ public class HeapMemoryMonitor implements NotificationListener, MemoryMonitor {
       NotificationEmitter emitter = (NotificationEmitter) ManagementFactory.getMemoryMXBean();
       try {
         emitter.removeNotificationListener(this, null, null);
-        this.cache.getLoggerI18n().fine("Removed Memory MXBean notification listener" + this);
+        if (logger.isTraceEnabled()) {
+          logger.trace("Removed Memory MXBean notification listener" + this);
+        }
       } catch (ListenerNotFoundException ignore) {
         logger.debug("This instance '{}' was not registered as a Memory MXBean listener", this);
       }
@@ -322,8 +324,8 @@ public class HeapMemoryMonitor implements NotificationListener, MemoryMonitor {
       Statistics si = getTenuredPoolStatistics(this.cache.getInternalDistributedSystem());
       if (si != null) {
         sampler.addLocalStatListener(this.statListener, si, "currentUsedMemory");
-        if (this.cache.getLogger().fineEnabled()) {
-          this.cache.getLogger().fine("Registered stat listener for " + si.getTextId());
+        if (logger.isTraceEnabled()) {
+          logger.trace("Registered stat listener for " + si.getTextId());
         }
 
         return true;
@@ -358,8 +360,8 @@ public class HeapMemoryMonitor implements NotificationListener, MemoryMonitor {
     this.pollerExecutor.scheduleAtFixedRate(new HeapPoller(), POLLER_INTERVAL, POLLER_INTERVAL,
         TimeUnit.MILLISECONDS);
 
-    if (this.cache.getLoggerI18n().fineEnabled()) {
-      this.cache.getLoggerI18n().fine(
+    if (logger.isTraceEnabled()) {
+      logger.trace(
           "Started GemfireHeapPoller to poll the heap every " + POLLER_INTERVAL + " milliseconds");
     }
   }
@@ -607,11 +609,10 @@ public class HeapMemoryMonitor implements NotificationListener, MemoryMonitor {
       this.evictionToleranceCounter++;
       this.criticalToleranceCounter = 0;
       if (this.evictionToleranceCounter <= memoryStateChangeTolerance) {
-        if (this.cache.getLoggerI18n().fineEnabled()) {
-          this.cache.getLoggerI18n()
-              .fine("State " + newState + " ignored. toleranceCounter:"
-                  + this.evictionToleranceCounter + " MEMORY_EVENT_TOLERANCE:"
-                  + memoryStateChangeTolerance);
+        if (logger.isTraceEnabled()) {
+          logger.trace("State " + newState + " ignored. toleranceCounter:"
+              + this.evictionToleranceCounter + " MEMORY_EVENT_TOLERANCE:"
+              + memoryStateChangeTolerance);
         }
         return true;
       }
@@ -619,19 +620,18 @@ public class HeapMemoryMonitor implements NotificationListener, MemoryMonitor {
       this.criticalToleranceCounter++;
       this.evictionToleranceCounter = 0;
       if (this.criticalToleranceCounter <= memoryStateChangeTolerance) {
-        if (this.cache.getLoggerI18n().fineEnabled()) {
-          this.cache.getLoggerI18n()
-              .fine("State " + newState + " ignored. toleranceCounter:"
-                  + this.criticalToleranceCounter + " MEMORY_EVENT_TOLERANCE:"
-                  + memoryStateChangeTolerance);
+        if (logger.isTraceEnabled()) {
+          logger.trace("State " + newState + " ignored. toleranceCounter:"
+              + this.criticalToleranceCounter + " MEMORY_EVENT_TOLERANCE:"
+              + memoryStateChangeTolerance);
         }
         return true;
       }
     } else {
       this.criticalToleranceCounter = 0;
       this.evictionToleranceCounter = 0;
-      if (this.cache.getLoggerI18n().fineEnabled()) {
-        this.cache.getLoggerI18n().fine("TOLERANCE counters reset");
+      if (logger.isTraceEnabled()) {
+        logger.trace("TOLERANCE counters reset");
       }
     }
     return false;
@@ -661,8 +661,8 @@ public class HeapMemoryMonitor implements NotificationListener, MemoryMonitor {
   synchronized void processLocalEvent(MemoryEvent event) {
     assert event.isLocal();
 
-    if (this.cache.getLoggerI18n().fineEnabled()) {
-      this.cache.getLoggerI18n().fine("Handling new local event " + event);
+    if (logger.isTraceEnabled()) {
+      logger.trace("Handling new local event " + event);
     }
 
     if (event.getState().isCritical() && !event.getPreviousState().isCritical()) {
@@ -691,8 +691,8 @@ public class HeapMemoryMonitor implements NotificationListener, MemoryMonitor {
           new Object[] {event.getMember(), "heap"});
     }
 
-    if (this.cache.getLoggerI18n().fineEnabled()) {
-      this.cache.getLoggerI18n().fine("Informing remote members of event " + event);
+    if (logger.isTraceEnabled()) {
+      logger.trace("Informing remote members of event " + event);
     }
 
     this.resourceAdvisor.updateRemoteProfile();
@@ -834,8 +834,8 @@ public class HeapMemoryMonitor implements NotificationListener, MemoryMonitor {
             }
           }
         });
-        if (HeapMemoryMonitor.this.cache.getLoggerI18n().fineEnabled()) {
-          HeapMemoryMonitor.this.cache.getLoggerI18n().fine(
+        if (HeapMemoryMonitor.logger.isTraceEnabled()) {
+          HeapMemoryMonitor.logger.trace(
               "StatSampler scheduled a " + "handleNotification call with " + usedBytes + " bytes");
         }
       } catch (RejectedExecutionException ignore) {
@@ -869,7 +869,7 @@ public class HeapMemoryMonitor implements NotificationListener, MemoryMonitor {
       try {
         updateStateAndSendEvent(getBytesUsed());
       } catch (Exception e) {
-        HeapMemoryMonitor.this.cache.getLoggerI18n().fine("Poller Thread caught exception:", e);
+        HeapMemoryMonitor.logger.debug("Poller Thread caught exception:", e);
       }
       // TODO: do we need to handle errors too?
     }
@@ -896,7 +896,7 @@ public class HeapMemoryMonitor implements NotificationListener, MemoryMonitor {
       builder.append(" maxMemoryBytes:").append(newThresholds.getMaxMemoryBytes());
       builder.append(" criticalThresholdBytes:").append(newThresholds.getCriticalThresholdBytes());
       builder.append(" evictionThresholdBytes:").append(newThresholds.getEvictionThresholdBytes());
-      this.cache.getLoggerI18n().fine(builder.toString());
+      logger.trace(builder.toString());
     }
   }
 


### PR DESCRIPTION
…amplerIntegrationTest needs to use production code to find the right Statistics to use.

* this fixes testLocalStatListenerRegistration test

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
