### PR TITLE
GEODE-5600: Fix extension developer issues with buildinfo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,10 +103,10 @@ task devBuild(dependsOn: [":assemble"]) {
 
 
 
-def readScmInfo() {
+ext.readScmInfo = { proj ->
   // Attempt to read git information, or else return UNKNOWN
   try {
-    def git = org.ajoberstar.grgit.Grgit.open(currentDir: projectDir)
+    def git = org.ajoberstar.grgit.Grgit.open(currentDir: project(proj).projectDir)
     try {
       return [
           'Source-Repository': git.branch.getCurrent().name,
@@ -134,7 +134,7 @@ def readScmInfo() {
 
 task writeBuildInfo {
   def buildInfo = file "$buildDir/.buildinfo"
-  def scmInfo = rootProject.readScmInfo()
+  def scmInfo = this.readScmInfo("geode-core")
 
   inputs.property("Source-Revision", scmInfo.getProperty("Source-Revision"))
   outputs.file buildInfo

--- a/geode-core/build.gradle
+++ b/geode-core/build.gradle
@@ -220,13 +220,17 @@ dependencies {
 }
 
 // Creates the version properties file and writes it to the classes dir
-task createVersionPropertiesFile {
+task createVersionPropertiesFile(dependsOn: ':writeBuildInfo') {
 
   def propertiesFile = file(generatedResources + "/org/apache/geode/internal/GemFireVersion.properties")
   def scmInfoFile = rootProject.tasks.writeBuildInfo.outputs.files
 
-  inputs.file scmInfoFile
-  outputs.file propertiesFile
+  inputs.files {
+    scmInfoFile
+  }
+  outputs.files {
+    propertiesFile
+  }
 
 
   doLast {


### PR DESCRIPTION
As an extension developer, gradle's `rootProject` may not refer
to the Geode root project, depending on the extension's structure.

Co-authored-by: Robert Houghton <rhoughton@pivotal.io>
Co-authored-by: Patrick Rhomberg <prhomberg@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
