### PR TITLE
GEODE-5748: Hold clearRegion write lock during cleanUpAfterFailedGII

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/internal/cache/DistributedRegionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/DistributedRegionTest.java
@@ -15,12 +15,20 @@
 package org.apache.geode.internal.cache;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.junit.Test;
+
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
+import org.apache.geode.internal.cache.versions.RegionVersionVector;
 
 
 public class DistributedRegionTest {
@@ -36,5 +44,41 @@ public class DistributedRegionTest {
 
     assertThat(mockDistributedRegion.validatedDestroy(new Object(), mockEntryEventImpl))
         .isSameAs(returnValue);
+  }
+
+  @Test
+  public void cleanUpAfterFailedGIIHoldsLockForClear() {
+    DistributedRegion distributedRegion = mock(DistributedRegion.class, RETURNS_DEEP_STUBS);
+    RegionVersionVector regionVersionVector = mock(RegionVersionVector.class);
+    RegionMap regionMap = mock(RegionMap.class);
+    InternalDistributedMember member = mock(InternalDistributedMember.class);
+
+    doCallRealMethod().when(distributedRegion).cleanUpAfterFailedGII(false);
+    when(distributedRegion.getVersionVector()).thenReturn(regionVersionVector);
+    when(distributedRegion.getRegionMap()).thenReturn(regionMap);
+    when(regionMap.isEmpty()).thenReturn(false);
+    when(distributedRegion.getMyId()).thenReturn(member);
+
+    distributedRegion.cleanUpAfterFailedGII(false);
+
+    verify(regionVersionVector).lockForClear(any(), any(), eq(member));
+    verify(distributedRegion).closeEntries();
+    verify(regionVersionVector).unlockForClear(eq(member));
+  }
+
+  @Test
+  public void cleanUpAfterFailedGIIDoesNotCloseEntriesIfIsPersistentRegionAndRecoveredFromDisk() {
+    DistributedRegion distributedRegion = mock(DistributedRegion.class);
+    DiskRegion diskRegion = mock(DiskRegion.class);
+
+    doCallRealMethod().when(distributedRegion).cleanUpAfterFailedGII(true);
+    when(distributedRegion.getDiskRegion()).thenReturn(diskRegion);
+    when(diskRegion.isBackup()).thenReturn(true);
+
+    distributedRegion.cleanUpAfterFailedGII(true);
+
+
+    verify(diskRegion).resetRecoveredEntries(eq(distributedRegion));
+    verify(distributedRegion, never()).closeEntries();
   }
 }


### PR DESCRIPTION
 * To avoid race with concurrent cache operation, a clearRegion write lock is needed
   when clearing entries and disk region entries during cleanUpAfterFailedGII, as cache
   operations hold clearRegion read lock.

