### PR TITLE
GEODE-5771: Deprecate PDX Persistence on Client

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/client/ClientCacheFactoryJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/client/ClientCacheFactoryJUnitTest.java
@@ -17,19 +17,23 @@ package org.apache.geode.cache.client;
 
 import static org.apache.geode.distributed.ConfigurationProperties.CACHE_XML_FILE;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
+import static org.apache.geode.distributed.ConfigurationProperties.LOG_FILE;
 import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.runners.MethodSorters.NAME_ASCENDING;
 
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URL;
-import java.util.ArrayList;
+import java.nio.charset.Charset;
 import java.util.Collections;
 import java.util.Properties;
 
@@ -38,8 +42,11 @@ import org.jgroups.util.UUID;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.FixMethodOrder;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestName;
 
 import org.apache.geode.DataSerializer;
 import org.apache.geode.cache.RegionService;
@@ -55,8 +62,11 @@ import org.apache.geode.internal.Version;
 import org.apache.geode.internal.VersionedDataInputStream;
 import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.cache.tier.sockets.ClientProxyMembershipID;
+import org.apache.geode.internal.cache.xmlcache.CacheXmlGenerator;
+import org.apache.geode.internal.cache.xmlcache.ClientCacheCreation;
 import org.apache.geode.pdx.ReflectionBasedAutoSerializer;
 import org.apache.geode.test.junit.categories.ClientServerTest;
+import org.apache.geode.test.junit.rules.serializable.SerializableTestName;
 
 /**
  * Unit test for the ClientCacheFactory class
@@ -64,19 +74,20 @@ import org.apache.geode.test.junit.categories.ClientServerTest;
  * @since GemFire 6.5
  */
 @FixMethodOrder(NAME_ASCENDING)
