### PR TITLE
GEODE-5212: fix failing DestroyRegionCommandDUnitTest on windows

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/DestroyRegionCommandDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/DestroyRegionCommandDUnitTest.java
@@ -115,11 +115,13 @@ public class DestroyRegionCommandDUnitTest {
       InternalConfigurationPersistenceService service =
           ClusterStartupRule.getLocator().getConfigurationPersistenceService();
       Configuration group1Config = service.getConfiguration("group1");
-      assertThat(group1Config.getCacheXmlContent()).contains("<region name=\"region1\">\n"
+      assertThat(group1Config.getCacheXmlContent()).contains("<region name=\"region1\">"
+          + System.getProperty("line.separator")
           + "    <region-attributes data-policy=\"empty\" scope=\"distributed-ack\"/>");
 
       Configuration clusterConfig = service.getConfiguration("group2");
-      assertThat(clusterConfig.getCacheXmlContent()).contains("<region name=\"region1\">\n"
+      assertThat(clusterConfig.getCacheXmlContent()).contains("<region name=\"region1\">"
+          + System.getProperty("line.separator")
           + "    <region-attributes data-policy=\"replicate\" scope=\"distributed-ack\"/>");
     });
 


### PR DESCRIPTION
  The assertion is asserting a multi-line string xml content
  which includes a new line which is hardcoded to '\n'.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
