### PR TITLE
GEODE-5747: Handling SocketException consistently

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/tcpserver/TcpServerJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/tcpserver/TcpServerJUnitTest.java
@@ -18,12 +18,18 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.EOFException;
 import java.io.IOException;
 import java.net.ConnectException;
 import java.net.InetAddress;
+import java.net.SocketException;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -34,6 +40,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 import org.apache.geode.DataSerializable;
 import org.apache.geode.cache.GemFireCache;
@@ -79,18 +87,20 @@ public class TcpServerJUnitTest {
     EchoHandler handler = new EchoHandler();
     start(handler);
 
+    TcpClient tcpClient = new TcpClient();
+
     TestObject test = new TestObject();
     test.id = 5;
     TestObject result =
-        (TestObject) new TcpClient().requestToServer(localhost, port, test, 60 * 1000);
+        (TestObject) tcpClient.requestToServer(localhost, port, test, 60 * 1000);
     assertEquals(test.id, result.id);
 
-    String[] info = new TcpClient().getInfo(localhost, port);
+    String[] info = tcpClient.getInfo(localhost, port);
     assertNotNull(info);
     assertTrue(info.length > 1);
 
     try {
-      new TcpClient().stop(localhost, port);
+      tcpClient.stop(localhost, port);
     } catch (ConnectException ignore) {
       // must not be running
     }
@@ -109,12 +119,14 @@ public class TcpServerJUnitTest {
     DelayHandler handler = new DelayHandler(latch);
     start(handler);
 
+    TcpClient tcpClient = new TcpClient();
+
     final AtomicBoolean done = new AtomicBoolean();
     Thread delayedThread = new Thread() {
       public void run() {
         Boolean delay = Boolean.valueOf(true);
         try {
-          new TcpClient().requestToServer(localhost, port, delay, 60 * 1000);
+          tcpClient.requestToServer(localhost, port, delay, 60 * 1000);
         } catch (IOException e) {
           e.printStackTrace();
         } catch (ClassNotFoundException e) {
@@ -127,7 +139,7 @@ public class TcpServerJUnitTest {
     try {
       Thread.sleep(500);
       assertFalse(done.get());
-      new TcpClient().requestToServer(localhost, port, Boolean.valueOf(false), 60 * 1000);
+      tcpClient.requestToServer(localhost, port, Boolean.valueOf(false), 60 * 1000);
       assertFalse(done.get());
 
       latch.countDown();
@@ -138,12 +150,61 @@ public class TcpServerJUnitTest {
       delayedThread.join(60 * 1000);
       assertTrue(!delayedThread.isAlive()); // GemStoneAddition
       try {
-        new TcpClient().stop(localhost, port);
+        tcpClient.stop(localhost, port);
       } catch (ConnectException ignore) {
         // must not be running
       }
       server.join(60 * 1000);
     }
+  }
+
+  @Test
+  public void testNewConnectionsAcceptedAfterSocketException() throws IOException,
+      ClassNotFoundException, InterruptedException {
+    // Initially mock the handler to throw a SocketException. We want to verify that the server
+    // can recover and serve new client requests after a SocketException is thrown.
+    TcpHandler mockTcpHandler = mock(TcpHandler.class);
+    doThrow(SocketException.class).when(mockTcpHandler).processRequest(any(Object.class));
+    start(mockTcpHandler);
+
+    TcpClient tcpClient = new TcpClient();
+
+    // Due to the mocked handler, an EOFException will be thrown on the client. This is expected,
+    // so we just catch it.
+    try {
+      tcpClient.requestToServer(localhost, port, new TestObject(), 60 * 1000);
+    } catch (EOFException eofEx) {
+    }
+
+    // Change the mock handler behavior to echo the request back
+    doAnswer(new Answer() {
+      @Override
+      public Object answer(InvocationOnMock invocation) throws Throwable {
+        return invocation.getArgument(0);
+      }
+    }).when(mockTcpHandler).processRequest(any(Object.class));
+
+    // Perform another request and validate that it was served successfully
+    TestObject test = new TestObject();
+    test.id = 5;
+    TestObject result =
+        (TestObject) tcpClient.requestToServer(localhost, port, test, 60 * 1000);
+
+    assertEquals(test.id, result.id);
+    String[] info = tcpClient.getInfo(localhost, port);
+    assertNotNull(info);
+    assertTrue(info.length > 1);
+
+    try {
+      tcpClient.stop(localhost, port);
+    } catch (ConnectException ignore) {
+      // must not be running
+    }
+    server.join(60 * 1000);
+    assertFalse(server.isAlive());
+
+    assertEquals(5, stats.started.get());
+    assertEquals(5, stats.ended.get());
   }
 
   private static class TestObject implements DataSerializable {

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/TcpServer.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/TcpServer.java
@@ -24,6 +24,7 @@ import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketAddress;
+import java.net.SocketException;
 import java.net.URL;
 import java.util.Date;
 import java.util.HashMap;
@@ -386,7 +387,7 @@ public class TcpServer {
         } else {
           rejectUnknownProtocolConnection(socket, firstByte);
         }
-      } catch (EOFException ignore) {
+      } catch (EOFException | SocketException ignore) {
         // client went away - ignore
       } catch (CancelException ignore) {
         // ignore


### PR DESCRIPTION
Attempting to make handling of EOFException and SocketException consistent.  This exception handling and an Assert were the only differences between readDataSerializable(DataInput) and readDataSerializableFixedID(DataInput), so we refactored that and were able to delete the FixedID version of the method.

It doesn't make sense that we would handle EOFException and SocketException in readDataSerializable(DataInput), but not in readDataSerializableFixedID(DataInput).  Looking back at the history of the original EOFException handling in readDataSerializable(DataInput), it looks like this was a quick patch fix because this exception was seen/unhandled in readDataSerializable(DataInput), but there is no reason the same issue couldn't happen in the readDataSerializableFixedID(DataInput) method as well.

In TCPServer, we were swallowing EOFExceptions, so it makes sense to do the same for SocketExceptions since they can also be caused by the client closing their socket.  This has no functional implications other than we won't log an info (or fatal, depending on if the socket is closed) error message.  We still will loop back around and accept new connections with this change.  A test was added verify this.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [X] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
