### PR TITLE
GEODE-5778: fix for failing rsync on windows CI jobs

### DIFF
--- a/ci/pipelines/geode-build/jinja.template.yml
+++ b/ci/pipelines/geode-build/jinja.template.yml
@@ -330,6 +330,7 @@ jobs:
         - name: geode
         - name: instance-data
       timeout: 15m
+      attempts: 100
     - task: execute_tests
       {{ alpine_tools_config()|indent(6) }}
         params:
@@ -355,6 +356,7 @@ jobs:
           outputs:
           - name: geode-results
         timeout: 15m
+        attempts: 100
       ensure:
         do:
         - aggregate:


### PR DESCRIPTION
rsync code to the build machine fails intermintently
on windows and so retrying for now until we find a
solution.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
