### PR TITLE
GEODE-5761: Exclude android-json transitive dependency

### DIFF
--- a/geode-junit/build.gradle
+++ b/geode-junit/build.gradle
@@ -34,7 +34,9 @@ dependencies {
     exclude module: 'hamcrest-core'
   }
   compile 'org.hamcrest:hamcrest-all:' + project.'hamcrest-all.version'
-  compile 'org.skyscreamer:jsonassert:' + project.'jsonassert.version'
+  compile ('org.skyscreamer:jsonassert:' + project.'jsonassert.version') {
+    exclude module: 'android-json'
+  }
 
   compile 'org.bouncycastle:bcpkix-jdk15on:' + project.'bounty-castle.version'
 


### PR DESCRIPTION
org.skyscreamer:jsonassert which brings in a transitive dependency
on com.vaadin.external.google:android-json which is incompatible
with geode-json.
