### PR TITLE
GEODE-5776: Use HexThreadIdPatternConverter for tid in logs

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/logging/log4j/HexThreadIdPatternConverter.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/logging/log4j/HexThreadIdPatternConverter.java
@@ -20,30 +20,30 @@ import org.apache.logging.log4j.core.pattern.ConverterKeys;
 import org.apache.logging.log4j.core.pattern.LogEventPatternConverter;
 
 /**
- * Formats the event thread id.
+ * Formats the event thread id in hex format.
  */
-@Plugin(name = "ThreadIdPatternConverter", category = "Converter")
-@ConverterKeys({"tid", "threadId"})
-public class ThreadIdPatternConverter extends LogEventPatternConverter {
+@Plugin(name = "HexThreadIdPatternConverter", category = "Converter")
+@ConverterKeys({"hexTid", "hexThreadId"})
+public class HexThreadIdPatternConverter extends LogEventPatternConverter {
   /**
    * Singleton.
    */
-  private static final ThreadIdPatternConverter INSTANCE = new ThreadIdPatternConverter();
+  static final HexThreadIdPatternConverter INSTANCE = new HexThreadIdPatternConverter();
 
   /**
    * Private constructor.
    */
-  private ThreadIdPatternConverter() {
-    super("ThreadId", "threadId");
+  private HexThreadIdPatternConverter() {
+    super("HexThreadId", "hexThreadId");
   }
 
   /**
-   * Obtains an instance of ThreadPatternConverter.
+   * Obtains an instance of HexThreadIdPatternConverter.
    *
    * @param options options, currently ignored, may be null.
-   * @return instance of ThreadPatternConverter.
+   * @return instance of HexThreadIdPatternConverter.
    */
-  public static ThreadIdPatternConverter newInstance(final String[] options) {
+  public static HexThreadIdPatternConverter newInstance(final String[] options) {
     return INSTANCE;
   }
 

--- a/geode-core/src/main/resources/log4j2-cli.xml
+++ b/geode-core/src/main/resources/log4j2-cli.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="FATAL" shutdownHook="disable" packages="org.apache.geode.internal.logging.log4j">
   <Properties>
-    <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%tid] %message%n%throwable%n</Property>
+    <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
   </Properties>
   <Appenders>
     <Console name="STDOUT" target="SYSTEM_OUT">

--- a/geode-core/src/main/resources/log4j2.xml
+++ b/geode-core/src/main/resources/log4j2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="FATAL" shutdownHook="disable" packages="org.apache.geode.internal.logging.log4j">
   <Properties>
-    <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%tid] %message%n%throwable%n</Property>
+    <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
     <Property name="geode-default">true</Property>
   </Properties>
   <Appenders>

--- a/geode-core/src/main/resources/org/apache/geode/internal/logging/log4j/log4j2-legacy.xml
+++ b/geode-core/src/main/resources/org/apache/geode/internal/logging/log4j/log4j2-legacy.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="FATAL" shutdownHook="disable" packages="org.apache.geode.internal.logging.log4j">
   <Properties>
-    <Property name="geode-pattern">[%level{FATAL=severe,ERROR=error,WARN=warning,INFO=info,DEBUG=fine,TRACE=finest} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%tid] %message%n%throwable%n</Property>
+    <Property name="geode-pattern">[%level{FATAL=severe,ERROR=error,WARN=warning,INFO=info,DEBUG=fine,TRACE=finest} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
   </Properties>
   <Appenders>
     <Console name="STDOUT" target="SYSTEM_OUT">

--- a/geode-core/src/test/java/org/apache/geode/internal/logging/log4j/HexThreadIdPatternConverterTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/logging/log4j/HexThreadIdPatternConverterTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.geode.internal.logging.log4j;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class HexThreadIdPatternConverterTest {
+
+  private HexThreadIdPatternConverter converter;
+  private StringBuilder toAppendTo;
+
+  @Before
+  public void setUp() {
+    converter = HexThreadIdPatternConverter.INSTANCE;
+    toAppendTo = new StringBuilder();
+  }
+
+  @Test
+  public void appendsCurrentThreadIdInHex() {
+    converter.format(null, toAppendTo);
+
+    assertThat(toAppendTo.toString())
+        .isEqualTo("0x" + Long.toHexString(Thread.currentThread().getId()));
+  }
+}

--- a/geode-core/src/test/resources/org/apache/geode/internal/logging/log4j/marker/log4j2-gemfire_verbose-accept.xml
+++ b/geode-core/src/test/resources/org/apache/geode/internal/logging/log4j/marker/log4j2-gemfire_verbose-accept.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="FATAL" shutdownHook="disable" packages="org.apache.geode.internal.logging.log4j">
   <Properties>
-    <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%tid] %message%n%throwable%n</Property>
+    <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
     <Property name="geode-default">true</Property>
   </Properties>
   <Appenders>

--- a/geode-core/src/test/resources/org/apache/geode/internal/logging/log4j/marker/log4j2-gemfire_verbose-deny.xml
+++ b/geode-core/src/test/resources/org/apache/geode/internal/logging/log4j/marker/log4j2-gemfire_verbose-deny.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="FATAL" shutdownHook="disable" packages="org.apache.geode.internal.logging.log4j">
   <Properties>
-    <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%tid] %message%n%throwable%n</Property>
+    <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
     <Property name="geode-default">true</Property>
   </Properties>
   <Appenders>

--- a/geode-core/src/test/resources/org/apache/geode/internal/logging/log4j/marker/log4j2-geode_verbose-accept.xml
+++ b/geode-core/src/test/resources/org/apache/geode/internal/logging/log4j/marker/log4j2-geode_verbose-accept.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="FATAL" shutdownHook="disable" packages="org.apache.geode.internal.logging.log4j">
   <Properties>
-    <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%tid] %message%n%throwable%n</Property>
+    <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
     <Property name="geode-default">true</Property>
   </Properties>
   <Appenders>

