### PR TITLE
GEODE-5212: Ensure that MergeLogs closes its InputStreams

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/util/MergeLogsDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/util/MergeLogsDUnitTest.java
@@ -26,8 +26,10 @@ import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.io.FileUtils;
+import org.awaitility.Awaitility;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -59,12 +61,19 @@ public class MergeLogsDUnitTest {
     MemberVM server = lsRule.startServerVM(1, properties, locator.getPort());
     MemberVM server2 = lsRule.startServerVM(2, properties, locator.getPort());
 
+    // Especially on Windows, wait for time to pass otherwise all log messages may appear in the
+    // same millisecond.
     locator.invoke(() -> LogService.getLogger().info(MESSAGE_1));
+    Awaitility.await().atLeast(1, TimeUnit.MILLISECONDS).until(() -> true);
     server.invoke(() -> LogService.getLogger().info(MESSAGE_2));
+    Awaitility.await().atLeast(1, TimeUnit.MILLISECONDS).until(() -> true);
     server2.invoke(() -> LogService.getLogger().info(MESSAGE_3));
+    Awaitility.await().atLeast(1, TimeUnit.MILLISECONDS).until(() -> true);
 
     locator.invoke(() -> LogService.getLogger().info(MESSAGE_4));
+    Awaitility.await().atLeast(1, TimeUnit.MILLISECONDS).until(() -> true);
     server.invoke(() -> LogService.getLogger().info(MESSAGE_5));
+    Awaitility.await().atLeast(1, TimeUnit.MILLISECONDS).until(() -> true);
     server2.invoke(() -> LogService.getLogger().info(MESSAGE_6));
   }
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/logging/MergeLogFilesJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/logging/MergeLogFilesJUnitTest.java
@@ -28,8 +28,10 @@ import java.io.PrintWriter;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -81,20 +83,18 @@ public class MergeLogFilesJUnitTest {
     }
 
     // Merge the log files together
-    InputStream[] streams = new InputStream[workers.size()];
-    String[] names = new String[workers.size()];
+    Map<String, InputStream> logs = new HashMap<>();
     for (int i = 0; i < workers.size(); i++) {
       Worker worker = (Worker) workers.get(i);
-      streams[i] = worker.getInputStream();
-      names[i] = worker.getName();
+      logs.put(worker.getName(), worker.getInputStream());
     }
     StringWriter sw = new StringWriter();
     PrintWriter pw = new PrintWriter(sw, true);
-    MergeLogFiles.mergeLogFiles(streams, names, pw);
+    MergeLogFiles.mergeLogFiles(logs, pw);
 
     // System.out.println(sw.toString());
 
-    // Verfiy that the entries are sorted
+    // Verify that the entries are sorted
     BufferedReader br = new BufferedReader(new StringReader(sw.toString()));
     Pattern pattern = Pattern.compile("^Worker \\d+: .* VALUE: (\\d+)");
     int lastValue = -1;

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/LogCollator.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/LogCollator.java
@@ -20,7 +20,9 @@ import java.io.InputStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.geode.internal.admin.ApplicationVM;
 import org.apache.geode.internal.admin.GemFireVM;
@@ -54,18 +56,16 @@ public class LogCollator {
 
   private String mergeLogs() {
     // combine logs...
-    InputStream[] logFiles = new InputStream[this.logTails.size()];
-    String[] logFileNames = new String[logFiles.length];
+    Map<String, InputStream> logFiles = new HashMap<>();
     for (int i = 0; i < this.logTails.size(); i++) {
       Loglet loglet = (Loglet) this.logTails.get(i);
-      logFiles[i] = new ByteArrayInputStream(loglet.tail.getBytes());
-      logFileNames[i] = loglet.name;
+      logFiles.put(loglet.name, new ByteArrayInputStream(loglet.tail.getBytes()));
     }
 
     // delegate to MergeLogFiles...
     StringWriter writer = new StringWriter();
     PrintWriter mergedLog = new PrintWriter(writer);
-    if (!MergeLogFiles.mergeLogFiles(logFiles, logFileNames, mergedLog)) {
+    if (!MergeLogFiles.mergeLogFiles(logFiles, mergedLog)) {
       return writer.toString();
     } else {
       return "";

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/util/MergeLogs.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/util/MergeLogs.java
@@ -27,7 +27,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.Logger;
@@ -101,12 +103,11 @@ public class MergeLogs {
   static File mergeLogFile(String dirName) throws Exception {
     Path dir = Paths.get(dirName);
     List<File> logsToMerge = findLogFilesToMerge(dir.toFile());
-    InputStream[] logFiles = new FileInputStream[logsToMerge.size()];
-    String[] logFileNames = new String[logFiles.length];
+    Map<String, InputStream> logFiles = new HashMap<>();
     for (int i = 0; i < logsToMerge.size(); i++) {
       try {
-        logFiles[i] = new FileInputStream(logsToMerge.get(i));
-        logFileNames[i] = dir.relativize(logsToMerge.get(i).toPath()).toString();
+        logFiles.put(dir.relativize(logsToMerge.get(i).toPath()).toString(),
+            new FileInputStream(logsToMerge.get(i)));
       } catch (FileNotFoundException e) {
         throw new Exception(
             logsToMerge.get(i) + " " + CliStrings.EXPORT_LOGS__MSG__FILE_DOES_NOT_EXIST);
@@ -120,7 +121,7 @@ public class MergeLogs {
           + new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss").format(new java.util.Date()) + ".log";
       mergedLogFile = new File(mergeLog);
       mergedLog = new PrintWriter(mergedLogFile);
-      MergeLogFiles.mergeLogFiles(logFiles, logFileNames, mergedLog);
+      MergeLogFiles.mergeLogFiles(logFiles, mergedLog);
     } catch (FileNotFoundException e) {
       throw new Exception(
           "FileNotFoundException in creating PrintWriter in MergeLogFiles" + e.getMessage());


### PR DESCRIPTION
- Other refactoring which converted a pair of linked structures (log filename
  and the associated InputStream) into a Map.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
