### PR TITLE
GEODE-4052: Fix StatusServerExitCodeAcceptanceTest.statusWithWrongPid failure

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/process/MBeanOrFileProcessController.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/process/MBeanOrFileProcessController.java
@@ -37,6 +37,12 @@ public class MBeanOrFileProcessController implements ProcessController {
       return mbeanController.status();
     } catch (IOException | MBeanInvocationFailedException | ConnectionFailedException
         | UnableToControlProcessException e) {
+      // if mbeanController already determines no such process exists, we can skip trying with
+      // fileController
+      String message = e.getMessage();
+      if (message != null && message.toLowerCase().contains("no such process")) {
+        throw e;
+      }
       return fileController.status();
     }
   }


### PR DESCRIPTION
…ilable, skip using the FileProcessController

* this would fix the issue that the StatusServerExitCodeAcceptanceTest.statusWithWrongPid taking too long to exit.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
