### PR TITLE
GEODE-5747: Handling SocketException in InternalDataSerializer

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/InternalDataSerializer.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/InternalDataSerializer.java
@@ -39,6 +39,7 @@ import java.lang.reflect.Proxy;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.InetAddress;
+import java.net.SocketException;
 import java.net.URL;
 import java.sql.Timestamp;
 import java.util.ArrayList;
@@ -2480,7 +2481,7 @@ public abstract class InternalDataSerializer extends DataSerializer {
           ((DataSerializable) ds).fromData(in);
         }
       }
-    } catch (EOFException | ClassNotFoundException | CacheClosedException ex) {
+    } catch (EOFException | ClassNotFoundException | CacheClosedException | SocketException ex) {
       // client went away - ignore
       throw ex;
     } catch (Exception ex) {


### PR DESCRIPTION
A SocketException has to be caught because we want to continue trying to connect to locators rather than shutdown the gateway sender event processor.  The SocketException appears to arise due to a temporary network connectivity issue when reading off the socket.  We already handle an unexpected EOF here, so we should most likely be handling the SocketException in the same way.

-------------------------------------------

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [X] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