--- a/geode-core/src/test/resources/org/apache/geode/internal/logging/log4j/marker/log4j2-geode_verbose-deny.xml
+++ b/geode-core/src/test/resources/org/apache/geode/internal/logging/log4j/marker/log4j2-geode_verbose-deny.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="FATAL" shutdownHook="disable" packages="org.apache.geode.internal.logging.log4j">
   <Properties>
-    <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%tid] %message%n%throwable%n</Property>
+    <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
     <Property name="geode-default">true</Property>
   </Properties>
   <Appenders>

--- a/geode-core/src/test/resources/org/apache/geode/test/golden/log4j2-test.xml
+++ b/geode-core/src/test/resources/org/apache/geode/test/golden/log4j2-test.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="ERROR" shutdownHook="disable" packages="org.apache.geode.internal.logging.log4j">
   <Properties>
-    <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%tid] %message%n%throwable%n</Property>
+    <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
   </Properties>
   <Appenders>
     <Console name="STDOUT" target="SYSTEM_OUT">

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/standalone/DUnitLauncher.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/standalone/DUnitLauncher.java
@@ -291,7 +291,7 @@ public class DUnitLauncher {
             .getContext();
 
     final PatternLayout layout = PatternLayout.createLayout(
-        "[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} <%thread> tid=%tid] %message%n%throwable%n",
+        "[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} <%thread> tid=%hexTid] %message%n%throwable%n",
         null, null, null, Charset.defaultCharset(), true, false, "", "");
 
     final FileAppender fileAppender = FileAppender.createAppender(suspectFilename, "true", "false",


### PR DESCRIPTION
Renamed Geode ThreadIdPatternConverter to HexThreadIdPatternConverter because the plugin details currently match an nearly identical class in Log4J2 which formats tid to be decimal instead of hex.