### PR TITLE
GEODE-5605: After removeAll/PutAll messages are processed on replicas, check for cache close is done.

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
@@ -2477,6 +2477,10 @@ public class DistributedRegion extends LocalRegion implements InternalDistribute
             this.getFullPath()), ex);
       }
     }
+    waitForCurrentOperations();
+  }
+
+  protected void waitForCurrentOperations() {
     // Fix for #48066 - make sure that region operations are completely
     // distributed to peers before destroying the region.
     Boolean flushOnClose =

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/RemoveAllPRMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/RemoveAllPRMessage.java
@@ -516,17 +516,7 @@ public class RemoveAllPRMessage extends PartitionMessageWithDirectReply {
             // encounter cacheWriter exception
             partialKeys.saveFailedKey(key, cwe);
           } finally {
-            try {
-              // Only RemoveAllPRMessage knows if the thread id is fake. Event has no idea.
-              // So we have to manually set useFakeEventId for this op
-              op.setUseFakeEventId(true);
-              r.checkReadiness();
-              bucketRegion.getDataView().postRemoveAll(op, this.versions, bucketRegion);
-            } finally {
-              if (lockedForPrimary) {
-                bucketRegion.doUnlockForPrimary();
-              }
-            }
+            doPostRemoveAll(r, op, bucketRegion, lockedForPrimary);
           }
           if (partialKeys.hasFailure()) {
             partialKeys.addKeysAndVersions(this.versions);
@@ -565,6 +555,22 @@ public class RemoveAllPRMessage extends PartitionMessageWithDirectReply {
     }
 
     return true;
+  }
+
+  void doPostRemoveAll(PartitionedRegion r, DistributedRemoveAllOperation op,
+      BucketRegion bucketRegion, boolean lockedForPrimary) {
+    try {
+      // Only RemoveAllPRMessage knows if the thread id is fake. Event has no idea.
+      // So we have to manually set useFakeEventId for this op
+      op.setUseFakeEventId(true);
+      r.checkReadiness();
+      bucketRegion.getDataView().postRemoveAll(op, this.versions, bucketRegion);
+      r.checkReadiness();
+    } finally {
+      if (lockedForPrimary) {
+        bucketRegion.doUnlockForPrimary();
+      }
+    }
   }
 
   public VersionedObjectList getVersions() {

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/PutAllPRMessageTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/PutAllPRMessageTest.java
@@ -14,50 +14,36 @@
  */
 package org.apache.geode.internal.cache.partitioned;
 
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.junit.Test;
 import org.mockito.InOrder;
 
 import org.apache.geode.internal.cache.BucketRegion;
-import org.apache.geode.internal.cache.DistributedRemoveAllOperation;
+import org.apache.geode.internal.cache.DistributedPutAllOperation;
 import org.apache.geode.internal.cache.InternalDataView;
 import org.apache.geode.internal.cache.PartitionedRegion;
 
-public class RemoveAllPRMessageTest {
+public class PutAllPRMessageTest {
 
   @Test
-  public void shouldBeMockable() throws Exception {
-    RemoveAllPRMessage mockRemoveAllPRMessage = mock(RemoveAllPRMessage.class);
-    StringBuilder stringBuilder = new StringBuilder();
-
-    mockRemoveAllPRMessage.appendFields(stringBuilder);
-
-    verify(mockRemoveAllPRMessage, times(1)).appendFields(stringBuilder);
-  }
-
-
-  @Test
-  public void doPostRemoveAllCallsCheckReadinessBeforeAndAfter() throws Exception {
+  public void doPostPutAllCallsCheckReadinessBeforeAndAfter() throws Exception {
     PartitionedRegion partitionedRegion = mock(PartitionedRegion.class);
-    DistributedRemoveAllOperation distributedRemoveAllOperation =
-        mock(DistributedRemoveAllOperation.class);
+    DistributedPutAllOperation distributedPutAllOperation = mock(DistributedPutAllOperation.class);
     BucketRegion bucketRegion = mock(BucketRegion.class);
     InternalDataView internalDataView = mock(InternalDataView.class);
     when(bucketRegion.getDataView()).thenReturn(internalDataView);
-    RemoveAllPRMessage removeAllPRMessage = new RemoveAllPRMessage();
+    PutAllPRMessage putAllPRMessage = new PutAllPRMessage();
 
-    removeAllPRMessage.doPostRemoveAll(partitionedRegion, distributedRemoveAllOperation,
-        bucketRegion, true);
+    putAllPRMessage.doPostPutAll(partitionedRegion, distributedPutAllOperation, bucketRegion, true);
 
     InOrder inOrder = inOrder(partitionedRegion, internalDataView);
     inOrder.verify(partitionedRegion).checkReadiness();
-    inOrder.verify(internalDataView).postRemoveAll(any(), any(), any());
+    inOrder.verify(internalDataView).postPutAll(any(), any(), any());
     inOrder.verify(partitionedRegion).checkReadiness();
   }
 }


### PR DESCRIPTION
An in-flight operation may not be seen by the new GII requester if the GII provider cache closes. This happens when there are more than one replica for the region.
The change checks for cache close after replicating the data; if cache is closed, throws exception back to the accessor/caller, which will retry the operation. This causes the operations are applied on all the present nodes.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [YES ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ NO] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ YES] Is your initial contribution a single, squashed commit?

- [ YES] Does `gradlew build` run cleanly?

- [ YES] Have you written or updated unit tests to verify your changes?

- [ NA] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
