### PR TITLE
GEODE-5741: Modified tests to be independent of environment

### DIFF
--- a/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/StartLocatorCommandDUnitTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/StartLocatorCommandDUnitTest.java
@@ -230,37 +230,9 @@ public class StartLocatorCommandDUnitTest {
   }
 
   @Test
-  public void testInMissingRelativeDirectoryWithoutCreatePermissions() {
-    // path to a missing dir that cannot be created due to insufficient permissions
-    String readOnlyPathname = "readOnlyDir";
-    File readOnlyDir = new File(readOnlyPathname);
-    final String missingDirPath =
-        Paths.get(readOnlyPathname, "missing", "path", "to", "start", "in").toString();
-
-    final String expectedMessage = "Could not create directory .*" + missingDirPath
-        + ". Please verify directory path or user permissions.";
-    final String memberName = "testInMissingRelativeDirectoryWithoutCreatePermissions-locator";
-
-    try {
-      assertThat(readOnlyDir.mkdir()).isTrue();
-      assertThat(readOnlyDir.setReadOnly()).isTrue();
-
-      CommandStringBuilder command = new CommandStringBuilder(START_LOCATOR)
-          .addOption(START_LOCATOR__MEMBER_NAME, memberName)
-          .addOption(START_LOCATOR__LOCATORS, locatorConnectionString)
-          .addOption(START_LOCATOR__DIR, missingDirPath);
-
-      CommandResult result = gfsh.executeCommand(command.getCommandString());
-
-      assertThat(result.getStatus()).isEqualTo(Result.Status.ERROR);
-      assertThat(result.getMessageFromContent()).containsPattern(expectedMessage);
-    } finally {
-      FileUtils.deleteQuietly(readOnlyDir);
-    }
-  }
-
-  @Test
   public void testInMissingRelativeDirectoryThatCanBeCreated() {
+    final Integer locatorPort = AvailablePortHelper.getRandomAvailableTCPPort();
+
     // path to a missing dir that can be created
     String readWritePathname = "readWriteDir";
     File readWriteDir = new File(readWritePathname);
@@ -273,11 +245,11 @@ public class StartLocatorCommandDUnitTest {
     CommandStringBuilder command = new CommandStringBuilder(START_LOCATOR)
         .addOption(START_LOCATOR__MEMBER_NAME, memberName)
         .addOption(START_LOCATOR__LOCATORS, locatorConnectionString)
-        .addOption(START_LOCATOR__DIR, missingDirPath);
+        .addOption(START_LOCATOR__DIR, missingDirPath)
+        .addOption(START_LOCATOR__PORT, locatorPort.toString());
 
     try {
       CommandResult result = gfsh.executeCommand(command.getCommandString());
-
 
       assertThat(result.getStatus()).isEqualTo(Result.Status.OK);
       assertThat(result.getMessageFromContent()).containsPattern(expectedMessage);
@@ -325,8 +297,7 @@ public class StartLocatorCommandDUnitTest {
       assertThat(result.getMessageFromContent()).contains(expectedMessage);
 
       // Verify GEODE-2138 (Geode commands do not contain GemFire in output)
-      assertThat(result.getMessageFromContent()).doesNotContain("Gemfire")
-          .doesNotContain("GemFire");
+      assertThat(result.getMessageFromContent()).doesNotContainPattern("Gem[Ff]ire Version");
       assertThat(result.getMessageFromContent()).containsPattern(expectedVersionPattern);
     } finally {
       String pathToFile = Paths.get(System.getProperty("user.dir"), memberName).toString();

--- a/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/StartServerCommandDUnitTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/StartServerCommandDUnitTest.java
@@ -42,6 +42,7 @@ import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.nio.file.Paths;
 
+import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -238,12 +239,17 @@ public class StartServerCommandDUnitTest {
   }
 
   @Test
-  public void testWithMissingStartDirectoryThatCannotBeCreated() {
+  public void testWithMissingStartDirectoryThatCanBeCreated() throws IOException {
     final Integer serverPort = AvailablePortHelper.getRandomAvailableTCPPort();
-    final String missingDirPath = "/missing/dir/to/start/in";
-    final String memberName = "testWithMissingStartDirectoryThatCannotBeCreated-server";
-    final String expectedError = "Could not create directory " + missingDirPath
-        + ". Please verify directory path or user permissions.";
+
+    // path to a missing dir that can be created
+    String readWritePathname = "readWriteDir";
+    File readWriteDir = new File(readWritePathname);
+    final String missingDirPath =
+        Paths.get(readWritePathname, "missing", "dir", "to", "start", "in").toString();
+
+    final String memberName = "testWithMissingStartDirectoryThatCanBeCreated-server";
+    final String expectedMessage = "Server in .*" + missingDirPath;
 
     String command = new CommandStringBuilder(START_SERVER)
         .addOption(START_SERVER__NAME, memberName)
@@ -252,34 +258,13 @@ public class StartServerCommandDUnitTest {
         .addOption(START_SERVER__DIR, missingDirPath)
         .getCommandString();
 
-    CommandResult result = gfsh.executeCommand(command);
-
-    assertThat(result.getStatus()).isEqualTo(Result.Status.ERROR);
-    assertThat(result.getMessageFromContent()).contains(expectedError);
-  }
-
-  @Test
-  public void testWithMissingStartDirectoryThatCanBeCreated() throws IOException {
-    final Integer serverPort = AvailablePortHelper.getRandomAvailableTCPPort();
-    final String missingDirPath = workingDir.getCanonicalPath() + "/missing/dir/to/start/in";
-    final String memberName = "testWithMissingStartDirectoryThatCanBeCreated-server";
-    final String expectedMessage = "Server in " + missingDirPath;
-
     try {
-      String command = new CommandStringBuilder(START_SERVER)
-          .addOption(START_SERVER__NAME, memberName)
-          .addOption(START_SERVER__LOCATORS, locatorConnectionString)
-          .addOption(START_SERVER__SERVER_PORT, serverPort.toString())
-          .addOption(START_SERVER__DIR, missingDirPath)
-          .getCommandString();
-
       CommandResult result = gfsh.executeCommand(command);
 
       assertThat(result.getStatus()).isEqualTo(Result.Status.OK);
-      assertThat(result.getMessageFromContent()).contains(expectedMessage);
+      assertThat(result.getMessageFromContent()).containsPattern(expectedMessage);
     } finally {
-      File toDelete = new File(missingDirPath);
-      deleteServerFiles(toDelete);
+      FileUtils.deleteQuietly(readWriteDir);
     }
   }
 
@@ -373,8 +358,7 @@ public class StartServerCommandDUnitTest {
     assertThat(result.getMessageFromContent()).contains(expectedMessage);
 
     // verify GEODE-2138 (Geode commands do not contain GemFire in output)
-    assertThat(result.getMessageFromContent()).doesNotContain("Gemfire")
-        .doesNotContain("GemFire");
+    assertThat(result.getMessageFromContent()).doesNotContainPattern("Gem[Ff]ire Version");
     assertThat(result.getMessageFromContent()).containsPattern(expectedVersionPattern);
   }
 
@@ -440,18 +424,6 @@ public class StartServerCommandDUnitTest {
     server.stop(Boolean.TRUE);
 
     assertThat(ProcessUtils.isProcessAlive(serverPid)).isFalse();
-  }
-
-  private void deleteServerFiles(File toDelete) {
-    File[] nestedToDelete = toDelete.listFiles();
-
-    if (nestedToDelete != null && nestedToDelete.length > 0) {
-      for (File file : nestedToDelete) {
-        deleteServerFiles(file);
-      }
-    }
-
-    toDelete.delete();
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartLocatorCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartLocatorCommand.java
@@ -129,7 +129,8 @@ public class StartLocatorCommand extends InternalGfshCommand {
       memberName = StartMemberUtils.getNameGenerator().generate('-');
     }
 
-    workingDirectory = StartMemberUtils.resolveWorkingDir(workingDirectory, memberName);
+    workingDirectory = StartMemberUtils.resolveWorkingDir(
+        workingDirectory == null ? null : new File(workingDirectory), new File(memberName));
 
     if (gemfirePropertiesFile != null && !gemfirePropertiesFile.exists()) {
       return ResultBuilder.createUserErrorResult(

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartMemberUtils.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartMemberUtils.java
@@ -70,9 +70,9 @@ public class StartMemberUtils {
     }
   }
 
-  static String resolveWorkingDir(String userSpecifiedDir, String memberName) {
+  static String resolveWorkingDir(File userSpecifiedDir, File memberNameDir) {
     File workingDir =
-        (userSpecifiedDir == null) ? new File(memberName) : new File(userSpecifiedDir);
+        (userSpecifiedDir == null) ? memberNameDir : userSpecifiedDir;
     String workingDirPath = IOUtils.tryGetCanonicalPathElseGetAbsolutePath(workingDir);
     if (!workingDir.exists()) {
       if (!workingDir.mkdirs()) {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartServerCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartServerCommand.java
@@ -198,7 +198,9 @@ public class StartServerCommand extends InternalGfshCommand {
       }
     }
 
-    workingDirectory = StartMemberUtils.resolveWorkingDir(workingDirectory, memberName);
+    // workingDirectory = StartMemberUtils.resolveWorkingDir(workingDirectory, memberName);
+    workingDirectory = StartMemberUtils.resolveWorkingDir(
+        workingDirectory == null ? null : new File(workingDirectory), new File(memberName));
 
     cacheXmlPathname = CliUtil.resolvePathname(cacheXmlPathname);
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartServerCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartServerCommand.java
@@ -198,7 +198,6 @@ public class StartServerCommand extends InternalGfshCommand {
       }
     }
 
-    // workingDirectory = StartMemberUtils.resolveWorkingDir(workingDirectory, memberName);
     workingDirectory = StartMemberUtils.resolveWorkingDir(
         workingDirectory == null ? null : new File(workingDirectory), new File(memberName));
 


### PR DESCRIPTION
Tests using relative paths had depended on running as a user other than root.
The tests expceted that file or directpory creation would fail because the user
would not have permission to write to filesystem root.

A further problem was the several tests had hardcoded '/' in pathnames,
which is incompatible with running on Windows.

* make tests use relative paths
* remove system dependent path separators
* move tests that expect directory creation to fail to StartMemberUtilsTest.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
