### PR TITLE
GEODE-2644: Cleanup config classes

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfig.java
@@ -12,7 +12,6 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package org.apache.geode.distributed.internal;
 
 import static org.apache.geode.distributed.ConfigurationProperties.ACK_SEVERE_ALERT_THRESHOLD;
@@ -192,12 +191,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import org.apache.geode.GemFireIOException;
+import org.apache.geode.LogWriter;
+import org.apache.geode.UnmodifiableException;
 import org.apache.geode.distributed.ConfigurationProperties;
 import org.apache.geode.distributed.DistributedSystem;
+import org.apache.geode.i18n.LogWriterI18n;
 import org.apache.geode.internal.Config;
 import org.apache.geode.internal.ConfigSource;
 import org.apache.geode.internal.logging.InternalLogWriter;
 import org.apache.geode.internal.logging.LogConfig;
+import org.apache.geode.internal.logging.LogWriterImpl;
 import org.apache.geode.internal.security.SecurableCommunicationChannel;
 import org.apache.geode.internal.tcp.Connection;
 import org.apache.geode.memcached.GemFireMemcachedServer;
@@ -207,16 +211,13 @@ import org.apache.geode.memcached.GemFireMemcachedServer;
  * configuration properties. The interface also provides constants for the names of properties and
  * their default values.
  * <p>
- * <p>
- * <p>
  * Descriptions of these properties can be found {@link ConfigurationProperties}.
  *
