### PR TITLE
GEODE-5212: fix failing ConcurrentDeployDUnitTest

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/DeployedJar.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/DeployedJar.java
@@ -267,11 +267,14 @@ public class DeployedJar {
 
   private byte[] fileDigest(File file) throws IOException {
     BufferedInputStream fis = new BufferedInputStream(new FileInputStream(file));
-    byte[] data = new byte[8192];
-
-    int read;
-    while ((read = fis.read(data)) > 0) {
-      messageDigest.update(data, 0, read);
+    try {
+      byte[] data = new byte[8192];
+      int read;
+      while ((read = fis.read(data)) > 0) {
+        messageDigest.update(data, 0, read);
+      }
+    } finally {
+      fis.close();
     }
 
     return messageDigest.digest();


### PR DESCRIPTION
  This test was failing on windows with a unexpected
  suspect string. The underlying problem is that an
  input stream kept open and causes the deletion to
  fail.

  This fix also fixes:
  * CreateRegionCommandDUnitTest
  * DeployCommandRedeployDUnitTest
        - hotDeployShouldNotResultInAnyFailedFunctionExecutions
        - redeployJarsWithNewVersionsOfFunctions

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
