### PR TITLE
GEODE-5728: Allow null coordinator in equals()

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocator.java
@@ -306,7 +306,7 @@ public class GMSLocator implements Locator, NetLocator {
       if (isCoordinator) {
         coordinator = localAddress;
 
-        if (v != null && !v.getCoordinator().equals(localAddress)) {
+        if (v != null && localAddress != null && !localAddress.equals(v.getCoordinator())) {
           logger.info("This member is becoming coordinator since view {}", v);
           v = null;
         }


### PR DESCRIPTION
The call to equals() assumed that coordinator was non-null, but
coordinator may legitimately be null.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.

Please review: @balesh2 @galen-pivotal @upthewaterspout @pdxrunner 