### PR TITLE
GEODE-5757: Remove Nexus publication plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,6 @@ buildscript {
 
   dependencies {
     classpath "gradle.plugin.org.nosphere.apache:creadur-rat-gradle:0.2.0"
-    classpath 'com.bmuschko:gradle-nexus-plugin:2.3.1'
     classpath 'org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.6.2'
     classpath "com.diffplug.spotless:spotless-plugin-gradle:3.10.0"
     classpath "me.champeau.gradle:jmh-gradle-plugin:0.4.7"

--- a/extensions/geode-modules-assembly/build.gradle
+++ b/extensions/geode-modules-assembly/build.gradle
@@ -27,11 +27,6 @@ dependencies {
 }
 
 jar.enabled = true
-extraArchive {
-  sources = false
-  javadoc = false
-  tests = false
-}
 
 disableMavenPublishing()
 disableSigning()
@@ -215,9 +210,6 @@ task distTcServer30(type: Zip, dependsOn: [':extensions:geode-modules:assemble',
 task dist(type: Task, dependsOn: ['distTcServer', 'distTcServer30', 'distTomcat', 'distAppServer'])
 
 build.dependsOn dist
-
-install.dependsOn dist
-uploadArchives.dependsOn dist
 
 artifacts {
   archives distTcServer

--- a/extensions/geode-modules-assembly/build.gradle
+++ b/extensions/geode-modules-assembly/build.gradle
@@ -29,7 +29,6 @@ dependencies {
 jar.enabled = true
 
 disableMavenPublishing()
-disableSigning()
 
 def getJarArtifact(module) {
   project(module).configurations.archives.artifacts.findAll {

--- a/geode-assembly/build.gradle
+++ b/geode-assembly/build.gradle
@@ -25,11 +25,6 @@ afterEvaluate {
 
 // disable artifact generation for this project
 jar.enabled = false
-extraArchive {
-  sources = false
-  javadoc = false
-  tests = false
-}
 
 publishing {
   publications {
@@ -59,7 +54,6 @@ configurations.all {
 }
 
 gradle.taskGraph.whenReady( { graph ->
-  tasks.install.enabled = false
   tasks.withType(Tar).each { tar ->
     tar.compression = Compression.GZIP
     tar.extension = 'tgz'

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -16,116 +16,9 @@
  */
 
 subprojects {
-  apply plugin: 'com.bmuschko.nexus'
+
   apply plugin: 'maven-publish'
-
-  extraArchive {
-    sources = true
-    javadoc = true
-    tests = false
-  }
-
-  nexus {
-    sign = Boolean.parseBoolean(nexusSignArchives)
-    repositoryUrl = 'https://repository.apache.org/service/local/staging/deploy/maven2'
-    snapshotRepositoryUrl = 'https://repository.apache.org/content/repositories/snapshots'
-  }
-
-
-  modifyPom {
-    withXml {
-      def elem = asElement()
-      def hdr = elem.getOwnerDocument().createComment(
-  '''
-  Licensed to the Apache Software Foundation (ASF) under one or more
-  contributor license agreements.  See the NOTICE file distributed with
-  this work for additional information regarding copyright ownership.
-  The ASF licenses this file to You under the Apache License, Version 2.0
-  (the "License"); you may not use this file except in compliance with
-  the License.  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-  ''')
-
-      elem.insertBefore(hdr, elem.getFirstChild())
-
-
-      //This black magic checks to see if a dependency has the flag ext.optional=true
-      //set on it, and if so marks the dependency as optional in the maven pom
-      def depMap = project.configurations.compile.dependencies.collectEntries { [it.name, it] }
-      def runtimeDeps = project.configurations.runtime.dependencies.collectEntries { [it.name, it] }
-      def runtimeOnlyDeps = project.configurations.runtimeOnly.dependencies.collectEntries { [it.name, it] }
-      depMap.putAll(runtimeDeps)
-      depMap.putAll(runtimeOnlyDeps)
-      asNode().dependencies.dependency.findAll {
-        def dep = depMap.get(it.artifactId.text())
-        return dep?.hasProperty('optional') && dep.optional
-      }.each {
-        if (it.optional) {
-            it.optional.value = 'true'
-        } else {
-            it.appendNode('optional', 'true')
-        }
-      }
-    }
-
-    project {
-      name 'Apache Geode'
-      description 'Apache Geode provides a database-like consistency model, reliable transaction processing and a shared-nothing architecture to maintain very low latency performance with high concurrency processing'
-      url 'http://geode.apache.org'
-
-      scm {
-        url 'https://github.com/apache/geode'
-        connection 'scm:git:https://github.com:apache/geode.git'
-        developerConnection 'scm:git:https://github.com:apache/geode.git'
-      }
-
-      licenses {
-        license {
-          name 'The Apache Software License, Version 2.0'
-          url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-        }
-      }
-
-      repositories {
-        repository {
-          id 'libs-release'
-          name 'Spring Maven libs-release Repository'
-          url 'http://repo.spring.io/libs-release'
-        }
-      }
-    }
-  }
-
-  // The nexus plugin reads authentication from ~/.gradle/gradle.properties but the
-  // jenkins server stores publishing credentials in ~/.m2/settings.xml (maven).
-  // We match on the expected snapshot repository id.
-  afterEvaluate {
-    if (!isReleaseVersion && System.env.USER == 'jenkins') {
-      def settingsXml = new File(System.getProperty('user.home'), '.m2/settings.xml')
-      if (settingsXml.exists()) {
-        def snapshotCreds = new XmlSlurper().parse(settingsXml).servers.server.find { server ->
-          server.id.text() == 'apache.snapshots.https'
-        }
-
-        if (snapshotCreds != null) {
-          tasks.uploadArchives.doFirst {
-            repositories.withType(MavenDeployer).each { repo ->
-              repo.snapshotRepository.authentication.userName = snapshotCreds.username.text()
-              repo.snapshotRepository.authentication.password = snapshotCreds.password.text()
-            }
-          }
-        }
-      }
-    }
-  }
-
+  apply plugin: 'signing'
 
   publishing {
     publications {
@@ -210,12 +103,31 @@ subprojects {
         if (project.hasProperty("mavenRepository")) {
           url = project.mavenRepository
         } else {
-          if (version.endsWith('SNAPSHOT')) {
+          if (project.isReleaseVersion) {
+            url = "https://repository.apache.org/service/local/staging/deploy/maven2"
+          } else {
+            // If testing from a non-GCE instance, then the shell needs service-account creds
+            // following the instructions at https://cloud.google.com/docs/authentication/production
             url = "gcs://maven.apachegeode-ci.info/snapshots"
+          }
+        }
+        if (! url.toString().startsWith("gcs:")) {
+          credentials {
+            if (project.hasProperty("mavenUsername")) {
+              username = project.mavenUsername
+            }
+            if (project.hasProperty("mavenPassword")) {
+              password = project.mavenPassword
+            }
           }
         }
       }
     }
+  }
+
+  signing {
+    required({project.isReleaseVersion})
+    sign publishing.publications.maven
   }
 
   task('checkPom') {
@@ -267,8 +179,8 @@ subprojects {
 } // subprojects
 
 //Prompt the user for a password to sign archives or upload artifacts, if requested
-gradle.taskGraph.whenReady { taskGraph ->
-  if (project.hasProperty('askpass')) {
+if (project.hasProperty('askpass')) {
+  gradle.taskGraph.whenReady { taskGraph ->
     if(taskGraph.allTasks.any {it instanceof Sign}) {
       if(!project.hasProperty('signing.keyId') || !project.hasProperty('signing.secretKeyRingFile')) {
         println "You must configure your signing.keyId and signing.secretKeyRingFile"
@@ -284,27 +196,21 @@ gradle.taskGraph.whenReady { taskGraph ->
       }
     }
 
-    if(taskGraph.allTasks.any {it.name == 'uploadArchives'}) {
-      if(!project.hasProperty('nexusUsername')) {
-        println "You must configure your nexusUsername in ~/.gradle/gradle.properties in order to uploadArchives\n"
+    if(taskGraph.allTasks.any {it instanceof PublishToMavenRepository}) {
+      if(!project.hasProperty('mavenUsername')) {
+        println "You must configure your mavenUsername in ~/.gradle/gradle.properties in order to publish\n"
         println "See https://cwiki.apache.org/confluence/display/GEODE/Release+Steps"
-        throw new GradleException("nexusUsername is missing")
+        throw new GradleException("mavenUsername is missing")
       }
+      if(!project.hasProperty('mavenPassword')) {
+        def getPassword = PasswordDialog.askPassword("Please enter your apache password to publish to Apache Maven")
 
-      if(!project.hasProperty('nexusPassword')) {
-        def password = PasswordDialog.askPassword("Please enter your apache password to uploadArchives to nexus")
-
-        subprojects { ext."nexusPassword" = password }
+        taskGraph.allTasks.each {
+          if(it instanceof PublishToMavenRepository) {
+            (it as PublishToMavenRepository).repository.credentials.password = getPassword
+          }
+        }
       }
-    }
-  }
-}
-
-
-allprojects {
-  afterEvaluate {
-    tasks.withType(PublishToMavenRepository) {
-      it.enabled = version.endsWith('SNAPSHOT')
     }
   }
 }

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -178,6 +178,7 @@ subprojects {
 
 } // subprojects
 
+
 //Prompt the user for a password to sign archives or upload artifacts, if requested
 if (project.hasProperty('askpass')) {
   gradle.taskGraph.whenReady { taskGraph ->

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -130,6 +130,8 @@ subprojects {
     sign publishing.publications.maven
   }
 
+  task install(dependsOn: publishToMavenLocal) {}
+
   task('checkPom') {
     dependsOn('generatePomFileForMavenPublication')
     description 'Checks the generated POM against an expected POM for dependency changes.'

--- a/gradle/utilities.gradle
+++ b/gradle/utilities.gradle
@@ -41,6 +41,9 @@ allprojects {
     disableMavenPublishing = {
       // Use this closure when a project should not publish anything to maven.
       afterEvaluate {
+        tasks.withType(PublishToMavenLocal) {
+          it.enabled = false
+        }
         tasks.withType(PublishToMavenRepository) {
           it.enabled = false
         }

--- a/gradle/utilities.gradle
+++ b/gradle/utilities.gradle
@@ -47,13 +47,8 @@ allprojects {
         tasks.withType(GenerateMavenPom) {
           it.enabled = false
         }
-      }
-    }
-    disableSigning = {
-      // Use this closure when a project should not publish anything to maven.
-      afterEvaluate {
         tasks.withType(Sign) {
-          onlyIf({false})
+          it.enabled = false
         }
       }
     }

--- a/gradle/utilities.gradle
+++ b/gradle/utilities.gradle
@@ -41,8 +41,6 @@ allprojects {
     disableMavenPublishing = {
       // Use this closure when a project should not publish anything to maven.
       afterEvaluate {
-        install.enabled = false
-        uploadArchives.enabled = false
         tasks.withType(PublishToMavenRepository) {
           it.enabled = false
         }
@@ -54,7 +52,9 @@ allprojects {
     disableSigning = {
       // Use this closure when a project should not publish anything to maven.
       afterEvaluate {
-        signArchives.enabled = false
+        tasks.withType(Sign) {
+          onlyIf({false})
+        }
       }
     }
 


### PR DESCRIPTION
Using maven-publish plugin instead of nexus plugin. This removes our
dependency on the old 'maven' plugin, and cleans up a lot of custom
disable-task code related to distributions.

Co-authored-by: Robert Houghton <rhoughton@pivotal.io>
Co-authored-by: Jacob Barrett <jbarrett@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
