### PR TITLE
GEODE-5765: Clean up soft references faster in dunit tests

### DIFF
--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/standalone/ProcessManager.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/standalone/ProcessManager.java
@@ -261,6 +261,7 @@ public class ProcessManager {
         + ConfigurationProperties.VALIDATE_SERIALIZABLE_OBJECTS + "=true");
     cmds.add("-ea");
     cmds.add("-XX:MetaspaceSize=512m");
+    cmds.add("-XX:SoftRefLRUPolicyMSPerMB=1");
     cmds.add(agent);
     cmds.add(ChildVM.class.getName());
     String[] rst = new String[cmds.size()];


### PR DESCRIPTION
We observed that several tests in AlterRuntimeCommandDUnitTest class
were taking minutes when they should be taking a few seconds at most.
After some debugging, we determined that the JVM itself is struggling to
deal with having 100K+ classes loaded. They are loaded because the test
is repeated starting and stopping the http service, which creates a
classloader and causes soft references to all of the loaded classes to
be cached.

By setting this flag to clear the soft references faster, the test times
go back to normal.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
