### PR TITLE
GEODE-5679: test waits for all stats changes to be written

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/statistics/StatSamplerIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/statistics/StatSamplerIntegrationTest.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -69,8 +68,8 @@ public class StatSamplerIntegrationTest {
 
   @Before
   public void setUp() {
-    this.statisticTypes = new HashMap<String, String>();
-    this.allStatistics = new HashMap<String, Map<String, Number>>();
+    this.statisticTypes = new HashMap<>();
+    this.allStatistics = new HashMap<>();
   }
 
   @After
@@ -150,7 +149,7 @@ public class StatSamplerIntegrationTest {
     incLong(st1_1, "long_counter_9", 9);
     incLong(st1_1, "long_gauge_11", 11);
 
-    awaitStatSample(samplerStats);
+    waitForStatSamplerToRun(samplerStats);
 
     incDouble(st1_1, "double_counter_1", 1);
     incDouble(st1_1, "double_counter_2", 1);
@@ -159,7 +158,7 @@ public class StatSamplerIntegrationTest {
     incInt(st1_1, "int_counter_5", 1);
     incInt(st1_1, "int_counter_6", 1);
 
-    awaitStatSample(samplerStats);
+    waitForStatSamplerToRun(samplerStats);
 
     incDouble(st1_1, "double_counter_1", 1);
     incDouble(st1_1, "double_counter_2", 1);
@@ -174,7 +173,7 @@ public class StatSamplerIntegrationTest {
     incLong(st1_1, "long_gauge_11", 1);
     incLong(st1_1, "long_gauge_12", 1);
 
-    awaitStatSample(samplerStats);
+    waitForStatSamplerToRun(samplerStats);
 
     incDouble(st1_1, "double_counter_1", 1);
     incDouble(st1_1, "double_counter_2", 1);
@@ -189,7 +188,7 @@ public class StatSamplerIntegrationTest {
     incLong(st1_1, "long_gauge_11", -1);
     incLong(st1_1, "long_gauge_12", 1);
 
-    awaitStatSample(samplerStats);
+    waitForStatSamplerToRun(samplerStats);
 
     incDouble(st1_1, "double_counter_1", 1);
     incDouble(st1_1, "double_counter_2", 1);
@@ -204,9 +203,9 @@ public class StatSamplerIntegrationTest {
     incLong(st1_1, "long_gauge_11", 1);
     incLong(st1_1, "long_gauge_12", 1);
 
-    awaitStatSample(samplerStats);
-    awaitStatSample(samplerStats);
-    awaitStatSample(samplerStats);
+    waitForStatSamplerToRun(samplerStats);
+    waitForStatSamplerToRun(samplerStats);
+    waitForStatSamplerToRun(samplerStats);
 
     incDouble(st1_1, "double_counter_1", 1);
     incDouble(st1_1, "double_gauge_3", 3);
@@ -215,7 +214,7 @@ public class StatSamplerIntegrationTest {
     incLong(st1_1, "long_counter_9", 9);
     incLong(st1_1, "long_gauge_11", 11);
 
-    awaitStatSample(samplerStats);
+    waitForStatSamplerToRun(samplerStats);
 
     incDouble(st1_1, "double_counter_1", 1);
     incDouble(st1_1, "double_counter_2", 1);
@@ -224,7 +223,7 @@ public class StatSamplerIntegrationTest {
     incInt(st1_1, "int_counter_5", 1);
     incInt(st1_1, "int_counter_6", 1);
 
-    awaitStatSample(samplerStats);
+    waitForStatSamplerToRun(samplerStats);
 
     incDouble(st1_1, "double_counter_1", 1);
     incDouble(st1_1, "double_counter_2", 1);
@@ -239,7 +238,7 @@ public class StatSamplerIntegrationTest {
     incLong(st1_1, "long_gauge_11", 1);
     incLong(st1_1, "long_gauge_12", 1);
 
-    awaitStatSample(samplerStats);
+    waitForStatSamplerToRun(samplerStats);
 
     incDouble(st1_1, "double_counter_1", 1);
     incDouble(st1_1, "double_counter_2", 1);
@@ -254,7 +253,7 @@ public class StatSamplerIntegrationTest {
     incLong(st1_1, "long_gauge_11", -1);
     incLong(st1_1, "long_gauge_12", 1);
 
-    awaitStatSample(samplerStats);
+    waitForStatSamplerToRun(samplerStats);
 
     incDouble(st1_1, "double_counter_1", 1);
     incDouble(st1_1, "double_counter_2", 1);
@@ -269,7 +268,13 @@ public class StatSamplerIntegrationTest {
     incLong(st1_1, "long_gauge_11", 1);
     incLong(st1_1, "long_gauge_12", 1);
 
-    awaitStatSample(samplerStats);
+    /*
+     * After updating all stats we should wait for the stat sampler to run at least twice. The
+     * first statSampler iteration may be running as the stats are being updated. The second
+     * statSampler iteration
+     * makes sure that all the stats we care about have been sampled and flush to the stat archive
+     */
+    waitForStatSamplerToRun(samplerStats, 2);
 
     factory.close();
 
@@ -278,8 +283,8 @@ public class StatSamplerIntegrationTest {
     final StatArchiveReader reader = new StatArchiveReader(new File[] {archiveFile}, null, false);
 
     List resources = reader.getResourceInstList();
-    for (Iterator iter = resources.iterator(); iter.hasNext();) {
-      StatArchiveReader.ResourceInst ri = (StatArchiveReader.ResourceInst) iter.next();
+    for (Object resource : resources) {
+      StatArchiveReader.ResourceInst ri = (StatArchiveReader.ResourceInst) resource;
       String resourceName = ri.getName();
       assertNotNull(resourceName);
 
@@ -317,10 +322,14 @@ public class StatSamplerIntegrationTest {
     return samplerStatsInstances != null && samplerStatsInstances.length > 0;
   }
 
-  private void awaitStatSample(final Statistics samplerStats) throws InterruptedException {
-    int startSampleCount = samplerStats.getInt("sampleCount");
-    await("awaiting stat sample").atMost(30, SECONDS)
-        .until(() -> samplerStats.getInt("sampleCount") > startSampleCount);
+  private void waitForStatSamplerToRun(final Statistics samplerStats, final int timesToRun) {
+    final int startSampleCount = samplerStats.getInt("sampleCount");
+    await("waiting for the StatSampler to run").atMost(30, SECONDS)
+        .until(() -> samplerStats.getInt("sampleCount") >= startSampleCount + timesToRun);
+  }
+
+  private void waitForStatSamplerToRun(final Statistics samplerStats) {
+    waitForStatSamplerToRun(samplerStats, 1);
   }
 
   private void incDouble(Statistics statistics, String stat, double value) {
@@ -344,12 +353,7 @@ public class StatSamplerIntegrationTest {
   }
 
   private Map<String, Number> getOrCreateExpectedValueMap(final Statistics statistics) {
-    Map<String, Number> statValues = this.allStatistics.get(statistics.getTextId());
-    if (statValues == null) {
-      statValues = new HashMap<String, Number>();
-      this.allStatistics.put(statistics.getTextId(), statValues);
-    }
-    return statValues;
+    return this.allStatistics.computeIfAbsent(statistics.getTextId(), k -> new HashMap<>());
   }
 
   private void incLong(Statistics statistics, String stat, long value) {


### PR DESCRIPTION
Test waits for stats sampler to run _twice_ before reading
archive (file). Prevents reading before all stat changes arrive in file.

Co-authored-by: Ken Howe <khowe@pivotal.io>
Co-authored-by: Bill Burcham <bburcham@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