-@Category({ClientServerTest.class})
+@Category(ClientServerTest.class)
 public class ClientCacheFactoryJUnitTest {
-
   private ClientCache clientCache;
-  private File tmpFile;
+
+  @Rule
+  public TestName testName = new SerializableTestName();
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   @After
   public void tearDown() throws Exception {
     if (this.clientCache != null && !this.clientCache.isClosed()) {
       clientCache.close();
-    }
-    if (tmpFile != null && tmpFile.exists()) {
-      tmpFile.delete();
     }
   }
 
@@ -92,58 +103,52 @@ public class ClientCacheFactoryJUnitTest {
   public void test000Defaults() throws Exception {
     this.clientCache = new ClientCacheFactory().create();
     GemFireCacheImpl gfc = (GemFireCacheImpl) this.clientCache;
-    assertEquals(true, gfc.isClient());
+    assertThat(gfc.isClient()).isTrue();
+
     Properties dsProps = this.clientCache.getDistributedSystem().getProperties();
-    assertEquals("0", dsProps.getProperty(MCAST_PORT));
-    assertEquals("", dsProps.getProperty(LOCATORS));
+    assertThat(dsProps.getProperty(MCAST_PORT)).isEqualTo("0");
+    assertThat(dsProps.getProperty(LOCATORS)).isEqualTo("");
+
     Pool defPool = gfc.getDefaultPool();
-    assertEquals("DEFAULT", defPool.getName());
-    assertEquals(new ArrayList(), defPool.getLocators());
-    assertEquals(
-        Collections.singletonList(
-            new InetSocketAddress(InetAddress.getLocalHost(), CacheServer.DEFAULT_PORT)),
-        defPool.getServers());
-    assertEquals(PoolFactory.DEFAULT_SOCKET_CONNECT_TIMEOUT, defPool.getSocketConnectTimeout());
+    assertThat(defPool.getName()).isEqualTo("DEFAULT");
+    assertThat(defPool.getLocators()).isEqualTo(Collections.emptyList());
+    assertThat(defPool.getSocketConnectTimeout())
+        .isEqualTo(PoolFactory.DEFAULT_SOCKET_CONNECT_TIMEOUT);
+    assertThat(defPool.getServers()).isEqualTo(Collections.singletonList(
+        new InetSocketAddress(InetAddress.getLocalHost(), CacheServer.DEFAULT_PORT)));
 
     ClientCache cc2 = new ClientCacheFactory().create();
-    if (cc2 != this.clientCache) {
-      fail("expected cc2 and cc to be == " + cc2 + this.clientCache);
-    }
-
-    try {
-      new ClientCacheFactory().set(LOG_LEVEL, "severe").create();
-      fail("expected create to fail");
-    } catch (IllegalStateException expected) {
-    }
-
-    try {
-      new ClientCacheFactory().addPoolLocator("127.0.0.1", 36666).create();
-      fail("expected create to fail");
-    } catch (IllegalStateException expected) {
-    }
+    assertThat(cc2).as("expected cc2 and cc to be == " + cc2 + this.clientCache)
+        .isSameAs(this.clientCache);
+    assertThatThrownBy(() -> new ClientCacheFactory().set(LOG_LEVEL, "severe").create())
+        .isInstanceOf(IllegalStateException.class);
+    assertThatThrownBy(() -> new ClientCacheFactory().addPoolLocator("127.0.0.1", 36666).create())
+        .isInstanceOf(IllegalStateException.class);
   }
 
   @Test
   public void test001FindDefaultFromXML() throws Exception {
-    this.tmpFile = File.createTempFile("ClientCacheFactoryJUnitTest", ".xml");
-    this.tmpFile.deleteOnExit();
+    File cacheXmlFile = temporaryFolder.newFile("ClientCacheFactoryJUnitTest.xml");
     URL url = ClientCacheFactoryJUnitTest.class
-        .getResource("ClientCacheFactoryJUnitTest_single_pool.xml");;
-    FileUtils.copyFile(new File(url.getFile()), this.tmpFile);
+        .getResource("ClientCacheFactoryJUnitTest_single_pool.xml");
+    FileUtils.copyFile(new File(url.getFile()), cacheXmlFile);
+
     this.clientCache =
-        new ClientCacheFactory().set(CACHE_XML_FILE, this.tmpFile.getAbsolutePath()).create();
+        new ClientCacheFactory().set(CACHE_XML_FILE, cacheXmlFile.getAbsolutePath()).create();
     GemFireCacheImpl gfc = (GemFireCacheImpl) this.clientCache;
-    assertEquals(true, gfc.isClient());
+    assertThat(gfc.isClient()).isTrue();
+
     Properties dsProps = this.clientCache.getDistributedSystem().getProperties();
-    assertEquals("0", dsProps.getProperty(MCAST_PORT));
-    assertEquals("", dsProps.getProperty(LOCATORS));
+    assertThat(dsProps.getProperty(MCAST_PORT)).isEqualTo("0");
+    assertThat(dsProps.getProperty(LOCATORS)).isEqualTo("");
+
     Pool defPool = gfc.getDefaultPool();
-    assertEquals("my_pool_name", defPool.getName());
-    assertEquals(new ArrayList(), defPool.getLocators());
-    assertEquals(
-        Collections.singletonList(new InetSocketAddress("localhost", CacheServer.DEFAULT_PORT)),
-        defPool.getServers());
-    assertEquals(PoolFactory.DEFAULT_SOCKET_CONNECT_TIMEOUT, defPool.getSocketConnectTimeout());
+    assertThat(defPool.getName()).isEqualTo("my_pool_name");
+    assertThat(defPool.getLocators()).isEqualTo(Collections.emptyList());
+    assertThat(defPool.getSocketConnectTimeout())
+        .isEqualTo(PoolFactory.DEFAULT_SOCKET_CONNECT_TIMEOUT);
+    assertThat(defPool.getServers()).isEqualTo(
+        Collections.singletonList(new InetSocketAddress("localhost", CacheServer.DEFAULT_PORT)));
   }
 
   /**
@@ -153,44 +158,37 @@ public class ClientCacheFactoryJUnitTest {
   public void test002DPsinglePool() throws Exception {
     Properties dsProps = new Properties();
     dsProps.setProperty(MCAST_PORT, "0");
-    DistributedSystem ds = DistributedSystem.connect(dsProps);
+    DistributedSystem.connect(dsProps);
     Pool p = PoolManager.createFactory().addServer(InetAddress.getLocalHost().getHostName(), 7777)
         .setSocketConnectTimeout(1400).create("singlePool");
+
     this.clientCache = new ClientCacheFactory().create();
     GemFireCacheImpl gfc = (GemFireCacheImpl) this.clientCache;
-    assertEquals(true, gfc.isClient());
+    assertThat(gfc.isClient()).isTrue();
+
     Pool defPool = gfc.getDefaultPool();
-    assertEquals(p, defPool);
-    assertEquals(1400, defPool.getSocketConnectTimeout());
+    assertThat(defPool).isEqualTo(p);
+    assertThat(defPool.getSocketConnectTimeout()).isEqualTo(1400);
 
-    // make sure if we can not create a secure user cache when one pool
-    // exists that is not multiuser enabled
-    try {
-      Properties suProps = new Properties();
-      suProps.setProperty("user", "foo");
-      RegionService cc = this.clientCache.createAuthenticatedView(suProps);
-      fail("expected IllegalStateException");
-    } catch (IllegalStateException ignore) {
-    }
+    // make sure if we can not create a secure user cache when one pool exists that is not multiuser
+    // enabled
+    Properties suProps = new Properties();
+    suProps.setProperty("user", "foo");
+    assertThatThrownBy(() -> this.clientCache.createAuthenticatedView(suProps))
+        .isInstanceOf(IllegalStateException.class);
+
     // however we should be to to create it by configuring a pool
-    {
-      Properties suProps = new Properties();
-      suProps.setProperty("user", "foo");
-
-      Pool pool = PoolManager.createFactory()
-          .addServer(InetAddress.getLocalHost().getHostName(), CacheServer.DEFAULT_PORT)
-          .setMultiuserAuthentication(true).setSocketConnectTimeout(2345).create("pool1");
-      RegionService cc = this.clientCache.createAuthenticatedView(suProps, pool.getName());
-      ProxyCache pc = (ProxyCache) cc;
-      UserAttributes ua = pc.getUserAttributes();
-      Pool proxyDefPool = ua.getPool();
-      assertEquals(
-          Collections.singletonList(
-              new InetSocketAddress(InetAddress.getLocalHost(), CacheServer.DEFAULT_PORT)),
-          proxyDefPool.getServers());
-      assertEquals(true, proxyDefPool.getMultiuserAuthentication());
-      assertEquals(2345, proxyDefPool.getSocketConnectTimeout());
-    }
+    Pool pool = PoolManager.createFactory()
+        .addServer(InetAddress.getLocalHost().getHostName(), CacheServer.DEFAULT_PORT)
+        .setMultiuserAuthentication(true).setSocketConnectTimeout(2345).create("pool1");
+    RegionService cc = this.clientCache.createAuthenticatedView(suProps, pool.getName());
+    ProxyCache pc = (ProxyCache) cc;
+    UserAttributes ua = pc.getUserAttributes();
+    Pool proxyDefPool = ua.getPool();
+    assertThat(proxyDefPool.getServers()).isEqualTo(Collections.singletonList(
+        new InetSocketAddress(InetAddress.getLocalHost(), CacheServer.DEFAULT_PORT)));
+    assertThat(proxyDefPool.getMultiuserAuthentication()).isTrue();
+    assertThat(proxyDefPool.getSocketConnectTimeout()).isEqualTo(2345);
   }
 
   /**
@@ -200,66 +198,58 @@ public class ClientCacheFactoryJUnitTest {
   public void test003DPmultiplePool() throws Exception {
     Properties dsProps = new Properties();
     dsProps.setProperty(MCAST_PORT, "0");
-    DistributedSystem ds = DistributedSystem.connect(dsProps);
+    DistributedSystem.connect(dsProps);
     PoolManager.createFactory().addServer(InetAddress.getLocalHost().getHostName(), 7777)
         .setSocketConnectTimeout(2500).create("p7");
     PoolManager.createFactory().addServer(InetAddress.getLocalHost().getHostName(), 6666)
         .setSocketConnectTimeout(5200).create("p6");
+
     this.clientCache = new ClientCacheFactory().create();
     GemFireCacheImpl gfc = (GemFireCacheImpl) this.clientCache;
-    assertEquals(true, gfc.isClient());
-    Pool defPool = gfc.getDefaultPool();
-    assertEquals(null, defPool);
-    assertEquals(2500, PoolManager.find("p7").getSocketConnectTimeout());
-    assertEquals(5200, PoolManager.find("p6").getSocketConnectTimeout());
+    assertThat(gfc.isClient()).isTrue();
 
-    // make sure if we can not create a secure user cache when more than one pool
-    // exists that is not multiuser enabled
-    try {
-      Properties suProps = new Properties();
-      suProps.setProperty("user", "foo");
-      RegionService cc = this.clientCache.createAuthenticatedView(suProps);
-      fail("expected IllegalStateException");
-    } catch (IllegalStateException ignore) {
-    }
+    Pool defPool = gfc.getDefaultPool();
+    assertThat(defPool).isNull();
+    assertThat(PoolManager.find("p7").getSocketConnectTimeout()).isEqualTo(2500);
+    assertThat(PoolManager.find("p6").getSocketConnectTimeout()).isEqualTo(5200);
+
+    // make sure if we can not create a secure user cache when more than one pool exists that is not
+    // multiuser enabled
+    Properties suProps = new Properties();
+    suProps.setProperty("user", "foo");
+    assertThatThrownBy(() -> this.clientCache.createAuthenticatedView(suProps))
+        .isInstanceOf(IllegalStateException.class);
+
     // however we should be to to create it by configuring a pool
-    {
-      Properties suProps = new Properties();
-      suProps.setProperty("user", "foo");
-      Pool pool = PoolManager.createFactory()
-          .addServer(InetAddress.getLocalHost().getHostName(), CacheServer.DEFAULT_PORT)
-          .setMultiuserAuthentication(true).create("pool1");
-      RegionService cc = this.clientCache.createAuthenticatedView(suProps, pool.getName());
-      ProxyCache pc = (ProxyCache) cc;
-      UserAttributes ua = pc.getUserAttributes();
-      Pool proxyDefPool = ua.getPool();
-      assertEquals(
-          Collections.singletonList(
-              new InetSocketAddress(InetAddress.getLocalHost(), CacheServer.DEFAULT_PORT)),
-          proxyDefPool.getServers());
-      assertEquals(true, proxyDefPool.getMultiuserAuthentication());
-      assertEquals(PoolFactory.DEFAULT_SOCKET_CONNECT_TIMEOUT,
-          proxyDefPool.getSocketConnectTimeout());
-    }
+    Pool pool = PoolManager.createFactory()
+        .addServer(InetAddress.getLocalHost().getHostName(), CacheServer.DEFAULT_PORT)
+        .setMultiuserAuthentication(true).create("pool1");
+    RegionService cc = this.clientCache.createAuthenticatedView(suProps, pool.getName());
+    ProxyCache pc = (ProxyCache) cc;
+    UserAttributes ua = pc.getUserAttributes();
+    Pool proxyDefPool = ua.getPool();
+    assertThat(proxyDefPool.getServers()).isEqualTo(Collections.singletonList(
+        new InetSocketAddress(InetAddress.getLocalHost(), CacheServer.DEFAULT_PORT)));
+    assertThat(proxyDefPool.getMultiuserAuthentication()).isTrue();
+    assertThat(proxyDefPool.getSocketConnectTimeout())
+        .isEqualTo(PoolFactory.DEFAULT_SOCKET_CONNECT_TIMEOUT);
   }
 
   @Test
-  public void test004SetMethod() throws Exception {
+  public void test004SetMethod() {
     this.clientCache =
         new ClientCacheFactory().set(LOG_LEVEL, "severe").setPoolSocketConnectTimeout(0).create();
     GemFireCacheImpl gfc = (GemFireCacheImpl) this.clientCache;
-    assertEquals(true, gfc.isClient());
-    Properties dsProps = this.clientCache.getDistributedSystem().getProperties();
-    assertEquals("0", dsProps.getProperty(MCAST_PORT));
-    assertEquals("", dsProps.getProperty(LOCATORS));
-    assertEquals("severe", dsProps.getProperty(LOG_LEVEL));
-    assertEquals(0, this.clientCache.getDefaultPool().getSocketConnectTimeout());
+    assertThat(gfc.isClient()).isTrue();
 
-    try {
-      new ClientCacheFactory().setPoolSocketConnectTimeout(-1).create();
-      fail("expected IllegalArgumentException");
-    } catch (IllegalArgumentException ignore) {
-    }
+    Properties dsProps = this.clientCache.getDistributedSystem().getProperties();
+    assertThat(dsProps.getProperty(MCAST_PORT)).isEqualTo("0");
+    assertThat(dsProps.getProperty(LOCATORS)).isEqualTo("");
+    assertThat(dsProps.getProperty(LOG_LEVEL)).isEqualTo("severe");
+    assertThat(this.clientCache.getDefaultPool().getSocketConnectTimeout()).isEqualTo(0);
+
+    assertThatThrownBy(() -> new ClientCacheFactory().setPoolSocketConnectTimeout(-1).create())
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
@@ -269,37 +259,34 @@ public class ClientCacheFactoryJUnitTest {
     GemFireCacheImpl gfc =
         (GemFireCacheImpl) new ClientCacheFactory().setPoolMultiuserAuthentication(true).create();
     this.clientCache = gfc;
-    RegionService cc1 = this.clientCache.createAuthenticatedView(suProps);
 
-    assertEquals(true, gfc.isClient());
+    RegionService cc1 = this.clientCache.createAuthenticatedView(suProps);
+    assertThat(gfc.isClient()).isTrue();
     Properties dsProps = this.clientCache.getDistributedSystem().getProperties();
-    assertEquals("0", dsProps.getProperty(MCAST_PORT));
-    assertEquals("", dsProps.getProperty(LOCATORS));
+    assertThat(dsProps.getProperty(MCAST_PORT)).isEqualTo("0");
+    assertThat(dsProps.getProperty(LOCATORS)).isEqualTo("");
+
     Pool defPool = gfc.getDefaultPool();
-    assertEquals("DEFAULT", defPool.getName());
-    assertEquals(new ArrayList(), defPool.getLocators());
-    assertEquals(
-        Collections.singletonList(
-            new InetSocketAddress(InetAddress.getLocalHost(), CacheServer.DEFAULT_PORT)),
-        defPool.getServers());
-    assertEquals(true, defPool.getMultiuserAuthentication());
+    assertThat(defPool.getName()).isEqualTo("DEFAULT");
+    assertThat(defPool.getMultiuserAuthentication()).isTrue();
+    assertThat(defPool.getLocators()).isEqualTo(Collections.emptyList());
+    assertThat(defPool.getServers()).isEqualTo(Collections.singletonList(
+        new InetSocketAddress(InetAddress.getLocalHost(), CacheServer.DEFAULT_PORT)));
 
     // make sure we can create another secure user cache
     RegionService cc2 = this.clientCache.createAuthenticatedView(suProps);
-    assertEquals(true, gfc.isClient());
-    assertEquals("0", dsProps.getProperty(MCAST_PORT));
-    assertEquals("", dsProps.getProperty(LOCATORS));
+    assertThat(gfc.isClient()).isTrue();
+    assertThat(dsProps.getProperty(MCAST_PORT)).isEqualTo("0");
+    assertThat(dsProps.getProperty(LOCATORS)).isEqualTo("");
+
     defPool = gfc.getDefaultPool();
-    assertEquals("DEFAULT", defPool.getName());
-    assertEquals(new ArrayList(), defPool.getLocators());
-    assertEquals(
-        Collections.singletonList(
-            new InetSocketAddress(InetAddress.getLocalHost(), CacheServer.DEFAULT_PORT)),
-        defPool.getServers());
-    assertEquals(true, defPool.getMultiuserAuthentication());
-    if (cc1 == cc2) {
-      fail("expected two different secure user caches");
-    }
+    assertThat(defPool.getName()).isEqualTo("DEFAULT");
+    assertThat(defPool.getMultiuserAuthentication()).isTrue();
+    assertThat(defPool.getLocators()).isEqualTo(Collections.emptyList());
+    assertThat(defPool.getServers()).isEqualTo(Collections.singletonList(
+        new InetSocketAddress(InetAddress.getLocalHost(), CacheServer.DEFAULT_PORT)));
+
+    assertThat(cc1).as("expected two different secure user caches").isNotSameAs(cc2);
   }
 
   @Test
@@ -307,36 +294,34 @@ public class ClientCacheFactoryJUnitTest {
     this.clientCache = new ClientCacheFactory()
         .addPoolServer(InetAddress.getLocalHost().getHostName(), 55555).create();
     GemFireCacheImpl gfc = (GemFireCacheImpl) this.clientCache;
-    assertEquals(true, gfc.isClient());
+    assertThat(gfc.isClient()).isTrue();
+
     Properties dsProps = this.clientCache.getDistributedSystem().getProperties();
-    assertEquals("0", dsProps.getProperty(MCAST_PORT));
-    assertEquals("", dsProps.getProperty(LOCATORS));
+    assertThat(dsProps.getProperty(LOCATORS)).isEqualTo("");
+    assertThat(dsProps.getProperty(MCAST_PORT)).isEqualTo("0");
+
     Pool defPool = gfc.getDefaultPool();
-    assertEquals("DEFAULT", defPool.getName());
-    assertEquals(new ArrayList(), defPool.getLocators());
-    assertEquals(
-        Collections.singletonList(new InetSocketAddress(InetAddress.getLocalHost(), 55555)),
-        defPool.getServers());
+    assertThat(defPool.getName()).isEqualTo("DEFAULT");
+    assertThat(defPool.getLocators()).isEqualTo(Collections.emptyList());
+    assertThat(defPool.getServers()).isEqualTo(
+        Collections.singletonList(new InetSocketAddress(InetAddress.getLocalHost(), 55555)));
 
-    ClientCache cc2 = new ClientCacheFactory().create();
     gfc = (GemFireCacheImpl) this.clientCache;
-    assertEquals(true, gfc.isClient());
-    dsProps = this.clientCache.getDistributedSystem().getProperties();
-    assertEquals("0", dsProps.getProperty(MCAST_PORT));
-    assertEquals("", dsProps.getProperty(LOCATORS));
-    defPool = gfc.getDefaultPool();
-    assertEquals("DEFAULT", defPool.getName());
-    assertEquals(new ArrayList(), defPool.getLocators());
-    assertEquals(
-        Collections.singletonList(new InetSocketAddress(InetAddress.getLocalHost(), 55555)),
-        defPool.getServers());
+    assertThat(gfc.isClient()).isTrue();
 
-    try {
-      clientCache = new ClientCacheFactory()
-          .addPoolServer(InetAddress.getLocalHost().getHostName(), 44444).create();
-      fail("expected create to fail");
-    } catch (IllegalStateException expected) {
-    }
+    dsProps = this.clientCache.getDistributedSystem().getProperties();
+    assertThat(dsProps.getProperty(LOCATORS)).isEqualTo("");
+    assertThat(dsProps.getProperty(MCAST_PORT)).isEqualTo("0");
+
+    defPool = gfc.getDefaultPool();
+    assertThat(defPool.getName()).isEqualTo("DEFAULT");
+    assertThat(defPool.getLocators()).isEqualTo(Collections.emptyList());
+    assertThat(defPool.getServers()).isEqualTo(
+        Collections.singletonList(new InetSocketAddress(InetAddress.getLocalHost(), 55555)));
+
+    assertThatThrownBy(() -> new ClientCacheFactory()
+        .addPoolServer(InetAddress.getLocalHost().getHostName(), 44444).create())
+            .isInstanceOf(IllegalStateException.class);
   }
 
   @Test
@@ -351,20 +336,19 @@ public class ClientCacheFactoryJUnitTest {
     clientCache = new ClientCacheFactory().setPoolSubscriptionTimeoutMultiplier(2)
         .addPoolServer(InetAddress.getLocalHost().getHostName(), 7777).create();
     Pool defaultPool = clientCache.getDefaultPool();
-    assertEquals(2, defaultPool.getSubscriptionTimeoutMultiplier());
+    assertThat(defaultPool.getSubscriptionTimeoutMultiplier()).isEqualTo(2);
   }
 
   @Test
   public void testOldClientIDDeserialization() throws Exception {
-    // during a HandShake a clientID is read w/o knowing the client's
-    // version
+    // during a HandShake a clientID is read w/o knowing the client's version
     clientCache = new ClientCacheFactory().create();
-    GemFireCacheImpl gfc = (GemFireCacheImpl) clientCache;
     InternalDistributedMember memberID =
         (InternalDistributedMember) clientCache.getDistributedSystem().getDistributedMember();
     GMSMember gmsID = (GMSMember) memberID.getNetMember();
     memberID.setVersionObjectForTest(Version.GFE_82);
-    assertEquals(Version.GFE_82, memberID.getVersionObject());
+    assertThat(memberID.getVersionObject()).isEqualTo(Version.GFE_82);
+
     ClientProxyMembershipID clientID = ClientProxyMembershipID.getClientId(memberID);
     HeapDataOutputStream out = new HeapDataOutputStream(Version.GFE_82);
     DataSerializer.writeObject(clientID, out);
@@ -374,13 +358,14 @@ public class ClientCacheFactoryJUnitTest {
     ClientProxyMembershipID newID = DataSerializer.readObject(in);
     InternalDistributedMember newMemberID =
         (InternalDistributedMember) newID.getDistributedMember();
-    assertEquals(Version.GFE_82, newMemberID.getVersionObject());
-    assertEquals(Version.GFE_82, newID.getClientVersion());
-    GMSMember newGmsID = (GMSMember) newMemberID.getNetMember();
-    assertEquals(0, newGmsID.getUuidLSBs());
-    assertEquals(0, newGmsID.getUuidMSBs());
+    assertThat(newMemberID.getVersionObject()).isEqualTo(Version.GFE_82);
+    assertThat(newID.getClientVersion()).isEqualTo(Version.GFE_82);
 
-    gmsID.setUUID(new UUID(1234l, 5678l));
+    GMSMember newGmsID = (GMSMember) newMemberID.getNetMember();
+    assertThat(newGmsID.getUuidLSBs()).isEqualTo(0);
+    assertThat(newGmsID.getUuidMSBs()).isEqualTo(0);
+
+    gmsID.setUUID(new UUID(1234L, 5678L));
     memberID.setVersionObjectForTest(Version.CURRENT);
     clientID = ClientProxyMembershipID.getClientId(memberID);
     out = new HeapDataOutputStream(Version.CURRENT);
@@ -389,11 +374,82 @@ public class ClientCacheFactoryJUnitTest {
     in = new VersionedDataInputStream(new ByteArrayInputStream(out.toByteArray()), Version.CURRENT);
     newID = DataSerializer.readObject(in);
     newMemberID = (InternalDistributedMember) newID.getDistributedMember();
-    assertEquals(Version.CURRENT, newMemberID.getVersionObject());
-    assertEquals(Version.CURRENT, newID.getClientVersion());
-    newGmsID = (GMSMember) newMemberID.getNetMember();
-    assertEquals(gmsID.getUuidLSBs(), newGmsID.getUuidLSBs());
-    assertEquals(gmsID.getUuidMSBs(), newGmsID.getUuidMSBs());
+    assertThat(newMemberID.getVersionObject()).isEqualTo(Version.CURRENT);
+    assertThat(newID.getClientVersion()).isEqualTo(Version.CURRENT);
 
+    newGmsID = (GMSMember) newMemberID.getNetMember();
+    assertThat(newGmsID.getUuidLSBs()).isEqualTo(gmsID.getUuidLSBs());
+    assertThat(newGmsID.getUuidMSBs()).isEqualTo(gmsID.getUuidMSBs());
+  }
+
+  @Test
+  public void configuringPdxPersistenceThroughAPIShouldLogWarningMessage() throws IOException {
+    File logFile = temporaryFolder.newFile(testName.getMethodName() + ".log");
+    clientCache = new ClientCacheFactory()
+        .set(LOG_LEVEL, "warn")
+        .set(LOG_FILE, logFile.getAbsolutePath())
+        .setPdxPersistent(true)
+        .setPdxSerializer(new ReflectionBasedAutoSerializer())
+        .create();
+
+    assertThat(FileUtils.readFileToString(logFile, Charset.defaultCharset())
+        .contains("PDX persistence is not supported on client side.")).isTrue();
+  }
+
+  @Test
+  public void configuringPdxDiskStoreThroughAPIShouldLogWarningMessage() throws IOException {
+    File logFile = temporaryFolder.newFile(testName.getMethodName() + ".log");
+    clientCache = new ClientCacheFactory()
+        .set(LOG_LEVEL, "warn")
+        .set(LOG_FILE, logFile.getAbsolutePath())
+        .setPdxDiskStore("pdxDiskStore")
+        .setPdxSerializer(new ReflectionBasedAutoSerializer())
+        .create();
+
+    assertThat(FileUtils.readFileToString(logFile, Charset.defaultCharset())
+        .contains("PDX persistence is not supported on client side.")).isTrue();
+  }
+
+  @Test
+  public void configuringPdxPersistenceThroughXMLShouldLogWarningMessage() throws IOException {
+    ClientCacheCreation clientCacheCreation = new ClientCacheCreation();
+    clientCacheCreation.setPdxPersistent(true);
+    clientCacheCreation.setPdxSerializer(new ReflectionBasedAutoSerializer());
+
+    File logFile = temporaryFolder.newFile(testName.getMethodName() + ".log");
+    File cacheXmlFile = temporaryFolder.newFile(testName.getMethodName() + ".xml");
+
+    try (PrintWriter printWriter = new PrintWriter(new FileWriter(cacheXmlFile), true)) {
+      CacheXmlGenerator.generate(clientCacheCreation, printWriter, true, false, false);
+      clientCache = new ClientCacheFactory()
+          .set(LOG_LEVEL, "warn")
+          .set(LOG_FILE, logFile.getAbsolutePath())
+          .set(CACHE_XML_FILE, cacheXmlFile.getAbsolutePath())
+          .create();
+
+      assertThat(FileUtils.readFileToString(logFile, Charset.defaultCharset())
+          .contains("PDX persistence is not supported on client side.")).isTrue();
+    }
+  }
+
+  @Test
+  public void configuringPdxDiskStoreThroughXMLShouldLogWarningMessage() throws IOException {
+    ClientCacheCreation clientCacheCreation = new ClientCacheCreation();
+    clientCacheCreation.setPdxDiskStore("pdxDiskStore");
+    clientCacheCreation.setPdxSerializer(new ReflectionBasedAutoSerializer());
+
+    File logFile = temporaryFolder.newFile(testName.getMethodName() + ".log");
+    File cacheXmlFile = temporaryFolder.newFile(testName.getMethodName() + ".xml");
+    try (PrintWriter printWriter = new PrintWriter(new FileWriter(cacheXmlFile), true)) {
+      CacheXmlGenerator.generate(clientCacheCreation, printWriter, true, false, false);
+      clientCache = new ClientCacheFactory()
+          .set(LOG_LEVEL, "warn")
+          .set(LOG_FILE, logFile.getAbsolutePath())
+          .set(CACHE_XML_FILE, cacheXmlFile.getAbsolutePath())
+          .create();
+
+      assertThat(FileUtils.readFileToString(logFile, Charset.defaultCharset())
+          .contains("PDX persistence is not supported on client side.")).isTrue();
+    }
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/cache/client/ClientCacheFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/ClientCacheFactory.java
@@ -705,7 +705,10 @@ public class ClientCacheFactory {
    * @param diskStoreName the name of the disk store to use for the PDX metadata.
    * @return this ClientCacheFactory
    * @since GemFire 6.6
+   * @deprecated Pdx Persistence is not supported on client side. Even when set, it's internally
+   *             ignored.
    */
+  @Deprecated
   public ClientCacheFactory setPdxDiskStore(String diskStoreName) {
     this.cacheConfig.setPdxDiskStore(diskStoreName);
     return this;
@@ -719,7 +722,10 @@ public class ClientCacheFactory {
    * @param isPersistent true if the metadata should be persistent
    * @return this ClientCacheFactory
    * @since GemFire 6.6
+   * @deprecated Pdx Persistence is not supported on client side. Even when set, it's internally
+   *             ignored.
    */
+  @Deprecated
   public ClientCacheFactory setPdxPersistent(boolean isPersistent) {
     this.cacheConfig.setPdxPersistent(isPersistent);
     return this;
@@ -743,5 +749,4 @@ public class ClientCacheFactory {
     this.cacheConfig.setPdxIgnoreUnreadFields(ignore);
     return this;
   }
-
 }

--- a/geode-core/src/main/java/org/apache/geode/pdx/internal/ClientTypeRegistration.java
+++ b/geode-core/src/main/java/org/apache/geode/pdx/internal/ClientTypeRegistration.java
@@ -21,6 +21,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.InternalGemFireError;
@@ -49,6 +50,11 @@ public class ClientTypeRegistration implements TypeRegistration {
 
   public ClientTypeRegistration(InternalCache cache) {
     this.cache = cache;
+
+    // See GEODE-5771: Even when set, PDX persistence is internally ignored.
+    if (cache.getPdxPersistent() || StringUtils.isNotBlank(cache.getPdxDiskStore())) {
+      logger.warn("PDX persistence is not supported on client side.");
+    }
   }
 
   public int defineType(PdxType newType) {

--- a/geode-core/src/main/resources/META-INF/schemas/geode.apache.org/schema/cache/cache-1.0.xsd
+++ b/geode-core/src/main/resources/META-INF/schemas/geode.apache.org/schema/cache/cache-1.0.xsd
@@ -333,7 +333,7 @@ declarative caching XML file elements unless indicated otherwise.
         <xsd:element maxOccurs="1" minOccurs="0" name="dynamic-region-factory" type="gf:dynamic-region-factory-type" />
         <xsd:element maxOccurs="unbounded" minOccurs="0" name="pool" type="gf:pool-type" />
         <xsd:element maxOccurs="unbounded" minOccurs="0" name="disk-store" type="gf:disk-store-type" />
-        <xsd:element maxOccurs="1" minOccurs="0" name="pdx" type="gf:pdx-type" />
+        <xsd:element maxOccurs="1" minOccurs="0" name="pdx" type="gf:client-pdx-type" />
         <xsd:element maxOccurs="unbounded" minOccurs="0" name="region-attributes" type="gf:region-attributes-type" />
         <xsd:choice maxOccurs="unbounded" minOccurs="0">
           <xsd:element name="jndi-bindings" type="gf:jndi-bindings-type" />
@@ -1164,6 +1164,51 @@ As of 6.5 disk-dirs is deprecated on region-attributes. Use disk-store-name inst
     <xsd:attribute name="ignore-unread-fields" type="xsd:boolean" use="optional" />
     <xsd:attribute name="persistent" type="xsd:boolean" use="optional" />
     <xsd:attribute name="disk-store-name" type="xsd:string" use="optional" />
+  </xsd:complexType>
+
+  <xsd:complexType name="client-pdx-type">
+    <xsd:annotation>
+      <xsd:documentation>
+        A "pdx" element specifies the configuration for the portable data exchange (PDX) method of
+        serialization. The "read-serialized" attribute is "early access".
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element maxOccurs="1" minOccurs="0" name="pdx-serializer">
+        <xsd:annotation>
+          <xsd:documentation>
+            A "pdx-serializer" element describes a serializer used to serialize objects in the
+            portable data exchange format.
+          </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="class-name" type="gf:class-name-type" />
+            <xsd:element maxOccurs="unbounded" minOccurs="0" name="parameter" type="gf:parameter-type" />
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="read-serialized" type="xsd:boolean"/>
+    <xsd:attribute name="ignore-unread-fields" type="xsd:boolean"/>
+    <xsd:attribute name="persistent" type="xsd:boolean">
+      <xsd:annotation>
+        <xsd:appinfo>deprecated</xsd:appinfo>
+        <xsd:documentation>
+          Pdx Persistence is not supported on client side; even when set, it's internally ignored.
+          The attribute will be removed in a later release.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="disk-store-name" type="xsd:string">
+      <xsd:annotation>
+        <xsd:appinfo>deprecated</xsd:appinfo>
+        <xsd:documentation>
+          Pdx Persistence is not supported on client side; even when set, it's internally ignored.
+          The attribute will be removed in a later release.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
   </xsd:complexType>
 
   <xsd:complexType name="pool-type">


### PR DESCRIPTION
GEODE-5771: Deprecate PDX Persistence on Client

Currently, even when set, the PDX metadata is not persisted on the
client side (to avoid dealing with problems that might arise if the
client's PDX data is inconsistent with the server).

- Methods `setPdxPersistent` and `setPdxDiskStore` from
  `ClientCacheFactory` have been deprecated.
- Attributes `persistent` and `disk-store-name` from the element `pdx`
  have been deprecated (new complex type `client-pdx-type` has been
  added to avoid messing with the pdx definition used for non-clients).
- A `warning` message will now be logged when creating the cache if we
  detect that PDX persistence has been configured for a client cache.
- Added test methods to `ClientCacheFactoryJUnitTest`, also replaced
  the usage of `junit.Assert` by `assertj`, and manual file
  manipulation/cleanup by `TemporaryFolder` rule.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
