### PR TITLE
GEODE-5551: Replace thread interleaving mechanism

### DIFF
--- a/geode-web/build.gradle
+++ b/geode-web/build.gradle
@@ -39,9 +39,9 @@ dependencies {
   runtimeOnly('commons-fileupload:commons-fileupload:' + project.'commons-fileupload.version') {
     exclude module: 'commons-io'
   }
-
-
+  
   testCompile project(':geode-core')
+  testCompile project(':geode-junit')
   // have to use output since we exclude the dependent classes from jar :(
   testCompile project(path: ':geode-core', configuration: 'classesOutput')
   testCompile 'org.springframework:spring-test:' + project.'springframework.version'

--- a/geode-web/src/test/java/org/apache/geode/management/internal/web/controllers/support/LoginHandlerInterceptorJUnitTest.java
+++ b/geode-web/src/test/java/org/apache/geode/management/internal/web/controllers/support/LoginHandlerInterceptorJUnitTest.java
@@ -144,7 +144,7 @@ public class LoginHandlerInterceptorJUnitTest {
     Callable<Void> request1Task = () -> processRequest("thread 1", thread1Permit, thread2Permit);
     Callable<Void> request2Task = () -> processRequest("thread 2", thread2Permit, thread1Permit);
 
-    runConcurrently.setTimeout(Duration.ofSeconds(10));
+    runConcurrently.setTimeout(Duration.ofMinutes(1));
     runConcurrently.add(request1Task);
     runConcurrently.add(request2Task);
     thread1Permit.release();

--- a/geode-web/src/test/java/org/apache/geode/management/internal/web/controllers/support/LoginHandlerInterceptorJUnitTest.java
+++ b/geode-web/src/test/java/org/apache/geode/management/internal/web/controllers/support/LoginHandlerInterceptorJUnitTest.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.management.internal.web.controllers.support;
 
+import static java.lang.Thread.currentThread;
+import static java.util.Collections.enumeration;
 import static org.apache.geode.management.internal.security.ResourceConstants.PASSWORD;
 import static org.apache.geode.management.internal.security.ResourceConstants.USER_NAME;
 import static org.apache.geode.management.internal.web.controllers.support.LoginHandlerInterceptor.ENVIRONMENT_VARIABLE_REQUEST_PARAMETER_PREFIX;
@@ -22,43 +24,48 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
 
-import java.util.Enumeration;
+import java.time.Duration;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Semaphore;
 
 import javax.servlet.http.HttpServletRequest;
 
-import edu.umd.cs.mtc.MultithreadedTestCase;
-import edu.umd.cs.mtc.TestFramework;
+import org.apache.logging.log4j.Logger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
+import org.mockito.Mock;
+import org.springframework.web.servlet.HandlerInterceptor;
 
+import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.security.SecurityService;
 import org.apache.geode.management.internal.security.ResourceConstants;
+import org.apache.geode.test.junit.rules.ConcurrencyRule;
 
-/**
- * The LoginHandlerInterceptorJUnitTest class is a test suite of test cases to test the contract and
- * functionality of the Spring HandlerInterceptor, LoginHandlerInterceptor class.
- *
- * @see org.junit.Test
- * @since GemFire 8.0
- */
 public class LoginHandlerInterceptorJUnitTest {
+  private static Logger log = LogService.getLogger();
+  @Mock
   private SecurityService securityService;
+  private HandlerInterceptor interceptor;
 
   @Rule
   public TestName name = new TestName();
 
+  @Rule
+  public ConcurrencyRule runConcurrently = new ConcurrencyRule();
+
   @Before
   public void setUp() {
     LoginHandlerInterceptor.getEnvironment().clear();
-    securityService = mock(SecurityService.class);
+    initMocks(this);
+    interceptor = new LoginHandlerInterceptor(securityService);
   }
 
   @After
@@ -66,44 +73,33 @@ public class LoginHandlerInterceptorJUnitTest {
     LoginHandlerInterceptor.getEnvironment().clear();
   }
 
-  private <T> Enumeration<T> enumeration(final Iterator<T> iterator) {
-    return new Enumeration<T>() {
-      public boolean hasMoreElements() {
-        return iterator.hasNext();
-      }
-
-      public T nextElement() {
-        return iterator.next();
-      }
-    };
-  }
-
   @Test
-  public void preHandleShouldSetEnvironmentVariablesFromSpecificRequestParameters()
+  public void preHandleSetsEnvironmentVariablesFromPrefixedRequestParameters()
       throws Exception {
     final Map<String, String> requestParameters = new HashMap<>(2);
     requestParameters.put("parameter", "one");
     requestParameters.put(ENVIRONMENT_VARIABLE_REQUEST_PARAMETER_PREFIX + "variable", "two");
     final HttpServletRequest mockHttpRequest = mock(HttpServletRequest.class, name.getMethodName());
-    when(mockHttpRequest.getParameterNames())
-        .thenReturn(enumeration(requestParameters.keySet().iterator()));
+    when(mockHttpRequest.getParameterNames()).thenReturn(enumeration(requestParameters.keySet()));
     when(mockHttpRequest.getHeader(USER_NAME)).thenReturn("admin");
     when(mockHttpRequest.getHeader(PASSWORD)).thenReturn("password");
     when(mockHttpRequest.getParameter(ENVIRONMENT_VARIABLE_REQUEST_PARAMETER_PREFIX + "variable"))
         .thenReturn("two");
 
-    LoginHandlerInterceptor handlerInterceptor = new LoginHandlerInterceptor(securityService);
     Map<String, String> environmentBeforePreHandle = LoginHandlerInterceptor.getEnvironment();
-    assertThat(environmentBeforePreHandle).isNotNull();
-    assertThat(environmentBeforePreHandle.isEmpty()).isTrue();
+    assertThat(environmentBeforePreHandle)
+        .describedAs("environment before preHandle()")
+        .isEmpty();
 
-    assertThat(handlerInterceptor.preHandle(mockHttpRequest, null, null)).isTrue();
-    Map<String, String> environmentAfterPreHandle = LoginHandlerInterceptor.getEnvironment();
-    assertThat(environmentAfterPreHandle).isNotNull();
-    assertThat(environmentAfterPreHandle).isNotSameAs(environmentBeforePreHandle);
-    assertThat(environmentAfterPreHandle.size()).isEqualTo(1);
-    assertThat(environmentAfterPreHandle.containsKey("variable")).isTrue();
-    assertThat(environmentAfterPreHandle.get("variable")).isEqualTo("two");
+    assertThat(interceptor.preHandle(mockHttpRequest, null, null))
+        .describedAs("preHandle() result")
+        .isTrue();
+    assertThat(LoginHandlerInterceptor.getEnvironment())
+        .describedAs("environment after preHandle()")
+        .isNotSameAs(environmentBeforePreHandle)
+        .hasSize(1)
+        .containsEntry("variable", "two");
+
     Properties expectedLoginProperties = new Properties();
     expectedLoginProperties.put(USER_NAME, "admin");
     expectedLoginProperties.put(PASSWORD, "password");
@@ -111,172 +107,127 @@ public class LoginHandlerInterceptorJUnitTest {
   }
 
   @Test
-  public void afterCompletionShouldCleanTheEnvironment() throws Exception {
-    final Map<String, String> requestParameters = new HashMap<>(2);
+  public void afterCompletionCleansTheEnvironment() throws Exception {
+    Map<String, String> requestParameters = new HashMap<>(2);
     requestParameters.put(ENVIRONMENT_VARIABLE_REQUEST_PARAMETER_PREFIX + "variable", "two");
-    final HttpServletRequest mockHttpRequest = mock(HttpServletRequest.class, name.getMethodName());
-    when(mockHttpRequest.getParameterNames())
-        .thenReturn(enumeration(requestParameters.keySet().iterator()));
+    HttpServletRequest mockHttpRequest = mock(HttpServletRequest.class, name.getMethodName());
+    when(mockHttpRequest.getParameterNames()).thenReturn(enumeration(requestParameters.keySet()));
     when(mockHttpRequest.getHeader(USER_NAME)).thenReturn("admin");
     when(mockHttpRequest.getHeader(PASSWORD)).thenReturn("password");
     when(mockHttpRequest.getParameter(ENVIRONMENT_VARIABLE_REQUEST_PARAMETER_PREFIX + "variable"))
         .thenReturn("two");
 
-    LoginHandlerInterceptor handlerInterceptor = new LoginHandlerInterceptor(securityService);
-    assertThat(handlerInterceptor.preHandle(mockHttpRequest, null, null)).isTrue();
-    Map<String, String> environmentAfterPreHandle = LoginHandlerInterceptor.getEnvironment();
-    assertThat(environmentAfterPreHandle).isNotNull();
-    assertThat(environmentAfterPreHandle.size()).isEqualTo(1);
-    assertThat(environmentAfterPreHandle.containsKey("variable")).isTrue();
-    assertThat(environmentAfterPreHandle.get("variable")).isEqualTo("two");
+    assertThat(interceptor.preHandle(mockHttpRequest, null, null))
+        .describedAs("preHandle() result")
+        .isTrue();
+
+    assertThat(LoginHandlerInterceptor.getEnvironment())
+        .describedAs("environment after preHandle()")
+        .hasSize(1)
+        .containsEntry("variable", "two");
+
     Properties expectedLoginProperties = new Properties();
     expectedLoginProperties.put(USER_NAME, "admin");
     expectedLoginProperties.put(PASSWORD, "password");
     verify(securityService, times(1)).login(expectedLoginProperties);
 
-    handlerInterceptor.afterCompletion(mockHttpRequest, null, null, null);
-    Map<String, String> environmentAfterCompletion = LoginHandlerInterceptor.getEnvironment();
-    assertThat(environmentAfterCompletion).isNotNull();
-    assertThat(environmentAfterCompletion.isEmpty()).isTrue();
+    interceptor.afterCompletion(mockHttpRequest, null, null, null);
+
+    assertThat(LoginHandlerInterceptor.getEnvironment())
+        .describedAs("environment after afterCompletion()")
+        .isEmpty();
     verify(securityService, times(1)).logout();
   }
 
   @Test
-  public void testHandlerInterceptorThreadSafety() throws Throwable {
-    TestFramework.runOnce(new HandlerInterceptorThreadSafetyMultiThreadedTestCase());
+  public void eachRequestThreadsEnvironmentIsConfinedToItsThread() {
+    Semaphore thread1Permit = new Semaphore(0);
+    Semaphore thread2Permit = new Semaphore(0);
+
+    Callable<Void> request1Task = () -> processRequest("thread 1", thread1Permit, thread2Permit);
+    Callable<Void> request2Task = () -> processRequest("thread 2", thread2Permit, thread1Permit);
+
+    runConcurrently.setTimeout(Duration.ofSeconds(1));
+    runConcurrently.add(request1Task);
+    runConcurrently.add(request2Task);
+    thread1Permit.release();
+    runConcurrently.executeInParallel();
   }
 
-  private class HandlerInterceptorThreadSafetyMultiThreadedTestCase extends MultithreadedTestCase {
-    private HttpServletRequest mockHttpRequestOne;
-    private HttpServletRequest mockHttpRequestTwo;
-    private LoginHandlerInterceptor handlerInterceptor;
+  private Void processRequest(String taskName, Semaphore thisTaskPermit,
+      Semaphore otherTaskPermit) throws Exception {
+    currentThread().setName(taskName);
+    log.info(taskName + " started");
 
-    @Override
-    public void initialize() {
-      super.initialize();
+    // sync up threads to allow both to start before proceeding
+    thisTaskPermit.acquire();
 
-      final Map<String, String> requestParametersOne = new HashMap<>(3);
-      requestParametersOne.put("param", "one");
-      requestParametersOne.put(ENVIRONMENT_VARIABLE_REQUEST_PARAMETER_PREFIX + "STAGE", "test");
-      requestParametersOne.put(ENVIRONMENT_VARIABLE_REQUEST_PARAMETER_PREFIX + "GEODE_HOME",
-          "/path/to/geode");
+    log.info(taskName + " handing off");
+    otherTaskPermit.release();
+    thisTaskPermit.acquire();
+    log.info(taskName + " running preHandle()");
 
-      mockHttpRequestOne =
-          mock(HttpServletRequest.class, "testHandlerInterceptorThreadSafety.HttpServletRequest.1");
-      when(mockHttpRequestOne.getParameterNames())
-          .thenReturn(enumeration(requestParametersOne.keySet().iterator()));
-      when(mockHttpRequestOne.getHeader(ResourceConstants.USER_NAME)).thenReturn("admin");
-      when(mockHttpRequestOne.getHeader(ResourceConstants.PASSWORD)).thenReturn("password");
-      when(mockHttpRequestOne.getParameter(ENVIRONMENT_VARIABLE_REQUEST_PARAMETER_PREFIX + "STAGE"))
-          .thenReturn("test");
-      when(mockHttpRequestOne
-          .getParameter(ENVIRONMENT_VARIABLE_REQUEST_PARAMETER_PREFIX + "GEODE_HOME"))
-              .thenReturn("/path/to/geode");
+    Map<String, String> requestParameters = new HashMap<>();
+    requestParameters.put(ENVIRONMENT_VARIABLE_REQUEST_PARAMETER_PREFIX + "COMMON",
+        "COMMON value for " + taskName);
+    requestParameters.put(ENVIRONMENT_VARIABLE_REQUEST_PARAMETER_PREFIX
+        + "REQUEST-SPECIFIC " + taskName,
+        "REQUEST-SPECIFIC value for " + taskName);
 
-      mockHttpRequestTwo =
-          mock(HttpServletRequest.class, "testHandlerInterceptorThreadSafety.HttpServletRequest.2");
-      final Map<String, String> requestParametersTwo = new HashMap<>(3);
-      requestParametersTwo.put("parameter", "two");
-      requestParametersTwo.put(ENVIRONMENT_VARIABLE_REQUEST_PARAMETER_PREFIX + "HOST", "localhost");
-      requestParametersTwo.put(ENVIRONMENT_VARIABLE_REQUEST_PARAMETER_PREFIX + "GEODE_HOME",
-          "/path/to/geode/180");
-      when(mockHttpRequestTwo.getParameterNames())
-          .thenReturn(enumeration(requestParametersTwo.keySet().iterator()));
-      when(mockHttpRequestTwo.getHeader(ResourceConstants.USER_NAME)).thenReturn("admin");
-      when(mockHttpRequestTwo.getHeader(ResourceConstants.PASSWORD)).thenReturn("password");
-      when(mockHttpRequestTwo.getParameter(ENVIRONMENT_VARIABLE_REQUEST_PARAMETER_PREFIX + "HOST"))
-          .thenReturn("localhost");
-      when(mockHttpRequestTwo
-          .getParameter(ENVIRONMENT_VARIABLE_REQUEST_PARAMETER_PREFIX + "GEODE_HOME"))
-              .thenReturn("/path/to/geode/180");
+    HttpServletRequest request = request(taskName, requestParameters);
 
-      handlerInterceptor = new LoginHandlerInterceptor(securityService);
-    }
+    assertThat(LoginHandlerInterceptor.getEnvironment())
+        .describedAs("environment before preHandle() in " + taskName)
+        .isEmpty();
 
-    @SuppressWarnings("unused")
-    public void thread1() throws Exception {
-      assertTick(0);
-      Thread.currentThread().setName("HTTP Request Processing Thread 1");
+    interceptor.preHandle(request, null, null);
 
-      Map<String, String> env = LoginHandlerInterceptor.getEnvironment();
-      assertThat(env).isNotNull();
-      assertThat(env.isEmpty()).isTrue();
-      assertThat(handlerInterceptor.preHandle(mockHttpRequestOne, null, null)).isTrue();
+    Map<String, String> requestEnvironment = LoginHandlerInterceptor.getEnvironment();
 
-      env = LoginHandlerInterceptor.getEnvironment();
-      assertThat(env).isNotNull();
-      assertThat(env.size()).isEqualTo(2);
-      assertThat(env.containsKey("param")).isFalse();
-      assertThat(env.containsKey("parameter")).isFalse();
-      assertThat(env.containsKey("HOST")).isFalse();
-      assertThat(env.containsKey("security-username")).isFalse();
-      assertThat(env.containsKey("security-password")).isFalse();
-      assertThat(env.get("STAGE")).isEqualTo("test");
-      assertThat(env.get("GEODE_HOME")).isEqualTo("/path/to/geode");
+    log.info(taskName + " handing off");
+    otherTaskPermit.release();
+    thisTaskPermit.acquire();
+    log.info(taskName + " checking for pollution of request environment");
 
-      waitForTick(2);
-      env = LoginHandlerInterceptor.getEnvironment();
-      assertThat(env).isNotNull();
-      assertThat(env.size()).isEqualTo(2);
-      assertThat(env.containsKey("param")).isFalse();
-      assertThat(env.containsKey("parameter")).isFalse();
-      assertThat(env.containsKey("HOST")).isFalse();
-      assertThat(env.containsKey("security-username")).isFalse();
-      assertThat(env.containsKey("security-password")).isFalse();
-      assertThat(env.get("STAGE")).isEqualTo("test");
-      assertThat(env.get("GEODE_HOME")).isEqualTo("/path/to/geode");
+    assertThat(LoginHandlerInterceptor.getEnvironment())
+        .describedAs("environment remains unchanged in " + taskName)
+        .containsAllEntriesOf(requestEnvironment)
+        .hasSameSizeAs(requestEnvironment);
 
-      waitForTick(4);
-      env = LoginHandlerInterceptor.getEnvironment();
-      assertThat(env).isNotNull();
-      assertThat(env.size()).isEqualTo(2);
-      assertThat(env.containsKey("param")).isFalse();
-      assertThat(env.containsKey("parameter")).isFalse();
-      assertThat(env.containsKey("HOST")).isFalse();
-      assertThat(env.containsKey("security-username")).isFalse();
-      assertThat(env.containsKey("security-password")).isFalse();
-      assertThat(env.get("STAGE")).isEqualTo("test");
-      assertThat(env.get("GEODE_HOME")).isEqualTo("/path/to/geode");
+    log.info(taskName + " handing off");
+    otherTaskPermit.release();
+    thisTaskPermit.acquire();
+    log.info(taskName + " checking for pollution of request environment");
 
-      handlerInterceptor.afterCompletion(mockHttpRequestOne, null, null, null);
-      env = LoginHandlerInterceptor.getEnvironment();
-      assertNotNull(env);
-      assertTrue(env.isEmpty());
-    }
+    assertThat(LoginHandlerInterceptor.getEnvironment())
+        .describedAs("environment before afterCompletion() in " + taskName)
+        .containsAllEntriesOf(requestEnvironment)
+        .hasSameSizeAs(requestEnvironment);
 
-    @SuppressWarnings("unused")
-    public void thread2() throws Exception {
-      assertTick(0);
-      Thread.currentThread().setName("HTTP Request Processing Thread 2");
+    log.info(taskName + " running afterCompletion()");
 
-      waitForTick(1);
-      Map<String, String> env = LoginHandlerInterceptor.getEnvironment();
-      assertThat(env).isNotNull();
-      assertThat(env.isEmpty()).isTrue();
-      assertThat(handlerInterceptor.preHandle(mockHttpRequestTwo, null, null)).isTrue();
+    interceptor.afterCompletion(request, null, null, null);
 
-      env = LoginHandlerInterceptor.getEnvironment();
-      assertThat(env).isNotNull();
-      assertThat(env.size()).isEqualTo(2);
-      assertThat(env.containsKey("parameter")).isFalse();
-      assertThat(env.containsKey("param")).isFalse();
-      assertThat(env.containsKey("STAGE")).isFalse();
-      assertThat(env.containsKey("security-username")).isFalse();
-      assertThat(env.containsKey("security-password")).isFalse();
-      assertThat(env.get("HOST")).isEqualTo("localhost");
-      assertThat(env.get("GEODE_HOME")).isEqualTo("/path/to/geode/180");
+    assertThat(LoginHandlerInterceptor.getEnvironment())
+        .describedAs("environment after afterCompletion() in " + taskName)
+        .isEmpty();
 
-      waitForTick(3);
-      handlerInterceptor.afterCompletion(mockHttpRequestTwo, null, null, null);
-      env = LoginHandlerInterceptor.getEnvironment();
-      assertThat(env).isNotNull();
-      assertThat(env.isEmpty()).isTrue();
-    }
+    log.info(taskName + " handing off and terminating");
+    otherTaskPermit.release();
 
-    @Override
-    public void finish() {
-      super.finish();
-      handlerInterceptor = null;
-    }
+    return null;
+  }
+
+  private static HttpServletRequest request(String taskName, Map<String, String> parameters) {
+    HttpServletRequest request = mock(HttpServletRequest.class, taskName + " request");
+
+    when(request.getParameterNames()).thenReturn(enumeration(parameters.keySet()));
+    parameters.keySet()
+        .forEach(name -> when(request.getParameter(name)).thenReturn(parameters.get(name)));
+
+    when(request.getHeader(ResourceConstants.USER_NAME)).thenReturn(taskName + " admin");
+    when(request.getHeader(ResourceConstants.PASSWORD)).thenReturn(taskName + " password");
+
+    return request;
   }
 }


### PR DESCRIPTION
The MultithreadedTestCase class is unreliable under heavy contention for
CPUs, causing the LoginHandlerInterceptorJUnitTest's thread safety test
to fail intermittently in CI. We replaced MultithreadedTestCase (in this
one class) with a more reliable Semaphore-based mechanism to coordinate
the threads.

Also:
* Used ConcurrencyRule to run the multiple threads and collect errors.
* Added geode-junit to geode-web test classpath, to pick up
ConcurrencyRule.
* Simplified the thread-safety test to focus on thread-safety, leaving
basic correctness to other tests.

Signed-off-by: Helena Bales <hbales@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.

Please review: @pdxrunner @kirklund @upthewaterspout @rhoughton-pivot @pivotal-jbarrett 