### PR TITLE
GEODE-5748: Hold a write lock during cleanUpAfterFailedGII

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegionMap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegionMap.java
@@ -1038,7 +1038,7 @@ public abstract class AbstractRegionMap
     final boolean hasRemoteOrigin = !txId.getMemberId().equals(owner.getMyId());
     boolean callbackEventAddedToPending = false;
     IndexManager oqlIndexManager = owner.getIndexManager();
-    boolean locked = owner.lockWhenRegionIsInitializing();
+    final boolean locked = owner.lockWhenRegionIsInitializing();
     try {
       RegionEntry re = getEntry(key);
       if (re != null) {
@@ -1342,17 +1342,17 @@ public abstract class AbstractRegionMap
     boolean clearOccured = false;
     DiskRegion dr = owner.getDiskRegion();
     boolean ownerIsInitialized = owner.isInitialized();
-    boolean locked = false;
+
+    // Fix for Bug #44431. We do NOT want to update the region and wait
+    // later for index INIT as region.clear() can cause inconsistency if
+    // happened in parallel as it also does index INIT.
+    IndexManager oqlIndexManager = owner.getIndexManager();
+    if (oqlIndexManager != null) {
+      oqlIndexManager.waitForIndexInit();
+    }
+    lockForCacheModification(owner, event);
+    final boolean locked = owner.lockWhenRegionIsInitializing();
     try {
-      // Fix for Bug #44431. We do NOT want to update the region and wait
-      // later for index INIT as region.clear() can cause inconsistency if
-      // happened in parallel as it also does index INIT.
-      IndexManager oqlIndexManager = owner.getIndexManager();
-      if (oqlIndexManager != null) {
-        oqlIndexManager.waitForIndexInit();
-      }
-      lockForCacheModification(owner, event);
-      locked = owner.lockWhenRegionIsInitializing();
       try {
         try {
           if (forceNewEntry || forceCallbacks) {
@@ -1716,10 +1716,10 @@ public abstract class AbstractRegionMap
         }
       }
     } finally {
-      releaseCacheModificationLock(owner, event);
       if (locked) {
         owner.unlockWhenRegionIsInitializing();
       }
+      releaseCacheModificationLock(owner, event);
     }
 
   }
@@ -1780,7 +1780,7 @@ public abstract class AbstractRegionMap
     }
 
     lockForCacheModification(owner, event);
-    boolean locked = owner.lockWhenRegionIsInitializing();
+    final boolean locked = owner.lockWhenRegionIsInitializing();
 
     try {
       RegionEntry re = getEntry(event.getKey());
@@ -1812,10 +1812,10 @@ public abstract class AbstractRegionMap
       this._getOwner().handleDiskAccessException(dae);
       throw dae;
     } finally {
-      releaseCacheModificationLock(owner, event);
       if (locked) {
         owner.unlockWhenRegionIsInitializing();
       }
+      releaseCacheModificationLock(owner, event);
       if (dr != null) {
         dr.removeClearCountReference();
       }
@@ -1845,7 +1845,7 @@ public abstract class AbstractRegionMap
     if (oqlIndexManager != null) {
       oqlIndexManager.waitForIndexInit();
     }
-    boolean locked = owner.lockWhenRegionIsInitializing();
+    final boolean locked = owner.lockWhenRegionIsInitializing();
     try {
       if (forceNewEntry) {
         boolean opCompleted = false;
@@ -2054,11 +2054,11 @@ public abstract class AbstractRegionMap
       owner.handleDiskAccessException(dae);
       throw dae;
     } finally {
-      if (oqlIndexManager != null) {
-        oqlIndexManager.countDownIndexUpdaters();
-      }
       if (locked) {
         owner.unlockWhenRegionIsInitializing();
+      }
+      if (oqlIndexManager != null) {
+        oqlIndexManager.countDownIndexUpdaters();
       }
     }
   }
@@ -2130,16 +2130,10 @@ public abstract class AbstractRegionMap
       callbackEvent.makeSerializedNewValue();
       txHandleWANEvent(owner, callbackEvent, txEntryState);
     }
-    boolean locked = owner.lockWhenRegionIsInitializing();
-    try {
-      RegionMapCommitPut commitPut = new RegionMapCommitPut(this, owner, callbackEvent, putOp,
-          didDestroy, txId, txEvent, pendingCallbacks, txEntryState);
-      commitPut.put();
-    } finally {
-      if (locked) {
-        owner.unlockWhenRegionIsInitializing();
-      }
-    }
+
+    RegionMapCommitPut commitPut = new RegionMapCommitPut(this, owner, callbackEvent, putOp,
+        didDestroy, txId, txEvent, pendingCallbacks, txEntryState);
+    commitPut.put();
   }
 
   private void txHandleWANEvent(final LocalRegion owner, EntryEventImpl callbackEvent,

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/BucketRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/BucketRegion.java
@@ -1341,8 +1341,10 @@ public class BucketRegion extends DistributedRegion implements Bucket {
 
     InternalRegion internalRegion = event.getRegion();
     AbstractRegionMap arm = ((AbstractRegionMap) internalRegion.getRegionMap());
+    boolean locked = false;
     try {
       arm.lockForCacheModification(internalRegion, event);
+      locked = internalRegion.lockWhenRegionIsInitializing();
       beginLocalWrite(event);
       try {
         if (!hasSeenEvent(event)) {
@@ -1366,6 +1368,9 @@ public class BucketRegion extends DistributedRegion implements Bucket {
       }
     } finally {
       arm.releaseCacheModificationLock(event.getRegion(), event);
+      if (locked) {
+        internalRegion.unlockWhenRegionIsInitializing();
+      }
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/BucketRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/BucketRegion.java
@@ -1341,10 +1341,10 @@ public class BucketRegion extends DistributedRegion implements Bucket {
 
     InternalRegion internalRegion = event.getRegion();
     AbstractRegionMap arm = ((AbstractRegionMap) internalRegion.getRegionMap());
-    boolean locked = false;
+
+    arm.lockForCacheModification(internalRegion, event);
+    final boolean locked = internalRegion.lockWhenRegionIsInitializing();
     try {
-      arm.lockForCacheModification(internalRegion, event);
-      locked = internalRegion.lockWhenRegionIsInitializing();
       beginLocalWrite(event);
       try {
         if (!hasSeenEvent(event)) {
@@ -1367,10 +1367,10 @@ public class BucketRegion extends DistributedRegion implements Bucket {
         endLocalWrite(event);
       }
     } finally {
-      arm.releaseCacheModificationLock(event.getRegion(), event);
       if (locked) {
         internalRegion.unlockWhenRegionIsInitializing();
       }
+      arm.releaseCacheModificationLock(event.getRegion(), event);
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalRegion.java
@@ -411,4 +411,10 @@ public interface InternalRegion extends Region, HasCachePerfStats, RegionEntryCo
   MemoryThresholdInfo getAtomicThresholdInfo();
 
   InternalCache getInternalCache();
+
+  default boolean lockWhenRegionIsInitializing() {
+    return false;
+  };
+
+  default void unlockWhenRegionIsInitializing() {};
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/map/AbstractRegionMapPut.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/map/AbstractRegionMapPut.java
@@ -163,6 +163,8 @@ public abstract class AbstractRegionMapPut {
     }
   }
 
+
+
   private void doPut() {
     try {
       doWithIndexInUpdateMode(this::doPutRetryingIfNeeded);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/map/AbstractRegionMapPut.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/map/AbstractRegionMapPut.java
@@ -113,7 +113,16 @@ public abstract class AbstractRegionMapPut {
 
   protected abstract void serializeNewValueIfNeeded();
 
-  protected abstract void runWhileLockedForCacheModification(Runnable r);
+  protected void runWhileLockedForCacheModification(Runnable r) {
+    final boolean locked = getOwner().lockWhenRegionIsInitializing();
+    try {
+      r.run();
+    } finally {
+      if (locked) {
+        getOwner().unlockWhenRegionIsInitializing();
+      }
+    }
+  }
 
   protected abstract void setOldValueForDelta();
 
@@ -162,8 +171,6 @@ public abstract class AbstractRegionMapPut {
       return null;
     }
   }
-
-
 
   private void doPut() {
     try {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/map/RegionMapCommitPut.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/map/RegionMapCommitPut.java
@@ -134,19 +134,6 @@ public class RegionMapCommitPut extends AbstractRegionMapPut {
   }
 
   @Override
-  protected void runWhileLockedForCacheModification(Runnable r) {
-    // no need to hold lockForCacheModification
-    final boolean locked = getOwner().lockWhenRegionIsInitializing();
-    try {
-      r.run();
-    } finally {
-      if (locked) {
-        getOwner().unlockWhenRegionIsInitializing();
-      }
-    }
-  }
-
-  @Override
   protected void setOldValueForDelta() {
     // nothing needed
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/map/RegionMapCommitPut.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/map/RegionMapCommitPut.java
@@ -135,8 +135,15 @@ public class RegionMapCommitPut extends AbstractRegionMapPut {
 
   @Override
   protected void runWhileLockedForCacheModification(Runnable r) {
-    // commit has already done the locking
-    r.run();
+    // no need to hold lockForCacheModification
+    final boolean locked = getOwner().lockWhenRegionIsInitializing();
+    try {
+      r.run();
+    } finally {
+      if (locked) {
+        getOwner().unlockWhenRegionIsInitializing();
+      }
+    }
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/map/RegionMapDestroy.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/map/RegionMapDestroy.java
@@ -105,6 +105,7 @@ public class RegionMapDestroy {
     }
 
     cacheModificationLock.lockForCacheModification(internalRegion, event);
+    boolean locked = internalRegion.lockWhenRegionIsInitializing();
     try {
 
       while (retry) {
@@ -173,6 +174,9 @@ public class RegionMapDestroy {
 
     } finally {
       cacheModificationLock.releaseCacheModificationLock(internalRegion, event);
+      if (locked) {
+        internalRegion.unlockWhenRegionIsInitializing();
+      }
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/map/RegionMapDestroy.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/map/RegionMapDestroy.java
@@ -105,7 +105,7 @@ public class RegionMapDestroy {
     }
 
     cacheModificationLock.lockForCacheModification(internalRegion, event);
-    boolean locked = internalRegion.lockWhenRegionIsInitializing();
+    final boolean locked = internalRegion.lockWhenRegionIsInitializing();
     try {
 
       while (retry) {
@@ -173,10 +173,10 @@ public class RegionMapDestroy {
       } // retry loop
 
     } finally {
-      cacheModificationLock.releaseCacheModificationLock(internalRegion, event);
       if (locked) {
         internalRegion.unlockWhenRegionIsInitializing();
       }
+      cacheModificationLock.releaseCacheModificationLock(internalRegion, event);
     }
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/map/RegionMapPut.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/map/RegionMapPut.java
@@ -146,14 +146,14 @@ public class RegionMapPut extends AbstractRegionMapPut {
   @Override
   protected void runWhileLockedForCacheModification(Runnable r) {
     cacheModificationLock.lockForCacheModification(getOwner(), getEvent());
-    boolean locked = getOwner().lockWhenRegionIsInitializing();
+    final boolean locked = getOwner().lockWhenRegionIsInitializing();
     try {
       r.run();
     } finally {
-      cacheModificationLock.releaseCacheModificationLock(getOwner(), getEvent());
       if (locked) {
         getOwner().unlockWhenRegionIsInitializing();
       }
+      cacheModificationLock.releaseCacheModificationLock(getOwner(), getEvent());
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/map/RegionMapPut.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/map/RegionMapPut.java
@@ -146,10 +146,14 @@ public class RegionMapPut extends AbstractRegionMapPut {
   @Override
   protected void runWhileLockedForCacheModification(Runnable r) {
     cacheModificationLock.lockForCacheModification(getOwner(), getEvent());
+    boolean locked = getOwner().lockWhenRegionIsInitializing();
     try {
       r.run();
     } finally {
       cacheModificationLock.releaseCacheModificationLock(getOwner(), getEvent());
+      if (locked) {
+        getOwner().unlockWhenRegionIsInitializing();
+      }
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/map/RegionMapPut.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/map/RegionMapPut.java
@@ -146,13 +146,9 @@ public class RegionMapPut extends AbstractRegionMapPut {
   @Override
   protected void runWhileLockedForCacheModification(Runnable r) {
     cacheModificationLock.lockForCacheModification(getOwner(), getEvent());
-    final boolean locked = getOwner().lockWhenRegionIsInitializing();
     try {
-      r.run();
+      super.runWhileLockedForCacheModification(r);
     } finally {
-      if (locked) {
-        getOwner().unlockWhenRegionIsInitializing();
-      }
       cacheModificationLock.releaseCacheModificationLock(getOwner(), getEvent());
     }
   }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/DistributedRegionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/DistributedRegionTest.java
@@ -44,7 +44,7 @@ public class DistributedRegionTest {
   }
 
   @Test
-  public void cleanUpAfterFailedGIIHoldsLockForClear() {
+  public void cleanUpAfterFailedInitialImageHoldsLockForClear() {
     DistributedRegion distributedRegion = mock(DistributedRegion.class, RETURNS_DEEP_STUBS);
     RegionMap regionMap = mock(RegionMap.class);
 
@@ -54,13 +54,13 @@ public class DistributedRegionTest {
 
     distributedRegion.cleanUpAfterFailedGII(false);
 
-    verify(distributedRegion).lockFailedGIIClearWriteLock();
+    verify(distributedRegion).lockFailedInitialImageWriteLock();
     verify(distributedRegion).closeEntries();
-    verify(distributedRegion).unlockFailedGIIClearWriteLock();
+    verify(distributedRegion).unlockFailedInitialImageWriteLock();
   }
 
   @Test
-  public void cleanUpAfterFailedGIIDoesNotCloseEntriesIfIsPersistentRegionAndRecoveredFromDisk() {
+  public void cleanUpAfterFailedInitialImageDoesNotCloseEntriesIfIsPersistentRegionAndRecoveredFromDisk() {
     DistributedRegion distributedRegion = mock(DistributedRegion.class);
     DiskRegion diskRegion = mock(DiskRegion.class);
 
@@ -81,7 +81,7 @@ public class DistributedRegionTest {
     when(distributedRegion.isInitialized()).thenReturn(false);
 
     assertThat(distributedRegion.lockWhenRegionIsInitializing()).isTrue();
-    verify(distributedRegion).lockFailedGIIClearReadLock();
+    verify(distributedRegion).lockFailedInitialImageReadLock();
   }
 
   @Test
@@ -91,6 +91,6 @@ public class DistributedRegionTest {
     when(distributedRegion.isInitialized()).thenReturn(true);
 
     assertThat(distributedRegion.lockWhenRegionIsInitializing()).isFalse();
-    verify(distributedRegion, never()).lockFailedGIIClearReadLock();
+    verify(distributedRegion, never()).lockFailedInitialImageReadLock();
   }
 }


### PR DESCRIPTION
 * Hold write lock when cleanUpAfterFailedGII.
 * Hold read lock when cache operation is performed on the farside if region is not yet initialized.
 * Also hold read lock when transaction is performed on the farside if region not initialized yet.
