### PR TITLE
GEODE-5523: Remove DefaultHashMap

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/stats/AggregateRegionStatsMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/stats/AggregateRegionStatsMonitor.java
@@ -60,11 +60,11 @@ public class AggregateRegionStatsMonitor extends MBeanStatsMonitor {
     return bucketCount;
   }
 
-  public long getLruDestroys() {
+  long getLruDestroys() {
     return lruDestroys;
   }
 
-  public long getLruEvictions() {
+  long getLruEvictions() {
     return lruEvictions;
   }
 
@@ -90,34 +90,34 @@ public class AggregateRegionStatsMonitor extends MBeanStatsMonitor {
     listeners = new HashMap<>();
   }
 
-  Number computeDelta(DefaultHashMap statsMap, String name, Number currentValue) {
+  Number computeDelta(Map<String, Number> statsMap, String name, Number currentValue) {
     if (name.equals(StatsKey.PRIMARY_BUCKET_COUNT)) {
-      Number prevValue = statsMap.get(StatsKey.PRIMARY_BUCKET_COUNT);
+      Number prevValue = statsMap.getOrDefault(StatsKey.PRIMARY_BUCKET_COUNT, 0);
       return currentValue.intValue() - prevValue.intValue();
     }
 
     if (name.equals(StatsKey.BUCKET_COUNT)) {
-      Number prevValue = statsMap.get(StatsKey.BUCKET_COUNT);
+      Number prevValue = statsMap.getOrDefault(StatsKey.BUCKET_COUNT, 0);
       return currentValue.intValue() - prevValue.intValue();
     }
 
     if (name.equals(StatsKey.TOTAL_BUCKET_SIZE)) {
-      Number prevValue = statsMap.get(StatsKey.TOTAL_BUCKET_SIZE);
+      Number prevValue = statsMap.getOrDefault(StatsKey.TOTAL_BUCKET_SIZE, 0);
       return currentValue.intValue() - prevValue.intValue();
     }
 
     if (name.equals(StatsKey.LRU_EVICTIONS)) {
-      Number prevValue = statsMap.get(StatsKey.LRU_EVICTIONS);
+      Number prevValue = statsMap.getOrDefault(StatsKey.LRU_EVICTIONS, 0);
       return currentValue.longValue() - prevValue.longValue();
     }
 
     if (name.equals(StatsKey.LRU_DESTROYS)) {
-      Number prevValue = statsMap.get(StatsKey.LRU_DESTROYS);
+      Number prevValue = statsMap.getOrDefault(StatsKey.LRU_DESTROYS, 0);
       return currentValue.longValue() - prevValue.longValue();
     }
 
     if (name.equals(StatsKey.DISK_SPACE)) {
-      Number prevValue = statsMap.get(StatsKey.DISK_SPACE);
+      Number prevValue = statsMap.getOrDefault(StatsKey.DISK_SPACE, 0);
       return currentValue.longValue() - prevValue.longValue();
     }
 
@@ -242,7 +242,7 @@ public class AggregateRegionStatsMonitor extends MBeanStatsMonitor {
   public void removeStatisticsFromMonitor(Statistics stats) {}
 
   class MemberLevelRegionStatisticsListener implements StatisticsListener {
-    final DefaultHashMap statsMap = new DefaultHashMap();
+    final Map<String, Number> statsMap = new HashMap<>();
     private boolean removed = false;
 
     @Override

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/stats/GCStatsMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/stats/GCStatsMonitor.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.management.internal.beans.stats;
 
+import java.util.Map;
+
 import org.apache.geode.StatisticDescriptor;
 import org.apache.geode.distributed.ConfigurationProperties;
 import org.apache.geode.internal.statistics.StatisticId;
@@ -52,9 +54,9 @@ public class GCStatsMonitor extends MBeanStatsMonitor {
     super(name);
   }
 
-  void decreasePrevValues(DefaultHashMap statsMap) {
-    collections -= statsMap.get(StatsKey.VM_GC_STATS_COLLECTIONS).longValue();
-    collectionTime -= statsMap.get(StatsKey.VM_GC_STATS_COLLECTION_TIME).longValue();
+  void decreasePrevValues(Map<String, Number> statsMap) {
+    collections -= statsMap.getOrDefault(StatsKey.VM_GC_STATS_COLLECTIONS, 0).longValue();
+    collectionTime -= statsMap.getOrDefault(StatsKey.VM_GC_STATS_COLLECTION_TIME, 0).longValue();
   }
 
   void increaseStats(String name, Number value) {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/stats/GatewaySenderOverflowMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/stats/GatewaySenderOverflowMonitor.java
@@ -50,7 +50,7 @@ public class GatewaySenderOverflowMonitor extends MBeanStatsMonitor {
   private final Map<Statistics, ValueMonitor> monitors;
   private final Map<Statistics, StatisticsListener> listeners;
 
-  public long getLruEvictions() {
+  long getLruEvictions() {
     return lruEvictions;
   }
 
@@ -76,19 +76,20 @@ public class GatewaySenderOverflowMonitor extends MBeanStatsMonitor {
     listeners = new HashMap<>();
   }
 
-  Number computeDelta(DefaultHashMap statsMap, String name, Number currentValue) {
+  Number computeDelta(Map<String, Number> statsMap, String name, Number currentValue) {
     if (name.equals(StatsKey.GATEWAYSENDER_LRU_EVICTIONS)) {
-      Number prevValue = statsMap.get(StatsKey.GATEWAYSENDER_LRU_EVICTIONS);
+      Number prevValue = statsMap.getOrDefault(StatsKey.GATEWAYSENDER_LRU_EVICTIONS, 0);
       return currentValue.longValue() - prevValue.longValue();
     }
 
     if (name.equals(StatsKey.GATEWAYSENDER_ENTRIES_OVERFLOWED_TO_DISK)) {
-      Number prevValue = statsMap.get(StatsKey.GATEWAYSENDER_ENTRIES_OVERFLOWED_TO_DISK);
+      Number prevValue =
+          statsMap.getOrDefault(StatsKey.GATEWAYSENDER_ENTRIES_OVERFLOWED_TO_DISK, 0);
       return currentValue.longValue() - prevValue.longValue();
     }
 
     if (name.equals(StatsKey.GATEWAYSENDER_BYTES_OVERFLOWED_TO_DISK)) {
-      Number prevValue = statsMap.get(StatsKey.GATEWAYSENDER_BYTES_OVERFLOWED_TO_DISK);
+      Number prevValue = statsMap.getOrDefault(StatsKey.GATEWAYSENDER_BYTES_OVERFLOWED_TO_DISK, 0);
       return currentValue.longValue() - prevValue.longValue();
     }
 
@@ -156,7 +157,7 @@ public class GatewaySenderOverflowMonitor extends MBeanStatsMonitor {
   public void removeStatisticsFromMonitor(Statistics stats) {}
 
   class GatewaySenderOverflowStatisticsListener implements StatisticsListener {
-    DefaultHashMap statsMap = new DefaultHashMap();
+    Map<String, Number> statsMap = new HashMap<>();
 
     @Override
     public void handleNotification(StatisticsNotification notification) {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/stats/MBeanStatsMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/stats/MBeanStatsMonitor.java
@@ -41,9 +41,9 @@ public class MBeanStatsMonitor implements StatisticsListener {
   /**
    * Map which contains statistics with their name and value
    */
-  protected DefaultHashMap statsMap;
+  protected Map<String, Number> statsMap;
 
-  protected String monitorName;
+  private String monitorName;
 
   public MBeanStatsMonitor(final String name) {
     this(name, new ValueMonitor());
@@ -52,7 +52,7 @@ public class MBeanStatsMonitor implements StatisticsListener {
   MBeanStatsMonitor(final String name, final ValueMonitor monitor) {
     this.monitorName = name;
     this.monitor = monitor;
-    this.statsMap = new DefaultHashMap();
+    this.statsMap = new HashMap<>();
   }
 
   public void addStatisticsToMonitor(final Statistics stats) {
@@ -63,6 +63,7 @@ public class MBeanStatsMonitor implements StatisticsListener {
     for (StatisticDescriptor d : descriptors) {
       statsMap.put(d.getName(), stats.get(d));
     }
+
     monitor.addStatistics(stats);
   }
 
@@ -75,7 +76,7 @@ public class MBeanStatsMonitor implements StatisticsListener {
   }
 
   public Number getStatistic(final String statName) {
-    Number value = statsMap.get(statName);
+    Number value = statsMap.getOrDefault(statName, 0);
     return value != null ? value : 0;
   }
 
@@ -100,30 +101,4 @@ public class MBeanStatsMonitor implements StatisticsListener {
       logger.trace("Monitor = {} descriptor = {} And value = {}", monitorName, name, value);
     }
   }
-
-  public static class DefaultHashMap { // TODO: delete this class
-    private Map<String, Number> internalMap = new HashMap<>();
-
-    public DefaultHashMap() {}
-
-    public Number get(final String key) {
-      return internalMap.get(key) != null ? internalMap.get(key) : 0;
-    }
-
-    public void put(final String key, final Number value) {
-      internalMap.put(key, value);
-    }
-
-    public void clear() {
-      internalMap.clear();
-    }
-
-    /**
-     * For testing only
-     */
-    Map<String, Number> getInternalMap() {
-      return this.internalMap;
-    }
-  }
-
 }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/stats/MemberLevelDiskMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/stats/MemberLevelDiskMonitor.java
@@ -62,15 +62,15 @@ public class MemberLevelDiskMonitor extends MBeanStatsMonitor {
     return queueSize;
   }
 
-  public long getFlushTime() {
+  long getFlushTime() {
     return flushTime;
   }
 
-  public long getFlushedBytes() {
+  long getFlushedBytes() {
     return flushedBytes;
   }
 
-  public long getDiskReadBytes() {
+  long getDiskReadBytes() {
     return diskReadBytes;
   }
 
@@ -78,7 +78,7 @@ public class MemberLevelDiskMonitor extends MBeanStatsMonitor {
     return backupsCompleted;
   }
 
-  public long getDiskWrittenBytes() {
+  long getDiskWrittenBytes() {
     return diskWrittenBytes;
   }
 
@@ -100,51 +100,51 @@ public class MemberLevelDiskMonitor extends MBeanStatsMonitor {
     listeners = new HashMap<>();
   }
 
-  Number computeDelta(DefaultHashMap statsMap, String name, Number currentValue) {
+  Number computeDelta(Map<String, Number> statsMap, String name, Number currentValue) {
     if (name.equals(StatsKey.DISK_READ_BYTES)) {
-      Number prevValue = statsMap.get(StatsKey.DISK_READ_BYTES);
+      Number prevValue = statsMap.getOrDefault(StatsKey.DISK_READ_BYTES, 0);
       return currentValue.longValue() - prevValue.longValue();
     }
 
     if (name.equals(StatsKey.DISK_RECOVERED_BYTES)) {
-      Number prevValue = statsMap.get(StatsKey.DISK_RECOVERED_BYTES);
+      Number prevValue = statsMap.getOrDefault(StatsKey.DISK_RECOVERED_BYTES, 0);
       return currentValue.longValue() - prevValue.longValue();
     }
 
     if (name.equals(StatsKey.DISK_WRITEN_BYTES)) {
-      Number prevValue = statsMap.get(StatsKey.DISK_WRITEN_BYTES);
+      Number prevValue = statsMap.getOrDefault(StatsKey.DISK_WRITEN_BYTES, 0);
       return currentValue.longValue() - prevValue.longValue();
     }
 
     if (name.equals(StatsKey.BACKUPS_IN_PROGRESS)) {
       // A negative value is also OK. previous backup_in_progress = 5 curr_backup_in_progress = 2
       // delta = -3 delta should be added to aggregate backup in progress
-      Number prevValue = statsMap.get(StatsKey.BACKUPS_IN_PROGRESS);
+      Number prevValue = statsMap.getOrDefault(StatsKey.BACKUPS_IN_PROGRESS, 0);
       return currentValue.intValue() - prevValue.intValue();
     }
 
     if (name.equals(StatsKey.BACKUPS_COMPLETED)) {
-      Number prevValue = statsMap.get(StatsKey.BACKUPS_COMPLETED);
+      Number prevValue = statsMap.getOrDefault(StatsKey.BACKUPS_COMPLETED, 0);
       return currentValue.intValue() - prevValue.intValue();
     }
 
     if (name.equals(StatsKey.FLUSHED_BYTES)) {
-      Number prevValue = statsMap.get(StatsKey.FLUSHED_BYTES);
+      Number prevValue = statsMap.getOrDefault(StatsKey.FLUSHED_BYTES, 0);
       return currentValue.longValue() - prevValue.longValue();
     }
 
     if (name.equals(StatsKey.NUM_FLUSHES)) {
-      Number prevValue = statsMap.get(StatsKey.NUM_FLUSHES);
+      Number prevValue = statsMap.getOrDefault(StatsKey.NUM_FLUSHES, 0);
       return currentValue.longValue() - prevValue.longValue();
     }
 
     if (name.equals(StatsKey.TOTAL_FLUSH_TIME)) {
-      Number prevValue = statsMap.get(StatsKey.TOTAL_FLUSH_TIME);
+      Number prevValue = statsMap.getOrDefault(StatsKey.TOTAL_FLUSH_TIME, 0);
       return currentValue.longValue() - prevValue.longValue();
     }
 
     if (name.equals(StatsKey.DISK_QUEUE_SIZE)) {
-      Number prevValue = statsMap.get(StatsKey.DISK_QUEUE_SIZE);
+      Number prevValue = statsMap.getOrDefault(StatsKey.DISK_QUEUE_SIZE, 0);
       return currentValue.intValue() - prevValue.intValue();
     }
 
@@ -271,7 +271,7 @@ public class MemberLevelDiskMonitor extends MBeanStatsMonitor {
   }
 
   class MemberLevelDiskStatisticsListener implements StatisticsListener {
-    DefaultHashMap statsMap = new DefaultHashMap();
+    Map<String, Number> statsMap = new HashMap<>();
     private boolean removed = false;
 
     @Override

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/stats/VMStatsMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/stats/VMStatsMonitor.java
@@ -93,7 +93,7 @@ public class VMStatsMonitor extends MBeanStatsMonitor {
    */
   synchronized void refreshStats() {
     if (processCPUTimeAvailable) {
-      Number processCpuTime = statsMap.get(StatsKey.VM_PROCESS_CPU_TIME);
+      Number processCpuTime = statsMap.getOrDefault(StatsKey.VM_PROCESS_CPU_TIME, 0);
 
       // Some JVM like IBM is not handled by Stats layer properly. Ignoring the attribute for such
       // cases

--- a/geode-core/src/test/java/org/apache/geode/management/internal/beans/stats/AggregateRegionStatsMonitorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/beans/stats/AggregateRegionStatsMonitorTest.java
@@ -22,6 +22,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -83,13 +86,14 @@ public class AggregateRegionStatsMonitorTest {
 
   @Test
   public void computeDeltaShouldReturnZeroForUnknownStatistics() {
-    assertThat(aggregateRegionStatsMonitor.computeDelta(new MBeanStatsMonitor.DefaultHashMap(),
-        "unknownStatistic", 6)).isEqualTo(0);
+    assertThat(
+        aggregateRegionStatsMonitor.computeDelta(Collections.emptyMap(), "unknownStatistic", 6))
+            .isEqualTo(0);
   }
 
   @Test
   public void computeDeltaShouldOperateForHandledStatistics() {
-    MBeanStatsMonitor.DefaultHashMap statsMap = new MBeanStatsMonitor.DefaultHashMap();
+    Map<String, Number> statsMap = new HashMap<>();
     statsMap.put(StatsKey.PRIMARY_BUCKET_COUNT, 5);
     statsMap.put(StatsKey.BUCKET_COUNT, 13);
     statsMap.put(StatsKey.TOTAL_BUCKET_SIZE, 1024);

--- a/geode-core/src/test/java/org/apache/geode/management/internal/beans/stats/GCStatsMonitorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/beans/stats/GCStatsMonitorTest.java
@@ -16,6 +16,9 @@ package org.apache.geode.management.internal.beans.stats;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -73,7 +76,7 @@ public class GCStatsMonitorTest {
     gcStatsMonitor.increaseStats(StatsKey.VM_GC_STATS_COLLECTION_TIME, 10000);
     assertThat(gcStatsMonitor.getStatistic(StatsKey.VM_GC_STATS_COLLECTIONS)).isEqualTo(10L);
     assertThat(gcStatsMonitor.getStatistic(StatsKey.VM_GC_STATS_COLLECTION_TIME)).isEqualTo(10000L);
-    MBeanStatsMonitor.DefaultHashMap statsMap = new MBeanStatsMonitor.DefaultHashMap();
+    Map<String, Number> statsMap = new HashMap<>();
     statsMap.put(StatsKey.VM_GC_STATS_COLLECTIONS, 5);
     statsMap.put(StatsKey.VM_GC_STATS_COLLECTION_TIME, 5000);
 

--- a/geode-core/src/test/java/org/apache/geode/management/internal/beans/stats/GatewaySenderOverflowMonitorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/beans/stats/GatewaySenderOverflowMonitorTest.java
@@ -22,6 +22,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -80,13 +83,14 @@ public class GatewaySenderOverflowMonitorTest {
 
   @Test
   public void computeDeltaShouldReturnZeroForUnknownStatistics() {
-    assertThat(gatewaySenderOverflowMonitor.computeDelta(new MBeanStatsMonitor.DefaultHashMap(),
-        "unknownStatistic", 6)).isEqualTo(0);
+    assertThat(
+        gatewaySenderOverflowMonitor.computeDelta(Collections.emptyMap(), "unknownStatistic", 6))
+            .isEqualTo(0);
   }
 
   @Test
   public void computeDeltaShouldOperateForHandledStatistics() {
-    MBeanStatsMonitor.DefaultHashMap statsMap = new MBeanStatsMonitor.DefaultHashMap();
+    Map<String, Number> statsMap = new HashMap<>();
     statsMap.put(StatsKey.GATEWAYSENDER_LRU_EVICTIONS, 50);
     statsMap.put(StatsKey.GATEWAYSENDER_BYTES_OVERFLOWED_TO_DISK, 2048);
     statsMap.put(StatsKey.GATEWAYSENDER_ENTRIES_OVERFLOWED_TO_DISK, 100);

--- a/geode-core/src/test/java/org/apache/geode/management/internal/beans/stats/MBeanStatsMonitorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/beans/stats/MBeanStatsMonitorTest.java
@@ -32,28 +32,19 @@ import org.junit.rules.TestName;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.mockito.Spy;
 
 import org.apache.geode.StatisticDescriptor;
 import org.apache.geode.Statistics;
 import org.apache.geode.StatisticsType;
-import org.apache.geode.i18n.LogWriterI18n;
 import org.apache.geode.internal.statistics.FakeValueMonitor;
 import org.apache.geode.internal.statistics.ValueMonitor;
-import org.apache.geode.management.internal.beans.stats.MBeanStatsMonitor.DefaultHashMap;
 
 public class MBeanStatsMonitorTest {
 
   private ValueMonitor statsMonitor;
 
-  private StatisticDescriptor[] descriptors;
-
   private Map<String, Number> expectedStatsMap;
 
-  @Spy
-  private DefaultHashMap statsMap;
-  @Mock
-  private LogWriterI18n logWriter;
   @Mock
   private Statistics stats;
   @Mock
@@ -73,47 +64,58 @@ public class MBeanStatsMonitorTest {
     MockitoAnnotations.initMocks(this);
 
     this.expectedStatsMap = new HashMap<>();
-    this.descriptors = new StatisticDescriptor[3];
-    for (int i = 0; i < this.descriptors.length; i++) {
+    StatisticDescriptor[] descriptors = new StatisticDescriptor[3];
+    for (int i = 0; i < descriptors.length; i++) {
       String key = "stat-" + String.valueOf(i + 1);
       Number value = i + 1;
 
       this.expectedStatsMap.put(key, value);
 
-      this.descriptors[i] = mock(StatisticDescriptor.class);
-      when(this.descriptors[i].getName()).thenReturn(key);
-      when(this.stats.get(this.descriptors[i])).thenReturn(value);
+      descriptors[i] = mock(StatisticDescriptor.class);
+      when(descriptors[i].getName()).thenReturn(key);
+      when(this.stats.get(descriptors[i])).thenReturn(value);
     }
 
-    when(this.statsType.getStatistics()).thenReturn(this.descriptors);
+    when(this.statsType.getStatistics()).thenReturn(descriptors);
     when(this.stats.getType()).thenReturn(this.statsType);
   }
 
   @Test
-  public void addStatisticsToMonitorShouldAddToInternalMap() throws Exception {
-    this.mbeanStatsMonitor.addStatisticsToMonitor(this.stats);
-
-    assertThat(statsMap.getInternalMap()).containsAllEntriesOf(this.expectedStatsMap);
+  public void getStatisticShouldReturnZeroWhenRequestedStatisticDoesNotExist() {
+    assertThat(mbeanStatsMonitor.getStatistic("unknownStatistic")).isNotNull().isEqualTo(0);
   }
 
   @Test
-  public void addStatisticsToMonitorShouldAddListener() throws Exception {
+  public void getStatisticShouldReturnStoredValueWhenRequestedStatisticExists() {
+    mbeanStatsMonitor.addStatisticsToMonitor(stats);
+    expectedStatsMap
+        .forEach((k, v) -> assertThat(mbeanStatsMonitor.getStatistic(k)).isNotNull().isEqualTo(v));
+  }
+
+  @Test
+  public void addStatisticsToMonitorShouldAddToInternalMap() {
+    this.mbeanStatsMonitor.addStatisticsToMonitor(this.stats);
+
+    assertThat(mbeanStatsMonitor.statsMap).containsAllEntriesOf(this.expectedStatsMap);
+  }
+
+  @Test
+  public void addStatisticsToMonitorShouldAddListener() {
     this.mbeanStatsMonitor.addStatisticsToMonitor(this.stats);
 
     verify(this.statsMonitor, times(1)).addListener(this.mbeanStatsMonitor);
   }
 
   @Test
-  public void addStatisticsToMonitorShouldAddStatistics() throws Exception {
+  public void addStatisticsToMonitorShouldAddStatistics() {
     this.mbeanStatsMonitor.addStatisticsToMonitor(this.stats);
 
     verify(this.statsMonitor, times(1)).addStatistics(this.stats);
   }
 
   @Test
-  public void addNullStatisticsToMonitorShouldThrowNPE() throws Exception {
+  public void addNullStatisticsToMonitorShouldThrowNPE() {
     assertThatThrownBy(() -> this.mbeanStatsMonitor.addStatisticsToMonitor(null))
         .isExactlyInstanceOf(NullPointerException.class);
   }
-
 }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/beans/stats/MemberLevelDiskMonitorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/beans/stats/MemberLevelDiskMonitorTest.java
@@ -22,6 +22,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -84,13 +87,13 @@ public class MemberLevelDiskMonitorTest {
 
   @Test
   public void computeDeltaShouldReturnZeroForUnknownStatistics() {
-    assertThat(memberLevelDiskMonitor.computeDelta(new MBeanStatsMonitor.DefaultHashMap(),
-        "unknownStatistic", 6)).isEqualTo(0);
+    assertThat(memberLevelDiskMonitor.computeDelta(Collections.emptyMap(), "unknownStatistic", 6))
+        .isEqualTo(0);
   }
 
   @Test
   public void computeDeltaShouldOperateForHandledStatistics() {
-    MBeanStatsMonitor.DefaultHashMap statsMap = new MBeanStatsMonitor.DefaultHashMap();
+    Map<String, Number> statsMap = new HashMap<>();
     statsMap.put(StatsKey.NUM_FLUSHES, 10);
     statsMap.put(StatsKey.DISK_QUEUE_SIZE, 148);
     statsMap.put(StatsKey.TOTAL_FLUSH_TIME, 10000);


### PR DESCRIPTION
The internal class `DefaultHashMap` was designed as an internal
workaround to return a default value whenever the value returned by
`Map.get(K)` was `null`. Starting with Java 8 the `Map` interface
added the method `getOrDefault`, which does something similar in a more
efficient way but it returns the default only if the key doesn't exist.
After inspecting the code, we don't insert `null` values into the
`statsMap`, so it is safe to delete the old `DefaultHashMap` class and
replace its usaged by `Map.getOrDefault`.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