- * @see org.apache.geode.internal.Config
+ * @see Config
  * @since GemFire 2.1
  */
 public interface DistributionConfig extends Config, LogConfig {
 
-  //////////////////// Instance Methods ////////////////////
   /**
    * The static String definition of the prefix used to defined ssl-* properties
    */
@@ -236,6 +237,7 @@ public interface DistributionConfig extends Config, LogConfig {
    *
    * @return the system's name.
    */
+  @Override
   @ConfigAttributeGetter(name = NAME)
   String getName();
 
@@ -245,8 +247,8 @@ public interface DistributionConfig extends Config, LogConfig {
    * The name can not be changed while the system is running.
    *
    * @throws IllegalArgumentException if the specified value is not acceptable.
-   * @throws org.apache.geode.UnmodifiableException if this attribute can not be modified.
-   * @throws org.apache.geode.GemFireIOException if the set failure is caused by an error when
+   * @throws UnmodifiableException if this attribute can not be modified.
+   * @throws GemFireIOException if the set failure is caused by an error when
    *         writing to the system's configuration file.
    */
   @ConfigAttributeSetter(name = NAME)
@@ -462,8 +464,8 @@ public interface DistributionConfig extends Config, LogConfig {
    *        and must be separated by a comma.
    *
    * @throws IllegalArgumentException if the specified value is not acceptable.
-   * @throws org.apache.geode.UnmodifiableException if this attribute can not be modified.
-   * @throws org.apache.geode.GemFireIOException if the set failure is caused by an error when
+   * @throws UnmodifiableException if this attribute can not be modified.
+   * @throws GemFireIOException if the set failure is caused by an error when
    *         writing to the system's configuration file.
    */
   @ConfigAttributeSetter(name = LOCATORS)
@@ -531,8 +533,8 @@ public interface DistributionConfig extends Config, LogConfig {
    * Sets the system's deploy working directory.
    *
    * @throws IllegalArgumentException if the specified value is not acceptable.
-   * @throws org.apache.geode.UnmodifiableException if this attribute can not be modified.
-   * @throws org.apache.geode.GemFireIOException if the set failure is caused by an error when
+   * @throws UnmodifiableException if this attribute can not be modified.
+   * @throws GemFireIOException if the set failure is caused by an error when
    *         writing to the system's configuration file.
    */
   @ConfigAttributeSetter(name = DEPLOY_WORKING_DIR)
@@ -560,8 +562,8 @@ public interface DistributionConfig extends Config, LogConfig {
    * Sets the system's user command path.
    *
    * @throws IllegalArgumentException if the specified value is not acceptable.
-   * @throws org.apache.geode.UnmodifiableException if this attribute can not be modified.
-   * @throws org.apache.geode.GemFireIOException if the set failure is caused by an error when
+   * @throws UnmodifiableException if this attribute can not be modified.
+   * @throws GemFireIOException if the set failure is caused by an error when
    *         writing to the system's configuration file.
    */
   @ConfigAttributeSetter(name = USER_COMMAND_PACKAGES)
@@ -583,6 +585,7 @@ public interface DistributionConfig extends Config, LogConfig {
    *
    * @return <code>null</code> if logging information goes to standard out
    */
+  @Override
   @ConfigAttributeGetter(name = LOG_FILE)
   File getLogFile();
 
@@ -594,11 +597,10 @@ public interface DistributionConfig extends Config, LogConfig {
    * The system log file can not be changed while the system is running.
    *
    * @throws IllegalArgumentException if the specified value is not acceptable.
-   * @throws org.apache.geode.UnmodifiableException if this attribute can not be modified.
-   * @throws org.apache.geode.GemFireIOException if the set failure is caused by an error when
+   * @throws UnmodifiableException if this attribute can not be modified.
+   * @throws GemFireIOException if the set failure is caused by an error when
    *         writing to the system's configuration file.
    */
-
   @ConfigAttributeSetter(name = LOG_FILE)
   void setLogFile(File value);
 
@@ -618,15 +620,16 @@ public interface DistributionConfig extends Config, LogConfig {
   /**
    * Returns the value of the {@link ConfigurationProperties#LOG_LEVEL} property
    *
-   * @see org.apache.geode.internal.logging.LogWriterImpl
+   * @see LogWriterImpl
    */
+  @Override
   @ConfigAttributeGetter(name = LOG_LEVEL)
   int getLogLevel();
 
   /**
    * Sets the value of the {@link ConfigurationProperties#LOG_LEVEL} property
    *
-   * @see org.apache.geode.internal.logging.LogWriterImpl
+   * @see LogWriterImpl
    */
   @ConfigAttributeSetter(name = LOG_LEVEL)
   void setLogLevel(int value);
@@ -922,6 +925,7 @@ public interface DistributionConfig extends Config, LogConfig {
   /**
    * Returns the value of the {@link ConfigurationProperties#LOG_FILE_SIZE_LIMIT} property
    */
+  @Override
   @ConfigAttributeGetter(name = LOG_FILE_SIZE_LIMIT)
   int getLogFileSizeLimit();
 
@@ -960,6 +964,7 @@ public interface DistributionConfig extends Config, LogConfig {
   /**
    * Returns the value of the {@link ConfigurationProperties#LOG_DISK_SPACE_LIMIT} property
    */
+  @Override
   @ConfigAttributeGetter(name = LOG_DISK_SPACE_LIMIT)
   int getLogDiskSpaceLimit();
 
@@ -1253,7 +1258,7 @@ public interface DistributionConfig extends Config, LogConfig {
   String CLUSTER_SSL_TRUSTSTORE_PASSWORD_NAME = CLUSTER_SSL_TRUSTSTORE_PASSWORD;
 
   /**
-   * The name of an internal property that specifies a {@link org.apache.geode.i18n.LogWriterI18n}
+   * The name of an internal property that specifies a {@link LogWriterI18n}
    * instance to log to. Set this property with put(), not with setProperty()
    *
    * @since GemFire 4.0
@@ -1283,7 +1288,7 @@ public interface DistributionConfig extends Config, LogConfig {
   String DS_QUORUM_CHECKER_NAME = "ds-quorum-checker";
 
   /**
-   * The name of an internal property that specifies a {@link org.apache.geode.LogWriter} instance
+   * The name of an internal property that specifies a {@link LogWriter} instance
    * to log security messages to. Set this property with put(), not with setProperty()
    *
    * @since GemFire 5.5
@@ -2485,8 +2490,8 @@ public interface DistributionConfig extends Config, LogConfig {
    * The security log file can not be changed while the system is running.
    *
    * @throws IllegalArgumentException if the specified value is not acceptable.
-   * @throws org.apache.geode.UnmodifiableException if this attribute can not be modified.
-   * @throws org.apache.geode.GemFireIOException if the set failure is caused by an error when
+   * @throws UnmodifiableException if this attribute can not be modified.
+   * @throws GemFireIOException if the set failure is caused by an error when
    *         writing to the system's configuration file.
    */
   @ConfigAttributeSetter(name = SECURITY_LOG_FILE)
@@ -2742,8 +2747,8 @@ public interface DistributionConfig extends Config, LogConfig {
    * The groups can not be changed while the system is running.
    *
    * @throws IllegalArgumentException if the specified value is not acceptable.
-   * @throws org.apache.geode.UnmodifiableException if this attribute can not be modified.
-   * @throws org.apache.geode.GemFireIOException if the set failure is caused by an error when
+   * @throws UnmodifiableException if this attribute can not be modified.
+   * @throws GemFireIOException if the set failure is caused by an error when
    *         writing to the system's configuration file.
    * @since GemFire 7.0
    */
@@ -2841,7 +2846,7 @@ public interface DistributionConfig extends Config, LogConfig {
    * The name of the {@link ConfigurationProperties#JMX_MANAGER_SSL_ENABLED} property
    *
    * @deprecated Geode 1.0 use
-   *             {@link org.apache.geode.distributed.ConfigurationProperties#CLUSTER_SSL_ENABLED}
+   *             {@link ConfigurationProperties#CLUSTER_SSL_ENABLED}
    */
   @Deprecated
   @ConfigAttribute(type = Boolean.class)
@@ -2915,11 +2920,11 @@ public interface DistributionConfig extends Config, LogConfig {
   String DEFAULT_JMX_MANAGER_SSL_PROTOCOLS = "any";
   /**
    * The name of the {@link ConfigurationProperties#JMX_MANAGER_SSL_PROTOCOLS} property The name of
-   * the {@link org.apache.geode.distributed.ConfigurationProperties#JMX_MANAGER_SSL_PROTOCOLS}
+   * the {@link ConfigurationProperties#JMX_MANAGER_SSL_PROTOCOLS}
    * property
    *
    * @deprecated Geode 1.0 use
-   *             {@link org.apache.geode.distributed.ConfigurationProperties#CLUSTER_SSL_PROTOCOLS}
+   *             {@link ConfigurationProperties#CLUSTER_SSL_PROTOCOLS}
    */
   @Deprecated
   @ConfigAttribute(type = String.class)
@@ -2954,11 +2959,11 @@ public interface DistributionConfig extends Config, LogConfig {
   String DEFAULT_JMX_MANAGER_SSL_CIPHERS = "any";
   /**
    * The name of the {@link ConfigurationProperties#JMX_MANAGER_SSL_CIPHERS} property The name of
-   * the {@link org.apache.geode.distributed.ConfigurationProperties#JMX_MANAGER_SSL_CIPHERS}
+   * the {@link ConfigurationProperties#JMX_MANAGER_SSL_CIPHERS}
    * property
    *
    * @deprecated Geode 1.0 use
-   *             {@link org.apache.geode.distributed.ConfigurationProperties#CLUSTER_SSL_CIPHERS}
+   *             {@link ConfigurationProperties#CLUSTER_SSL_CIPHERS}
    */
   @Deprecated
   @ConfigAttribute(type = String.class)
@@ -2996,11 +3001,11 @@ public interface DistributionConfig extends Config, LogConfig {
   /**
    * The name of the {@link ConfigurationProperties#JMX_MANAGER_SSL_REQUIRE_AUTHENTICATION} property
    * The name of the
-   * {@link org.apache.geode.distributed.ConfigurationProperties#JMX_MANAGER_SSL_REQUIRE_AUTHENTICATION}
+   * {@link ConfigurationProperties#JMX_MANAGER_SSL_REQUIRE_AUTHENTICATION}
    * property
    *
    * @deprecated Geode 1.0 use
-   *             {@link org.apache.geode.distributed.ConfigurationProperties#CLUSTER_SSL_REQUIRE_AUTHENTICATION}
+   *             {@link ConfigurationProperties#CLUSTER_SSL_REQUIRE_AUTHENTICATION}
    */
   @Deprecated
   @ConfigAttribute(type = Boolean.class)
@@ -3036,11 +3041,11 @@ public interface DistributionConfig extends Config, LogConfig {
 
   /**
    * The name of the {@link ConfigurationProperties#JMX_MANAGER_SSL_KEYSTORE} property The name of
-   * the {@link org.apache.geode.distributed.ConfigurationProperties#JMX_MANAGER_SSL_KEYSTORE}
+   * the {@link ConfigurationProperties#JMX_MANAGER_SSL_KEYSTORE}
    * property
    *
    * @deprecated Geode 1.0 use
-   *             {@link org.apache.geode.distributed.ConfigurationProperties#CLUSTER_SSL_KEYSTORE}
+   *             {@link ConfigurationProperties#CLUSTER_SSL_KEYSTORE}
    */
   @Deprecated
   @ConfigAttribute(type = String.class)
@@ -3078,11 +3083,11 @@ public interface DistributionConfig extends Config, LogConfig {
   /**
    * The name of the {@link ConfigurationProperties#JMX_MANAGER_SSL_KEYSTORE_TYPE} property The name
    * of the
-   * {@link org.apache.geode.distributed.ConfigurationProperties#JMX_MANAGER_SSL_KEYSTORE_TYPE}
+   * {@link ConfigurationProperties#JMX_MANAGER_SSL_KEYSTORE_TYPE}
    * property
    *
    * @deprecated Geode 1.0 use
-   *             {@link org.apache.geode.distributed.ConfigurationProperties#CLUSTER_SSL_KEYSTORE_TYPE}
+   *             {@link ConfigurationProperties#CLUSTER_SSL_KEYSTORE_TYPE}
    */
   @ConfigAttribute(type = String.class)
   String JMX_MANAGER_SSL_KEYSTORE_TYPE_NAME = JMX_MANAGER_SSL_KEYSTORE_TYPE;
@@ -3120,7 +3125,7 @@ public interface DistributionConfig extends Config, LogConfig {
   /**
    * The name of the {@link ConfigurationProperties#JMX_MANAGER_SSL_KEYSTORE_PASSWORD} property The
    * name of the
-   * {@link org.apache.geode.distributed.ConfigurationProperties#JMX_MANAGER_SSL_KEYSTORE_PASSWORD}
+   * {@link ConfigurationProperties#JMX_MANAGER_SSL_KEYSTORE_PASSWORD}
    * propery
    *
    * @deprecated Geode 1.0 use {@link #DEFAULT_SSL_KEYSTORE_PASSWORD}
@@ -3159,11 +3164,11 @@ public interface DistributionConfig extends Config, LogConfig {
 
   /**
    * The name of the {@link ConfigurationProperties#JMX_MANAGER_SSL_TRUSTSTORE} property The name of
-   * the {@link org.apache.geode.distributed.ConfigurationProperties#JMX_MANAGER_SSL_TRUSTSTORE}
+   * the {@link ConfigurationProperties#JMX_MANAGER_SSL_TRUSTSTORE}
    * property
    *
    * @deprecated Geode 1.0 use
-   *             {@link org.apache.geode.distributed.ConfigurationProperties#CLUSTER_SSL_TRUSTSTORE}
+   *             {@link ConfigurationProperties#CLUSTER_SSL_TRUSTSTORE}
    */
   @ConfigAttribute(type = String.class)
   String JMX_MANAGER_SSL_TRUSTSTORE_NAME = JMX_MANAGER_SSL_TRUSTSTORE;
@@ -3201,11 +3206,11 @@ public interface DistributionConfig extends Config, LogConfig {
   /**
    * The name of the {@link ConfigurationProperties#JMX_MANAGER_SSL_TRUSTSTORE_PASSWORD} property
    * The name of the
-   * {@link org.apache.geode.distributed.ConfigurationProperties#JMX_MANAGER_SSL_TRUSTSTORE_PASSWORD}
+   * {@link ConfigurationProperties#JMX_MANAGER_SSL_TRUSTSTORE_PASSWORD}
    * property
    *
    * @deprecated Geode 1.0 use
-   *             {@link org.apache.geode.distributed.ConfigurationProperties#CLUSTER_SSL_TRUSTSTORE_PASSWORD}
+   *             {@link ConfigurationProperties#CLUSTER_SSL_TRUSTSTORE_PASSWORD}
    */
   @Deprecated
   @ConfigAttribute(type = String.class)
@@ -3255,7 +3260,7 @@ public interface DistributionConfig extends Config, LogConfig {
    * Returns the value of the {@link ConfigurationProperties#JMX_MANAGER_HTTP_PORT} property
    * <p>
    * Returns the value of the
-   * {@link org.apache.geode.distributed.ConfigurationProperties#JMX_MANAGER_HTTP_PORT} property
+   * {@link ConfigurationProperties#JMX_MANAGER_HTTP_PORT} property
    *
    * @deprecated as of 8.0 use {@link #getHttpServicePort()} instead.
    */
@@ -3265,7 +3270,7 @@ public interface DistributionConfig extends Config, LogConfig {
   /**
    * Set the {@link ConfigurationProperties#JMX_MANAGER_HTTP_PORT} for jmx-manager.
    * <p>
-   * Set the {@link org.apache.geode.distributed.ConfigurationProperties#JMX_MANAGER_HTTP_PORT} for
+   * Set the {@link ConfigurationProperties#JMX_MANAGER_HTTP_PORT} for
    * jmx-manager.
    *
    * @param value the port number for jmx-manager HTTP service
@@ -3279,7 +3284,7 @@ public interface DistributionConfig extends Config, LogConfig {
    * The name of the {@link ConfigurationProperties#JMX_MANAGER_HTTP_PORT} property.
    * <p>
    * The name of the
-   * {@link org.apache.geode.distributed.ConfigurationProperties#JMX_MANAGER_HTTP_PORT} property.
+   * {@link ConfigurationProperties#JMX_MANAGER_HTTP_PORT} property.
    *
    * @deprecated as of 8.0 use {{@link #HTTP_SERVICE_PORT_NAME} instead.
    */
@@ -3311,7 +3316,7 @@ public interface DistributionConfig extends Config, LogConfig {
    * Returns the value of the {@link ConfigurationProperties#MEMCACHED_PORT} property
    * <p>
    * Returns the value of the
-   * {@link org.apache.geode.distributed.ConfigurationProperties#MEMCACHED_PORT} property
+   * {@link ConfigurationProperties#MEMCACHED_PORT} property
    *
    * @return the port on which GemFireMemcachedServer should be started
    *
@@ -3331,7 +3336,7 @@ public interface DistributionConfig extends Config, LogConfig {
    * Returns the value of the {@link ConfigurationProperties#MEMCACHED_PROTOCOL} property
    * <p>
    * Returns the value of the
-   * {@link org.apache.geode.distributed.ConfigurationProperties#MEMCACHED_PROTOCOL} property
+   * {@link ConfigurationProperties#MEMCACHED_PROTOCOL} property
    *
    * @return the protocol for GemFireMemcachedServer
    *
@@ -3351,7 +3356,7 @@ public interface DistributionConfig extends Config, LogConfig {
    * Returns the value of the {@link ConfigurationProperties#MEMCACHED_BIND_ADDRESS} property
    * <p>
    * Returns the value of the
-   * {@link org.apache.geode.distributed.ConfigurationProperties#MEMCACHED_BIND_ADDRESS} property
+   * {@link ConfigurationProperties#MEMCACHED_BIND_ADDRESS} property
    *
    * @return the bind address for GemFireMemcachedServer
    *
@@ -3388,7 +3393,7 @@ public interface DistributionConfig extends Config, LogConfig {
    * Returns the value of the {@link ConfigurationProperties#REDIS_BIND_ADDRESS} property
    * <p>
    * Returns the value of the
-   * {@link org.apache.geode.distributed.ConfigurationProperties#REDIS_BIND_ADDRESS} property
+   * {@link ConfigurationProperties#REDIS_BIND_ADDRESS} property
    *
    * @return the bind address for GemFireRedisServer
    *
@@ -3408,7 +3413,7 @@ public interface DistributionConfig extends Config, LogConfig {
    * Returns the value of the {@link ConfigurationProperties#REDIS_PASSWORD} property
    * <p>
    * Returns the value of the
-   * {@link org.apache.geode.distributed.ConfigurationProperties#REDIS_PASSWORD} property
+   * {@link ConfigurationProperties#REDIS_PASSWORD} property
    *
    * @return the authentication password for GemFireRedisServer
    *
@@ -3430,7 +3435,7 @@ public interface DistributionConfig extends Config, LogConfig {
    * Returns the value of the {@link ConfigurationProperties#HTTP_SERVICE_PORT} property
    * <p>
    * Returns the value of the
-   * {@link org.apache.geode.distributed.ConfigurationProperties#HTTP_SERVICE_PORT} property
+   * {@link ConfigurationProperties#HTTP_SERVICE_PORT} property
    *
    * @return the HTTP service port
    *
@@ -3442,7 +3447,7 @@ public interface DistributionConfig extends Config, LogConfig {
   /**
    * Set the {@link ConfigurationProperties#HTTP_SERVICE_PORT} for HTTP service.
    * <p>
-   * Set the {@link org.apache.geode.distributed.ConfigurationProperties#HTTP_SERVICE_PORT} for HTTP
+   * Set the {@link ConfigurationProperties#HTTP_SERVICE_PORT} for HTTP
    * service.
    *
    * @param value the port number for HTTP service
@@ -3455,7 +3460,7 @@ public interface DistributionConfig extends Config, LogConfig {
   /**
    * The name of the {@link ConfigurationProperties#HTTP_SERVICE_PORT} property
    * <p>
-   * The name of the {@link org.apache.geode.distributed.ConfigurationProperties#HTTP_SERVICE_PORT}
+   * The name of the {@link ConfigurationProperties#HTTP_SERVICE_PORT}
    * property
    *
    * @since GemFire 8.0
@@ -3475,7 +3480,7 @@ public interface DistributionConfig extends Config, LogConfig {
    * Returns the value of the {@link ConfigurationProperties#HTTP_SERVICE_BIND_ADDRESS} property
    * <p>
    * Returns the value of the
-   * {@link org.apache.geode.distributed.ConfigurationProperties#HTTP_SERVICE_BIND_ADDRESS} property
+   * {@link ConfigurationProperties#HTTP_SERVICE_BIND_ADDRESS} property
    *
    * @return the bind-address for HTTP service
    *
@@ -3487,7 +3492,7 @@ public interface DistributionConfig extends Config, LogConfig {
   /**
    * Set the {@link ConfigurationProperties#HTTP_SERVICE_BIND_ADDRESS} for HTTP service.
    * <p>
-   * Set the {@link org.apache.geode.distributed.ConfigurationProperties#HTTP_SERVICE_BIND_ADDRESS}
+   * Set the {@link ConfigurationProperties#HTTP_SERVICE_BIND_ADDRESS}
    * for HTTP service.
    *
    * @param value the bind-address for HTTP service
@@ -3545,11 +3550,11 @@ public interface DistributionConfig extends Config, LogConfig {
 
   /**
    * The name of the {@link ConfigurationProperties#HTTP_SERVICE_SSL_ENABLED} property The name of
-   * the {@link org.apache.geode.distributed.ConfigurationProperties#HTTP_SERVICE_SSL_ENABLED}
+   * the {@link ConfigurationProperties#HTTP_SERVICE_SSL_ENABLED}
    * property
    *
    * @deprecated Geode 1.0 use
-   *             {@link org.apache.geode.distributed.ConfigurationProperties#CLUSTER_SSL_ENABLED}
+   *             {@link ConfigurationProperties#CLUSTER_SSL_ENABLED}
    */
   @Deprecated
   @ConfigAttribute(type = Boolean.class)
@@ -3588,11 +3593,11 @@ public interface DistributionConfig extends Config, LogConfig {
   /**
    * The name of the {@link ConfigurationProperties#HTTP_SERVICE_SSL_REQUIRE_AUTHENTICATION}
    * property The name of the
-   * {@link org.apache.geode.distributed.ConfigurationProperties#HTTP_SERVICE_SSL_REQUIRE_AUTHENTICATION}
+   * {@link ConfigurationProperties#HTTP_SERVICE_SSL_REQUIRE_AUTHENTICATION}
    * property
    *
    * @deprecated Geode 1.0 use
-   *             {@link org.apache.geode.distributed.ConfigurationProperties#CLUSTER_SSL_REQUIRE_AUTHENTICATION}
+   *             {@link ConfigurationProperties#CLUSTER_SSL_REQUIRE_AUTHENTICATION}
    */
   @Deprecated
   @ConfigAttribute(type = Boolean.class)
@@ -3628,11 +3633,11 @@ public interface DistributionConfig extends Config, LogConfig {
 
   /**
    * The name of the {@link ConfigurationProperties#HTTP_SERVICE_SSL_PROTOCOLS} property The name of
-   * the {@link org.apache.geode.distributed.ConfigurationProperties#HTTP_SERVICE_SSL_PROTOCOLS}
+   * the {@link ConfigurationProperties#HTTP_SERVICE_SSL_PROTOCOLS}
    * property
    *
    * @deprecated Geode 1.0 use
-   *             {@link org.apache.geode.distributed.ConfigurationProperties#CLUSTER_SSL_PROTOCOLS}
+   *             {@link ConfigurationProperties#CLUSTER_SSL_PROTOCOLS}
    */
   @Deprecated
   @ConfigAttribute(type = String.class)
@@ -3668,11 +3673,11 @@ public interface DistributionConfig extends Config, LogConfig {
 
   /**
    * The name of the {@link ConfigurationProperties#HTTP_SERVICE_SSL_CIPHERS} property The name of
-   * the {@link org.apache.geode.distributed.ConfigurationProperties#HTTP_SERVICE_SSL_CIPHERS}
+   * the {@link ConfigurationProperties#HTTP_SERVICE_SSL_CIPHERS}
    * property
    *
    * @deprecated Geode 1.0 use
-   *             {@link org.apache.geode.distributed.ConfigurationProperties#CLUSTER_SSL_CIPHERS}
+   *             {@link ConfigurationProperties#CLUSTER_SSL_CIPHERS}
    */
   @Deprecated
   @ConfigAttribute(type = String.class)
@@ -3708,11 +3713,11 @@ public interface DistributionConfig extends Config, LogConfig {
 
   /**
    * The name of the {@link ConfigurationProperties#HTTP_SERVICE_SSL_KEYSTORE} property The name of
-   * the {@link org.apache.geode.distributed.ConfigurationProperties#HTTP_SERVICE_SSL_KEYSTORE}
+   * the {@link ConfigurationProperties#HTTP_SERVICE_SSL_KEYSTORE}
    * property
    *
    * @deprecated Geode 1.0 use
-   *             {@link org.apache.geode.distributed.ConfigurationProperties#CLUSTER_SSL_KEYSTORE}
+   *             {@link ConfigurationProperties#CLUSTER_SSL_KEYSTORE}
    */
   @Deprecated
   @ConfigAttribute(type = String.class)
@@ -3751,11 +3756,11 @@ public interface DistributionConfig extends Config, LogConfig {
   /**
    * The name of the {@link ConfigurationProperties#HTTP_SERVICE_SSL_KEYSTORE_PASSWORD} property The
    * name of the
-   * {@link org.apache.geode.distributed.ConfigurationProperties#HTTP_SERVICE_SSL_KEYSTORE_PASSWORD}
+   * {@link ConfigurationProperties#HTTP_SERVICE_SSL_KEYSTORE_PASSWORD}
    * property
    *
    * @deprecated Geode 1.0 use
-   *             {@link org.apache.geode.distributed.ConfigurationProperties#CLUSTER_SSL_KEYSTORE_PASSWORD}
+   *             {@link ConfigurationProperties#CLUSTER_SSL_KEYSTORE_PASSWORD}
    */
   @Deprecated
   @ConfigAttribute(type = String.class)
@@ -3792,11 +3797,11 @@ public interface DistributionConfig extends Config, LogConfig {
   /**
    * The name of the {@link ConfigurationProperties#HTTP_SERVICE_SSL_KEYSTORE_TYPE} property The
    * name of the
-   * {@link org.apache.geode.distributed.ConfigurationProperties#HTTP_SERVICE_SSL_KEYSTORE_TYPE}
+   * {@link ConfigurationProperties#HTTP_SERVICE_SSL_KEYSTORE_TYPE}
    * property
    *
    * @deprecated Geode 1.0 use
-   *             {@link org.apache.geode.distributed.ConfigurationProperties#CLUSTER_SSL_KEYSTORE_TYPE}
+   *             {@link ConfigurationProperties#CLUSTER_SSL_KEYSTORE_TYPE}
    */
   @Deprecated
   @ConfigAttribute(type = String.class)
@@ -3832,11 +3837,11 @@ public interface DistributionConfig extends Config, LogConfig {
 
   /**
    * The name of the {@link ConfigurationProperties#HTTP_SERVICE_SSL_TRUSTSTORE} property The name
-   * of the {@link org.apache.geode.distributed.ConfigurationProperties#HTTP_SERVICE_SSL_TRUSTSTORE}
+   * of the {@link ConfigurationProperties#HTTP_SERVICE_SSL_TRUSTSTORE}
    * property
    *
    * @deprecated Geode 1.0 use
-   *             {@link org.apache.geode.distributed.ConfigurationProperties#CLUSTER_SSL_TRUSTSTORE}
+   *             {@link ConfigurationProperties#CLUSTER_SSL_TRUSTSTORE}
    */
   @Deprecated
   @ConfigAttribute(type = String.class)
@@ -3875,11 +3880,11 @@ public interface DistributionConfig extends Config, LogConfig {
   /**
    * The name of the {@link ConfigurationProperties#HTTP_SERVICE_SSL_TRUSTSTORE_PASSWORD} property
    * The name of the
-   * {@link org.apache.geode.distributed.ConfigurationProperties#HTTP_SERVICE_SSL_TRUSTSTORE_PASSWORD}
+   * {@link ConfigurationProperties#HTTP_SERVICE_SSL_TRUSTSTORE_PASSWORD}
    * property
    *
    * @deprecated Geode 1.0 use
-   *             {@link org.apache.geode.distributed.ConfigurationProperties#CLUSTER_SSL_TRUSTSTORE_PASSWORD}
+   *             {@link ConfigurationProperties#CLUSTER_SSL_TRUSTSTORE_PASSWORD}
    */
   @Deprecated
   @ConfigAttribute(type = String.class)
@@ -3897,7 +3902,7 @@ public interface DistributionConfig extends Config, LogConfig {
    * Returns the value of the {@link ConfigurationProperties#START_DEV_REST_API} property
    * <p>
    * Returns the value of the
-   * {@link org.apache.geode.distributed.ConfigurationProperties#START_DEV_REST_API} property
+   * {@link ConfigurationProperties#START_DEV_REST_API} property
    *
    * @return the value of the property
    *
@@ -3910,7 +3915,7 @@ public interface DistributionConfig extends Config, LogConfig {
   /**
    * Set the {@link ConfigurationProperties#START_DEV_REST_API} for HTTP service.
    * <p>
-   * Set the {@link org.apache.geode.distributed.ConfigurationProperties#START_DEV_REST_API} for
+   * Set the {@link ConfigurationProperties#START_DEV_REST_API} for
    * HTTP service.
    *
    * @param value for the property
@@ -3923,7 +3928,7 @@ public interface DistributionConfig extends Config, LogConfig {
   /**
    * The name of the {@link ConfigurationProperties#START_DEV_REST_API} property
    * <p>
-   * The name of the {@link org.apache.geode.distributed.ConfigurationProperties#START_DEV_REST_API}
+   * The name of the {@link ConfigurationProperties#START_DEV_REST_API}
    * property
    *
    * @since GemFire 8.0
@@ -3992,10 +3997,10 @@ public interface DistributionConfig extends Config, LogConfig {
   boolean DEFAULT_SERVER_SSL_ENABLED = false;
   /**
    * The name of the {@link ConfigurationProperties#SERVER_SSL_ENABLED} property The name of the
-   * {@link org.apache.geode.distributed.ConfigurationProperties#SERVER_SSL_ENABLED} property
+   * {@link ConfigurationProperties#SERVER_SSL_ENABLED} property
    *
    * @deprecated Geode 1.0 use
-   *             {@link org.apache.geode.distributed.ConfigurationProperties#SERVER_SSL_ENABLED}
+   *             {@link ConfigurationProperties#SERVER_SSL_ENABLED}
    */
   @Deprecated
   @ConfigAttribute(type = Boolean.class)
@@ -4036,10 +4041,10 @@ public interface DistributionConfig extends Config, LogConfig {
   String DEFAULT_SERVER_SSL_PROTOCOLS = "any";
   /**
    * The name of the {@link ConfigurationProperties#SERVER_SSL_PROTOCOLS} property The name of the
-   * {@link org.apache.geode.distributed.ConfigurationProperties#SERVER_SSL_PROTOCOLS} property
+   * {@link ConfigurationProperties#SERVER_SSL_PROTOCOLS} property
    *
    * @deprecated Geode 1.0 use
-   *             {@link org.apache.geode.distributed.ConfigurationProperties#CLUSTER_SSL_PROTOCOLS}
+   *             {@link ConfigurationProperties#CLUSTER_SSL_PROTOCOLS}
    */
   @Deprecated
   @ConfigAttribute(type = String.class)
@@ -4074,10 +4079,10 @@ public interface DistributionConfig extends Config, LogConfig {
   String DEFAULT_SERVER_SSL_CIPHERS = "any";
   /**
    * The name of the {@link ConfigurationProperties#SERVER_SSL_CIPHERS} property The name of the
-   * {@link org.apache.geode.distributed.ConfigurationProperties#SERVER_SSL_CIPHERS} property
+   * {@link ConfigurationProperties#SERVER_SSL_CIPHERS} property
    *
    * @deprecated Geode 1.0 use
-   *             {@link org.apache.geode.distributed.ConfigurationProperties#CLUSTER_SSL_CIPHERS} 
+   *             {@link ConfigurationProperties#CLUSTER_SSL_CIPHERS} 
    */
   @Deprecated
   @ConfigAttribute(type = String.class)
@@ -4115,11 +4120,11 @@ public interface DistributionConfig extends Config, LogConfig {
   /**
    * The name of the {@link ConfigurationProperties#SERVER_SSL_REQUIRE_AUTHENTICATION} property The
    * name of the
-   * {@link org.apache.geode.distributed.ConfigurationProperties#SERVER_SSL_REQUIRE_AUTHENTICATION}
+   * {@link ConfigurationProperties#SERVER_SSL_REQUIRE_AUTHENTICATION}
    * property
    *
    * @deprecated Geode 1.0 use
-   *             {@link org.apache.geode.distributed.ConfigurationProperties#CLUSTER_SSL_REQUIRE_AUTHENTICATION}
+   *             {@link ConfigurationProperties#CLUSTER_SSL_REQUIRE_AUTHENTICATION}
    */
   @Deprecated
   @ConfigAttribute(type = Boolean.class)
@@ -4155,10 +4160,10 @@ public interface DistributionConfig extends Config, LogConfig {
 
   /**
    * The name of the {@link ConfigurationProperties#SERVER_SSL_KEYSTORE} property The name of the
-   * {@link org.apache.geode.distributed.ConfigurationProperties#SERVER_SSL_KEYSTORE} property
+   * {@link ConfigurationProperties#SERVER_SSL_KEYSTORE} property
    *
    * @deprecated Geode 1.0 use
-   *             {@link org.apache.geode.distributed.ConfigurationProperties#CLUSTER_SSL_KEYSTORE}
+   *             {@link ConfigurationProperties#CLUSTER_SSL_KEYSTORE}
    */
   @Deprecated
   @ConfigAttribute(type = String.class)
@@ -4194,11 +4199,11 @@ public interface DistributionConfig extends Config, LogConfig {
 
   /**
    * The name of the {@link ConfigurationProperties#SERVER_SSL_KEYSTORE_TYPE} property The name of
-   * the {@link org.apache.geode.distributed.ConfigurationProperties#SERVER_SSL_KEYSTORE_TYPE}
+   * the {@link ConfigurationProperties#SERVER_SSL_KEYSTORE_TYPE}
    * property
    *
    * @deprecated Geode 1.0 use
-   *             {@link org.apache.geode.distributed.ConfigurationProperties#CLUSTER_SSL_KEYSTORE_TYPE}
+   *             {@link ConfigurationProperties#CLUSTER_SSL_KEYSTORE_TYPE}
    */
   @Deprecated
   @ConfigAttribute(type = String.class)
@@ -4235,11 +4240,11 @@ public interface DistributionConfig extends Config, LogConfig {
   /**
    * The name of the {@link ConfigurationProperties#SERVER_SSL_KEYSTORE_PASSWORD} property The name
    * of the
-   * {@link org.apache.geode.distributed.ConfigurationProperties#SERVER_SSL_KEYSTORE_PASSWORD}
+   * {@link ConfigurationProperties#SERVER_SSL_KEYSTORE_PASSWORD}
    * property
    *
    * @deprecated Geode 1.0 use
-   *             {@link org.apache.geode.distributed.ConfigurationProperties#CLUSTER_SSL_KEYSTORE_PASSWORD}
+   *             {@link ConfigurationProperties#CLUSTER_SSL_KEYSTORE_PASSWORD}
    */
   @Deprecated
   @ConfigAttribute(type = String.class)
@@ -4274,10 +4279,10 @@ public interface DistributionConfig extends Config, LogConfig {
 
   /**
    * The name of the {@link ConfigurationProperties#SERVER_SSL_TRUSTSTORE} property The name of the
-   * {@link org.apache.geode.distributed.ConfigurationProperties#SERVER_SSL_TRUSTSTORE} property
+   * {@link ConfigurationProperties#SERVER_SSL_TRUSTSTORE} property
    *
    * @deprecated Geode 1.0 use
-   *             {@link org.apache.geode.distributed.ConfigurationProperties#CLUSTER_SSL_TRUSTSTORE}
+   *             {@link ConfigurationProperties#CLUSTER_SSL_TRUSTSTORE}
    */
   @Deprecated
   @ConfigAttribute(type = String.class)
@@ -4315,11 +4320,11 @@ public interface DistributionConfig extends Config, LogConfig {
   /**
    * The name of the {@link ConfigurationProperties#SERVER_SSL_TRUSTSTORE_PASSWORD} property The
    * name of the
-   * {@link org.apache.geode.distributed.ConfigurationProperties#SERVER_SSL_TRUSTSTORE_PASSWORD}
+   * {@link ConfigurationProperties#SERVER_SSL_TRUSTSTORE_PASSWORD}
    * property
    *
    * @deprecated Geode 1.0 use
-   *             {@link org.apache.geode.distributed.ConfigurationProperties#CLUSTER_SSL_TRUSTSTORE_PASSWORD}
+   *             {@link ConfigurationProperties#CLUSTER_SSL_TRUSTSTORE_PASSWORD}
    */
   @Deprecated
   @ConfigAttribute(type = String.class)
@@ -4345,10 +4350,10 @@ public interface DistributionConfig extends Config, LogConfig {
   boolean DEFAULT_GATEWAY_SSL_ENABLED = false;
   /**
    * The name of the {@link ConfigurationProperties#GATEWAY_SSL_ENABLED} property The name of the
-   * {@link org.apache.geode.distributed.ConfigurationProperties#GATEWAY_SSL_ENABLED} property
+   * {@link ConfigurationProperties#GATEWAY_SSL_ENABLED} property
    *
    * @deprecated Geode 1.0 use
-   *             {@link org.apache.geode.distributed.ConfigurationProperties#CLUSTER_SSL_ENABLED}
+   *             {@link ConfigurationProperties#CLUSTER_SSL_ENABLED}
    */
   @Deprecated
   @ConfigAttribute(type = Boolean.class)
@@ -4391,10 +4396,10 @@ public interface DistributionConfig extends Config, LogConfig {
   String DEFAULT_GATEWAY_SSL_PROTOCOLS = "any";
   /**
    * The name of the {@link ConfigurationProperties#GATEWAY_SSL_PROTOCOLS} property The name of the
-   * {@link org.apache.geode.distributed.ConfigurationProperties#GATEWAY_SSL_PROTOCOLS} property
+   * {@link ConfigurationProperties#GATEWAY_SSL_PROTOCOLS} property
    *
    * @deprecated Geode 1.0 use
-   *             {@link org.apache.geode.distributed.ConfigurationProperties#CLUSTER_SSL_PROTOCOLS}
+   *             {@link ConfigurationProperties#CLUSTER_SSL_PROTOCOLS}
    */
   @Deprecated
   @ConfigAttribute(type = String.class)
@@ -4428,10 +4433,10 @@ public interface DistributionConfig extends Config, LogConfig {
   String DEFAULT_GATEWAY_SSL_CIPHERS = "any";
   /**
    * The name of the {@link ConfigurationProperties#GATEWAY_SSL_CIPHERS} property The name of the
-   * {@link org.apache.geode.distributed.ConfigurationProperties#GATEWAY_SSL_CIPHERS} property
+   * {@link ConfigurationProperties#GATEWAY_SSL_CIPHERS} property
    *
    * @deprecated Geode 1.0 use
-   *             {@link org.apache.geode.distributed.ConfigurationProperties#CLUSTER_SSL_CIPHERS} 
+   *             {@link ConfigurationProperties#CLUSTER_SSL_CIPHERS} 
    */
   @Deprecated
   @ConfigAttribute(type = String.class)
@@ -4469,11 +4474,11 @@ public interface DistributionConfig extends Config, LogConfig {
   /**
    * The name of the {@link ConfigurationProperties#GATEWAY_SSL_REQUIRE_AUTHENTICATION} property The
    * name of the
-   * {@link org.apache.geode.distributed.ConfigurationProperties#GATEWAY_SSL_REQUIRE_AUTHENTICATION}
+   * {@link ConfigurationProperties#GATEWAY_SSL_REQUIRE_AUTHENTICATION}
    * property
    *
    * @deprecated Geode 1.0 use
-   *             {@link org.apache.geode.distributed.ConfigurationProperties#CLUSTER_SSL_REQUIRE_AUTHENTICATION}
+   *             {@link ConfigurationProperties#CLUSTER_SSL_REQUIRE_AUTHENTICATION}
    */
   @Deprecated
   @ConfigAttribute(type = Boolean.class)
@@ -4509,10 +4514,10 @@ public interface DistributionConfig extends Config, LogConfig {
 
   /**
    * The name of the {@link ConfigurationProperties#GATEWAY_SSL_KEYSTORE} property The name of the
-   * {@link org.apache.geode.distributed.ConfigurationProperties#GATEWAY_SSL_KEYSTORE} property
+   * {@link ConfigurationProperties#GATEWAY_SSL_KEYSTORE} property
    *
    * @deprecated Geode 1.0 use
-   *             {@link org.apache.geode.distributed.ConfigurationProperties#CLUSTER_SSL_KEYSTORE}
+   *             {@link ConfigurationProperties#CLUSTER_SSL_KEYSTORE}
    */
   @Deprecated
   @ConfigAttribute(type = String.class)
@@ -4548,11 +4553,11 @@ public interface DistributionConfig extends Config, LogConfig {
 
   /**
    * The name of the {@link ConfigurationProperties#GATEWAY_SSL_KEYSTORE_TYPE} property The name of
-   * the {@link org.apache.geode.distributed.ConfigurationProperties#GATEWAY_SSL_KEYSTORE_TYPE}
+   * the {@link ConfigurationProperties#GATEWAY_SSL_KEYSTORE_TYPE}
    * property
    *
    * @deprecated Geode 1.0 use
-   *             {@link org.apache.geode.distributed.ConfigurationProperties#CLUSTER_SSL_KEYSTORE_TYPE}
+   *             {@link ConfigurationProperties#CLUSTER_SSL_KEYSTORE_TYPE}
    */
   @Deprecated
   @ConfigAttribute(type = String.class)
@@ -4590,11 +4595,11 @@ public interface DistributionConfig extends Config, LogConfig {
   /**
    * The name of the {@link ConfigurationProperties#GATEWAY_SSL_KEYSTORE_PASSWORD} property The name
    * of the
-   * {@link org.apache.geode.distributed.ConfigurationProperties#GATEWAY_SSL_KEYSTORE_PASSWORD}
+   * {@link ConfigurationProperties#GATEWAY_SSL_KEYSTORE_PASSWORD}
    * property
    *
    * @deprecated Geode 1.0 use
-   *             {@link org.apache.geode.distributed.ConfigurationProperties#CLUSTER_SSL_KEYSTORE_PASSWORD}
+   *             {@link ConfigurationProperties#CLUSTER_SSL_KEYSTORE_PASSWORD}
    */
   @Deprecated
   @ConfigAttribute(type = String.class)
@@ -4630,10 +4635,10 @@ public interface DistributionConfig extends Config, LogConfig {
 
   /**
    * The name of the {@link ConfigurationProperties#GATEWAY_SSL_TRUSTSTORE} property The name of the
-   * {@link org.apache.geode.distributed.ConfigurationProperties#GATEWAY_SSL_TRUSTSTORE} property
+   * {@link ConfigurationProperties#GATEWAY_SSL_TRUSTSTORE} property
    *
    * @deprecated Geode 1.0 use
-   *             {@link org.apache.geode.distributed.ConfigurationProperties#CLUSTER_SSL_TRUSTSTORE}
+   *             {@link ConfigurationProperties#CLUSTER_SSL_TRUSTSTORE}
    */
   @Deprecated
   @ConfigAttribute(type = String.class)
@@ -4671,11 +4676,11 @@ public interface DistributionConfig extends Config, LogConfig {
   /**
    * The name of the {@link ConfigurationProperties#GATEWAY_SSL_TRUSTSTORE_PASSWORD} property The
    * name of the
-   * {@link org.apache.geode.distributed.ConfigurationProperties#GATEWAY_SSL_TRUSTSTORE_PASSWORD}
+   * {@link ConfigurationProperties#GATEWAY_SSL_TRUSTSTORE_PASSWORD}
    * property
    *
    * @deprecated Geode 1.0 use
-   *             {@link org.apache.geode.distributed.ConfigurationProperties#CLUSTER_SSL_TRUSTSTORE_PASSWORD}
+   *             {@link ConfigurationProperties#CLUSTER_SSL_TRUSTSTORE_PASSWORD}
    */
   @Deprecated
   @ConfigAttribute(type = String.class)
@@ -4702,7 +4707,7 @@ public interface DistributionConfig extends Config, LogConfig {
   /**
    * Gets the value of {@link ConfigurationProperties#LOCK_MEMORY}
    * <p>
-   * Gets the value of {@link org.apache.geode.distributed.ConfigurationProperties#LOCK_MEMORY}
+   * Gets the value of {@link ConfigurationProperties#LOCK_MEMORY}
    *
    * @since Geode 1.0
    */

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfigImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfigImpl.java
@@ -12,7 +12,6 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package org.apache.geode.distributed.internal;
 
 import static org.apache.geode.distributed.ConfigurationProperties.CLUSTER_SSL_CIPHERS;
@@ -87,10 +86,10 @@ import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.geode.GemFireConfigException;
 import org.apache.geode.GemFireIOException;
 import org.apache.geode.InternalGemFireException;
-import org.apache.geode.distributed.ConfigurationProperties;
 import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.internal.ConfigSource;
 import org.apache.geode.internal.i18n.LocalizedStrings;
+import org.apache.geode.internal.logging.LogWriterImpl;
 import org.apache.geode.internal.net.SocketCreator;
 import org.apache.geode.internal.process.ProcessLauncherContext;
 import org.apache.geode.internal.security.SecurableCommunicationChannel;
@@ -100,8 +99,6 @@ import org.apache.geode.redis.GeodeRedisServer;
 /**
  * Provides an implementation of <code>DistributionConfig</code> that knows how to read the
  * configuration file.
- * <p>
- * <p>
  * <p>
  * Note that if you add a property to this interface, should should update the
  * {@link #DistributionConfigImpl(DistributionConfig) copy constructor}.
@@ -172,12 +169,12 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
    */
   private File logFile = DEFAULT_LOG_FILE;
 
-  protected File deployWorkingDir = new File(System.getProperty("user.dir"));
+  private File deployWorkingDir = new File(System.getProperty("user.dir"));
 
   /**
    * The level at which log messages are logged
    *
-   * @see org.apache.geode.internal.logging.LogWriterImpl#levelNameToCode(String)
+   * @see LogWriterImpl#levelNameToCode(String)
    */
   protected int logLevel = DEFAULT_LOG_LEVEL;
 
@@ -204,7 +201,7 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
   /**
    * The name of the file to which statistics should be archived
    */
-  protected File statisticArchiveFile = DEFAULT_STATISTIC_ARCHIVE_FILE;
+  File statisticArchiveFile = DEFAULT_STATISTIC_ARCHIVE_FILE;
 
   /**
    * The amount of time to wait for a ACK message
@@ -252,28 +249,28 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
   /**
    * multicast send buffer size, in bytes
    */
-  protected int mcastSendBufferSize = DEFAULT_MCAST_SEND_BUFFER_SIZE;
+  private int mcastSendBufferSize = DEFAULT_MCAST_SEND_BUFFER_SIZE;
   /**
    * multicast receive buffer size, in bytes
    */
-  protected int mcastRecvBufferSize = DEFAULT_MCAST_RECV_BUFFER_SIZE;
+  private int mcastRecvBufferSize = DEFAULT_MCAST_RECV_BUFFER_SIZE;
   /**
    * flow-of-control parameters for multicast messaging
    */
-  protected FlowControlParams mcastFlowControl = DEFAULT_MCAST_FLOW_CONTROL;
+  private FlowControlParams mcastFlowControl = DEFAULT_MCAST_FLOW_CONTROL;
 
   /**
    * datagram socket send buffer size, in bytes
    */
-  protected int udpSendBufferSize = DEFAULT_UDP_SEND_BUFFER_SIZE;
+  private int udpSendBufferSize = DEFAULT_UDP_SEND_BUFFER_SIZE;
   /**
    * datagram socket receive buffer size, in bytes
    */
-  protected int udpRecvBufferSize = DEFAULT_UDP_RECV_BUFFER_SIZE;
+  private int udpRecvBufferSize = DEFAULT_UDP_RECV_BUFFER_SIZE;
   /**
    * max datagram message size, in bytes. This should be < 64k
    */
-  protected int udpFragmentSize = DEFAULT_UDP_FRAGMENT_SIZE;
+  private int udpFragmentSize = DEFAULT_UDP_FRAGMENT_SIZE;
 
   /**
    * whether tcp/ip sockets should be disabled
@@ -303,7 +300,6 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
    * Max number of tries allowed for reconnect in case of required role loss.
    */
   private int maxNumReconnectTries = DEFAULT_MAX_NUM_RECONNECT_TRIES;
-
 
   private int asyncDistributionTimeout = DEFAULT_ASYNC_DISTRIBUTION_TIMEOUT;
   private int asyncQueueTimeout = DEFAULT_ASYNC_QUEUE_TIMEOUT;
@@ -377,9 +373,9 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
   /**
    * The level at which security related log messages are logged
    *
-   * @see org.apache.geode.internal.logging.LogWriterImpl#levelNameToCode(String)
+   * @see LogWriterImpl#levelNameToCode(String)
    */
-  protected int securityLogLevel = DEFAULT_LOG_LEVEL;
+  private int securityLogLevel = DEFAULT_LOG_LEVEL;
 
   /**
    * whether network partition detection algorithms are enabled
@@ -404,12 +400,12 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
   /**
    * The member security credentials
    */
-  private Properties security = new Properties();
+  private final Properties security = new Properties();
 
   /**
    * The User defined properties to be used for cache.xml replacements
    */
-  private Properties userDefinedProps = new Properties();
+  private final Properties userDefinedProps = new Properties();
   /**
    * Prefix to use for properties that are put as JVM java properties for use with layers (e.g.
    * jgroups membership) that do not have a <code>DistributionConfig</code> object.
@@ -451,12 +447,12 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
 
   private String groups = DEFAULT_GROUPS;
 
-  protected boolean enableSharedConfiguration =
+  private boolean enableSharedConfiguration =
       DistributionConfig.DEFAULT_ENABLE_CLUSTER_CONFIGURATION;
-  protected boolean useSharedConfiguration = DistributionConfig.DEFAULT_USE_CLUSTER_CONFIGURATION;
-  protected boolean loadSharedConfigurationFromDir =
+  private boolean useSharedConfiguration = DistributionConfig.DEFAULT_USE_CLUSTER_CONFIGURATION;
+  private boolean loadSharedConfigurationFromDir =
       DistributionConfig.DEFAULT_LOAD_CLUSTER_CONFIG_FROM_DIR;
-  protected String clusterConfigDir = "";
+  private String clusterConfigDir = "";
 
 
   private int httpServicePort = DEFAULT_HTTP_SERVICE_PORT;
@@ -464,6 +460,7 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
   private String httpServiceBindAddress = DEFAULT_HTTP_SERVICE_BIND_ADDRESS;
 
   private boolean startDevRestApi = DEFAULT_START_DEV_REST_API;
+
   /**
    * port on which {@link GemFireMemcachedServer} server is started
    */
@@ -484,7 +481,6 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
    */
   private boolean distributedTransactions = DEFAULT_DISTRIBUTED_TRANSACTIONS;
 
-
   /**
    * port on which {@link GeodeRedisServer} is started
    */
@@ -498,7 +494,7 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
   private String redisPassword = DEFAULT_REDIS_PASSWORD;
 
   private boolean jmxManager =
-      Boolean.getBoolean(InternalLocator.FORCE_LOCATOR_DM_TYPE) ? true : DEFAULT_JMX_MANAGER;
+      Boolean.getBoolean(InternalLocator.FORCE_LOCATOR_DM_TYPE) || DEFAULT_JMX_MANAGER;
   private boolean jmxManagerStart = DEFAULT_JMX_MANAGER_START;
   private int jmxManagerPort = DEFAULT_JMX_MANAGER_PORT;
   private String jmxManagerBindAddress = DEFAULT_JMX_MANAGER_BIND_ADDRESS;
@@ -576,7 +572,6 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
   @Deprecated
   private String gatewaySSLTrustStorePassword = DEFAULT_GATEWAY_SSL_TRUSTSTORE_PASSWORD;
 
-
   private String gatewaySSLAlias = DEFAULT_SSL_ALIAS;
 
   @Deprecated
@@ -626,9 +621,9 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
   private String sslDefaultAlias = DEFAULT_SSL_ALIAS;
 
   private Map<String, ConfigSource> sourceMap =
-      Collections.synchronizedMap(new HashMap<String, ConfigSource>());
+      Collections.synchronizedMap(new HashMap<>());
 
-  protected String userCommandPackages = DEFAULT_USER_COMMAND_PACKAGES;
+  private String userCommandPackages = DEFAULT_USER_COMMAND_PACKAGES;
 
   private boolean validateSerializableObjects = DEFAULT_VALIDATE_SERIALIZABLE_OBJECTS;
   private String serializableObjectFilter = DEFAULT_SERIALIZABLE_OBJECT_FILTER;
@@ -636,7 +631,6 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
   /**
    * "off-heap-memory-size" with value of "" or "<size>[g|m]"
    */
-
   protected String offHeapMemorySize = DEFAULT_OFF_HEAP_MEMORY_SIZE;
 
   /**
@@ -646,209 +640,206 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
 
   private String shiroInit = "";
 
-  ////////////////////// thread monitoring///////////////////
   /**
    * Is thread monitoring enabled
    */
-  protected boolean threadMonitorEnabled = DEFAULT_THREAD_MONITOR_ENABLED;
+  private boolean threadMonitorEnabled = DEFAULT_THREAD_MONITOR_ENABLED;
 
   /**
    * the thread monitoring interval
    */
-  protected int threadMonitorInterval = DEFAULT_THREAD_MONITOR_INTERVAL;
+  private int threadMonitorInterval = DEFAULT_THREAD_MONITOR_INTERVAL;
 
   /**
    * the thread monitoring time limit after which the monitored thread is considered stuck
    */
-  protected int threadMonitorTimeLimit = DEFAULT_THREAD_MONITOR_TIME_LIMIT;
-
-  ////////////////////// Constructors //////////////////////
+  private int threadMonitorTimeLimit = DEFAULT_THREAD_MONITOR_TIME_LIMIT;
 
   /**
    * Create a new <code>DistributionConfigImpl</code> from the contents of another
    * <code>DistributionConfig</code>.
    */
   public DistributionConfigImpl(DistributionConfig other) {
-    this.name = other.getName();
-    this.tcpPort = other.getTcpPort();
-    this.mcastPort = other.getMcastPort();
-    this.mcastTtl = other.getMcastTtl();
-    this.socketLeaseTime = other.getSocketLeaseTime();
-    this.socketBufferSize = other.getSocketBufferSize();
-    this.conserveSockets = other.getConserveSockets();
-    this.roles = other.getRoles();
-    this.mcastAddress = other.getMcastAddress();
-    this.bindAddress = other.getBindAddress();
-    this.serverBindAddress = other.getServerBindAddress();
-    this.locators = ((DistributionConfigImpl) other).locators;
-    this.locatorWaitTime = other.getLocatorWaitTime();
-    this.remoteLocators = other.getRemoteLocators();
-    this.startLocator = other.getStartLocator();
-    this.startLocatorPort = ((DistributionConfigImpl) other).startLocatorPort;
-    this.deployWorkingDir = other.getDeployWorkingDir();
-    this.logFile = other.getLogFile();
-    this.logLevel = other.getLogLevel();
-    this.statisticSamplingEnabled = other.getStatisticSamplingEnabled();
-    this.threadMonitorEnabled = other.getThreadMonitorEnabled();
-    this.threadMonitorInterval = other.getThreadMonitorInterval();
-    this.threadMonitorTimeLimit = other.getThreadMonitorTimeLimit();
-    this.statisticSampleRate = other.getStatisticSampleRate();
-    this.statisticArchiveFile = other.getStatisticArchiveFile();
-    this.ackWaitThreshold = other.getAckWaitThreshold();
-    this.ackForceDisconnectThreshold = other.getAckSevereAlertThreshold();
-    this.cacheXmlFile = other.getCacheXmlFile();
-    this.archiveDiskSpaceLimit = other.getArchiveDiskSpaceLimit();
-    this.archiveFileSizeLimit = other.getArchiveFileSizeLimit();
-    this.logDiskSpaceLimit = other.getLogDiskSpaceLimit();
-    this.logFileSizeLimit = other.getLogFileSizeLimit();
-    this.clusterSSLEnabled = other.getClusterSSLEnabled();
-    this.clusterSSLProtocols = other.getClusterSSLProtocols();
-    this.clusterSSLCiphers = other.getClusterSSLCiphers();
-    this.clusterSSLRequireAuthentication = other.getClusterSSLRequireAuthentication();
-    this.clusterSSLKeyStore = other.getClusterSSLKeyStore();
-    this.clusterSSLKeyStoreType = other.getClusterSSLKeyStoreType();
-    this.clusterSSLKeyStorePassword = other.getClusterSSLKeyStorePassword();
-    this.clusterSSLTrustStore = other.getClusterSSLTrustStore();
-    this.clusterSSLTrustStorePassword = other.getClusterSSLTrustStorePassword();
-    this.asyncDistributionTimeout = other.getAsyncDistributionTimeout();
-    this.asyncQueueTimeout = other.getAsyncQueueTimeout();
-    this.asyncMaxQueueSize = other.getAsyncMaxQueueSize();
-    this.modifiable = true;
+    name = other.getName();
+    tcpPort = other.getTcpPort();
+    mcastPort = other.getMcastPort();
+    mcastTtl = other.getMcastTtl();
+    socketLeaseTime = other.getSocketLeaseTime();
+    socketBufferSize = other.getSocketBufferSize();
+    conserveSockets = other.getConserveSockets();
+    roles = other.getRoles();
+    mcastAddress = other.getMcastAddress();
+    bindAddress = other.getBindAddress();
+    serverBindAddress = other.getServerBindAddress();
+    locators = ((DistributionConfigImpl) other).locators;
+    locatorWaitTime = other.getLocatorWaitTime();
+    remoteLocators = other.getRemoteLocators();
+    startLocator = other.getStartLocator();
+    startLocatorPort = ((DistributionConfigImpl) other).startLocatorPort;
+    deployWorkingDir = other.getDeployWorkingDir();
+    logFile = other.getLogFile();
+    logLevel = other.getLogLevel();
+    statisticSamplingEnabled = other.getStatisticSamplingEnabled();
+    threadMonitorEnabled = other.getThreadMonitorEnabled();
+    threadMonitorInterval = other.getThreadMonitorInterval();
+    threadMonitorTimeLimit = other.getThreadMonitorTimeLimit();
+    statisticSampleRate = other.getStatisticSampleRate();
+    statisticArchiveFile = other.getStatisticArchiveFile();
+    ackWaitThreshold = other.getAckWaitThreshold();
+    ackForceDisconnectThreshold = other.getAckSevereAlertThreshold();
+    cacheXmlFile = other.getCacheXmlFile();
+    archiveDiskSpaceLimit = other.getArchiveDiskSpaceLimit();
+    archiveFileSizeLimit = other.getArchiveFileSizeLimit();
+    logDiskSpaceLimit = other.getLogDiskSpaceLimit();
+    logFileSizeLimit = other.getLogFileSizeLimit();
+    clusterSSLEnabled = other.getClusterSSLEnabled();
+    clusterSSLProtocols = other.getClusterSSLProtocols();
+    clusterSSLCiphers = other.getClusterSSLCiphers();
+    clusterSSLRequireAuthentication = other.getClusterSSLRequireAuthentication();
+    clusterSSLKeyStore = other.getClusterSSLKeyStore();
+    clusterSSLKeyStoreType = other.getClusterSSLKeyStoreType();
+    clusterSSLKeyStorePassword = other.getClusterSSLKeyStorePassword();
+    clusterSSLTrustStore = other.getClusterSSLTrustStore();
+    clusterSSLTrustStorePassword = other.getClusterSSLTrustStorePassword();
+    asyncDistributionTimeout = other.getAsyncDistributionTimeout();
+    asyncQueueTimeout = other.getAsyncQueueTimeout();
+    asyncMaxQueueSize = other.getAsyncMaxQueueSize();
+    modifiable = true;
     // the following were added after version 4.1.2
-    this.mcastSendBufferSize = other.getMcastSendBufferSize();
-    this.mcastRecvBufferSize = other.getMcastRecvBufferSize();
-    this.mcastFlowControl = other.getMcastFlowControl();
-    this.udpSendBufferSize = other.getUdpSendBufferSize();
-    this.udpRecvBufferSize = other.getUdpRecvBufferSize();
-    this.udpFragmentSize = other.getUdpFragmentSize();
-    this.disableTcp = other.getDisableTcp();
-    this.enableTimeStatistics = other.getEnableTimeStatistics();
-    this.memberTimeout = other.getMemberTimeout();
-    this.membershipPortRange = other.getMembershipPortRange();
-    this.maxWaitTimeForReconnect = other.getMaxWaitTimeForReconnect();
-    this.maxNumReconnectTries = other.getMaxNumReconnectTries();
-    this.clientConflation = other.getClientConflation();
-    this.durableClientId = other.getDurableClientId();
-    this.durableClientTimeout = other.getDurableClientTimeout();
+    mcastSendBufferSize = other.getMcastSendBufferSize();
+    mcastRecvBufferSize = other.getMcastRecvBufferSize();
+    mcastFlowControl = other.getMcastFlowControl();
+    udpSendBufferSize = other.getUdpSendBufferSize();
+    udpRecvBufferSize = other.getUdpRecvBufferSize();
+    udpFragmentSize = other.getUdpFragmentSize();
+    disableTcp = other.getDisableTcp();
+    enableTimeStatistics = other.getEnableTimeStatistics();
+    memberTimeout = other.getMemberTimeout();
+    membershipPortRange = other.getMembershipPortRange();
+    maxWaitTimeForReconnect = other.getMaxWaitTimeForReconnect();
+    maxNumReconnectTries = other.getMaxNumReconnectTries();
+    clientConflation = other.getClientConflation();
+    durableClientId = other.getDurableClientId();
+    durableClientTimeout = other.getDurableClientTimeout();
 
-    this.enableNetworkPartitionDetection = other.getEnableNetworkPartitionDetection();
-    this.disableAutoReconnect = other.getDisableAutoReconnect();
+    enableNetworkPartitionDetection = other.getEnableNetworkPartitionDetection();
+    disableAutoReconnect = other.getDisableAutoReconnect();
 
-    this.securityClientAuthInit = other.getSecurityClientAuthInit();
-    this.securityClientAuthenticator = other.getSecurityClientAuthenticator();
-    this.securityClientDHAlgo = other.getSecurityClientDHAlgo();
-    this.securityUDPDHAlgo = other.getSecurityUDPDHAlgo();
-    this.securityPeerAuthInit = other.getSecurityPeerAuthInit();
-    this.securityPeerAuthenticator = other.getSecurityPeerAuthenticator();
-    this.securityClientAccessor = other.getSecurityClientAccessor();
-    this.securityClientAccessorPP = other.getSecurityClientAccessorPP();
-    this.securityPeerMembershipTimeout = other.getSecurityPeerMembershipTimeout();
-    this.securityLogLevel = other.getSecurityLogLevel();
-    this.securityLogFile = other.getSecurityLogFile();
-    this.security.putAll(other.getSecurityProps());
-    this.removeUnresponsiveClient = other.getRemoveUnresponsiveClient();
-    this.deltaPropagation = other.getDeltaPropagation();
-    this.distributedSystemId = other.getDistributedSystemId();
-    this.redundancyZone = other.getRedundancyZone();
-    this.enforceUniqueHost = other.getEnforceUniqueHost();
-    this.sslProperties = other.getSSLProperties();
-    this.clusterSSLProperties = other.getClusterSSLProperties();
-    this.jmxManagerSslProperties = other.getJmxSSLProperties();
+    securityClientAuthInit = other.getSecurityClientAuthInit();
+    securityClientAuthenticator = other.getSecurityClientAuthenticator();
+    securityClientDHAlgo = other.getSecurityClientDHAlgo();
+    securityUDPDHAlgo = other.getSecurityUDPDHAlgo();
+    securityPeerAuthInit = other.getSecurityPeerAuthInit();
+    securityPeerAuthenticator = other.getSecurityPeerAuthenticator();
+    securityClientAccessor = other.getSecurityClientAccessor();
+    securityClientAccessorPP = other.getSecurityClientAccessorPP();
+    securityPeerMembershipTimeout = other.getSecurityPeerMembershipTimeout();
+    securityLogLevel = other.getSecurityLogLevel();
+    securityLogFile = other.getSecurityLogFile();
+    security.putAll(other.getSecurityProps());
+    removeUnresponsiveClient = other.getRemoveUnresponsiveClient();
+    deltaPropagation = other.getDeltaPropagation();
+    distributedSystemId = other.getDistributedSystemId();
+    redundancyZone = other.getRedundancyZone();
+    enforceUniqueHost = other.getEnforceUniqueHost();
+    sslProperties = other.getSSLProperties();
+    clusterSSLProperties = other.getClusterSSLProperties();
+    jmxManagerSslProperties = other.getJmxSSLProperties();
     // Similar to this.security, assigning userDefinedProps
-    this.userDefinedProps.putAll(other.getUserDefinedProps());
+    userDefinedProps.putAll(other.getUserDefinedProps());
 
     // following added for 7.0
-    this.groups = other.getGroups();
-    this.jmxManager = other.getJmxManager();
-    this.jmxManagerStart = other.getJmxManagerStart();
-    this.jmxManagerSSLEnabled = other.getJmxManagerSSLEnabled();
-    this.jmxManagerSslRequireAuthentication = other.getJmxManagerSSLRequireAuthentication();
-    this.jmxManagerSslProtocols = other.getJmxManagerSSLProtocols();
-    this.jmxManagerSslCiphers = other.getJmxManagerSSLCiphers();
-    this.jmxManagerSSLKeyStore = other.getJmxManagerSSLKeyStore();
-    this.jmxManagerSSLKeyStoreType = other.getJmxManagerSSLKeyStoreType();
-    this.jmxManagerSSLKeyStorePassword = other.getJmxManagerSSLKeyStorePassword();
-    this.jmxManagerSSLTrustStore = other.getJmxManagerSSLTrustStore();
-    this.jmxManagerSSLTrustStorePassword = other.getJmxManagerSSLTrustStorePassword();
-    this.jmxManagerSslProperties = other.getJmxSSLProperties();
-    this.jmxManagerPort = other.getJmxManagerPort();
-    this.jmxManagerBindAddress = other.getJmxManagerBindAddress();
-    this.jmxManagerHostnameForClients = other.getJmxManagerHostnameForClients();
-    this.jmxManagerPasswordFile = other.getJmxManagerPasswordFile();
-    this.jmxManagerAccessFile = other.getJmxManagerAccessFile();
-    this.jmxManagerHttpPort = other.getJmxManagerHttpPort();
-    this.jmxManagerUpdateRate = other.getJmxManagerUpdateRate();
-    this.memcachedPort = other.getMemcachedPort();
-    this.memcachedProtocol = other.getMemcachedProtocol();
-    this.memcachedBindAddress = other.getMemcachedBindAddress();
-    this.redisPort = other.getRedisPort();
-    this.redisBindAddress = other.getRedisBindAddress();
-    this.redisPassword = other.getRedisPassword();
-    this.userCommandPackages = other.getUserCommandPackages();
+    groups = other.getGroups();
+    jmxManager = other.getJmxManager();
+    jmxManagerStart = other.getJmxManagerStart();
+    jmxManagerSSLEnabled = other.getJmxManagerSSLEnabled();
+    jmxManagerSslRequireAuthentication = other.getJmxManagerSSLRequireAuthentication();
+    jmxManagerSslProtocols = other.getJmxManagerSSLProtocols();
+    jmxManagerSslCiphers = other.getJmxManagerSSLCiphers();
+    jmxManagerSSLKeyStore = other.getJmxManagerSSLKeyStore();
+    jmxManagerSSLKeyStoreType = other.getJmxManagerSSLKeyStoreType();
+    jmxManagerSSLKeyStorePassword = other.getJmxManagerSSLKeyStorePassword();
+    jmxManagerSSLTrustStore = other.getJmxManagerSSLTrustStore();
+    jmxManagerSSLTrustStorePassword = other.getJmxManagerSSLTrustStorePassword();
+    jmxManagerSslProperties = other.getJmxSSLProperties();
+    jmxManagerPort = other.getJmxManagerPort();
+    jmxManagerBindAddress = other.getJmxManagerBindAddress();
+    jmxManagerHostnameForClients = other.getJmxManagerHostnameForClients();
+    jmxManagerPasswordFile = other.getJmxManagerPasswordFile();
+    jmxManagerAccessFile = other.getJmxManagerAccessFile();
+    jmxManagerHttpPort = other.getJmxManagerHttpPort();
+    jmxManagerUpdateRate = other.getJmxManagerUpdateRate();
+    memcachedPort = other.getMemcachedPort();
+    memcachedProtocol = other.getMemcachedProtocol();
+    memcachedBindAddress = other.getMemcachedBindAddress();
+    redisPort = other.getRedisPort();
+    redisBindAddress = other.getRedisBindAddress();
+    redisPassword = other.getRedisPassword();
+    userCommandPackages = other.getUserCommandPackages();
 
     // following added for 8.0
-    this.enableSharedConfiguration = other.getEnableClusterConfiguration();
-    this.loadSharedConfigurationFromDir = other.getLoadClusterConfigFromDir();
-    this.clusterConfigDir = other.getClusterConfigDir();
-    this.useSharedConfiguration = other.getUseSharedConfiguration();
-    this.serverSSLEnabled = other.getServerSSLEnabled();
-    this.serverSslRequireAuthentication = other.getServerSSLRequireAuthentication();
-    this.serverSslProtocols = other.getServerSSLProtocols();
-    this.serverSslCiphers = other.getServerSSLCiphers();
-    this.serverSSLKeyStore = other.getServerSSLKeyStore();
-    this.serverSSLKeyStoreType = other.getServerSSLKeyStoreType();
-    this.serverSSLKeyStorePassword = other.getServerSSLKeyStorePassword();
-    this.serverSSLTrustStore = other.getServerSSLTrustStore();
-    this.serverSSLTrustStorePassword = other.getServerSSLTrustStorePassword();
-    this.serverSslProperties = other.getServerSSLProperties();
+    enableSharedConfiguration = other.getEnableClusterConfiguration();
+    loadSharedConfigurationFromDir = other.getLoadClusterConfigFromDir();
+    clusterConfigDir = other.getClusterConfigDir();
+    useSharedConfiguration = other.getUseSharedConfiguration();
+    serverSSLEnabled = other.getServerSSLEnabled();
+    serverSslRequireAuthentication = other.getServerSSLRequireAuthentication();
+    serverSslProtocols = other.getServerSSLProtocols();
+    serverSslCiphers = other.getServerSSLCiphers();
+    serverSSLKeyStore = other.getServerSSLKeyStore();
+    serverSSLKeyStoreType = other.getServerSSLKeyStoreType();
+    serverSSLKeyStorePassword = other.getServerSSLKeyStorePassword();
+    serverSSLTrustStore = other.getServerSSLTrustStore();
+    serverSSLTrustStorePassword = other.getServerSSLTrustStorePassword();
+    serverSslProperties = other.getServerSSLProperties();
 
-    this.gatewaySSLEnabled = other.getGatewaySSLEnabled();
-    this.gatewaySslRequireAuthentication = other.getGatewaySSLRequireAuthentication();
-    this.gatewaySslProtocols = other.getGatewaySSLProtocols();
-    this.gatewaySslCiphers = other.getGatewaySSLCiphers();
-    this.gatewaySSLKeyStore = other.getGatewaySSLKeyStore();
-    this.gatewaySSLKeyStoreType = other.getGatewaySSLKeyStoreType();
-    this.gatewaySSLKeyStorePassword = other.getGatewaySSLKeyStorePassword();
-    this.gatewaySSLTrustStore = other.getGatewaySSLTrustStore();
-    this.gatewaySSLTrustStorePassword = other.getGatewaySSLTrustStorePassword();
-    this.gatewaySslProperties = other.getGatewaySSLProperties();
+    gatewaySSLEnabled = other.getGatewaySSLEnabled();
+    gatewaySslRequireAuthentication = other.getGatewaySSLRequireAuthentication();
+    gatewaySslProtocols = other.getGatewaySSLProtocols();
+    gatewaySslCiphers = other.getGatewaySSLCiphers();
+    gatewaySSLKeyStore = other.getGatewaySSLKeyStore();
+    gatewaySSLKeyStoreType = other.getGatewaySSLKeyStoreType();
+    gatewaySSLKeyStorePassword = other.getGatewaySSLKeyStorePassword();
+    gatewaySSLTrustStore = other.getGatewaySSLTrustStore();
+    gatewaySSLTrustStorePassword = other.getGatewaySSLTrustStorePassword();
+    gatewaySslProperties = other.getGatewaySSLProperties();
 
-    this.httpServicePort = other.getHttpServicePort();
-    this.httpServiceBindAddress = other.getHttpServiceBindAddress();
+    httpServicePort = other.getHttpServicePort();
+    httpServiceBindAddress = other.getHttpServiceBindAddress();
 
-    this.httpServiceSSLEnabled = other.getHttpServiceSSLEnabled();
-    this.httpServiceSSLCiphers = other.getHttpServiceSSLCiphers();
-    this.httpServiceSSLProtocols = other.getHttpServiceSSLProtocols();
-    this.httpServiceSSLRequireAuthentication = other.getHttpServiceSSLRequireAuthentication();
-    this.httpServiceSSLKeyStore = other.getHttpServiceSSLKeyStore();
-    this.httpServiceSSLKeyStorePassword = other.getHttpServiceSSLKeyStorePassword();
-    this.httpServiceSSLKeyStoreType = other.getHttpServiceSSLKeyStoreType();
-    this.httpServiceSSLTrustStore = other.getHttpServiceSSLTrustStore();
-    this.httpServiceSSLTrustStorePassword = other.getHttpServiceSSLTrustStorePassword();
-    this.httpServiceSSLProperties = other.getHttpServiceSSLProperties();
+    httpServiceSSLEnabled = other.getHttpServiceSSLEnabled();
+    httpServiceSSLCiphers = other.getHttpServiceSSLCiphers();
+    httpServiceSSLProtocols = other.getHttpServiceSSLProtocols();
+    httpServiceSSLRequireAuthentication = other.getHttpServiceSSLRequireAuthentication();
+    httpServiceSSLKeyStore = other.getHttpServiceSSLKeyStore();
+    httpServiceSSLKeyStorePassword = other.getHttpServiceSSLKeyStorePassword();
+    httpServiceSSLKeyStoreType = other.getHttpServiceSSLKeyStoreType();
+    httpServiceSSLTrustStore = other.getHttpServiceSSLTrustStore();
+    httpServiceSSLTrustStorePassword = other.getHttpServiceSSLTrustStorePassword();
+    httpServiceSSLProperties = other.getHttpServiceSSLProperties();
 
-    this.startDevRestApi = other.getStartDevRestApi();
+    startDevRestApi = other.getStartDevRestApi();
 
     // following added for 9.0
-    this.offHeapMemorySize = other.getOffHeapMemorySize();
+    offHeapMemorySize = other.getOffHeapMemorySize();
 
     Map<String, ConfigSource> otherSources = ((DistributionConfigImpl) other).sourceMap;
     if (otherSources != null) {
-      this.sourceMap = new HashMap<String, ConfigSource>(otherSources);
+      sourceMap = new HashMap<>(otherSources);
     }
 
-    this.lockMemory = other.getLockMemory();
-    this.distributedTransactions = other.getDistributedTransactions();
-    this.shiroInit = other.getShiroInit();
-    this.securityManager = other.getSecurityManager();
-    this.postProcessor = other.getPostProcessor();
+    lockMemory = other.getLockMemory();
+    distributedTransactions = other.getDistributedTransactions();
+    shiroInit = other.getShiroInit();
+    securityManager = other.getSecurityManager();
+    postProcessor = other.getPostProcessor();
 
-    this.clusterSSLAlias = other.getClusterSSLAlias();
-    this.gatewaySSLAlias = other.getGatewaySSLAlias();
-    this.httpServiceSSLAlias = other.getHTTPServiceSSLAlias();
-    this.jmxManagerSSLAlias = other.getJMXSSLAlias();
-    this.serverSSLAlias = other.getServerSSLAlias();
-    this.locatorSSLAlias = other.getLocatorSSLAlias();
+    clusterSSLAlias = other.getClusterSSLAlias();
+    gatewaySSLAlias = other.getGatewaySSLAlias();
+    httpServiceSSLAlias = other.getHTTPServiceSSLAlias();
+    jmxManagerSSLAlias = other.getJMXSSLAlias();
+    serverSSLAlias = other.getServerSSLAlias();
+    locatorSSLAlias = other.getLocatorSSLAlias();
 
     this.sslEndPointIdentificationEnabled = other.getSSLEndPointIdentificationEnabled();
     this.securableCommunicationChannels =
@@ -868,15 +859,15 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
     this.sslDefaultAlias = other.getSSLDefaultAlias();
     this.sslWebServiceRequireAuthentication = other.getSSLWebRequireAuthentication();
 
-    this.validateSerializableObjects = other.getValidateSerializableObjects();
-    this.serializableObjectFilter = other.getSerializableObjectFilter();
+    validateSerializableObjects = other.getValidateSerializableObjects();
+    serializableObjectFilter = other.getSerializableObjectFilter();
   }
 
   /**
    * Set to true to make attributes writable. Set to false to make attributes read only. By default
    * they are read only.
    */
-  protected boolean modifiable = false;
+  protected boolean modifiable;
 
   @Override
   protected boolean _modifiableDefault() {
@@ -893,7 +884,7 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
 
   /**
    * Creates a new <code>DistributionConfigImpl</code> with the given non-default configuration
-   * properties. See {@link org.apache.geode.distributed.DistributedSystem#connect} for a list of
+   * properties. See {@link DistributedSystem#connect} for a list of
    * exceptions that may be thrown.
    *
    * @param nonDefault The configuration properties specified by the caller
@@ -904,7 +895,7 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
 
   /**
    * Creates a new <code>DistributionConfigImpl</code> with the given non-default configuration
-   * properties. See {@link org.apache.geode.distributed.DistributedSystem#connect} for a list of
+   * properties. See {@link DistributedSystem#connect} for a list of
    * exceptions that may be thrown.
    *
    * @param nonDefault The configuration properties specified by the caller
@@ -920,7 +911,7 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
 
   /**
    * Creates a new <code>DistributionConfigImpl</code> with the given non-default configuration
-   * properties. See {@link org.apache.geode.distributed.DistributedSystem#connect} for a list of
+   * properties. See {@link DistributedSystem#connect} for a list of
    * exceptions that may be thrown.
    *
    * @param nonDefault The configuration properties specified by the caller
@@ -934,7 +925,7 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
    */
   public DistributionConfigImpl(Properties nonDefault, boolean ignoreGemFirePropsFile,
       boolean isConnected) {
-    HashMap props = new HashMap();
+    Map<Object, Object> props = new HashMap<>();
     if (!ignoreGemFirePropsFile) {// For admin bug #40434
       props.putAll(loadPropertiesFromURL(DistributedSystem.getPropertyFileURL(), false));
     }
@@ -949,7 +940,7 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
     // Now remove all user defined properties from props.
     for (Object entry : props.entrySet()) {
       Map.Entry<String, String> ent = (Map.Entry<String, String>) entry;
-      if (((String) ent.getKey()).startsWith(USERDEFINED_PREFIX_NAME)) {
+      if (ent.getKey().startsWith(USERDEFINED_PREFIX_NAME)) {
         userDefinedProps.put(ent.getKey(), ent.getValue());
       }
     }
@@ -972,7 +963,7 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
         if (sysValue != null) {
           String attName = key.substring(GEMFIRE_PREFIX.length());
           props.put(attName, sysValue);
-          this.sourceMap.put(attName, ConfigSource.sysprop());
+          sourceMap.put(attName, ConfigSource.sysprop());
         }
       }
     }
@@ -983,9 +974,9 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
         // only apply the overridden default if it's not already specified in props
         final String property =
             key.substring(ProcessLauncherContext.OVERRIDDEN_DEFAULTS_PREFIX.length());
-        if (!props.containsKey((property))) {
+        if (!props.containsKey(property)) {
           props.put(property, overriddenDefaults.getProperty(key));
-          this.sourceMap.put(property, ConfigSource.launcher());
+          sourceMap.put(property, ConfigSource.launcher());
         }
       }
     }
@@ -1008,20 +999,19 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
     }
 
     // Make attributes writeable only
-    this.modifiable = true;
+    modifiable = true;
     validateConfigurationProperties(props);
     validateSSLEnabledComponentsConfiguration();
     // Make attributes read only
-    this.modifiable = false;
-
+    modifiable = false;
   }
 
   private void validateSSLEnabledComponentsConfiguration() {
     Object value = null;
     try {
-      Method method = getters.get(ConfigurationProperties.SSL_ENABLED_COMPONENTS);
+      Method method = getters.get(SSL_ENABLED_COMPONENTS);
       if (method != null) {
-        value = method.invoke(this, new Object[] {});
+        value = method.invoke(this);
       }
     } catch (Exception e) {
       if (e instanceof RuntimeException) {
@@ -1031,7 +1021,7 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
         throw (RuntimeException) e.getCause();
       } else {
         throw new InternalGemFireException(
-            "error invoking getter for property" + ConfigurationProperties.SSL_ENABLED_COMPONENTS);
+            "error invoking getter for property" + SSL_ENABLED_COMPONENTS);
       }
     }
     SecurableCommunicationChannel[] sslEnabledComponents = (SecurableCommunicationChannel[]) value;
@@ -1042,7 +1032,6 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
                 .toLocalizedString());
       }
     }
-
   }
 
   /**
@@ -1075,34 +1064,34 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
         }
       }
       case CLUSTER: {
-        return StringUtils.isEmpty(getClusterSSLAlias()) ? true
-            : (getSecurableCommunicationChannels().length > 1
-                ? !StringUtils.isEmpty(getSSLDefaultAlias()) : true);
+        return StringUtils.isEmpty(getClusterSSLAlias())
+            || getSecurableCommunicationChannels().length <= 1 || !StringUtils
+                .isEmpty(getSSLDefaultAlias());
       }
       case GATEWAY: {
-        return StringUtils.isEmpty(getGatewaySSLAlias()) ? true
-            : (getSecurableCommunicationChannels().length > 1
-                ? !StringUtils.isEmpty(getSSLDefaultAlias()) : true);
+        return StringUtils.isEmpty(getGatewaySSLAlias())
+            || getSecurableCommunicationChannels().length <= 1 || !StringUtils
+                .isEmpty(getSSLDefaultAlias());
       }
       case WEB: {
-        return StringUtils.isEmpty(getHTTPServiceSSLAlias()) ? true
-            : (getSecurableCommunicationChannels().length > 1
-                ? !StringUtils.isEmpty(getSSLDefaultAlias()) : true);
+        return StringUtils.isEmpty(getHTTPServiceSSLAlias())
+            || getSecurableCommunicationChannels().length <= 1 || !StringUtils
+                .isEmpty(getSSLDefaultAlias());
       }
       case JMX: {
-        return StringUtils.isEmpty(getJMXSSLAlias()) ? true
-            : (getSecurableCommunicationChannels().length > 1
-                ? !StringUtils.isEmpty(getSSLDefaultAlias()) : true);
+        return StringUtils.isEmpty(getJMXSSLAlias())
+            || getSecurableCommunicationChannels().length <= 1 || !StringUtils
+                .isEmpty(getSSLDefaultAlias());
       }
       case LOCATOR: {
-        return StringUtils.isEmpty(getLocatorSSLAlias()) ? true
-            : (getSecurableCommunicationChannels().length > 1
-                ? !StringUtils.isEmpty(getSSLDefaultAlias()) : true);
+        return StringUtils.isEmpty(getLocatorSSLAlias())
+            || getSecurableCommunicationChannels().length <= 1 || !StringUtils
+                .isEmpty(getSSLDefaultAlias());
       }
       case SERVER: {
-        return StringUtils.isEmpty(getServerSSLAlias()) ? true
-            : (getSecurableCommunicationChannels().length > 1
-                ? !StringUtils.isEmpty(getSSLDefaultAlias()) : true);
+        return StringUtils.isEmpty(getServerSSLAlias())
+            || getSecurableCommunicationChannels().length <= 1 || !StringUtils
+                .isEmpty(getSSLDefaultAlias());
       }
       default:
         return false;
@@ -1112,16 +1101,15 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
   /**
    * Here we will validate the correctness of the set properties as per the CheckAttributeChecker
    * annotations defined in #AbstractDistributionConfig
-   *
    */
-  private void validateConfigurationProperties(final HashMap props) {
+  private void validateConfigurationProperties(final Map<Object, Object> props) {
     for (Object o : props.keySet()) {
       String propertyName = (String) o;
       Object value = null;
       try {
         Method method = getters.get(propertyName);
         if (method != null) {
-          value = method.invoke(this, new Object[] {});
+          value = method.invoke(this);
         }
       } catch (Exception e) {
         if (e instanceof RuntimeException) {
@@ -1137,178 +1125,178 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
     }
   }
 
-  /*
+  /**
    * if jmx-manager-ssl is true and jmx-manager-ssl-enabled is false then override
    * jmx-manager-ssl-enabled with jmx-manager-ssl if jmx-manager-ssl-enabled is false, then use the
    * properties from cluster-ssl-* properties if jmx-manager-ssl-*properties are given then use
    * them, and copy the unspecified jmx-manager properties from cluster-properties
    */
   private void copySSLPropsToJMXSSLProps() {
-    boolean jmxSSLEnabledOverriden = this.sourceMap.get(JMX_MANAGER_SSL_ENABLED) != null;
-    boolean clusterSSLOverRidden = this.sourceMap.get(CLUSTER_SSL_ENABLED) != null;
-    boolean hasSSLComponents = this.sourceMap.get(SSL_ENABLED_COMPONENTS) != null;
+    boolean jmxSSLEnabledOverriden = sourceMap.get(JMX_MANAGER_SSL_ENABLED) != null;
+    boolean clusterSSLOverRidden = sourceMap.get(CLUSTER_SSL_ENABLED) != null;
+    boolean hasSSLComponents = sourceMap.get(SSL_ENABLED_COMPONENTS) != null;
 
     if (clusterSSLOverRidden && !jmxSSLEnabledOverriden && !hasSSLComponents) {
-      this.jmxManagerSSLEnabled = this.clusterSSLEnabled;
-      this.sourceMap.put(JMX_MANAGER_SSL_ENABLED, this.sourceMap.get(CLUSTER_SSL_ENABLED));
-      if (this.sourceMap.get(CLUSTER_SSL_CIPHERS) != null) {
-        this.jmxManagerSslCiphers = this.clusterSSLCiphers;
-        this.sourceMap.put(JMX_MANAGER_SSL_CIPHERS, this.sourceMap.get(CLUSTER_SSL_CIPHERS));
+      jmxManagerSSLEnabled = clusterSSLEnabled;
+      sourceMap.put(JMX_MANAGER_SSL_ENABLED, sourceMap.get(CLUSTER_SSL_ENABLED));
+      if (sourceMap.get(CLUSTER_SSL_CIPHERS) != null) {
+        jmxManagerSslCiphers = clusterSSLCiphers;
+        sourceMap.put(JMX_MANAGER_SSL_CIPHERS, sourceMap.get(CLUSTER_SSL_CIPHERS));
       }
 
-      if (this.sourceMap.get(CLUSTER_SSL_PROTOCOLS) != null) {
-        this.jmxManagerSslProtocols = this.clusterSSLProtocols;
-        this.sourceMap.put(JMX_MANAGER_SSL_PROTOCOLS, this.sourceMap.get(CLUSTER_SSL_PROTOCOLS));
+      if (sourceMap.get(CLUSTER_SSL_PROTOCOLS) != null) {
+        jmxManagerSslProtocols = clusterSSLProtocols;
+        sourceMap.put(JMX_MANAGER_SSL_PROTOCOLS, sourceMap.get(CLUSTER_SSL_PROTOCOLS));
       }
 
-      if (this.sourceMap.get(CLUSTER_SSL_REQUIRE_AUTHENTICATION) != null) {
-        this.jmxManagerSslRequireAuthentication = this.clusterSSLRequireAuthentication;
-        this.sourceMap.put(JMX_MANAGER_SSL_REQUIRE_AUTHENTICATION,
-            this.sourceMap.get(CLUSTER_SSL_REQUIRE_AUTHENTICATION));
+      if (sourceMap.get(CLUSTER_SSL_REQUIRE_AUTHENTICATION) != null) {
+        jmxManagerSslRequireAuthentication = clusterSSLRequireAuthentication;
+        sourceMap.put(JMX_MANAGER_SSL_REQUIRE_AUTHENTICATION,
+            sourceMap.get(CLUSTER_SSL_REQUIRE_AUTHENTICATION));
       }
 
-      if (this.sourceMap.get(CLUSTER_SSL_KEYSTORE) != null) {
-        this.jmxManagerSSLKeyStore = this.clusterSSLKeyStore;
-        this.sourceMap.put(JMX_MANAGER_SSL_KEYSTORE, this.sourceMap.get(CLUSTER_SSL_KEYSTORE));
+      if (sourceMap.get(CLUSTER_SSL_KEYSTORE) != null) {
+        jmxManagerSSLKeyStore = clusterSSLKeyStore;
+        sourceMap.put(JMX_MANAGER_SSL_KEYSTORE, sourceMap.get(CLUSTER_SSL_KEYSTORE));
       }
-      if (this.sourceMap.get(CLUSTER_SSL_KEYSTORE_TYPE) != null) {
-        this.jmxManagerSSLKeyStoreType = this.clusterSSLKeyStoreType;
-        this.sourceMap.put(JMX_MANAGER_SSL_KEYSTORE_TYPE,
-            this.sourceMap.get(CLUSTER_SSL_KEYSTORE_TYPE));
+      if (sourceMap.get(CLUSTER_SSL_KEYSTORE_TYPE) != null) {
+        jmxManagerSSLKeyStoreType = clusterSSLKeyStoreType;
+        sourceMap.put(JMX_MANAGER_SSL_KEYSTORE_TYPE,
+            sourceMap.get(CLUSTER_SSL_KEYSTORE_TYPE));
       }
-      if (this.sourceMap.get(CLUSTER_SSL_KEYSTORE_PASSWORD) != null) {
-        this.jmxManagerSSLKeyStorePassword = this.clusterSSLKeyStorePassword;
-        this.sourceMap.put(JMX_MANAGER_SSL_KEYSTORE_PASSWORD,
-            this.sourceMap.get(CLUSTER_SSL_KEYSTORE_PASSWORD));
+      if (sourceMap.get(CLUSTER_SSL_KEYSTORE_PASSWORD) != null) {
+        jmxManagerSSLKeyStorePassword = clusterSSLKeyStorePassword;
+        sourceMap.put(JMX_MANAGER_SSL_KEYSTORE_PASSWORD,
+            sourceMap.get(CLUSTER_SSL_KEYSTORE_PASSWORD));
       }
-      if (this.sourceMap.get(CLUSTER_SSL_TRUSTSTORE) != null) {
-        this.jmxManagerSSLTrustStore = this.clusterSSLTrustStore;
-        this.sourceMap.put(JMX_MANAGER_SSL_TRUSTSTORE, this.sourceMap.get(CLUSTER_SSL_TRUSTSTORE));
+      if (sourceMap.get(CLUSTER_SSL_TRUSTSTORE) != null) {
+        jmxManagerSSLTrustStore = clusterSSLTrustStore;
+        sourceMap.put(JMX_MANAGER_SSL_TRUSTSTORE, sourceMap.get(CLUSTER_SSL_TRUSTSTORE));
       }
-      if (this.sourceMap.get(CLUSTER_SSL_TRUSTSTORE_PASSWORD) != null) {
-        this.jmxManagerSSLTrustStorePassword = this.clusterSSLTrustStorePassword;
-        this.sourceMap.put(JMX_MANAGER_SSL_TRUSTSTORE_PASSWORD,
-            this.sourceMap.get(CLUSTER_SSL_TRUSTSTORE_PASSWORD));
+      if (sourceMap.get(CLUSTER_SSL_TRUSTSTORE_PASSWORD) != null) {
+        jmxManagerSSLTrustStorePassword = clusterSSLTrustStorePassword;
+        sourceMap.put(JMX_MANAGER_SSL_TRUSTSTORE_PASSWORD,
+            sourceMap.get(CLUSTER_SSL_TRUSTSTORE_PASSWORD));
       }
-      this.jmxManagerSslProperties.putAll(this.clusterSSLProperties);
+      jmxManagerSslProperties.putAll(clusterSSLProperties);
     }
 
     if (jmxSSLEnabledOverriden) {
-      if (this.sourceMap.get(JMX_MANAGER_SSL_KEYSTORE) == null
-          && this.sourceMap.get(CLUSTER_SSL_KEYSTORE) != null) {
-        this.jmxManagerSSLKeyStore = this.clusterSSLKeyStore;
-        this.sourceMap.put(JMX_MANAGER_SSL_KEYSTORE, this.sourceMap.get(CLUSTER_SSL_KEYSTORE));
+      if (sourceMap.get(JMX_MANAGER_SSL_KEYSTORE) == null
+          && sourceMap.get(CLUSTER_SSL_KEYSTORE) != null) {
+        jmxManagerSSLKeyStore = clusterSSLKeyStore;
+        sourceMap.put(JMX_MANAGER_SSL_KEYSTORE, sourceMap.get(CLUSTER_SSL_KEYSTORE));
       }
-      if (this.sourceMap.get(JMX_MANAGER_SSL_KEYSTORE_TYPE) == null
-          && this.sourceMap.get(CLUSTER_SSL_KEYSTORE_TYPE) != null) {
-        this.jmxManagerSSLKeyStoreType = this.clusterSSLKeyStoreType;
-        this.sourceMap.put(JMX_MANAGER_SSL_KEYSTORE_TYPE,
-            this.sourceMap.get(CLUSTER_SSL_KEYSTORE_TYPE));
+      if (sourceMap.get(JMX_MANAGER_SSL_KEYSTORE_TYPE) == null
+          && sourceMap.get(CLUSTER_SSL_KEYSTORE_TYPE) != null) {
+        jmxManagerSSLKeyStoreType = clusterSSLKeyStoreType;
+        sourceMap.put(JMX_MANAGER_SSL_KEYSTORE_TYPE,
+            sourceMap.get(CLUSTER_SSL_KEYSTORE_TYPE));
       }
-      if (this.sourceMap.get(JMX_MANAGER_SSL_KEYSTORE_PASSWORD) == null
-          && this.sourceMap.get(CLUSTER_SSL_KEYSTORE_PASSWORD) != null) {
-        this.jmxManagerSSLKeyStorePassword = this.clusterSSLKeyStorePassword;
-        this.sourceMap.put(JMX_MANAGER_SSL_KEYSTORE_PASSWORD,
-            this.sourceMap.get(CLUSTER_SSL_KEYSTORE_PASSWORD));
+      if (sourceMap.get(JMX_MANAGER_SSL_KEYSTORE_PASSWORD) == null
+          && sourceMap.get(CLUSTER_SSL_KEYSTORE_PASSWORD) != null) {
+        jmxManagerSSLKeyStorePassword = clusterSSLKeyStorePassword;
+        sourceMap.put(JMX_MANAGER_SSL_KEYSTORE_PASSWORD,
+            sourceMap.get(CLUSTER_SSL_KEYSTORE_PASSWORD));
       }
-      if (this.sourceMap.get(JMX_MANAGER_SSL_TRUSTSTORE) == null
-          && this.sourceMap.get(CLUSTER_SSL_TRUSTSTORE) != null) {
-        this.jmxManagerSSLTrustStore = this.clusterSSLTrustStore;
-        this.sourceMap.put(JMX_MANAGER_SSL_TRUSTSTORE, this.sourceMap.get(CLUSTER_SSL_TRUSTSTORE));
+      if (sourceMap.get(JMX_MANAGER_SSL_TRUSTSTORE) == null
+          && sourceMap.get(CLUSTER_SSL_TRUSTSTORE) != null) {
+        jmxManagerSSLTrustStore = clusterSSLTrustStore;
+        sourceMap.put(JMX_MANAGER_SSL_TRUSTSTORE, sourceMap.get(CLUSTER_SSL_TRUSTSTORE));
       }
-      if (this.sourceMap.get(JMX_MANAGER_SSL_TRUSTSTORE_PASSWORD) == null
-          && this.sourceMap.get(CLUSTER_SSL_TRUSTSTORE_PASSWORD) != null) {
-        this.jmxManagerSSLTrustStorePassword = this.clusterSSLTrustStorePassword;
-        this.sourceMap.put(JMX_MANAGER_SSL_TRUSTSTORE_PASSWORD,
-            this.sourceMap.get(CLUSTER_SSL_TRUSTSTORE_PASSWORD));
+      if (sourceMap.get(JMX_MANAGER_SSL_TRUSTSTORE_PASSWORD) == null
+          && sourceMap.get(CLUSTER_SSL_TRUSTSTORE_PASSWORD) != null) {
+        jmxManagerSSLTrustStorePassword = clusterSSLTrustStorePassword;
+        sourceMap.put(JMX_MANAGER_SSL_TRUSTSTORE_PASSWORD,
+            sourceMap.get(CLUSTER_SSL_TRUSTSTORE_PASSWORD));
       }
     }
   }
 
-  /*
+  /**
    * if http-service-ssl-enabled is false, then use the properties from cluster-ssl-* properties if
    * http-service-ssl-*properties are given then use them, and copy the unspecified http-service
    * properties from cluster-properties
    */
   private void copySSLPropsToHTTPSSLProps() {
-    boolean httpServiceSSLEnabledOverriden = this.sourceMap.get(HTTP_SERVICE_SSL_ENABLED) != null;
-    boolean clusterSSLOverRidden = this.sourceMap.get(CLUSTER_SSL_ENABLED) != null;
-    boolean hasSSLComponents = this.sourceMap.get(SSL_ENABLED_COMPONENTS) != null;
+    boolean httpServiceSSLEnabledOverriden = sourceMap.get(HTTP_SERVICE_SSL_ENABLED) != null;
+    boolean clusterSSLOverRidden = sourceMap.get(CLUSTER_SSL_ENABLED) != null;
+    boolean hasSSLComponents = sourceMap.get(SSL_ENABLED_COMPONENTS) != null;
 
     if (clusterSSLOverRidden && !httpServiceSSLEnabledOverriden && !hasSSLComponents) {
-      this.httpServiceSSLEnabled = this.clusterSSLEnabled;
-      this.sourceMap.put(HTTP_SERVICE_SSL_ENABLED, this.sourceMap.get(CLUSTER_SSL_ENABLED));
+      httpServiceSSLEnabled = clusterSSLEnabled;
+      sourceMap.put(HTTP_SERVICE_SSL_ENABLED, sourceMap.get(CLUSTER_SSL_ENABLED));
 
-      if (this.sourceMap.get(CLUSTER_SSL_CIPHERS) != null) {
-        this.httpServiceSSLCiphers = this.clusterSSLCiphers;
-        this.sourceMap.put(HTTP_SERVICE_SSL_CIPHERS, this.sourceMap.get(CLUSTER_SSL_CIPHERS));
-      }
-
-      if (this.sourceMap.get(CLUSTER_SSL_PROTOCOLS) != null) {
-        this.httpServiceSSLProtocols = this.clusterSSLProtocols;
-        this.sourceMap.put(HTTP_SERVICE_SSL_PROTOCOLS, this.sourceMap.get(CLUSTER_SSL_PROTOCOLS));
+      if (sourceMap.get(CLUSTER_SSL_CIPHERS) != null) {
+        httpServiceSSLCiphers = clusterSSLCiphers;
+        sourceMap.put(HTTP_SERVICE_SSL_CIPHERS, sourceMap.get(CLUSTER_SSL_CIPHERS));
       }
 
-      if (this.sourceMap.get(CLUSTER_SSL_REQUIRE_AUTHENTICATION) != null) {
-        this.httpServiceSSLRequireAuthentication = this.clusterSSLRequireAuthentication;
-        this.sourceMap.put(HTTP_SERVICE_SSL_REQUIRE_AUTHENTICATION,
-            this.sourceMap.get(CLUSTER_SSL_REQUIRE_AUTHENTICATION));
+      if (sourceMap.get(CLUSTER_SSL_PROTOCOLS) != null) {
+        httpServiceSSLProtocols = clusterSSLProtocols;
+        sourceMap.put(HTTP_SERVICE_SSL_PROTOCOLS, sourceMap.get(CLUSTER_SSL_PROTOCOLS));
       }
 
-      if (this.sourceMap.get(CLUSTER_SSL_KEYSTORE) != null) {
-        setHttpServiceSSLKeyStore(this.clusterSSLKeyStore);
-        this.sourceMap.put(HTTP_SERVICE_SSL_KEYSTORE, this.sourceMap.get(CLUSTER_SSL_KEYSTORE));
+      if (sourceMap.get(CLUSTER_SSL_REQUIRE_AUTHENTICATION) != null) {
+        httpServiceSSLRequireAuthentication = clusterSSLRequireAuthentication;
+        sourceMap.put(HTTP_SERVICE_SSL_REQUIRE_AUTHENTICATION,
+            sourceMap.get(CLUSTER_SSL_REQUIRE_AUTHENTICATION));
       }
-      if (this.sourceMap.get(CLUSTER_SSL_KEYSTORE_TYPE) != null) {
-        setHttpServiceSSLKeyStoreType(this.clusterSSLKeyStoreType);
-        this.sourceMap.put(HTTP_SERVICE_SSL_KEYSTORE_TYPE,
-            this.sourceMap.get(CLUSTER_SSL_KEYSTORE_TYPE));
+
+      if (sourceMap.get(CLUSTER_SSL_KEYSTORE) != null) {
+        setHttpServiceSSLKeyStore(clusterSSLKeyStore);
+        sourceMap.put(HTTP_SERVICE_SSL_KEYSTORE, sourceMap.get(CLUSTER_SSL_KEYSTORE));
       }
-      if (this.sourceMap.get(CLUSTER_SSL_KEYSTORE_PASSWORD) != null) {
-        setHttpServiceSSLKeyStorePassword(this.clusterSSLKeyStorePassword);
-        this.sourceMap.put(HTTP_SERVICE_SSL_KEYSTORE_PASSWORD,
-            this.sourceMap.get(CLUSTER_SSL_KEYSTORE_PASSWORD));
+      if (sourceMap.get(CLUSTER_SSL_KEYSTORE_TYPE) != null) {
+        setHttpServiceSSLKeyStoreType(clusterSSLKeyStoreType);
+        sourceMap.put(HTTP_SERVICE_SSL_KEYSTORE_TYPE,
+            sourceMap.get(CLUSTER_SSL_KEYSTORE_TYPE));
       }
-      if (this.sourceMap.get(CLUSTER_SSL_TRUSTSTORE) != null) {
-        setHttpServiceSSLTrustStore(this.clusterSSLTrustStore);
-        this.sourceMap.put(HTTP_SERVICE_SSL_TRUSTSTORE, this.sourceMap.get(CLUSTER_SSL_TRUSTSTORE));
+      if (sourceMap.get(CLUSTER_SSL_KEYSTORE_PASSWORD) != null) {
+        setHttpServiceSSLKeyStorePassword(clusterSSLKeyStorePassword);
+        sourceMap.put(HTTP_SERVICE_SSL_KEYSTORE_PASSWORD,
+            sourceMap.get(CLUSTER_SSL_KEYSTORE_PASSWORD));
       }
-      if (this.sourceMap.get(CLUSTER_SSL_TRUSTSTORE_PASSWORD) != null) {
-        setHttpServiceSSLTrustStorePassword(this.clusterSSLTrustStorePassword);
-        this.sourceMap.put(HTTP_SERVICE_SSL_TRUSTSTORE_PASSWORD,
-            this.sourceMap.get(CLUSTER_SSL_TRUSTSTORE_PASSWORD));
+      if (sourceMap.get(CLUSTER_SSL_TRUSTSTORE) != null) {
+        setHttpServiceSSLTrustStore(clusterSSLTrustStore);
+        sourceMap.put(HTTP_SERVICE_SSL_TRUSTSTORE, sourceMap.get(CLUSTER_SSL_TRUSTSTORE));
       }
-      this.httpServiceSSLProperties.putAll(this.clusterSSLProperties);
+      if (sourceMap.get(CLUSTER_SSL_TRUSTSTORE_PASSWORD) != null) {
+        setHttpServiceSSLTrustStorePassword(clusterSSLTrustStorePassword);
+        sourceMap.put(HTTP_SERVICE_SSL_TRUSTSTORE_PASSWORD,
+            sourceMap.get(CLUSTER_SSL_TRUSTSTORE_PASSWORD));
+      }
+      httpServiceSSLProperties.putAll(clusterSSLProperties);
     }
 
     if (httpServiceSSLEnabledOverriden) {
-      if (this.sourceMap.get(HTTP_SERVICE_SSL_KEYSTORE) == null
-          && this.sourceMap.get(CLUSTER_SSL_KEYSTORE) != null) {
-        this.httpServiceSSLKeyStore = this.clusterSSLKeyStore;
-        this.sourceMap.put(HTTP_SERVICE_SSL_KEYSTORE, this.sourceMap.get(CLUSTER_SSL_KEYSTORE));
+      if (sourceMap.get(HTTP_SERVICE_SSL_KEYSTORE) == null
+          && sourceMap.get(CLUSTER_SSL_KEYSTORE) != null) {
+        httpServiceSSLKeyStore = clusterSSLKeyStore;
+        sourceMap.put(HTTP_SERVICE_SSL_KEYSTORE, sourceMap.get(CLUSTER_SSL_KEYSTORE));
       }
-      if (this.sourceMap.get(HTTP_SERVICE_SSL_KEYSTORE_TYPE) == null
-          && this.sourceMap.get(CLUSTER_SSL_KEYSTORE_TYPE) != null) {
-        this.httpServiceSSLKeyStoreType = this.clusterSSLKeyStoreType;
-        this.sourceMap.put(HTTP_SERVICE_SSL_KEYSTORE_TYPE,
-            this.sourceMap.get(CLUSTER_SSL_KEYSTORE_TYPE));
+      if (sourceMap.get(HTTP_SERVICE_SSL_KEYSTORE_TYPE) == null
+          && sourceMap.get(CLUSTER_SSL_KEYSTORE_TYPE) != null) {
+        httpServiceSSLKeyStoreType = clusterSSLKeyStoreType;
+        sourceMap.put(HTTP_SERVICE_SSL_KEYSTORE_TYPE,
+            sourceMap.get(CLUSTER_SSL_KEYSTORE_TYPE));
       }
-      if (this.sourceMap.get(HTTP_SERVICE_SSL_KEYSTORE_PASSWORD) == null
-          && this.sourceMap.get(CLUSTER_SSL_KEYSTORE_PASSWORD) != null) {
-        this.httpServiceSSLKeyStorePassword = this.clusterSSLKeyStorePassword;
-        this.sourceMap.put(HTTP_SERVICE_SSL_KEYSTORE_PASSWORD,
-            this.sourceMap.get(CLUSTER_SSL_KEYSTORE_PASSWORD));
+      if (sourceMap.get(HTTP_SERVICE_SSL_KEYSTORE_PASSWORD) == null
+          && sourceMap.get(CLUSTER_SSL_KEYSTORE_PASSWORD) != null) {
+        httpServiceSSLKeyStorePassword = clusterSSLKeyStorePassword;
+        sourceMap.put(HTTP_SERVICE_SSL_KEYSTORE_PASSWORD,
+            sourceMap.get(CLUSTER_SSL_KEYSTORE_PASSWORD));
       }
-      if (this.sourceMap.get(HTTP_SERVICE_SSL_TRUSTSTORE) == null
-          && this.sourceMap.get(CLUSTER_SSL_TRUSTSTORE) != null) {
-        this.httpServiceSSLTrustStore = this.clusterSSLTrustStore;
-        this.sourceMap.put(HTTP_SERVICE_SSL_TRUSTSTORE, this.sourceMap.get(CLUSTER_SSL_TRUSTSTORE));
+      if (sourceMap.get(HTTP_SERVICE_SSL_TRUSTSTORE) == null
+          && sourceMap.get(CLUSTER_SSL_TRUSTSTORE) != null) {
+        httpServiceSSLTrustStore = clusterSSLTrustStore;
+        sourceMap.put(HTTP_SERVICE_SSL_TRUSTSTORE, sourceMap.get(CLUSTER_SSL_TRUSTSTORE));
       }
-      if (this.sourceMap.get(HTTP_SERVICE_SSL_TRUSTSTORE_PASSWORD) == null
-          && this.sourceMap.get(CLUSTER_SSL_TRUSTSTORE_PASSWORD) != null) {
-        this.httpServiceSSLTrustStorePassword = this.clusterSSLTrustStorePassword;
-        this.sourceMap.put(HTTP_SERVICE_SSL_TRUSTSTORE_PASSWORD,
-            this.sourceMap.get(CLUSTER_SSL_TRUSTSTORE_PASSWORD));
+      if (sourceMap.get(HTTP_SERVICE_SSL_TRUSTSTORE_PASSWORD) == null
+          && sourceMap.get(CLUSTER_SSL_TRUSTSTORE_PASSWORD) != null) {
+        httpServiceSSLTrustStorePassword = clusterSSLTrustStorePassword;
+        sourceMap.put(HTTP_SERVICE_SSL_TRUSTSTORE_PASSWORD,
+            sourceMap.get(CLUSTER_SSL_TRUSTSTORE_PASSWORD));
       }
     }
 
@@ -1320,172 +1308,171 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
    * cluster-properties
    */
   private void copySSLPropsToServerSSLProps() {
-    boolean cacheServerSSLOverriden = this.sourceMap.get(SERVER_SSL_ENABLED) != null;
-    boolean clusterSSLOverRidden = this.sourceMap.get(CLUSTER_SSL_ENABLED) != null;
-    boolean hasSSLComponents = this.sourceMap.get(SSL_ENABLED_COMPONENTS) != null;
+    boolean cacheServerSSLOverriden = sourceMap.get(SERVER_SSL_ENABLED) != null;
+    boolean clusterSSLOverRidden = sourceMap.get(CLUSTER_SSL_ENABLED) != null;
+    boolean hasSSLComponents = sourceMap.get(SSL_ENABLED_COMPONENTS) != null;
 
     if (clusterSSLOverRidden && !cacheServerSSLOverriden && !hasSSLComponents) {
-      this.serverSSLEnabled = this.clusterSSLEnabled;
-      this.sourceMap.put(SERVER_SSL_ENABLED, this.sourceMap.get(CLUSTER_SSL_ENABLED));
-      if (this.sourceMap.get(CLUSTER_SSL_CIPHERS) != null) {
-        this.serverSslCiphers = this.clusterSSLCiphers;
-        this.sourceMap.put(SERVER_SSL_CIPHERS, this.sourceMap.get(CLUSTER_SSL_CIPHERS));
+      serverSSLEnabled = clusterSSLEnabled;
+      sourceMap.put(SERVER_SSL_ENABLED, sourceMap.get(CLUSTER_SSL_ENABLED));
+      if (sourceMap.get(CLUSTER_SSL_CIPHERS) != null) {
+        serverSslCiphers = clusterSSLCiphers;
+        sourceMap.put(SERVER_SSL_CIPHERS, sourceMap.get(CLUSTER_SSL_CIPHERS));
       }
 
-      if (this.sourceMap.get(CLUSTER_SSL_PROTOCOLS) != null) {
-        this.serverSslProtocols = this.clusterSSLProtocols;
-        this.sourceMap.put(SERVER_SSL_PROTOCOLS, this.sourceMap.get(CLUSTER_SSL_PROTOCOLS));
+      if (sourceMap.get(CLUSTER_SSL_PROTOCOLS) != null) {
+        serverSslProtocols = clusterSSLProtocols;
+        sourceMap.put(SERVER_SSL_PROTOCOLS, sourceMap.get(CLUSTER_SSL_PROTOCOLS));
       }
 
-      if (this.sourceMap.get(CLUSTER_SSL_REQUIRE_AUTHENTICATION) != null) {
-        this.serverSslRequireAuthentication = this.clusterSSLRequireAuthentication;
-        this.sourceMap.put(SERVER_SSL_REQUIRE_AUTHENTICATION,
-            this.sourceMap.get(CLUSTER_SSL_REQUIRE_AUTHENTICATION));
+      if (sourceMap.get(CLUSTER_SSL_REQUIRE_AUTHENTICATION) != null) {
+        serverSslRequireAuthentication = clusterSSLRequireAuthentication;
+        sourceMap.put(SERVER_SSL_REQUIRE_AUTHENTICATION,
+            sourceMap.get(CLUSTER_SSL_REQUIRE_AUTHENTICATION));
       }
 
-      if (this.sourceMap.get(CLUSTER_SSL_KEYSTORE) != null) {
-        this.serverSSLKeyStore = this.clusterSSLKeyStore;
-        this.sourceMap.put(SERVER_SSL_KEYSTORE, this.sourceMap.get(CLUSTER_SSL_KEYSTORE));
+      if (sourceMap.get(CLUSTER_SSL_KEYSTORE) != null) {
+        serverSSLKeyStore = clusterSSLKeyStore;
+        sourceMap.put(SERVER_SSL_KEYSTORE, sourceMap.get(CLUSTER_SSL_KEYSTORE));
       }
-      if (this.sourceMap.get(CLUSTER_SSL_KEYSTORE_TYPE) != null) {
-        this.serverSSLKeyStoreType = this.clusterSSLKeyStoreType;
-        this.sourceMap.put(SERVER_SSL_KEYSTORE_TYPE, this.sourceMap.get(CLUSTER_SSL_KEYSTORE_TYPE));
+      if (sourceMap.get(CLUSTER_SSL_KEYSTORE_TYPE) != null) {
+        serverSSLKeyStoreType = clusterSSLKeyStoreType;
+        sourceMap.put(SERVER_SSL_KEYSTORE_TYPE, sourceMap.get(CLUSTER_SSL_KEYSTORE_TYPE));
       }
-      if (this.sourceMap.get(CLUSTER_SSL_KEYSTORE_PASSWORD) != null) {
-        this.serverSSLKeyStorePassword = this.clusterSSLKeyStorePassword;
-        this.sourceMap.put(SERVER_SSL_KEYSTORE_PASSWORD,
-            this.sourceMap.get(CLUSTER_SSL_KEYSTORE_PASSWORD));
+      if (sourceMap.get(CLUSTER_SSL_KEYSTORE_PASSWORD) != null) {
+        serverSSLKeyStorePassword = clusterSSLKeyStorePassword;
+        sourceMap.put(SERVER_SSL_KEYSTORE_PASSWORD,
+            sourceMap.get(CLUSTER_SSL_KEYSTORE_PASSWORD));
       }
-      if (this.sourceMap.get(CLUSTER_SSL_TRUSTSTORE) != null) {
-        this.serverSSLTrustStore = this.clusterSSLTrustStore;
-        this.sourceMap.put(SERVER_SSL_TRUSTSTORE, this.sourceMap.get(CLUSTER_SSL_TRUSTSTORE));
+      if (sourceMap.get(CLUSTER_SSL_TRUSTSTORE) != null) {
+        serverSSLTrustStore = clusterSSLTrustStore;
+        sourceMap.put(SERVER_SSL_TRUSTSTORE, sourceMap.get(CLUSTER_SSL_TRUSTSTORE));
       }
-      if (this.sourceMap.get(CLUSTER_SSL_TRUSTSTORE_PASSWORD) != null) {
-        this.serverSSLTrustStorePassword = this.clusterSSLTrustStorePassword;
-        this.sourceMap.put(SERVER_SSL_TRUSTSTORE_PASSWORD,
-            this.sourceMap.get(CLUSTER_SSL_TRUSTSTORE_PASSWORD));
+      if (sourceMap.get(CLUSTER_SSL_TRUSTSTORE_PASSWORD) != null) {
+        serverSSLTrustStorePassword = clusterSSLTrustStorePassword;
+        sourceMap.put(SERVER_SSL_TRUSTSTORE_PASSWORD,
+            sourceMap.get(CLUSTER_SSL_TRUSTSTORE_PASSWORD));
       }
-      this.serverSslProperties.putAll(this.clusterSSLProperties);
+      serverSslProperties.putAll(clusterSSLProperties);
     }
 
     if (cacheServerSSLOverriden) {
-      if (this.sourceMap.get(SERVER_SSL_KEYSTORE) == null
-          && this.sourceMap.get(CLUSTER_SSL_KEYSTORE) != null) {
-        this.serverSSLKeyStore = this.clusterSSLKeyStore;
-        this.sourceMap.put(SERVER_SSL_KEYSTORE, this.sourceMap.get(CLUSTER_SSL_KEYSTORE));
+      if (sourceMap.get(SERVER_SSL_KEYSTORE) == null
+          && sourceMap.get(CLUSTER_SSL_KEYSTORE) != null) {
+        serverSSLKeyStore = clusterSSLKeyStore;
+        sourceMap.put(SERVER_SSL_KEYSTORE, sourceMap.get(CLUSTER_SSL_KEYSTORE));
       }
-      if (this.sourceMap.get(SERVER_SSL_KEYSTORE_TYPE) == null
-          && this.sourceMap.get(CLUSTER_SSL_KEYSTORE_TYPE) != null) {
-        this.serverSSLKeyStoreType = this.clusterSSLKeyStoreType;
-        this.sourceMap.put(SERVER_SSL_KEYSTORE_TYPE, this.sourceMap.get(CLUSTER_SSL_KEYSTORE_TYPE));
+      if (sourceMap.get(SERVER_SSL_KEYSTORE_TYPE) == null
+          && sourceMap.get(CLUSTER_SSL_KEYSTORE_TYPE) != null) {
+        serverSSLKeyStoreType = clusterSSLKeyStoreType;
+        sourceMap.put(SERVER_SSL_KEYSTORE_TYPE, sourceMap.get(CLUSTER_SSL_KEYSTORE_TYPE));
       }
-      if (this.sourceMap.get(SERVER_SSL_KEYSTORE_PASSWORD) == null
-          && this.sourceMap.get(CLUSTER_SSL_KEYSTORE_PASSWORD) != null) {
-        this.serverSSLKeyStorePassword = this.clusterSSLKeyStorePassword;
-        this.sourceMap.put(SERVER_SSL_KEYSTORE_PASSWORD,
-            this.sourceMap.get(CLUSTER_SSL_KEYSTORE_PASSWORD));
+      if (sourceMap.get(SERVER_SSL_KEYSTORE_PASSWORD) == null
+          && sourceMap.get(CLUSTER_SSL_KEYSTORE_PASSWORD) != null) {
+        serverSSLKeyStorePassword = clusterSSLKeyStorePassword;
+        sourceMap.put(SERVER_SSL_KEYSTORE_PASSWORD,
+            sourceMap.get(CLUSTER_SSL_KEYSTORE_PASSWORD));
       }
-      if (this.sourceMap.get(SERVER_SSL_TRUSTSTORE) == null
-          && this.sourceMap.get(CLUSTER_SSL_TRUSTSTORE) != null) {
-        this.serverSSLTrustStore = this.clusterSSLTrustStore;
-        this.sourceMap.put(SERVER_SSL_TRUSTSTORE, this.sourceMap.get(CLUSTER_SSL_TRUSTSTORE));
+      if (sourceMap.get(SERVER_SSL_TRUSTSTORE) == null
+          && sourceMap.get(CLUSTER_SSL_TRUSTSTORE) != null) {
+        serverSSLTrustStore = clusterSSLTrustStore;
+        sourceMap.put(SERVER_SSL_TRUSTSTORE, sourceMap.get(CLUSTER_SSL_TRUSTSTORE));
       }
-      if (this.sourceMap.get(SERVER_SSL_TRUSTSTORE_PASSWORD) == null
-          && this.sourceMap.get(CLUSTER_SSL_TRUSTSTORE_PASSWORD) != null) {
-        this.serverSSLTrustStorePassword = this.clusterSSLTrustStorePassword;
-        this.sourceMap.put(SERVER_SSL_TRUSTSTORE_PASSWORD,
-            this.sourceMap.get(CLUSTER_SSL_TRUSTSTORE_PASSWORD));
+      if (sourceMap.get(SERVER_SSL_TRUSTSTORE_PASSWORD) == null
+          && sourceMap.get(CLUSTER_SSL_TRUSTSTORE_PASSWORD) != null) {
+        serverSSLTrustStorePassword = clusterSSLTrustStorePassword;
+        sourceMap.put(SERVER_SSL_TRUSTSTORE_PASSWORD,
+            sourceMap.get(CLUSTER_SSL_TRUSTSTORE_PASSWORD));
       }
     }
   }
 
-  /*
+  /**
    * if gateway-ssl-enabled is false, then use the properties from cluster-ssl-* properties if
    * gateway-ssl-*properties are given then use them, and copy the unspecified gateway properties
    * from cluster-properties
    */
   private void copyClusterSSLPropsToGatewaySSLProps() {
-    boolean gatewaySSLOverriden = this.sourceMap.get(GATEWAY_SSL_ENABLED) != null;
-    boolean clusterSSLOverRidden = this.sourceMap.get(CLUSTER_SSL_ENABLED) != null;
-    boolean hasSSLComponents = this.sourceMap.get(SSL_ENABLED_COMPONENTS) != null;
+    boolean gatewaySSLOverriden = sourceMap.get(GATEWAY_SSL_ENABLED) != null;
+    boolean clusterSSLOverRidden = sourceMap.get(CLUSTER_SSL_ENABLED) != null;
+    boolean hasSSLComponents = sourceMap.get(SSL_ENABLED_COMPONENTS) != null;
 
     if (clusterSSLOverRidden && !gatewaySSLOverriden && !hasSSLComponents) {
-      this.gatewaySSLEnabled = this.clusterSSLEnabled;
-      this.sourceMap.put(GATEWAY_SSL_ENABLED, this.sourceMap.get(CLUSTER_SSL_ENABLED));
-      if (this.sourceMap.get(CLUSTER_SSL_CIPHERS) != null) {
-        this.gatewaySslCiphers = this.clusterSSLCiphers;
-        this.sourceMap.put(GATEWAY_SSL_CIPHERS, this.sourceMap.get(CLUSTER_SSL_CIPHERS));
+      gatewaySSLEnabled = clusterSSLEnabled;
+      sourceMap.put(GATEWAY_SSL_ENABLED, sourceMap.get(CLUSTER_SSL_ENABLED));
+      if (sourceMap.get(CLUSTER_SSL_CIPHERS) != null) {
+        gatewaySslCiphers = clusterSSLCiphers;
+        sourceMap.put(GATEWAY_SSL_CIPHERS, sourceMap.get(CLUSTER_SSL_CIPHERS));
       }
 
-      if (this.sourceMap.get(CLUSTER_SSL_PROTOCOLS) != null) {
-        this.gatewaySslProtocols = this.clusterSSLProtocols;
-        this.sourceMap.put(GATEWAY_SSL_PROTOCOLS, this.sourceMap.get(CLUSTER_SSL_PROTOCOLS));
+      if (sourceMap.get(CLUSTER_SSL_PROTOCOLS) != null) {
+        gatewaySslProtocols = clusterSSLProtocols;
+        sourceMap.put(GATEWAY_SSL_PROTOCOLS, sourceMap.get(CLUSTER_SSL_PROTOCOLS));
       }
 
-      if (this.sourceMap.get(CLUSTER_SSL_REQUIRE_AUTHENTICATION) != null) {
-        this.gatewaySslRequireAuthentication = this.clusterSSLRequireAuthentication;
-        this.sourceMap.put(GATEWAY_SSL_REQUIRE_AUTHENTICATION,
-            this.sourceMap.get(CLUSTER_SSL_REQUIRE_AUTHENTICATION));
+      if (sourceMap.get(CLUSTER_SSL_REQUIRE_AUTHENTICATION) != null) {
+        gatewaySslRequireAuthentication = clusterSSLRequireAuthentication;
+        sourceMap.put(GATEWAY_SSL_REQUIRE_AUTHENTICATION,
+            sourceMap.get(CLUSTER_SSL_REQUIRE_AUTHENTICATION));
       }
 
-      if (this.sourceMap.get(CLUSTER_SSL_KEYSTORE) != null) {
-        this.gatewaySSLKeyStore = this.clusterSSLKeyStore;
-        this.sourceMap.put(GATEWAY_SSL_KEYSTORE, this.sourceMap.get(CLUSTER_SSL_KEYSTORE));
+      if (sourceMap.get(CLUSTER_SSL_KEYSTORE) != null) {
+        gatewaySSLKeyStore = clusterSSLKeyStore;
+        sourceMap.put(GATEWAY_SSL_KEYSTORE, sourceMap.get(CLUSTER_SSL_KEYSTORE));
       }
-      if (this.sourceMap.get(CLUSTER_SSL_KEYSTORE_TYPE) != null) {
-        this.gatewaySSLKeyStoreType = this.clusterSSLKeyStoreType;
-        this.sourceMap.put(GATEWAY_SSL_KEYSTORE_TYPE,
-            this.sourceMap.get(CLUSTER_SSL_KEYSTORE_TYPE));
+      if (sourceMap.get(CLUSTER_SSL_KEYSTORE_TYPE) != null) {
+        gatewaySSLKeyStoreType = clusterSSLKeyStoreType;
+        sourceMap.put(GATEWAY_SSL_KEYSTORE_TYPE,
+            sourceMap.get(CLUSTER_SSL_KEYSTORE_TYPE));
       }
-      if (this.sourceMap.get(CLUSTER_SSL_KEYSTORE_PASSWORD) != null) {
-        this.gatewaySSLKeyStorePassword = this.clusterSSLKeyStorePassword;
-        this.sourceMap.put(GATEWAY_SSL_KEYSTORE_PASSWORD,
-            this.sourceMap.get(CLUSTER_SSL_KEYSTORE_PASSWORD));
+      if (sourceMap.get(CLUSTER_SSL_KEYSTORE_PASSWORD) != null) {
+        gatewaySSLKeyStorePassword = clusterSSLKeyStorePassword;
+        sourceMap.put(GATEWAY_SSL_KEYSTORE_PASSWORD,
+            sourceMap.get(CLUSTER_SSL_KEYSTORE_PASSWORD));
       }
-      if (this.sourceMap.get(CLUSTER_SSL_TRUSTSTORE) != null) {
-        this.gatewaySSLTrustStore = this.clusterSSLTrustStore;
-        this.sourceMap.put(GATEWAY_SSL_TRUSTSTORE, this.sourceMap.get(CLUSTER_SSL_TRUSTSTORE));
+      if (sourceMap.get(CLUSTER_SSL_TRUSTSTORE) != null) {
+        gatewaySSLTrustStore = clusterSSLTrustStore;
+        sourceMap.put(GATEWAY_SSL_TRUSTSTORE, sourceMap.get(CLUSTER_SSL_TRUSTSTORE));
       }
-      if (this.sourceMap.get(CLUSTER_SSL_TRUSTSTORE_PASSWORD) != null) {
-        this.gatewaySSLTrustStorePassword = this.clusterSSLTrustStorePassword;
-        this.sourceMap.put(GATEWAY_SSL_TRUSTSTORE_PASSWORD,
-            this.sourceMap.get(CLUSTER_SSL_TRUSTSTORE_PASSWORD));
+      if (sourceMap.get(CLUSTER_SSL_TRUSTSTORE_PASSWORD) != null) {
+        gatewaySSLTrustStorePassword = clusterSSLTrustStorePassword;
+        sourceMap.put(GATEWAY_SSL_TRUSTSTORE_PASSWORD,
+            sourceMap.get(CLUSTER_SSL_TRUSTSTORE_PASSWORD));
       }
-      this.gatewaySslProperties.putAll(this.clusterSSLProperties);
+      gatewaySslProperties.putAll(clusterSSLProperties);
     }
 
     if (gatewaySSLOverriden) {
-      if (this.sourceMap.get(GATEWAY_SSL_KEYSTORE) == null
-          && this.sourceMap.get(CLUSTER_SSL_KEYSTORE) != null) {
-        this.gatewaySSLKeyStore = this.clusterSSLKeyStore;
-        this.sourceMap.put(GATEWAY_SSL_KEYSTORE, this.sourceMap.get(CLUSTER_SSL_KEYSTORE));
+      if (sourceMap.get(GATEWAY_SSL_KEYSTORE) == null
+          && sourceMap.get(CLUSTER_SSL_KEYSTORE) != null) {
+        gatewaySSLKeyStore = clusterSSLKeyStore;
+        sourceMap.put(GATEWAY_SSL_KEYSTORE, sourceMap.get(CLUSTER_SSL_KEYSTORE));
       }
-      if (this.sourceMap.get(GATEWAY_SSL_KEYSTORE_TYPE) == null
-          && this.sourceMap.get(CLUSTER_SSL_KEYSTORE_TYPE) != null) {
-        this.gatewaySSLKeyStoreType = this.clusterSSLKeyStoreType;
-        this.sourceMap.put(GATEWAY_SSL_KEYSTORE_TYPE,
-            this.sourceMap.get(CLUSTER_SSL_KEYSTORE_TYPE));
+      if (sourceMap.get(GATEWAY_SSL_KEYSTORE_TYPE) == null
+          && sourceMap.get(CLUSTER_SSL_KEYSTORE_TYPE) != null) {
+        gatewaySSLKeyStoreType = clusterSSLKeyStoreType;
+        sourceMap.put(GATEWAY_SSL_KEYSTORE_TYPE,
+            sourceMap.get(CLUSTER_SSL_KEYSTORE_TYPE));
       }
-      if (this.sourceMap.get(GATEWAY_SSL_KEYSTORE_PASSWORD) == null
-          && this.sourceMap.get(CLUSTER_SSL_KEYSTORE_PASSWORD) != null) {
-        this.gatewaySSLKeyStorePassword = this.clusterSSLKeyStorePassword;
-        this.sourceMap.put(GATEWAY_SSL_KEYSTORE_PASSWORD,
-            this.sourceMap.get(CLUSTER_SSL_KEYSTORE_PASSWORD));
+      if (sourceMap.get(GATEWAY_SSL_KEYSTORE_PASSWORD) == null
+          && sourceMap.get(CLUSTER_SSL_KEYSTORE_PASSWORD) != null) {
+        gatewaySSLKeyStorePassword = clusterSSLKeyStorePassword;
+        sourceMap.put(GATEWAY_SSL_KEYSTORE_PASSWORD,
+            sourceMap.get(CLUSTER_SSL_KEYSTORE_PASSWORD));
       }
-      if (this.sourceMap.get(GATEWAY_SSL_TRUSTSTORE) == null
-          && this.sourceMap.get(CLUSTER_SSL_TRUSTSTORE) != null) {
-        this.gatewaySSLTrustStore = this.clusterSSLTrustStore;
-        this.sourceMap.put(GATEWAY_SSL_TRUSTSTORE, this.sourceMap.get(CLUSTER_SSL_TRUSTSTORE));
+      if (sourceMap.get(GATEWAY_SSL_TRUSTSTORE) == null
+          && sourceMap.get(CLUSTER_SSL_TRUSTSTORE) != null) {
+        gatewaySSLTrustStore = clusterSSLTrustStore;
+        sourceMap.put(GATEWAY_SSL_TRUSTSTORE, sourceMap.get(CLUSTER_SSL_TRUSTSTORE));
       }
-      if (this.sourceMap.get(GATEWAY_SSL_TRUSTSTORE_PASSWORD) == null
-          && this.sourceMap.get(CLUSTER_SSL_TRUSTSTORE_PASSWORD) != null) {
-        this.gatewaySSLTrustStorePassword = this.clusterSSLTrustStorePassword;
-        this.sourceMap.put(GATEWAY_SSL_TRUSTSTORE_PASSWORD,
-            this.sourceMap.get(CLUSTER_SSL_TRUSTSTORE_PASSWORD));
+      if (sourceMap.get(GATEWAY_SSL_TRUSTSTORE_PASSWORD) == null
+          && sourceMap.get(CLUSTER_SSL_TRUSTSTORE_PASSWORD) != null) {
+        gatewaySSLTrustStorePassword = clusterSSLTrustStorePassword;
+        sourceMap.put(GATEWAY_SSL_TRUSTSTORE_PASSWORD,
+            sourceMap.get(CLUSTER_SSL_TRUSTSTORE_PASSWORD));
       }
     }
   }
-
 
   /**
    * Produce a DistributionConfigImpl for the given properties and return it.
@@ -1513,29 +1500,29 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
     return new DistributionConfigImpl(props, false, isConnected);
   }
 
-  public void setApiProps(Properties apiProps) {
+  void setApiProps(Properties apiProps) {
     if (apiProps != null) {
       setSource(apiProps, ConfigSource.api());
-      this.modifiable = true;
+      modifiable = true;
       Iterator it = apiProps.entrySet().iterator();
       while (it.hasNext()) {
         Map.Entry me = (Map.Entry) it.next();
         String propName = (String) me.getKey();
-        this.props.put(propName, me.getValue());
+        props.put(propName, me.getValue());
         if (specialPropName(propName)) {
           continue;
         }
         String propVal = (String) me.getValue();
         if (propVal != null) {
-          this.setAttribute(propName, propVal.trim(), this.sourceMap.get(propName));
+          setAttribute(propName, propVal.trim(), sourceMap.get(propName));
         }
       }
       // Make attributes read only
-      this.modifiable = false;
+      modifiable = false;
     }
   }
 
-  public static boolean specialPropName(String propName) {
+  private static boolean specialPropName(String propName) {
     return propName.equalsIgnoreCase(CLUSTER_SSL_ENABLED)
         || propName.equals(SECURITY_PEER_AUTH_INIT) || propName.equals(SECURITY_PEER_AUTHENTICATOR)
         || propName.equals(LOG_WRITER_NAME) || propName.equals(DS_CONFIG_NAME)
@@ -1545,9 +1532,10 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
 
   @Override
   protected Map<String, ConfigSource> getAttSourceMap() {
-    return this.sourceMap;
+    return sourceMap;
   }
 
+  @Override
   public Properties getUserDefinedProps() {
     return userDefinedProps;
   }
@@ -1556,12 +1544,12 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
    * Loads the properties from gemfire.properties & gfsecurity.properties files into given
    * Properties object.
    *
-   * @param p the Properties to fill in
+   * @param properties the Properties to fill in
    *
    * @throws GemFireIOException when error occurs while reading properties file
    */
-  public static void loadGemFireProperties(Properties p) throws GemFireIOException {
-    loadGemFireProperties(p, false);
+  public static void loadGemFireProperties(Properties properties) throws GemFireIOException {
+    loadGemFireProperties(properties, false);
   }
 
   /**
@@ -1569,19 +1557,19 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
    * Properties object. if <code>ignoreGemFirePropsFile</code> is <code>true</code>, properties are
    * not read from gemfire.properties.
    *
-   * @param p the Properties to fill in
+   * @param properties the Properties to fill in
    * @param ignoreGemFirePropsFile whether to ignore properties from gemfire.properties
    *
    * @throws GemFireIOException when error occurs while reading properties file
    */
   // Fix for #44924
-  public static void loadGemFireProperties(Properties p, boolean ignoreGemFirePropsFile)
+  public static void loadGemFireProperties(Properties properties, boolean ignoreGemFirePropsFile)
       throws GemFireIOException {
     if (!ignoreGemFirePropsFile) {
-      loadPropertiesFromURL(p, DistributedSystem.getPropertyFileURL());
+      loadPropertiesFromURL(properties, DistributedSystem.getPropertyFileURL());
     }
     // load the security properties file
-    loadPropertiesFromURL(p, DistributedSystem.getSecurityPropertiesFileURL());
+    loadPropertiesFromURL(properties, DistributedSystem.getSecurityPropertiesFileURL());
   }
 
   /**
@@ -1592,7 +1580,7 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
       throw new IllegalArgumentException("Valid ConfigSource must be specified instead of null.");
     }
     for (Object k : p.keySet()) {
-      this.sourceMap.put((String) k, source);
+      sourceMap.put((String) k, source);
     }
   }
 
@@ -1605,10 +1593,10 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
     return result;
   }
 
-  private static void loadPropertiesFromURL(Properties p, URL url) {
+  private static void loadPropertiesFromURL(Properties properties, URL url) {
     if (url != null) {
       try {
-        p.load(url.openStream());
+        properties.load(url.openStream());
       } catch (IOException io) {
         throw new GemFireIOException(
             LocalizedStrings.DistributionConfigImpl_FAILED_READING_0.toLocalizedString(url), io);
@@ -1618,7 +1606,7 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
 
   private void initialize(Map props) {
     // Allow attributes to be modified
-    this.modifiable = true;
+    modifiable = true;
     this.props = props;
     Iterator it = props.entrySet().iterator();
     while (it.hasNext()) {
@@ -1630,110 +1618,123 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
         continue;
       }
       Object propVal = me.getValue();
-      if (propVal != null && (propVal instanceof String)) { // weed out extraneous non-string
-                                                            // properties
-        this.setAttribute(propName, ((String) propVal).trim(), this.sourceMap.get(propName));
+      // weed out extraneous non-string properties
+      if (propVal instanceof String) {
+        setAttribute(propName, ((String) propVal).trim(), sourceMap.get(propName));
       }
     }
     if (props.containsKey(CLUSTER_SSL_ENABLED)) {
-      this.setAttribute(CLUSTER_SSL_ENABLED, (String) props.get(CLUSTER_SSL_ENABLED),
-          this.sourceMap.get(CLUSTER_SSL_ENABLED));
+      setAttribute(CLUSTER_SSL_ENABLED, (String) props.get(CLUSTER_SSL_ENABLED),
+          sourceMap.get(CLUSTER_SSL_ENABLED));
     }
     // now set the security authInit if needed
     if (props.containsKey(SECURITY_PEER_AUTH_INIT)) {
-      this.setAttribute(SECURITY_PEER_AUTH_INIT, (String) props.get(SECURITY_PEER_AUTH_INIT),
-          this.sourceMap.get(SECURITY_PEER_AUTH_INIT));
+      setAttribute(SECURITY_PEER_AUTH_INIT, (String) props.get(SECURITY_PEER_AUTH_INIT),
+          sourceMap.get(SECURITY_PEER_AUTH_INIT));
     }
     // and security authenticator if needed
     if (props.containsKey(SECURITY_PEER_AUTHENTICATOR)) {
-      this.setAttribute(SECURITY_PEER_AUTHENTICATOR,
+      setAttribute(SECURITY_PEER_AUTHENTICATOR,
           (String) props.get(SECURITY_PEER_AUTHENTICATOR),
-          this.sourceMap.get(SECURITY_PEER_AUTHENTICATOR));
+          sourceMap.get(SECURITY_PEER_AUTHENTICATOR));
     }
 
     // Make attributes read only
-    this.modifiable = false;
+    modifiable = false;
   }
 
   private String convertCommaDelimitedToSpaceDelimitedString(final String propVal) {
     return propVal.replace(",", " ");
   }
 
+  @Override
   public void close() {
     // Clear the extra stuff from System properties
-    Properties props = System.getProperties();
-    props.remove(SECURITY_SYSTEM_PREFIX + SECURITY_PEER_AUTH_INIT);
-    props.remove(SECURITY_SYSTEM_PREFIX + SECURITY_PEER_AUTHENTICATOR);
+    Properties properties = System.getProperties();
+    properties.remove(SECURITY_SYSTEM_PREFIX + SECURITY_PEER_AUTH_INIT);
+    properties.remove(SECURITY_SYSTEM_PREFIX + SECURITY_PEER_AUTHENTICATOR);
 
     Iterator iter = security.keySet().iterator();
     while (iter.hasNext()) {
-      props.remove(SECURITY_SYSTEM_PREFIX + (String) iter.next());
+      properties.remove(SECURITY_SYSTEM_PREFIX + iter.next());
     }
-    System.setProperties(props);
+    System.setProperties(properties);
   }
 
-  //////////////////// Configuration Methods ////////////////////
-
+  @Override
   public String getName() {
-    return this.name;
+    return name;
   }
 
+  @Override
   public int getTcpPort() {
-    return this.tcpPort;
+    return tcpPort;
   }
 
+  @Override
   public int getMcastPort() {
-    return this.mcastPort;
+    return mcastPort;
   }
 
+  @Override
   public int getMcastTtl() {
-    return this.mcastTtl;
+    return mcastTtl;
   }
 
+  @Override
   public int getSocketLeaseTime() {
-    return this.socketLeaseTime;
+    return socketLeaseTime;
   }
 
+  @Override
   public int getSocketBufferSize() {
-    return this.socketBufferSize;
+    return socketBufferSize;
   }
 
+  @Override
   public boolean getConserveSockets() {
-    return this.conserveSockets;
+    return conserveSockets;
   }
 
+  @Override
   public String getRoles() {
-    return this.roles;
+    return roles;
   }
 
+  @Override
   public int getMaxWaitTimeForReconnect() {
-    return this.maxWaitTimeForReconnect;
+    return maxWaitTimeForReconnect;
   }
 
+  @Override
   public int getMaxNumReconnectTries() {
-    return this.maxNumReconnectTries;
+    return maxNumReconnectTries;
   }
 
+  @Override
   public InetAddress getMcastAddress() {
     try {
-      return this.mcastAddress;
+      return mcastAddress;
     } catch (Exception e) {
       e.printStackTrace();
       return null;
     }
   }
 
+  @Override
   public String getBindAddress() {
-    return this.bindAddress;
+    return bindAddress;
   }
 
+  @Override
   public String getServerBindAddress() {
-    return this.serverBindAddress;
+    return serverBindAddress;
   }
 
+  @Override
   public String getLocators() {
-    if (this.startLocator != null && this.startLocator.length() > 0) {
-      String locs = this.locators;
+    if (startLocator != null && startLocator.length() > 0) {
+      String locs = locators;
       String startL = getStartLocator();
       int comma = startL.indexOf(',');
       if (comma >= 0) {
@@ -1748,228 +1749,279 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
         return startL;
       }
     }
-    return this.locators;
+    return locators;
   }
 
+  @Override
   public String getStartLocator() {
-    if (this.startLocatorPort > 0) {
-      if (this.bindAddress != null) {
-        return this.bindAddress + "[" + this.startLocatorPort + "]";
+    if (startLocatorPort > 0) {
+      if (bindAddress != null) {
+        return bindAddress + "[" + startLocatorPort + "]";
       }
       try {
-        return SocketCreator.getHostName(SocketCreator.getLocalHost()) + "[" + this.startLocatorPort
+        return SocketCreator.getHostName(SocketCreator.getLocalHost()) + "[" + startLocatorPort
             + "]";
-      } catch (UnknownHostException e) {
+      } catch (UnknownHostException ignore) {
         // punt and use this.startLocator instead
       }
     }
-    return this.startLocator;
+    return startLocator;
   }
 
+  @Override
   public File getDeployWorkingDir() {
-    return this.deployWorkingDir;
+    return deployWorkingDir;
   }
 
+  @Override
   public File getLogFile() {
-    return this.logFile;
+    return logFile;
   }
 
+  @Override
   public int getLogLevel() {
-    return this.logLevel;
+    return logLevel;
   }
 
+  @Override
   public boolean getStatisticSamplingEnabled() {
-    return this.statisticSamplingEnabled;
+    return statisticSamplingEnabled;
   }
 
+  @Override
   public int getStatisticSampleRate() {
-    return this.statisticSampleRate;
+    return statisticSampleRate;
   }
 
+  @Override
   public File getStatisticArchiveFile() {
-    return this.statisticArchiveFile;
+    return statisticArchiveFile;
   }
 
+  @Override
   public int getAckWaitThreshold() {
-    return this.ackWaitThreshold;
+    return ackWaitThreshold;
   }
 
+  @Override
   public int getAckSevereAlertThreshold() {
-    return this.ackForceDisconnectThreshold;
+    return ackForceDisconnectThreshold;
   }
 
+  @Override
   public File getCacheXmlFile() {
-    return this.cacheXmlFile;
+    return cacheXmlFile;
   }
 
+  @Override
   public boolean getClusterSSLEnabled() {
-    return this.clusterSSLEnabled;
+    return clusterSSLEnabled;
   }
 
+  @Override
   public String getClusterSSLProtocols() {
-    return this.clusterSSLProtocols;
+    return clusterSSLProtocols;
   }
 
+  @Override
   public String getClusterSSLCiphers() {
-    return this.clusterSSLCiphers;
+    return clusterSSLCiphers;
   }
 
+  @Override
   public boolean getClusterSSLRequireAuthentication() {
-    return this.clusterSSLRequireAuthentication;
+    return clusterSSLRequireAuthentication;
   }
 
+  @Override
   public String getClusterSSLKeyStore() {
-    return this.clusterSSLKeyStore;
+    return clusterSSLKeyStore;
   }
 
+  @Override
   public String getClusterSSLKeyStoreType() {
-    return this.clusterSSLKeyStoreType;
+    return clusterSSLKeyStoreType;
   }
 
+  @Override
   public String getClusterSSLKeyStorePassword() {
-    return this.clusterSSLKeyStorePassword;
+    return clusterSSLKeyStorePassword;
   }
 
+  @Override
   public String getClusterSSLTrustStore() {
-    return this.clusterSSLTrustStore;
+    return clusterSSLTrustStore;
   }
 
+  @Override
   public String getClusterSSLTrustStorePassword() {
-    return this.clusterSSLTrustStorePassword;
+    return clusterSSLTrustStorePassword;
   }
 
+  @Override
   public int getAsyncDistributionTimeout() {
-    return this.asyncDistributionTimeout;
+    return asyncDistributionTimeout;
   }
 
+  @Override
   public int getAsyncQueueTimeout() {
-    return this.asyncQueueTimeout;
+    return asyncQueueTimeout;
   }
 
+  @Override
   public int getAsyncMaxQueueSize() {
-    return this.asyncMaxQueueSize;
+    return asyncMaxQueueSize;
   }
 
+  @Override
   public String getUserCommandPackages() {
-    return this.userCommandPackages;
+    return userCommandPackages;
   }
 
+  @Override
   public int getHttpServicePort() {
-    return this.httpServicePort;
+    return httpServicePort;
   }
 
+  @Override
   public void setHttpServicePort(int value) {
-    this.httpServicePort = value;
+    httpServicePort = value;
   }
 
+  @Override
   public String getHttpServiceBindAddress() {
-    return this.httpServiceBindAddress;
+    return httpServiceBindAddress;
   }
 
+  @Override
   public void setHttpServiceBindAddress(String value) {
-    this.httpServiceBindAddress = value;
+    httpServiceBindAddress = value;
   }
 
+  @Override
   public boolean getStartDevRestApi() {
-    return this.startDevRestApi;
+    return startDevRestApi;
   }
 
+  @Override
   public void setStartDevRestApi(boolean value) {
-    this.startDevRestApi = value;
+    startDevRestApi = value;
   }
 
+  @Override
   public void setUserCommandPackages(String value) {
-    this.userCommandPackages = value;
+    userCommandPackages = value;
   }
 
+  @Override
   public boolean getDeltaPropagation() {
-    return this.deltaPropagation;
+    return deltaPropagation;
   }
 
+  @Override
   public void setDeltaPropagation(boolean value) {
-    this.deltaPropagation = (Boolean) value;
+    deltaPropagation = value;
   }
 
+  @Override
   public void setName(String value) {
     if (value == null) {
       value = DEFAULT_NAME;
     }
-    this.name = (String) value;
+    name = value;
   }
 
+  @Override
   public void setTcpPort(int value) {
-    this.tcpPort = (Integer) value;
+    tcpPort = value;
   }
 
+  @Override
   public void setMcastPort(int value) {
-    this.mcastPort = (Integer) value;
+    mcastPort = value;
   }
 
+  @Override
   public void setMcastTtl(int value) {
-    this.mcastTtl = (Integer) value;
+    mcastTtl = value;
   }
 
+  @Override
   public void setSocketLeaseTime(int value) {
-    this.socketLeaseTime = (Integer) value;
+    socketLeaseTime = value;
   }
 
+  @Override
   public void setSocketBufferSize(int value) {
-    this.socketBufferSize = (Integer) value;
+    socketBufferSize = value;
   }
 
-  public void setConserveSockets(boolean value) {
-    this.conserveSockets = (Boolean) value;
+  @Override
+  public void setConserveSockets(boolean newValue) {
+    conserveSockets = newValue;
   }
 
-  public void setRoles(String value) {
-    this.roles = (String) value;
+  @Override
+  public void setRoles(String roles) {
+    this.roles = roles;
   }
 
-  public void setMaxWaitTimeForReconnect(int value) {
-    this.maxWaitTimeForReconnect = value;
+  @Override
+  public void setMaxWaitTimeForReconnect(int timeOut) {
+    maxWaitTimeForReconnect = timeOut;
   }
 
-  public void setMaxNumReconnectTries(int value) {
-    this.maxNumReconnectTries = value;
+  @Override
+  public void setMaxNumReconnectTries(int tries) {
+    maxNumReconnectTries = tries;
   }
 
+  @Override
   public void setMcastAddress(InetAddress value) {
-    this.mcastAddress = (InetAddress) value;
+    mcastAddress = value;
   }
 
+  @Override
   public void setBindAddress(String value) {
-    this.bindAddress = (String) value;
+    bindAddress = value;
   }
 
+  @Override
   public void setServerBindAddress(String value) {
-    this.serverBindAddress = (String) value;
+    serverBindAddress = value;
   }
 
+  @Override
   public void setLocators(String value) {
     if (value == null) {
       value = DEFAULT_LOCATORS;
     }
-    this.locators = (String) value;
+    locators = value;
   }
 
-  public void setLocatorWaitTime(int value) {
-    this.locatorWaitTime = value;
+  @Override
+  public void setLocatorWaitTime(int seconds) {
+    locatorWaitTime = seconds;
   }
 
+  @Override
   public int getLocatorWaitTime() {
-    return this.locatorWaitTime;
+    return locatorWaitTime;
   }
 
+  @Override
   public void setDeployWorkingDir(File value) {
-    this.deployWorkingDir = (File) value;
+    deployWorkingDir = value;
   }
 
+  @Override
   public void setLogFile(File value) {
-    this.logFile = (File) value;
+    logFile = value;
   }
 
+  @Override
   public void setLogLevel(int value) {
-    this.logLevel = (Integer) value;
+    logLevel = value;
   }
 
   /**
@@ -1978,10 +2030,11 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
    * file, but only in the configuration settings - it won't affect a running distributed system's
    * log file
    */
-  public void unsafeSetLogFile(File value) {
-    this.logFile = value;
+  void unsafeSetLogFile(File value) {
+    logFile = value;
   }
 
+  @Override
   public void setStartLocator(String value) {
     startLocatorPort = 0;
     if (value == null) {
@@ -2006,19 +2059,18 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
         } catch (NumberFormatException e) {
           throw new GemFireConfigException("Illegal port specified for start-locator", e);
         }
-      } else {
-
       }
     }
-    this.startLocator = value;
+    startLocator = value;
   }
 
-  public void setStatisticSamplingEnabled(boolean value) {
-    this.statisticSamplingEnabled = (Boolean) value;
+  @Override
+  public void setStatisticSamplingEnabled(boolean newValue) {
+    statisticSamplingEnabled = newValue;
   }
 
+  @Override
   public void setStatisticSampleRate(int value) {
-    value = (Integer) value;
     if (value < DEFAULT_STATISTIC_SAMPLE_RATE) {
       // fix 48228
       InternalDistributedSystem ids = InternalDistributedSystem.getConnectedInstance();
@@ -2030,335 +2082,414 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
       }
       value = DEFAULT_STATISTIC_SAMPLE_RATE;
     }
-    this.statisticSampleRate = value;
+    statisticSampleRate = value;
   }
 
+  @Override
   public void setStatisticArchiveFile(File value) {
     if (value == null) {
       value = new File("");
     }
-    this.statisticArchiveFile = (File) value;
+    statisticArchiveFile = value;
   }
 
+  @Override
   public void setCacheXmlFile(File value) {
-    this.cacheXmlFile = (File) value;
+    cacheXmlFile = value;
   }
 
-  public void setAckWaitThreshold(int value) {
-    this.ackWaitThreshold = (Integer) value;
+  @Override
+  public void setAckWaitThreshold(int newThreshold) {
+    ackWaitThreshold = newThreshold;
   }
 
-  public void setAckSevereAlertThreshold(int value) {
-    this.ackForceDisconnectThreshold = (Integer) value;
+  @Override
+  public void setAckSevereAlertThreshold(int newThreshold) {
+    ackForceDisconnectThreshold = newThreshold;
   }
 
+  @Override
   public int getArchiveDiskSpaceLimit() {
-    return this.archiveDiskSpaceLimit;
+    return archiveDiskSpaceLimit;
   }
 
+  @Override
   public void setArchiveDiskSpaceLimit(int value) {
-    this.archiveDiskSpaceLimit = (Integer) value;
+    archiveDiskSpaceLimit = value;
   }
 
+  @Override
   public int getArchiveFileSizeLimit() {
-    return this.archiveFileSizeLimit;
+    return archiveFileSizeLimit;
   }
 
+  @Override
   public void setArchiveFileSizeLimit(int value) {
-    this.archiveFileSizeLimit = (Integer) value;
+    archiveFileSizeLimit = value;
   }
 
+  @Override
   public int getLogDiskSpaceLimit() {
-    return this.logDiskSpaceLimit;
+    return logDiskSpaceLimit;
   }
 
+  @Override
   public void setLogDiskSpaceLimit(int value) {
-    this.logDiskSpaceLimit = (Integer) value;
+    logDiskSpaceLimit = value;
   }
 
+  @Override
   public int getLogFileSizeLimit() {
-    return this.logFileSizeLimit;
+    return logFileSizeLimit;
   }
 
+  @Override
   public void setLogFileSizeLimit(int value) {
-    this.logFileSizeLimit = (Integer) value;
+    logFileSizeLimit = value;
   }
 
-  public void setClusterSSLEnabled(boolean value) {
-    this.clusterSSLEnabled = (Boolean) value;
+  @Override
+  public void setClusterSSLEnabled(boolean enabled) {
+    clusterSSLEnabled = enabled;
   }
 
-  public void setClusterSSLProtocols(String value) {
-    this.clusterSSLProtocols = (String) value;
+  @Override
+  public void setClusterSSLProtocols(String protocols) {
+    clusterSSLProtocols = protocols;
   }
 
-  public void setClusterSSLCiphers(String value) {
-    this.clusterSSLCiphers = (String) value;
+  @Override
+  public void setClusterSSLCiphers(String ciphers) {
+    clusterSSLCiphers = ciphers;
   }
 
-  public void setClusterSSLRequireAuthentication(boolean value) {
-    this.clusterSSLRequireAuthentication = (Boolean) value;
+  @Override
+  public void setClusterSSLRequireAuthentication(boolean enabled) {
+    clusterSSLRequireAuthentication = enabled;
   }
 
-  public void setClusterSSLKeyStore(String value) {
-    this.getClusterSSLProperties().setProperty(SSL_SYSTEM_PROPS_NAME + KEY_STORE_NAME, value);
-    this.clusterSSLKeyStore = value;
+  @Override
+  public void setClusterSSLKeyStore(String keyStore) {
+    getClusterSSLProperties().setProperty(SSL_SYSTEM_PROPS_NAME + KEY_STORE_NAME, keyStore);
+    clusterSSLKeyStore = keyStore;
   }
 
-  public void setClusterSSLKeyStoreType(String value) {
-    this.getClusterSSLProperties().setProperty(SSL_SYSTEM_PROPS_NAME + KEY_STORE_TYPE_NAME, value);
-    this.clusterSSLKeyStoreType = value;
+  @Override
+  public void setClusterSSLKeyStoreType(String keyStoreType) {
+    getClusterSSLProperties().setProperty(SSL_SYSTEM_PROPS_NAME + KEY_STORE_TYPE_NAME,
+        keyStoreType);
+    clusterSSLKeyStoreType = keyStoreType;
   }
 
-  public void setClusterSSLKeyStorePassword(String value) {
-    this.getClusterSSLProperties().setProperty(SSL_SYSTEM_PROPS_NAME + KEY_STORE_PASSWORD_NAME,
-        value);
-    this.clusterSSLKeyStorePassword = value;
+  @Override
+  public void setClusterSSLKeyStorePassword(String keyStorePassword) {
+    getClusterSSLProperties().setProperty(SSL_SYSTEM_PROPS_NAME + KEY_STORE_PASSWORD_NAME,
+        keyStorePassword);
+    clusterSSLKeyStorePassword = keyStorePassword;
   }
 
-  public void setClusterSSLTrustStore(String value) {
-    this.getClusterSSLProperties().setProperty(SSL_SYSTEM_PROPS_NAME + TRUST_STORE_NAME, value);
-    this.clusterSSLTrustStore = value;
+  @Override
+  public void setClusterSSLTrustStore(String trustStore) {
+    getClusterSSLProperties().setProperty(SSL_SYSTEM_PROPS_NAME + TRUST_STORE_NAME, trustStore);
+    clusterSSLTrustStore = trustStore;
   }
 
-  public void setClusterSSLTrustStorePassword(String value) {
-    this.getClusterSSLProperties().setProperty(SSL_SYSTEM_PROPS_NAME + TRUST_STORE_PASSWORD_NAME,
-        value);
-    this.clusterSSLTrustStorePassword = value;
+  @Override
+  public void setClusterSSLTrustStorePassword(String trusStorePassword) {
+    getClusterSSLProperties().setProperty(SSL_SYSTEM_PROPS_NAME + TRUST_STORE_PASSWORD_NAME,
+        trusStorePassword);
+    clusterSSLTrustStorePassword = trusStorePassword;
   }
 
+  @Override
   public int getMcastSendBufferSize() {
     return mcastSendBufferSize;
   }
 
+  @Override
   public void setMcastSendBufferSize(int value) {
-    mcastSendBufferSize = (Integer) value;
+    mcastSendBufferSize = value;
   }
 
+  @Override
   public int getMcastRecvBufferSize() {
     return mcastRecvBufferSize;
   }
 
+  @Override
   public void setMcastRecvBufferSize(int value) {
-    mcastRecvBufferSize = (Integer) value;
+    mcastRecvBufferSize = value;
   }
 
-  public void setAsyncDistributionTimeout(int value) {
-    this.asyncDistributionTimeout = (Integer) value;
+  @Override
+  public void setAsyncDistributionTimeout(int newValue) {
+    asyncDistributionTimeout = newValue;
   }
 
-  public void setAsyncQueueTimeout(int value) {
-    this.asyncQueueTimeout = (Integer) value;
+  @Override
+  public void setAsyncQueueTimeout(int newValue) {
+    asyncQueueTimeout = newValue;
   }
 
-  public void setAsyncMaxQueueSize(int value) {
-    this.asyncMaxQueueSize = (Integer) value;
+  @Override
+  public void setAsyncMaxQueueSize(int newValue) {
+    asyncMaxQueueSize = newValue;
   }
 
+  @Override
   public FlowControlParams getMcastFlowControl() {
     return mcastFlowControl;
   }
 
+  @Override
   public void setMcastFlowControl(FlowControlParams values) {
-    mcastFlowControl = (FlowControlParams) values;
+    mcastFlowControl = values;
   }
 
+  @Override
   public int getUdpFragmentSize() {
     return udpFragmentSize;
   }
 
+  @Override
   public void setUdpFragmentSize(int value) {
-    udpFragmentSize = (Integer) value;
+    udpFragmentSize = value;
   }
 
+  @Override
   public int getUdpSendBufferSize() {
     return udpSendBufferSize;
   }
 
+  @Override
   public void setUdpSendBufferSize(int value) {
-    udpSendBufferSize = (Integer) value;
+    udpSendBufferSize = value;
   }
 
+  @Override
   public int getUdpRecvBufferSize() {
     return udpRecvBufferSize;
   }
 
+  @Override
   public void setUdpRecvBufferSize(int value) {
-    udpRecvBufferSize = (Integer) value;
+    udpRecvBufferSize = value;
   }
 
+  @Override
   public boolean getDisableTcp() {
     return disableTcp;
   }
 
+  @Override
   public void setDisableTcp(boolean newValue) {
     disableTcp = newValue;
   }
 
+  @Override
   public boolean getEnableTimeStatistics() {
     return enableTimeStatistics;
   }
 
+  @Override
   public void setEnableTimeStatistics(boolean newValue) {
     enableTimeStatistics = newValue;
   }
 
+  @Override
   public int getMemberTimeout() {
     return memberTimeout;
   }
 
+  @Override
   public void setMemberTimeout(int value) {
-    memberTimeout = (Integer) value;
+    memberTimeout = value;
   }
 
   /**
    * @since GemFire 5.7
    */
+  @Override
   public String getClientConflation() {
-    return this.clientConflation;
+    return clientConflation;
   }
 
   /**
    * @since GemFire 5.7
    */
-  public void setClientConflation(String value) {
-    this.clientConflation = (String) value;
+  @Override
+  public void setClientConflation(String clientConflation) {
+    this.clientConflation = clientConflation;
   }
 
+  @Override
   public String getDurableClientId() {
     return durableClientId;
   }
 
-  public void setDurableClientId(String value) {
-    durableClientId = (String) value;
+  @Override
+  public void setDurableClientId(String durableClientId) {
+    this.durableClientId = durableClientId;
   }
 
+  @Override
   public int getDurableClientTimeout() {
     return durableClientTimeout;
   }
 
-  public void setDurableClientTimeout(int value) {
-    durableClientTimeout = (Integer) value;
+  @Override
+  public void setDurableClientTimeout(int durableClientTimeout) {
+    this.durableClientTimeout = durableClientTimeout;
   }
 
+  @Override
   public String getSecurityClientAuthInit() {
     return securityClientAuthInit;
   }
 
-  public void setSecurityClientAuthInit(String value) {
-    securityClientAuthInit = (String) value;
+  @Override
+  public void setSecurityClientAuthInit(String attValue) {
+    securityClientAuthInit = attValue;
   }
 
+  @Override
   public String getSecurityClientAuthenticator() {
     return securityClientAuthenticator;
   }
 
+  @Override
   public String getSecurityManager() {
     return securityManager;
   }
 
+  @Override
   public String getPostProcessor() {
     return postProcessor;
   }
 
+  @Override
   public boolean getEnableNetworkPartitionDetection() {
-    return this.enableNetworkPartitionDetection;
+    return enableNetworkPartitionDetection;
   }
 
-  public void setEnableNetworkPartitionDetection(boolean value) {
-    this.enableNetworkPartitionDetection = value;
+  @Override
+  public void setEnableNetworkPartitionDetection(boolean newValue) {
+    enableNetworkPartitionDetection = newValue;
   }
 
+  @Override
   public boolean getDisableAutoReconnect() {
-    return this.disableAutoReconnect;
+    return disableAutoReconnect;
   }
 
+  @Override
   public void setDisableAutoReconnect(boolean value) {
-    this.disableAutoReconnect = value;
+    disableAutoReconnect = value;
   }
 
-  public void setSecurityClientAuthenticator(String value) {
-    securityClientAuthenticator = value;
+  @Override
+  public void setSecurityClientAuthenticator(String attValue) {
+    securityClientAuthenticator = attValue;
   }
 
-  public void setSecurityManager(String value) {
-    securityManager = value;
+  @Override
+  public void setSecurityManager(String attValue) {
+    securityManager = attValue;
   }
 
-  public void setPostProcessor(String value) {
-    postProcessor = value;
+  @Override
+  public void setPostProcessor(String attValue) {
+    postProcessor = attValue;
   }
 
+  @Override
   public String getSecurityClientDHAlgo() {
     return securityClientDHAlgo;
   }
 
-  public void setSecurityClientDHAlgo(String value) {
-    securityClientDHAlgo = (String) value;
+  @Override
+  public void setSecurityClientDHAlgo(String attValue) {
+    securityClientDHAlgo = attValue;
   }
 
+  @Override
   public String getSecurityUDPDHAlgo() {
     return securityUDPDHAlgo;
   }
 
-  public void setSecurityUDPDHAlgo(String value) {
-    securityUDPDHAlgo = (String) checkAttribute(SECURITY_UDP_DHALGO, value);
+  @Override
+  public void setSecurityUDPDHAlgo(String attValue) {
+    securityUDPDHAlgo = (String) checkAttribute(SECURITY_UDP_DHALGO, attValue);
   }
 
+  @Override
   public String getSecurityPeerAuthInit() {
     return securityPeerAuthInit;
   }
 
-  public void setSecurityPeerAuthInit(String value) {
-    securityPeerAuthInit = (String) value;
+  @Override
+  public void setSecurityPeerAuthInit(String attValue) {
+    securityPeerAuthInit = attValue;
   }
 
+  @Override
   public String getSecurityPeerAuthenticator() {
     return securityPeerAuthenticator;
   }
 
-  public void setSecurityPeerAuthenticator(String value) {
-    securityPeerAuthenticator = (String) value;
+  @Override
+  public void setSecurityPeerAuthenticator(String attValue) {
+    securityPeerAuthenticator = attValue;
   }
 
+  @Override
   public String getSecurityClientAccessor() {
     return securityClientAccessor;
   }
 
-  public void setSecurityClientAccessor(String value) {
-    securityClientAccessor = (String) value;
+  @Override
+  public void setSecurityClientAccessor(String attValue) {
+    securityClientAccessor = attValue;
   }
 
+  @Override
   public String getSecurityClientAccessorPP() {
     return securityClientAccessorPP;
   }
 
-  public void setSecurityClientAccessorPP(String value) {
-    securityClientAccessorPP = (String) value;
+  @Override
+  public void setSecurityClientAccessorPP(String attValue) {
+    securityClientAccessorPP = attValue;
   }
 
+  @Override
   public int getSecurityLogLevel() {
     return securityLogLevel;
   }
 
-  public void setSecurityLogLevel(int value) {
-    securityLogLevel = (Integer) value;
+  @Override
+  public void setSecurityLogLevel(int level) {
+    securityLogLevel = level;
   }
 
+  @Override
   public File getSecurityLogFile() {
     return securityLogFile;
   }
 
+  @Override
   public void setSecurityLogFile(File value) {
-    securityLogFile = (File) value;
+    securityLogFile = value;
   }
 
+  @Override
   public int getSecurityPeerMembershipTimeout() {
     return securityPeerMembershipTimeout;
   }
 
-  public void setSecurityPeerMembershipTimeout(int value) {
-    securityPeerMembershipTimeout = (Integer) value;
+  @Override
+  public void setSecurityPeerMembershipTimeout(int attValue) {
+    securityPeerMembershipTimeout = attValue;
   }
 
   @Override
@@ -2381,238 +2512,260 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
     return result;
   }
 
+  @Override
   public String getSecurity(String attName) {
 
     String attValue = security.getProperty(attName);
-    return (attValue == null ? "" : attValue);
+    return attValue == null ? "" : attValue;
   }
 
+  @Override
   public void setSecurity(String attName, String attValue) {
     security.setProperty(attName, attValue);
   }
 
+  @Override
   public boolean getRemoveUnresponsiveClient() {
     return removeUnresponsiveClient;
   }
 
+  @Override
   public void setRemoveUnresponsiveClient(boolean value) {
     removeUnresponsiveClient = value;
   }
 
+  @Override
   public int getDistributedSystemId() {
     return distributedSystemId;
   }
 
+  @Override
   public void setDistributedSystemId(int distributedSystemId) {
-    this.distributedSystemId = (Integer) distributedSystemId;
+    this.distributedSystemId = distributedSystemId;
 
   }
 
+  @Override
   public boolean getEnforceUniqueHost() {
     return enforceUniqueHost;
   }
 
+  @Override
   public String getRedundancyZone() {
     // TODO Auto-generated method stub
     return redundancyZone;
   }
 
+  @Override
   public void setEnforceUniqueHost(boolean enforceUniqueHost) {
-    this.enforceUniqueHost = (Boolean) enforceUniqueHost;
+    this.enforceUniqueHost = enforceUniqueHost;
 
   }
 
+  @Override
   public void setRedundancyZone(String redundancyZone) {
-    this.redundancyZone = (String) redundancyZone;
+    this.redundancyZone = redundancyZone;
 
   }
 
+  @Override
   public void setSSLProperty(String attName, String attValue) {
     if (attName.startsWith(SYS_PROP_NAME)) {
       attName = attName.substring(SYS_PROP_NAME.length());
     }
     if (attName.endsWith(JMX_SSL_PROPS_SUFFIX)) {
-      this.jmxManagerSslProperties.setProperty(
+      jmxManagerSslProperties.setProperty(
           attName.substring(0, attName.length() - JMX_SSL_PROPS_SUFFIX.length()), attValue);
     } else {
-      this.sslProperties.setProperty(attName, attValue);
+      sslProperties.setProperty(attName, attValue);
 
-      if (!this.jmxManagerSslProperties.containsKey(attName)) {
+      if (!jmxManagerSslProperties.containsKey(attName)) {
         // use sslProperties as base and let props with suffix JMX_SSL_PROPS_SUFFIX override that
         // base
-        this.jmxManagerSslProperties.setProperty(attName, attValue);
+        jmxManagerSslProperties.setProperty(attName, attValue);
       }
 
-      if (!this.serverSslProperties.containsKey(attName)) {
+      if (!serverSslProperties.containsKey(attName)) {
         // use sslProperties as base and let props with suffix CACHESERVER_SSL_PROPS_SUFFIX override
         // that base
-        this.serverSslProperties.setProperty(attName, attValue);
+        serverSslProperties.setProperty(attName, attValue);
       }
-      if (!this.gatewaySslProperties.containsKey(attName)) {
+      if (!gatewaySslProperties.containsKey(attName)) {
         // use sslProperties as base and let props with suffix GATEWAY_SSL_PROPS_SUFFIX override
         // that base
-        this.gatewaySslProperties.setProperty(attName, attValue);
+        gatewaySslProperties.setProperty(attName, attValue);
       }
-      if (!this.httpServiceSSLProperties.containsKey(attName)) {
+      if (!httpServiceSSLProperties.containsKey(attName)) {
         // use sslProperties as base and let props with suffix GATEWAY_SSL_PROPS_SUFFIX override
         // that base
-        this.httpServiceSSLProperties.setProperty(attName, attValue);
+        httpServiceSSLProperties.setProperty(attName, attValue);
       }
-      if (!this.clusterSSLProperties.containsKey(attName)) {
+      if (!clusterSSLProperties.containsKey(attName)) {
         // use sslProperties as base and let props with suffix GATEWAY_SSL_PROPS_SUFFIX override
         // that base
-        this.clusterSSLProperties.setProperty(attName, attValue);
+        clusterSSLProperties.setProperty(attName, attValue);
       }
     }
   }
 
+  @Override
   public Properties getSSLProperties() {
-    return this.sslProperties;
+    return sslProperties;
   }
 
+  @Override
   public Properties getClusterSSLProperties() {
-    return this.clusterSSLProperties;
+    return clusterSSLProperties;
   }
 
+  @Override
   public Properties getJmxSSLProperties() {
-    return this.jmxManagerSslProperties;
+    return jmxManagerSslProperties;
   }
 
+  @Override
   public String getGroups() {
-    return this.groups;
+    return groups;
   }
 
+  @Override
   public void setGroups(String value) {
     if (value == null) {
       value = DEFAULT_GROUPS;
     }
-    this.groups = (String) value;
+    groups = value;
   }
 
   @Override
   public boolean getJmxManager() {
-    return this.jmxManager;
+    return jmxManager;
   }
 
   @Override
   public void setJmxManager(boolean value) {
-    this.jmxManager = value;
+    jmxManager = value;
   }
 
   @Override
   public boolean getJmxManagerStart() {
-    return this.jmxManagerStart;
+    return jmxManagerStart;
   }
 
   @Override
   public void setJmxManagerStart(boolean value) {
-    this.jmxManagerStart = value;
+    jmxManagerStart = value;
   }
 
   @Override
   public boolean getJmxManagerSSLEnabled() {
-    return this.jmxManagerSSLEnabled;
+    return jmxManagerSSLEnabled;
   }
 
   @Override
-  public void setJmxManagerSSLEnabled(boolean value) {
-    this.jmxManagerSSLEnabled = value;
+  public void setJmxManagerSSLEnabled(boolean enabled) {
+    jmxManagerSSLEnabled = enabled;
   }
 
   @Override
   public boolean getJmxManagerSSLRequireAuthentication() {
-    return this.jmxManagerSslRequireAuthentication;
+    return jmxManagerSslRequireAuthentication;
   }
 
   @Override
-  public void setJmxManagerSSLRequireAuthentication(boolean jmxManagerSslRequireAuthentication) {
-    this.jmxManagerSslRequireAuthentication = jmxManagerSslRequireAuthentication;
+  public void setJmxManagerSSLRequireAuthentication(boolean enabled) {
+    jmxManagerSslRequireAuthentication = enabled;
   }
 
   @Override
   public String getJmxManagerSSLProtocols() {
-    return this.jmxManagerSslProtocols;
+    return jmxManagerSslProtocols;
   }
 
   @Override
   public void setJmxManagerSSLProtocols(String protocols) {
-    this.jmxManagerSslProtocols = protocols;
+    jmxManagerSslProtocols = protocols;
   }
 
   @Override
   public String getJmxManagerSSLCiphers() {
-    return this.jmxManagerSslCiphers;
+    return jmxManagerSslCiphers;
   }
 
   @Override
   public void setJmxManagerSSLCiphers(String ciphers) {
-    this.jmxManagerSslCiphers = ciphers;
+    jmxManagerSslCiphers = ciphers;
   }
 
-  public void setJmxManagerSSLKeyStore(String value) {
-
-    this.getJmxSSLProperties().setProperty(SSL_SYSTEM_PROPS_NAME + KEY_STORE_NAME, value);
-    this.jmxManagerSSLKeyStore = value;
+  @Override
+  public void setJmxManagerSSLKeyStore(String keyStore) {
+    getJmxSSLProperties().setProperty(SSL_SYSTEM_PROPS_NAME + KEY_STORE_NAME, keyStore);
+    jmxManagerSSLKeyStore = keyStore;
   }
 
-  public void setJmxManagerSSLKeyStoreType(String value) {
-
-    this.getJmxSSLProperties().setProperty(SSL_SYSTEM_PROPS_NAME + KEY_STORE_TYPE_NAME, value);
-    this.jmxManagerSSLKeyStoreType = value;
+  @Override
+  public void setJmxManagerSSLKeyStoreType(String keyStoreType) {
+    getJmxSSLProperties().setProperty(SSL_SYSTEM_PROPS_NAME + KEY_STORE_TYPE_NAME, keyStoreType);
+    jmxManagerSSLKeyStoreType = keyStoreType;
   }
 
-  public void setJmxManagerSSLKeyStorePassword(String value) {
-
-    this.getJmxSSLProperties().setProperty(SSL_SYSTEM_PROPS_NAME + KEY_STORE_PASSWORD_NAME, value);
-    this.jmxManagerSSLKeyStorePassword = value;
+  @Override
+  public void setJmxManagerSSLKeyStorePassword(String keyStorePassword) {
+    getJmxSSLProperties().setProperty(SSL_SYSTEM_PROPS_NAME + KEY_STORE_PASSWORD_NAME,
+        keyStorePassword);
+    jmxManagerSSLKeyStorePassword = keyStorePassword;
   }
 
-  public void setJmxManagerSSLTrustStore(String value) {
-
-    this.getJmxSSLProperties().setProperty(SSL_SYSTEM_PROPS_NAME + TRUST_STORE_NAME, value);
-    this.jmxManagerSSLTrustStore = value;
+  @Override
+  public void setJmxManagerSSLTrustStore(String trustStore) {
+    getJmxSSLProperties().setProperty(SSL_SYSTEM_PROPS_NAME + TRUST_STORE_NAME, trustStore);
+    jmxManagerSSLTrustStore = trustStore;
   }
 
-  public void setJmxManagerSSLTrustStorePassword(String value) {
-
-    this.getJmxSSLProperties().setProperty(SSL_SYSTEM_PROPS_NAME + TRUST_STORE_PASSWORD_NAME,
-        value);
-    this.jmxManagerSSLTrustStorePassword = value;
+  @Override
+  public void setJmxManagerSSLTrustStorePassword(String trusStorePassword) {
+    getJmxSSLProperties().setProperty(SSL_SYSTEM_PROPS_NAME + TRUST_STORE_PASSWORD_NAME,
+        trusStorePassword);
+    jmxManagerSSLTrustStorePassword = trusStorePassword;
   }
 
+  @Override
   public String getJmxManagerSSLKeyStore() {
-    return this.jmxManagerSSLKeyStore;
+    return jmxManagerSSLKeyStore;
   }
 
+  @Override
   public String getJmxManagerSSLKeyStoreType() {
-    return this.jmxManagerSSLKeyStoreType;
+    return jmxManagerSSLKeyStoreType;
   }
 
+  @Override
   public String getJmxManagerSSLKeyStorePassword() {
-    return this.jmxManagerSSLKeyStorePassword;
+    return jmxManagerSSLKeyStorePassword;
   }
 
+  @Override
   public String getJmxManagerSSLTrustStore() {
-    return this.jmxManagerSSLTrustStore;
+    return jmxManagerSSLTrustStore;
   }
 
+  @Override
   public String getJmxManagerSSLTrustStorePassword() {
-    return this.jmxManagerSSLTrustStorePassword;
+    return jmxManagerSSLTrustStorePassword;
   }
 
   @Override
   public int getJmxManagerPort() {
-    return this.jmxManagerPort;
+    return jmxManagerPort;
   }
 
   @Override
   public void setJmxManagerPort(int value) {
-    this.jmxManagerPort = (Integer) value;
+    jmxManagerPort = value;
   }
 
   @Override
   public String getJmxManagerBindAddress() {
-    return this.jmxManagerBindAddress;
+    return jmxManagerBindAddress;
   }
 
   @Override
@@ -2620,12 +2773,12 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
     if (value == null) {
       value = "";
     }
-    this.jmxManagerBindAddress = (String) value;
+    jmxManagerBindAddress = value;
   }
 
   @Override
   public String getJmxManagerHostnameForClients() {
-    return this.jmxManagerHostnameForClients;
+    return jmxManagerHostnameForClients;
   }
 
   @Override
@@ -2633,12 +2786,12 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
     if (value == null) {
       value = "";
     }
-    this.jmxManagerHostnameForClients = (String) value;
+    jmxManagerHostnameForClients = value;
   }
 
   @Override
   public String getJmxManagerPasswordFile() {
-    return this.jmxManagerPasswordFile;
+    return jmxManagerPasswordFile;
   }
 
   @Override
@@ -2646,12 +2799,12 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
     if (value == null) {
       value = "";
     }
-    this.jmxManagerPasswordFile = (String) value;
+    jmxManagerPasswordFile = value;
   }
 
   @Override
   public String getJmxManagerAccessFile() {
-    return this.jmxManagerAccessFile;
+    return jmxManagerAccessFile;
   }
 
   @Override
@@ -2659,7 +2812,7 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
     if (value == null) {
       value = "";
     }
-    this.jmxManagerAccessFile = (String) value;
+    jmxManagerAccessFile = value;
   }
 
   @Override
@@ -2674,32 +2827,32 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
 
   @Override
   public int getJmxManagerUpdateRate() {
-    return this.jmxManagerUpdateRate;
+    return jmxManagerUpdateRate;
   }
 
   @Override
   public void setJmxManagerUpdateRate(int value) {
-    this.jmxManagerUpdateRate = (Integer) value;
+    jmxManagerUpdateRate = value;
   }
 
   @Override
   public boolean getLockMemory() {
-    return this.lockMemory;
+    return lockMemory;
   }
 
   @Override
   public void setLockMemory(final boolean value) {
-    this.lockMemory = value;
+    lockMemory = value;
   }
 
   @Override
   public void setShiroInit(String value) {
-    this.shiroInit = value;
+    shiroInit = value;
   }
 
   @Override
   public String getShiroInit() {
-    return this.shiroInit;
+    return shiroInit;
   }
 
   @Override
@@ -2718,8 +2871,8 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
   }
 
   @Override
-  public void setLocatorSSLAlias(final String locatorSSLAlias) {
-    this.locatorSSLAlias = locatorSSLAlias;
+  public void setLocatorSSLAlias(final String alias) {
+    locatorSSLAlias = alias;
   }
 
   @Override
@@ -2786,7 +2939,7 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
   @Override
   public void setSecurableCommunicationChannels(
       final SecurableCommunicationChannel[] sslEnabledComponents) {
-    this.securableCommunicationChannels = sslEnabledComponents;
+    securableCommunicationChannels = sslEnabledComponents;
   }
 
   @Override
@@ -2808,9 +2961,9 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
   }
 
   @Override
-  public void setSSLProtocols(final String sslProtocols) {
+  public void setSSLProtocols(final String protocols) {
     // This conversion is required due to backwards compatibility of the existing protocols code
-    this.sslProtocols = convertCommaDelimitedToSpaceDelimitedString(sslProtocols);
+    sslProtocols = convertCommaDelimitedToSpaceDelimitedString(protocols);
   }
 
   @Override
@@ -2819,9 +2972,9 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
   }
 
   @Override
-  public void setSSLCiphers(final String sslCiphers) {
+  public void setSSLCiphers(final String ciphers) {
     // This conversion is required due to backwards compatibility of the existing cipher code
-    this.sslCiphers = convertCommaDelimitedToSpaceDelimitedString(sslCiphers);
+    sslCiphers = convertCommaDelimitedToSpaceDelimitedString(ciphers);
   }
 
   @Override
@@ -2830,8 +2983,8 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
   }
 
   @Override
-  public void setSSLRequireAuthentication(final boolean sslRequireAuthentication) {
-    this.sslRequireAuthentication = sslRequireAuthentication;
+  public void setSSLRequireAuthentication(final boolean enabled) {
+    sslRequireAuthentication = enabled;
   }
 
   @Override
@@ -2840,8 +2993,8 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
   }
 
   @Override
-  public void setSSLKeyStore(final String sslKeyStore) {
-    this.sslKeyStore = sslKeyStore;
+  public void setSSLKeyStore(final String keyStore) {
+    sslKeyStore = keyStore;
   }
 
   @Override
@@ -2850,8 +3003,8 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
   }
 
   @Override
-  public void setSSLKeyStoreType(final String sslKeyStoreType) {
-    this.sslKeyStoreType = sslKeyStoreType;
+  public void setSSLKeyStoreType(final String keyStoreType) {
+    sslKeyStoreType = keyStoreType;
   }
 
   @Override
@@ -2860,8 +3013,8 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
   }
 
   @Override
-  public void setSSLKeyStorePassword(final String sslKeyStorePassword) {
-    this.sslKeyStorePassword = sslKeyStorePassword;
+  public void setSSLKeyStorePassword(final String keyStorePassword) {
+    sslKeyStorePassword = keyStorePassword;
   }
 
   @Override
@@ -2870,8 +3023,8 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
   }
 
   @Override
-  public void setSSLTrustStore(final String sslTrustStore) {
-    this.sslTrustStore = sslTrustStore;
+  public void setSSLTrustStore(final String trustStore) {
+    sslTrustStore = trustStore;
   }
 
   @Override
@@ -2890,8 +3043,8 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
   }
 
   @Override
-  public void setSSLTrustStorePassword(final String sslTrustStorePassword) {
-    this.sslTrustStorePassword = sslTrustStorePassword;
+  public void setSSLTrustStorePassword(final String trustStorePassword) {
+    sslTrustStorePassword = trustStorePassword;
   }
 
   @Override
@@ -2900,8 +3053,8 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
   }
 
   @Override
-  public void setSSLTrustStoreType(final String sslTrustStoreType) {
-    this.sslTrustStoreType = sslTrustStoreType;
+  public void setSSLTrustStoreType(final String trustStoreType) {
+    sslTrustStoreType = trustStoreType;
   }
 
   @Override
@@ -2910,8 +3063,8 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
   }
 
   @Override
-  public void setSSLWebRequireAuthentication(final boolean requiresAuthenatication) {
-    this.sslWebServiceRequireAuthentication = requiresAuthenatication;
+  public void setSSLWebRequireAuthentication(final boolean requiresAuthentication) {
+    sslWebServiceRequireAuthentication = requiresAuthentication;
   }
 
   @Override
@@ -2921,7 +3074,7 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
 
   @Override
   public void setValidateSerializableObjects(boolean value) {
-    this.validateSerializableObjects = value;
+    validateSerializableObjects = value;
   }
 
   @Override
@@ -2931,11 +3084,8 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
 
   @Override
   public void setSerializableObjectFilter(String value) {
-    this.serializableObjectFilter = value;
+    serializableObjectFilter = value;
   }
-
-  /////////////////////// Utility Methods ///////////////////////
-
 
   /**
    * Two instances of <code>DistributedConfigImpl</code> are equal if all of their configuration
@@ -2943,16 +3093,16 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
    * #50939.
    */
   @Override
-  public boolean equals(final Object o) {
-    if (this == o) {
+  public boolean equals(final Object obj) {
+    if (this == obj) {
       return true;
     }
 
-    if (o == null || getClass() != o.getClass()) {
+    if (obj == null || getClass() != obj.getClass()) {
       return false;
     }
 
-    final DistributionConfigImpl that = (DistributionConfigImpl) o;
+    final DistributionConfigImpl that = (DistributionConfigImpl) obj;
 
     return new EqualsBuilder().append(tcpPort, that.tcpPort).append(mcastPort, that.mcastPort)
         .append(mcastTtl, that.mcastTtl).append(socketLeaseTime, that.socketLeaseTime)
@@ -3177,7 +3327,7 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
    * AvailablePort.getRandomAvailablePort(AvailablePort.JGROUPS) to obtain a free port for your
    * test.
    */
-  public void checkForDisallowedDefaults() {
+  void checkForDisallowedDefaults() {
     if (Boolean.getBoolean(DistributionConfig.GEMFIRE_PREFIX + "disallowMcastDefaults")) {
       if (getMcastPort() != 0) { // it is not disabled
         if (getMcastAddress().equals(DistributionConfig.DEFAULT_MCAST_ADDRESS)
@@ -3189,36 +3339,30 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
     }
   }
 
-  /*
-   * (non-Javadoc)
-   *
-   * @see org.apache.geode.distributed.internal.DistributionConfig#getMembershipPortRange()
-   */
+  @Override
   public int[] getMembershipPortRange() {
     return membershipPortRange;
   }
 
-  /*
-   * (non-Javadoc)
-   *
-   * @see org.apache.geode.distributed.internal.DistributionConfig#setMembershipPortRange(int[])
-   */
+  @Override
   public void setMembershipPortRange(int[] range) {
-    membershipPortRange = (int[]) range;
+    membershipPortRange = range;
   }
 
   /**
    * Set the host-port information of remote site locator
    */
-  public void setRemoteLocators(String value) {
-    this.remoteLocators = (String) value;
+  @Override
+  public void setRemoteLocators(String locators) {
+    remoteLocators = locators;
   }
 
   /**
    * get the host-port information of remote site locator
    */
+  @Override
   public String getRemoteLocators() {
-    return this.remoteLocators;
+    return remoteLocators;
   }
 
   public Map getProps() {
@@ -3227,113 +3371,113 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
 
   @Override
   public int getMemcachedPort() {
-    return this.memcachedPort;
+    return memcachedPort;
   }
 
   @Override
   public void setMemcachedPort(int value) {
-    this.memcachedPort = (Integer) value;
+    memcachedPort = value;
   }
 
   @Override
   public String getMemcachedProtocol() {
-    return this.memcachedProtocol;
+    return memcachedProtocol;
   }
 
   @Override
   public void setMemcachedProtocol(String protocol) {
-    this.memcachedProtocol = (String) protocol;
+    memcachedProtocol = protocol;
   }
 
   @Override
   public int getRedisPort() {
-    return this.redisPort;
+    return redisPort;
   }
 
   @Override
   public void setRedisPort(int value) {
-    this.redisPort = (Integer) value;
+    redisPort = value;
   }
 
   @Override
   public String getRedisBindAddress() {
-    return this.redisBindAddress;
+    return redisBindAddress;
   }
 
   @Override
   public void setRedisBindAddress(String bindAddress) {
-    this.redisBindAddress = (String) bindAddress;
+    redisBindAddress = bindAddress;
   }
 
   @Override
   public String getRedisPassword() {
-    return this.redisPassword;
+    return redisPassword;
   }
 
   @Override
   public void setRedisPassword(String password) {
-    this.redisPassword = password;
+    redisPassword = password;
   }
 
   @Override
   public String getOffHeapMemorySize() {
-    return this.offHeapMemorySize;
+    return offHeapMemorySize;
   }
 
   @Override
   public void setOffHeapMemorySize(String value) {
-    this.offHeapMemorySize = (String) value;
+    offHeapMemorySize = value;
   }
 
   @Override
   public String getMemcachedBindAddress() {
-    return this.memcachedBindAddress;
+    return memcachedBindAddress;
   }
 
   @Override
   public void setMemcachedBindAddress(String bindAddress) {
-    this.memcachedBindAddress = (String) bindAddress;
+    memcachedBindAddress = bindAddress;
   }
 
   @Override
-  public void setEnableClusterConfiguration(boolean value) {
-    this.enableSharedConfiguration = (Boolean) value;
+  public void setEnableClusterConfiguration(boolean newValue) {
+    enableSharedConfiguration = newValue;
   }
 
   @Override
   public boolean getEnableClusterConfiguration() {
-    return this.enableSharedConfiguration;
+    return enableSharedConfiguration;
   }
 
 
   @Override
   public void setUseSharedConfiguration(boolean newValue) {
-    this.useSharedConfiguration = (Boolean) newValue;
+    useSharedConfiguration = newValue;
   }
 
   @Override
   public boolean getUseSharedConfiguration() {
-    return this.useSharedConfiguration;
+    return useSharedConfiguration;
   }
 
   @Override
   public void setLoadClusterConfigFromDir(boolean newValue) {
-    this.loadSharedConfigurationFromDir = (Boolean) newValue;
+    loadSharedConfigurationFromDir = newValue;
   }
 
   @Override
   public boolean getLoadClusterConfigFromDir() {
-    return this.loadSharedConfigurationFromDir;
+    return loadSharedConfigurationFromDir;
   }
 
   @Override
   public void setClusterConfigDir(String clusterConfigDir) {
-    this.clusterConfigDir = (String) clusterConfigDir;
+    this.clusterConfigDir = clusterConfigDir;
   }
 
   @Override
   public String getClusterConfigDir() {
-    return this.clusterConfigDir;
+    return clusterConfigDir;
   }
 
   @Override
@@ -3342,8 +3486,8 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
   }
 
   @Override
-  public void setServerSSLEnabled(boolean value) {
-    this.serverSSLEnabled = (Boolean) value;
+  public void setServerSSLEnabled(boolean enabled) {
+    serverSSLEnabled = enabled;
 
   }
 
@@ -3353,80 +3497,90 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
   }
 
   @Override
-  public void setServerSSLRequireAuthentication(boolean value) {
-    this.serverSslRequireAuthentication = (Boolean) value;
+  public void setServerSSLRequireAuthentication(boolean enabled) {
+    serverSslRequireAuthentication = enabled;
   }
 
   @Override
   public String getServerSSLProtocols() {
-    return this.serverSslProtocols;
+    return serverSslProtocols;
   }
 
   @Override
   public void setServerSSLProtocols(String protocols) {
-    this.serverSslProtocols = (String) protocols;
+    serverSslProtocols = protocols;
   }
 
   @Override
   public String getServerSSLCiphers() {
-    return this.serverSslCiphers;
+    return serverSslCiphers;
   }
 
   @Override
   public void setServerSSLCiphers(String ciphers) {
-    this.serverSslCiphers = (String) ciphers;
+    serverSslCiphers = ciphers;
   }
 
-  public void setServerSSLKeyStore(String value) {
-    this.getServerSSLProperties().setProperty(SSL_SYSTEM_PROPS_NAME + KEY_STORE_NAME, value);
-    this.serverSSLKeyStore = value;
+  @Override
+  public void setServerSSLKeyStore(String keyStore) {
+    getServerSSLProperties().setProperty(SSL_SYSTEM_PROPS_NAME + KEY_STORE_NAME, keyStore);
+    serverSSLKeyStore = keyStore;
   }
 
-  public void setServerSSLKeyStoreType(String value) {
-    this.getServerSSLProperties().setProperty(SSL_SYSTEM_PROPS_NAME + KEY_STORE_TYPE_NAME, value);
-    this.serverSSLKeyStoreType = value;
+  @Override
+  public void setServerSSLKeyStoreType(String keyStoreType) {
+    getServerSSLProperties().setProperty(SSL_SYSTEM_PROPS_NAME + KEY_STORE_TYPE_NAME, keyStoreType);
+    serverSSLKeyStoreType = keyStoreType;
   }
 
-  public void setServerSSLKeyStorePassword(String value) {
-    this.getServerSSLProperties().setProperty(SSL_SYSTEM_PROPS_NAME + KEY_STORE_PASSWORD_NAME,
-        value);
-    this.serverSSLKeyStorePassword = value;
+  @Override
+  public void setServerSSLKeyStorePassword(String keyStorePassword) {
+    getServerSSLProperties().setProperty(SSL_SYSTEM_PROPS_NAME + KEY_STORE_PASSWORD_NAME,
+        keyStorePassword);
+    serverSSLKeyStorePassword = keyStorePassword;
   }
 
-  public void setServerSSLTrustStore(String value) {
-    this.getServerSSLProperties().setProperty(SSL_SYSTEM_PROPS_NAME + TRUST_STORE_NAME, value);
-    this.serverSSLTrustStore = value;
+  @Override
+  public void setServerSSLTrustStore(String trustStore) {
+    getServerSSLProperties().setProperty(SSL_SYSTEM_PROPS_NAME + TRUST_STORE_NAME, trustStore);
+    serverSSLTrustStore = trustStore;
   }
 
-  public void setServerSSLTrustStorePassword(String value) {
-    this.getServerSSLProperties().setProperty(SSL_SYSTEM_PROPS_NAME + TRUST_STORE_PASSWORD_NAME,
-        value);
-    this.serverSSLTrustStorePassword = value;
+  @Override
+  public void setServerSSLTrustStorePassword(String trusStorePassword) {
+    getServerSSLProperties().setProperty(SSL_SYSTEM_PROPS_NAME + TRUST_STORE_PASSWORD_NAME,
+        trusStorePassword);
+    serverSSLTrustStorePassword = trusStorePassword;
   }
 
+  @Override
   public String getServerSSLKeyStore() {
-    return this.serverSSLKeyStore;
+    return serverSSLKeyStore;
   }
 
+  @Override
   public String getServerSSLKeyStoreType() {
-    return this.serverSSLKeyStoreType;
+    return serverSSLKeyStoreType;
   }
 
+  @Override
   public String getServerSSLKeyStorePassword() {
-    return this.serverSSLKeyStorePassword;
+    return serverSSLKeyStorePassword;
   }
 
+  @Override
   public String getServerSSLTrustStore() {
-    return this.serverSSLTrustStore;
+    return serverSSLTrustStore;
   }
 
+  @Override
   public String getServerSSLTrustStorePassword() {
-    return this.serverSSLTrustStorePassword;
+    return serverSSLTrustStorePassword;
   }
 
   @Override
   public Properties getServerSSLProperties() {
-    return this.serverSslProperties;
+    return serverSslProperties;
   }
 
   @Override
@@ -3435,8 +3589,8 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
   }
 
   @Override
-  public void setGatewaySSLEnabled(boolean value) {
-    this.gatewaySSLEnabled = (Boolean) value;
+  public void setGatewaySSLEnabled(boolean enabled) {
+    gatewaySSLEnabled = enabled;
 
   }
 
@@ -3446,83 +3600,93 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
   }
 
   @Override
-  public void setGatewaySSLRequireAuthentication(boolean value) {
-    this.gatewaySslRequireAuthentication = (Boolean) value;
+  public void setGatewaySSLRequireAuthentication(boolean enabled) {
+    gatewaySslRequireAuthentication = enabled;
   }
 
   @Override
   public String getGatewaySSLProtocols() {
-    return this.gatewaySslProtocols;
+    return gatewaySslProtocols;
   }
 
   @Override
   public void setGatewaySSLProtocols(String protocols) {
-    this.gatewaySslProtocols = (String) protocols;
+    gatewaySslProtocols = protocols;
   }
 
   @Override
   public String getGatewaySSLCiphers() {
-    return this.gatewaySslCiphers;
+    return gatewaySslCiphers;
   }
 
   @Override
   public void setGatewaySSLCiphers(String ciphers) {
-    this.gatewaySslCiphers = (String) ciphers;
+    gatewaySslCiphers = ciphers;
   }
 
-  public void setGatewaySSLKeyStore(String value) {
-    this.getGatewaySSLProperties().setProperty(SSL_SYSTEM_PROPS_NAME + KEY_STORE_NAME, value);
-    this.gatewaySSLKeyStore = value;
+  @Override
+  public void setGatewaySSLKeyStore(String keyStore) {
+    getGatewaySSLProperties().setProperty(SSL_SYSTEM_PROPS_NAME + KEY_STORE_NAME, keyStore);
+    gatewaySSLKeyStore = keyStore;
   }
 
-  public void setGatewaySSLKeyStoreType(String value) {
-    this.getGatewaySSLProperties().setProperty(SSL_SYSTEM_PROPS_NAME + KEY_STORE_TYPE_NAME, value);
-    this.gatewaySSLKeyStoreType = value;
+  @Override
+  public void setGatewaySSLKeyStoreType(String keyStoreType) {
+    getGatewaySSLProperties().setProperty(SSL_SYSTEM_PROPS_NAME + KEY_STORE_TYPE_NAME,
+        keyStoreType);
+    gatewaySSLKeyStoreType = keyStoreType;
   }
 
-  public void setGatewaySSLKeyStorePassword(String value) {
-    this.getGatewaySSLProperties().setProperty(SSL_SYSTEM_PROPS_NAME + KEY_STORE_PASSWORD_NAME,
-        value);
-    this.gatewaySSLKeyStorePassword = value;
+  @Override
+  public void setGatewaySSLKeyStorePassword(String keyStorePassword) {
+    getGatewaySSLProperties().setProperty(SSL_SYSTEM_PROPS_NAME + KEY_STORE_PASSWORD_NAME,
+        keyStorePassword);
+    gatewaySSLKeyStorePassword = keyStorePassword;
   }
 
-  public void setGatewaySSLTrustStore(String value) {
-    this.getGatewaySSLProperties().setProperty(SSL_SYSTEM_PROPS_NAME + TRUST_STORE_NAME, value);
-    this.gatewaySSLTrustStore = value;
+  @Override
+  public void setGatewaySSLTrustStore(String trustStore) {
+    getGatewaySSLProperties().setProperty(SSL_SYSTEM_PROPS_NAME + TRUST_STORE_NAME, trustStore);
+    gatewaySSLTrustStore = trustStore;
   }
 
-  public void setGatewaySSLTrustStorePassword(String value) {
-    this.getGatewaySSLProperties().setProperty(SSL_SYSTEM_PROPS_NAME + TRUST_STORE_PASSWORD_NAME,
-        value);
-    this.gatewaySSLTrustStorePassword = value;
+  @Override
+  public void setGatewaySSLTrustStorePassword(String trusStorePassword) {
+    getGatewaySSLProperties().setProperty(SSL_SYSTEM_PROPS_NAME + TRUST_STORE_PASSWORD_NAME,
+        trusStorePassword);
+    gatewaySSLTrustStorePassword = trusStorePassword;
   }
 
+  @Override
   public String getGatewaySSLKeyStore() {
-    return this.gatewaySSLKeyStore;
+    return gatewaySSLKeyStore;
   }
 
+  @Override
   public String getGatewaySSLKeyStoreType() {
-    return this.gatewaySSLKeyStoreType;
+    return gatewaySSLKeyStoreType;
   }
 
+  @Override
   public String getGatewaySSLKeyStorePassword() {
-    return this.gatewaySSLKeyStorePassword;
+    return gatewaySSLKeyStorePassword;
   }
 
+  @Override
   public String getGatewaySSLTrustStore() {
-    return this.gatewaySSLTrustStore;
+    return gatewaySSLTrustStore;
   }
 
+  @Override
   public String getGatewaySSLTrustStorePassword() {
-    return this.gatewaySSLTrustStorePassword;
+    return gatewaySSLTrustStorePassword;
   }
 
   @Override
   public Properties getGatewaySSLProperties() {
-    return this.gatewaySslProperties;
+    return gatewaySslProperties;
   }
 
-  // Adding HTTP Service SSL properties
   @Override
   public boolean getHttpServiceSSLEnabled() {
     return httpServiceSSLEnabled;
@@ -3549,8 +3713,8 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
   }
 
   @Override
-  public void setHttpServiceSSLProtocols(String httpServiceSSLProtocols) {
-    this.httpServiceSSLProtocols = httpServiceSSLProtocols;
+  public void setHttpServiceSSLProtocols(String protocols) {
+    httpServiceSSLProtocols = protocols;
   }
 
   @Override
@@ -3559,10 +3723,9 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
   }
 
   @Override
-  public void setHttpServiceSSLCiphers(String httpServiceSSLCiphers) {
-    this.httpServiceSSLCiphers = httpServiceSSLCiphers;
+  public void setHttpServiceSSLCiphers(String ciphers) {
+    httpServiceSSLCiphers = ciphers;
   }
-
 
   @Override
   public String getHttpServiceSSLKeyStore() {
@@ -3570,10 +3733,10 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
   }
 
   @Override
-  public void setHttpServiceSSLKeyStore(String httpServiceSSLKeyStore) {
-    this.getHttpServiceSSLProperties().setProperty(SSL_SYSTEM_PROPS_NAME + KEY_STORE_NAME,
-        httpServiceSSLKeyStore);
-    this.httpServiceSSLKeyStore = httpServiceSSLKeyStore;
+  public void setHttpServiceSSLKeyStore(String keyStore) {
+    getHttpServiceSSLProperties().setProperty(SSL_SYSTEM_PROPS_NAME + KEY_STORE_NAME,
+        keyStore);
+    httpServiceSSLKeyStore = keyStore;
   }
 
   @Override
@@ -3582,10 +3745,10 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
   }
 
   @Override
-  public void setHttpServiceSSLKeyStoreType(String httpServiceSSLKeyStoreType) {
-    this.getHttpServiceSSLProperties().setProperty(SSL_SYSTEM_PROPS_NAME + KEY_STORE_TYPE_NAME,
-        httpServiceSSLKeyStoreType);
-    this.httpServiceSSLKeyStoreType = httpServiceSSLKeyStoreType;
+  public void setHttpServiceSSLKeyStoreType(String keyStoreType) {
+    getHttpServiceSSLProperties().setProperty(SSL_SYSTEM_PROPS_NAME + KEY_STORE_TYPE_NAME,
+        keyStoreType);
+    httpServiceSSLKeyStoreType = keyStoreType;
   }
 
   @Override
@@ -3594,10 +3757,10 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
   }
 
   @Override
-  public void setHttpServiceSSLKeyStorePassword(String httpServiceSSLKeyStorePassword) {
-    this.getHttpServiceSSLProperties().setProperty(SSL_SYSTEM_PROPS_NAME + KEY_STORE_PASSWORD_NAME,
-        httpServiceSSLKeyStorePassword);
-    this.httpServiceSSLKeyStorePassword = httpServiceSSLKeyStorePassword;
+  public void setHttpServiceSSLKeyStorePassword(String keyStorePassword) {
+    getHttpServiceSSLProperties().setProperty(SSL_SYSTEM_PROPS_NAME + KEY_STORE_PASSWORD_NAME,
+        keyStorePassword);
+    httpServiceSSLKeyStorePassword = keyStorePassword;
   }
 
   @Override
@@ -3606,10 +3769,10 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
   }
 
   @Override
-  public void setHttpServiceSSLTrustStore(String httpServiceSSLTrustStore) {
-    this.getHttpServiceSSLProperties().setProperty(SSL_SYSTEM_PROPS_NAME + TRUST_STORE_NAME,
-        httpServiceSSLTrustStore);
-    this.httpServiceSSLTrustStore = httpServiceSSLTrustStore;
+  public void setHttpServiceSSLTrustStore(String trustStore) {
+    getHttpServiceSSLProperties().setProperty(SSL_SYSTEM_PROPS_NAME + TRUST_STORE_NAME,
+        trustStore);
+    httpServiceSSLTrustStore = trustStore;
   }
 
   @Override
@@ -3618,56 +3781,59 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
   }
 
   @Override
-  public void setHttpServiceSSLTrustStorePassword(String httpServiceSSLTrustStorePassword) {
-    this.getHttpServiceSSLProperties().setProperty(
-        SSL_SYSTEM_PROPS_NAME + TRUST_STORE_PASSWORD_NAME, httpServiceSSLTrustStorePassword);
-    this.httpServiceSSLTrustStorePassword = httpServiceSSLTrustStorePassword;
+  public void setHttpServiceSSLTrustStorePassword(String trustStorePassword) {
+    getHttpServiceSSLProperties().setProperty(
+        SSL_SYSTEM_PROPS_NAME + TRUST_STORE_PASSWORD_NAME, trustStorePassword);
+    httpServiceSSLTrustStorePassword = trustStorePassword;
   }
 
+  @Override
   public Properties getHttpServiceSSLProperties() {
     return httpServiceSSLProperties;
   }
 
+  @Override
   public ConfigSource getConfigSource(String attName) {
-    return this.sourceMap.get(attName);
+    return sourceMap.get(attName);
   }
 
+  @Override
   public boolean getDistributedTransactions() {
-    return this.distributedTransactions;
+    return distributedTransactions;
   }
 
+  @Override
   public void setDistributedTransactions(boolean value) {
-    this.distributedTransactions = value;
+    distributedTransactions = value;
   }
 
   @Override
   public boolean getThreadMonitorEnabled() {
-    return this.threadMonitorEnabled;
+    return threadMonitorEnabled;
   }
 
   @Override
-  public void setThreadMonitorEnabled(boolean value) {
-    this.threadMonitorEnabled = (Boolean) value;
+  public void setThreadMonitorEnabled(boolean newValue) {
+    threadMonitorEnabled = newValue;
   }
 
   @Override
   public int getThreadMonitorInterval() {
-    return this.threadMonitorInterval;
+    return threadMonitorInterval;
   }
 
   @Override
-  public void setThreadMonitorInterval(int value) {
-    this.threadMonitorInterval = value;
+  public void setThreadMonitorInterval(int newValue) {
+    threadMonitorInterval = newValue;
   }
 
   @Override
   public int getThreadMonitorTimeLimit() {
-    return this.threadMonitorTimeLimit;
+    return threadMonitorTimeLimit;
   }
 
   @Override
-  public void setThreadMonitorTimeLimit(int value) {
-    this.threadMonitorTimeLimit = value;
+  public void setThreadMonitorTimeLimit(int newValue) {
+    threadMonitorTimeLimit = newValue;
   }
-
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfigSnapshot.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfigSnapshot.java
@@ -12,10 +12,10 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package org.apache.geode.distributed.internal;
 
 import java.util.HashSet;
+import java.util.Set;
 
 import org.apache.geode.internal.i18n.LocalizedStrings;
 
@@ -24,17 +24,18 @@ import org.apache.geode.internal.i18n.LocalizedStrings;
  * application's configuration. The snapshot can be taken, given to others, modified, and then
  * applied to a currently running application.
  * <p>
- * Settors will fail if called on attributes that can not be modified when a system is running.
+ * Setters will fail if called on attributes that can not be modified when a system is running.
  * <p>
  * Instances should be obtained by calling {@link RuntimeDistributionConfigImpl#takeSnapshot}.
- * <p/>
+ * <p>
  * Removed implementations of hashCode() and equals() that were throwing
  * UnsupportedOperationException. See bug #50939 if you need to override those.
  */
 public class DistributionConfigSnapshot extends DistributionConfigImpl {
+
   private static final long serialVersionUID = 7445728132965092798L;
 
-  private HashSet modifiable;
+  private final Set modifiable;
 
   /**
    * Constructs an internal system config given an existing one.
@@ -43,25 +44,25 @@ public class DistributionConfigSnapshot extends DistributionConfigImpl {
    */
   public DistributionConfigSnapshot(DistributionConfig dc) {
     super(dc);
-    this.modifiable = new HashSet(20);
+    modifiable = new HashSet(20);
     String[] attNames = dc.getAttributeNames();
     for (int i = 0; i < attNames.length; i++) {
       if (dc.isAttributeModifiable(attNames[i])) {
-        this.modifiable.add(attNames[i]);
+        modifiable.add(attNames[i]);
       }
     }
   }
 
   @Override
-  protected String _getUnmodifiableMsg(String attName) {
+  protected String _getUnmodifiableMsg(String name) {
     return LocalizedStrings.DistributionConfigSnapshot_THE_0_CONFIGURATION_ATTRIBUTE_CAN_NOT_BE_MODIFIED_WHILE_THE_SYSTEM_IS_RUNNING
-        .toLocalizedString(attName);
+        .toLocalizedString(name);
   }
 
   @Override
-  public boolean isAttributeModifiable(String attName) {
-    checkAttributeName(attName);
-    return modifiable.contains(attName);
+  public boolean isAttributeModifiable(String name) {
+    checkAttributeName(name);
+    return modifiable.contains(name);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/RuntimeDistributionConfigImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/RuntimeDistributionConfigImpl.java
@@ -138,6 +138,7 @@ public class RuntimeDistributionConfigImpl extends DistributionConfigImpl {
     return new DistributionConfigSnapshot(this);
   }
 
+  @Override
   public List<String> getModifiableAttributes() {
     String[] modifiables = {HTTP_SERVICE_PORT, JMX_MANAGER_HTTP_PORT, ARCHIVE_DISK_SPACE_LIMIT,
         ARCHIVE_FILE_SIZE_LIMIT, LOG_DISK_SPACE_LIMIT, LOG_FILE_SIZE_LIMIT, LOG_LEVEL,

--- a/geode-core/src/main/java/org/apache/geode/internal/AbstractConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/AbstractConfig.java
@@ -68,22 +68,22 @@ public abstract class AbstractConfig implements Config {
 
   @Override
   public String toLoggerString() {
-    StringWriter sw = new StringWriter();
-    PrintWriter pw = new PrintWriter(sw);
-    printSourceSection(ConfigSource.runtime(), pw);
-    printSourceSection(ConfigSource.sysprop(), pw);
-    printSourceSection(ConfigSource.api(), pw);
+    StringWriter stringWriter = new StringWriter();
+    PrintWriter printWriter = new PrintWriter(stringWriter);
+    printSourceSection(ConfigSource.runtime(), printWriter);
+    printSourceSection(ConfigSource.sysprop(), printWriter);
+    printSourceSection(ConfigSource.api(), printWriter);
     for (ConfigSource fileSource : getFileSources()) {
-      printSourceSection(fileSource, pw);
+      printSourceSection(fileSource, printWriter);
     }
-    printSourceSection(ConfigSource.xml(), pw);
-    printSourceSection(ConfigSource.launcher(), pw); // fix for bug 46653
-    printSourceSection(null, pw);
-    pw.close();
-    return sw.toString();
+    printSourceSection(ConfigSource.xml(), printWriter);
+    printSourceSection(ConfigSource.launcher(), printWriter); // fix for bug 46653
+    printSourceSection(null, printWriter);
+    printWriter.close();
+    return stringWriter.toString();
   }
 
-  /***
+  /**
    * Gets the Map of GemFire properties and values from a given ConfigSource
    *
    * @return map of GemFire properties and values
@@ -93,17 +93,17 @@ public abstract class AbstractConfig implements Config {
     String[] validAttributeNames = getAttributeNames();
     Map<String, ConfigSource> sm = getAttSourceMap();
 
-    for (String attName : validAttributeNames) {
-      if ((source == null && sm.get(attName) != null)
-          || (source != null && !source.equals(sm.get(attName)))) {
+    for (String name : validAttributeNames) {
+      if (source == null && sm.get(name) != null
+          || source != null && !source.equals(sm.get(name))) {
         continue;
       }
-      configProps.put(attName, this.getAttribute(attName));
+      configProps.put(name, getAttribute(name));
     }
     return configProps;
   }
 
-  /****
+  /**
    * Gets all the GemFire properties defined using file(s)
    *
    * @return Map of GemFire properties and values set using property files
@@ -120,15 +120,15 @@ public abstract class AbstractConfig implements Config {
   public Properties toProperties() {
     Properties result = new SortedProperties();
     String[] attNames = getAttributeNames();
-    for (String attName : attNames) {
-      result.setProperty(attName, getAttribute(attName));
+    for (String name : attNames) {
+      result.setProperty(name, getAttribute(name));
     }
     return result;
   }
 
   @Override
-  public void toFile(File f) throws IOException {
-    try (FileOutputStream out = new FileOutputStream(f)) {
+  public void toFile(File file) throws IOException {
+    try (FileOutputStream out = new FileOutputStream(file)) {
       toProperties().store(out, null);
     }
   }
@@ -141,13 +141,13 @@ public abstract class AbstractConfig implements Config {
     if (other == null) {
       return false;
     }
-    if (!this.getClass().equals(other.getClass())) {
+    if (!getClass().equals(other.getClass())) {
       return false;
     }
     String[] validAttributeNames = getAttributeNames();
-    for (String attName : validAttributeNames) {
-      Object thisAtt = this.getAttributeObject(attName);
-      Object otherAtt = other.getAttributeObject(attName);
+    for (String name : validAttributeNames) {
+      Object thisAtt = getAttributeObject(name);
+      Object otherAtt = other.getAttributeObject(name);
       if (thisAtt != otherAtt) {
         if (thisAtt == null) {
           return false;
@@ -176,20 +176,19 @@ public abstract class AbstractConfig implements Config {
     return true;
   }
 
-
   @Override
-  public String getAttribute(String attName) {
-    Object result = getAttributeObject(attName);
+  public String getAttribute(String name) {
+    Object result = getAttributeObject(name);
     if (result instanceof String) {
       return (String) result;
     }
 
-    if (attName.equalsIgnoreCase(MEMBERSHIP_PORT_RANGE)) {
+    if (name.equalsIgnoreCase(MEMBERSHIP_PORT_RANGE)) {
       int[] value = (int[]) result;
       return "" + value[0] + "-" + value[1];
     }
 
-    if (result.getClass().isArray() && attName.startsWith("ssl-")) {
+    if (result.getClass().isArray() && name.startsWith("ssl-")) {
       return SystemAdmin.join((Object[]) result, ",");
     }
 
@@ -201,7 +200,8 @@ public abstract class AbstractConfig implements Config {
       InetAddress addr = (InetAddress) result;
       String addrName;
       if (addr.isMulticastAddress() || !SocketCreator.resolve_dns) {
-        addrName = addr.getHostAddress(); // on Windows getHostName on mcast addrs takes ~5 seconds
+        // on Windows getHostName on mcast addrs takes ~5 seconds
+        addrName = addr.getHostAddress();
       } else {
         addrName = SocketCreator.getHostName(addr);
       }
@@ -212,60 +212,62 @@ public abstract class AbstractConfig implements Config {
   }
 
   @Override
-  public ConfigSource getAttributeSource(String attName) {
-    return getAttSourceMap().get(attName);
+  public ConfigSource getAttributeSource(String name) {
+    return getAttSourceMap().get(name);
   }
 
   @Override
-  public void setAttribute(String attName, String attValue, ConfigSource source) {
+  public void setAttribute(String name, String value, ConfigSource source) {
     Object attObjectValue;
-    Class valueType = getAttributeType(attName);
+    Class valueType = getAttributeType(name);
     try {
       if (valueType.equals(String.class)) {
-        attObjectValue = attValue;
+        attObjectValue = value;
       } else if (valueType.equals(String[].class)) {
-        attObjectValue = attValue.split(",");
+        // TODO:GEODE-5784: DUPLICATE CONDITION with different behavior
+        attObjectValue = value.split(",");
       } else if (valueType.equals(Integer.class)) {
-        attObjectValue = Integer.valueOf(attValue);
+        attObjectValue = Integer.valueOf(value);
       } else if (valueType.equals(Long.class)) {
-        attObjectValue = Long.valueOf(attValue);
+        attObjectValue = Long.valueOf(value);
       } else if (valueType.equals(Boolean.class)) {
-        attObjectValue = Boolean.valueOf(attValue);
+        attObjectValue = Boolean.valueOf(value);
       } else if (valueType.equals(File.class)) {
-        attObjectValue = new File(attValue);
+        attObjectValue = new File(value);
       } else if (valueType.equals(int[].class)) {
-        int[] value = new int[2];
-        int minus = attValue.indexOf('-');
+        int minus = value.indexOf('-');
         if (minus <= 0) {
           throw new IllegalArgumentException(
-              "expected a setting in the form X-Y but found no dash for attribute " + attName);
+              "expected a setting in the form X-Y but found no dash for attribute " + name);
         }
-        value[0] = Integer.valueOf(attValue.substring(0, minus));
-        value[1] = Integer.valueOf(attValue.substring(minus + 1));
-        attObjectValue = value;
+        int[] tempValue = new int[2];
+        tempValue[0] = Integer.valueOf(value.substring(0, minus));
+        tempValue[1] = Integer.valueOf(value.substring(minus + 1));
+        attObjectValue = tempValue;
       } else if (valueType.equals(InetAddress.class)) {
         try {
-          attObjectValue = InetAddress.getByName(attValue);
+          attObjectValue = InetAddress.getByName(value);
         } catch (UnknownHostException ex) {
           throw new IllegalArgumentException(
               LocalizedStrings.AbstractConfig_0_VALUE_1_MUST_BE_A_VALID_HOST_NAME_2
-                  .toLocalizedString(attName, attValue, ex.toString()));
+                  .toLocalizedString(name, value, ex.toString()));
         }
       } else if (valueType.equals(String[].class)) {
-        if (attValue == null || attValue.length() == 0) {
+        // TODO:GEODE-5784: DUPLICATE CONDITION with different behavior
+        if (value == null || value.length() == 0) {
           attObjectValue = null;
         } else {
-          String trimAttName = attName.substring(0, attName.length() - 1);
+          String trimAttName = name.substring(0, name.length() - 1);
           throw new UnmodifiableException(
               LocalizedStrings.AbstractConfig_THE_0_CONFIGURATION_ATTRIBUTE_CAN_NOT_BE_SET_FROM_THE_COMMAND_LINE_SET_1_FOR_EACH_INDIVIDUAL_PARAMETER_INSTEAD
-                  .toLocalizedString(attName, trimAttName));
+                  .toLocalizedString(name, trimAttName));
         }
       } else if (valueType.equals(FlowControlParams.class)) {
-        String values[] = attValue.split(",");
+        String[] values = value.split(",");
         if (values.length != 3) {
           throw new IllegalArgumentException(
               LocalizedStrings.AbstractConfig_0_VALUE_1_MUST_HAVE_THREE_ELEMENTS_SEPARATED_BY_COMMAS
-                  .toLocalizedString(attName, attValue));
+                  .toLocalizedString(name, value));
         }
         int allowance;
         float threshold;
@@ -277,42 +279,42 @@ public abstract class AbstractConfig implements Config {
         } catch (NumberFormatException e) {
           throw new IllegalArgumentException(
               LocalizedStrings.AbstractConfig_0_VALUE_1_MUST_BE_COMPOSED_OF_AN_INTEGER_A_FLOAT_AND_AN_INTEGER
-                  .toLocalizedString(attName, attValue));
+                  .toLocalizedString(name, value));
         }
         attObjectValue = new FlowControlParams(allowance, threshold, waitTime);
       } else if (valueType.isArray()
           && SecurableCommunicationChannel.class.equals(valueType.getComponentType())) {
-        attObjectValue = commaDelimitedStringToSecurableCommunicationChannels(attValue);
+        attObjectValue = commaDelimitedStringToSecurableCommunicationChannels(value);
       } else {
         throw new InternalGemFireException(
             LocalizedStrings.AbstractConfig_UNHANDLED_ATTRIBUTE_TYPE_0_FOR_1
-                .toLocalizedString(valueType, attName));
+                .toLocalizedString(valueType, name));
       }
     } catch (NumberFormatException ex) {
       throw new IllegalArgumentException(LocalizedStrings.AbstractConfig_0_VALUE_1_MUST_BE_A_NUMBER
-          .toLocalizedString(attName, attValue));
+          .toLocalizedString(name, value));
     }
 
-    setAttributeObject(attName, attObjectValue, source);
+    setAttributeObject(name, attObjectValue, source);
   }
 
   @Override
-  public String getAttributeDescription(String attName) {
-    checkAttributeName(attName);
-    if (!getAttDescMap().containsKey(attName)) {
+  public String getAttributeDescription(String name) {
+    checkAttributeName(name);
+    if (!getAttDescMap().containsKey(name)) {
       throw new InternalGemFireException(
-          LocalizedStrings.AbstractConfig_UNHANDLED_ATTRIBUTE_NAME_0.toLocalizedString(attName));
+          LocalizedStrings.AbstractConfig_UNHANDLED_ATTRIBUTE_NAME_0.toLocalizedString(name));
     }
-    return (String) getAttDescMap().get(attName);
+    return (String) getAttDescMap().get(name);
   }
 
   /**
    * Returns the string to use as the exception message when an attempt is made to set an
    * unmodifiable attribute.
    */
-  protected String _getUnmodifiableMsg(String attName) {
+  protected String _getUnmodifiableMsg(String name) {
     return LocalizedStrings.AbstractConfig_THE_0_CONFIGURATION_ATTRIBUTE_CAN_NOT_BE_MODIFIED
-        .toLocalizedString(attName);
+        .toLocalizedString(name);
   }
 
   /**
@@ -330,12 +332,12 @@ public abstract class AbstractConfig implements Config {
     return false;
   }
 
-  protected void checkAttributeName(String attName) {
+  protected void checkAttributeName(String name) {
     String[] validAttNames = getAttributeNames();
-    if (!Arrays.asList(validAttNames).contains(attName.toLowerCase())) {
+    if (!Arrays.asList(validAttNames).contains(name.toLowerCase())) {
       throw new IllegalArgumentException(
           LocalizedStrings.AbstractConfig_UNKNOWN_CONFIGURATION_ATTRIBUTE_NAME_0_VALID_ATTRIBUTE_NAMES_ARE_1
-              .toLocalizedString(attName, SystemAdmin.join(validAttNames)));
+              .toLocalizedString(name, SystemAdmin.join(validAttNames)));
     }
   }
 
@@ -351,7 +353,7 @@ public abstract class AbstractConfig implements Config {
     return result;
   }
 
-  private void printSourceSection(ConfigSource source, PrintWriter pw) {
+  private void printSourceSection(ConfigSource source, PrintWriter printWriter) {
     String[] validAttributeNames = getAttributeNames();
     boolean sourceFound = false;
     Map<String, ConfigSource> sourceMap = getAttSourceMap();
@@ -359,44 +361,44 @@ public abstract class AbstractConfig implements Config {
     if (source != null && source.getType() == ConfigSource.Type.SECURE_FILE) {
       sourceIsSecured = true;
     }
-    for (String attName : validAttributeNames) {
+    for (String name : validAttributeNames) {
       if (source == null) {
-        if (sourceMap.get(attName) != null) {
+        if (sourceMap.get(name) != null) {
           continue;
         }
-      } else if (!source.equals(sourceMap.get(attName))) {
+      } else if (!source.equals(sourceMap.get(name))) {
         continue;
       }
       if (!sourceFound) {
         sourceFound = true;
         if (source == null) {
-          pw.println(GEM_FIRE_PROPERTIES_USING_DEFAULT_VALUES);
+          printWriter.println(GEM_FIRE_PROPERTIES_USING_DEFAULT_VALUES);
         } else {
-          pw.println(GEM_FIRE_PROPERTIES_DEFINED_WITH_PREFIX + source.getDescription()
+          printWriter.println(GEM_FIRE_PROPERTIES_DEFINED_WITH_PREFIX + source.getDescription()
               + GEM_FIRE_PROPERTIES_DEFINED_WITH_SUFFIX);
         }
       }
       // hide the shiro-init configuration for now. Remove after we can allow customer to specify
       // shiro.ini file
-      if (attName.equals(SECURITY_SHIRO_INIT)) {
+      if (name.equals(SECURITY_SHIRO_INIT)) {
         continue;
       }
 
       String attributeValueToPrint;
       if (source == null) {
         // always show defaults values
-        attributeValueToPrint = getAttribute(attName);
+        attributeValueToPrint = getAttribute(name);
       } else if (sourceIsSecured) {
         // Never show secure sources
         attributeValueToPrint = ArgumentRedactor.redacted;
       } else {
         // Otherwise, redact based on the key string
         attributeValueToPrint =
-            ArgumentRedactor.redactArgumentIfNecessary(attName, getAttribute(attName));
+            ArgumentRedactor.redactArgumentIfNecessary(name, getAttribute(name));
       }
-      pw.print(attName);
-      pw.print('=');
-      pw.println(attributeValueToPrint);
+      printWriter.print(name);
+      printWriter.print('=');
+      printWriter.println(attributeValueToPrint);
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/Config.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/Config.java
@@ -18,10 +18,14 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Properties;
 
+import org.apache.geode.InvalidValueException;
+import org.apache.geode.UnmodifiableException;
+
 /**
  * Provides generic configuration features.
  */
 public interface Config {
+
   /**
    * Given the attribute's name return its value as a string. This method is used as a way to get
    * command line arguments that specify the attribute name and fetch them safely from a Config
@@ -29,57 +33,58 @@ public interface Config {
    *
    * @throws IllegalArgumentException if the specified name is illegal
    */
-  String getAttribute(String attName);
+  String getAttribute(String name);
 
   /**
    * Given the attribute's name return its value as an Object.
    *
    * @throws IllegalArgumentException if the specified name is illegal
    */
-  Object getAttributeObject(String attName);
+  Object getAttributeObject(String name);
 
   /**
    * Given the attribute's name set its value. This method is used as a way to get command line
    * arguments that specify the attribute name and value and get them safely into a Config instance.
    *
    * @throws IllegalArgumentException if the specified name or value are illegal
-   * @throws org.apache.geode.UnmodifiableException if the attribute can not be modified.
+   * @throws UnmodifiableException if the attribute can not be modified.
    */
-  void setAttribute(String attName, String attValue, ConfigSource source);
+  void setAttribute(String name, String value, ConfigSource source);
 
   /**
    * Given the attribute's name set its value to the specified Object.
    *
    * @throws IllegalArgumentException if the specified name is unknown
-   * @throws org.apache.geode.InvalidValueException if the specified value is not compatible with
+   * @throws InvalidValueException if the specified value is not compatible with
    *         the attributes type
-   * @throws org.apache.geode.UnmodifiableException if the attribute can not be modified.
+   * @throws UnmodifiableException if the attribute can not be modified.
    */
-  void setAttributeObject(String attName, Object attValue, ConfigSource source);
+  void setAttributeObject(String name, Object value, ConfigSource source);
 
   /**
    * Returns true if the named configuration attribute can be modified.
    *
    * @throws IllegalArgumentException if the specified name is illegal
    */
-  boolean isAttributeModifiable(String attName);
+  boolean isAttributeModifiable(String name);
 
   /**
    * Returns the source of the given attribute. This lets you figure out where an attribute's value
    * came from.
    *
-   * @param attName the name of the attribute whose source is returned
+   * @param name the name of the attribute whose source is returned
+   *
    * @return null if the attribute has not been configured; otherwise returns the source of the
    *         given attribute
    */
-  ConfigSource getAttributeSource(String attName);
+  ConfigSource getAttributeSource(String name);
 
   /**
    * Returns a description of the named configuration attribute.
    *
    * @throws IllegalArgumentException if the specified name is illegal
    */
-  String getAttributeDescription(String attName);
+  String getAttributeDescription(String name);
 
   /**
    * Returns the class that defines the type of this attribute. The attribute's values will be
@@ -87,7 +92,7 @@ public interface Config {
    *
    * @throws IllegalArgumentException if the specified name is illegal
    */
-  Class getAttributeType(String attName);
+  Class getAttributeType(String name);
 
   /**
    * Returns an array containing the names of all the attributes.
@@ -102,7 +107,7 @@ public interface Config {
   /**
    * Returns whether or not this configuration is the same as another configuration.
    */
-  boolean sameAs(Config v);
+  boolean sameAs(Config other);
 
   /**
    * Converts the non-secure contents of this config to a property instance.
@@ -123,7 +128,7 @@ public interface Config {
    *
    * @since GemFire 3.5
    */
-  void toFile(File f) throws IOException;
+  void toFile(File file) throws IOException;
 
   /**
    * Returns a formatted string suitable for logging.
@@ -131,5 +136,4 @@ public interface Config {
    * @since GemFire 7.0
    */
   String toLoggerString();
-
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/logging/LogConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/logging/LogConfig.java
@@ -15,7 +15,6 @@
 package org.apache.geode.internal.logging;
 
 import java.io.File;
-import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.geode.distributed.internal.DistributionConfig;
 
@@ -61,39 +60,4 @@ public interface LogConfig {
   String getName();
 
   String toLoggerString();
-
-  LogConfig DEFAULT = new LogConfig() {
-
-    @Override
-    public int getLogLevel() {
-      return 0;
-    }
-
-    @Override
-    public File getLogFile() {
-      return null;
-    }
-
-    @Override
-    public int getLogFileSizeLimit() {
-      return 0;
-    }
-
-    @Override
-    public int getLogDiskSpaceLimit() {
-      return 0;
-    }
-
-    @Override
-    public String getName() {
-      return "";
-    }
-
-    @Override
-    public String toLoggerString() {
-      return "Default LogConfig";
-    }
-  };
-
-  AtomicReference<LogConfig> CURRENT = new AtomicReference<>(DEFAULT);
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/logging/LogConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/logging/LogConfig.java
@@ -15,12 +15,16 @@
 package org.apache.geode.internal.logging;
 
 import java.io.File;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.geode.distributed.internal.DistributionConfig;
 
 public interface LogConfig {
+
   /**
    * Returns the value of the <a href="../DistributedSystem.html#log-level">"log-level"</a> property
    *
-   * @see org.apache.geode.internal.logging.LogWriterImpl
+   * @see LogWriterImpl
    */
   int getLogLevel();
 
@@ -47,13 +51,49 @@ public interface LogConfig {
    * Returns the value of the <a href="../DistributedSystem.html#name">"name"</a> property Gets the
    * member's name. A name is optional and by default empty. If set it must be unique in the ds.
    * When set its used by tools to help identify the member.
+   *
    * <p>
    * The default value is:
-   * {@link org.apache.geode.distributed.internal.DistributionConfig#DEFAULT_NAME}.
+   * {@link DistributionConfig#DEFAULT_NAME}.
    *
    * @return the system's name.
    */
   String getName();
 
   String toLoggerString();
+
+  LogConfig DEFAULT = new LogConfig() {
+
+    @Override
+    public int getLogLevel() {
+      return 0;
+    }
+
+    @Override
+    public File getLogFile() {
+      return null;
+    }
+
+    @Override
+    public int getLogFileSizeLimit() {
+      return 0;
+    }
+
+    @Override
+    public int getLogDiskSpaceLimit() {
+      return 0;
+    }
+
+    @Override
+    public String getName() {
+      return "";
+    }
+
+    @Override
+    public String toLoggerString() {
+      return "Default LogConfig";
+    }
+  };
+
+  AtomicReference<LogConfig> CURRENT = new AtomicReference<>(DEFAULT);
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/logging/LogConfigSupplier.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/logging/LogConfigSupplier.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.geode.internal.logging;
+
+public interface LogConfigSupplier {
+
+  LogConfig getLogConfig();
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/logging/SecurityLogConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/logging/SecurityLogConfig.java
@@ -21,43 +21,44 @@ import org.apache.geode.distributed.internal.DistributionConfig;
 /**
  * LogConfig implementation for Security logging configuration that delegates to a
  * DistributionConfig.
- *
  */
-public class SecurityLogConfig implements LogConfig {
+class SecurityLogConfig implements LogConfig {
 
   private final DistributionConfig config;
 
-  public SecurityLogConfig(final DistributionConfig config) {
+  SecurityLogConfig(final DistributionConfig config) {
     this.config = config;
   }
 
   @Override
   public int getLogLevel() {
-    return this.config.getSecurityLogLevel();
+    // missing from LogConfig
+    return config.getSecurityLogLevel();
   }
 
   @Override
   public File getLogFile() {
-    return this.config.getSecurityLogFile();
+    // missing from LogConfig
+    return config.getSecurityLogFile();
   }
 
   @Override
   public int getLogFileSizeLimit() {
-    return this.config.getLogFileSizeLimit();
+    return config.getLogFileSizeLimit();
   }
 
   @Override
   public int getLogDiskSpaceLimit() {
-    return this.config.getLogDiskSpaceLimit();
+    return config.getLogDiskSpaceLimit();
   }
 
   @Override
   public String toLoggerString() {
-    return this.config.toLoggerString();
+    return config.toLoggerString();
   }
 
   @Override
   public String getName() {
-    return this.config.getName();
+    return config.getName();
   }
 }


### PR DESCRIPTION
Add LogConfigSupplier and some additional changes to LogConfig for
logging changes.

This is only part of the work for GEODE-2644. Aside from LogConfigSupplier and LogConfig, this PR simply removes warnings, renames variables, and fixes some comments.