### PR TITLE
GEODE-2644: Use LINE_SEPARATOR in logging classes

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/logging/LogFileParser.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/logging/LogFileParser.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.logging;
 
+import static org.apache.commons.lang.SystemUtils.LINE_SEPARATOR;
+
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
@@ -287,7 +289,7 @@ public class LogFileParser {
             if (idx > 0) {
               idx = line.indexOf("]", idx + 4);
               if (idx + 1 < line.length()) {
-                line.insert(idx + 1, "\n ");
+                line.insert(idx + 1, LINE_SEPARATOR + " ");
               }
             }
           }
@@ -335,7 +337,7 @@ public class LogFileParser {
           }
           sb.append("[dump ");
           sb.append(timestamp);
-          sb.append("]\n\n");
+          sb.append("]").append(LINE_SEPARATOR).append(LINE_SEPARATOR);
 
         } catch (ParseException ex) {
           // Oh well...
@@ -346,7 +348,7 @@ public class LogFileParser {
       }
 
       sb.append(line);
-      sb.append("\n");
+      sb.append(LINE_SEPARATOR);
 
       if (entry != null) {
         return entry;
@@ -366,7 +368,7 @@ public class LogFileParser {
       LocalLogWriter tempLogger = new LocalLogWriter(InternalLogWriter.ALL_LEVEL, pw);
       tempLogger.info(LocalizedStrings.LogFileParser_MISSING_TIME_STAMP);
       pw.flush();
-      sb.insert(0, "\n\n");
+      sb.insert(0, LINE_SEPARATOR + LINE_SEPARATOR);
       sb.insert(0, sw.toString().trim());
       sb.insert(0, this.extLogFileName);
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/logging/LogWriterImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/logging/LogWriterImpl.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.logging;
 
+import static org.apache.commons.lang.SystemUtils.LINE_SEPARATOR;
+
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.text.BreakIterator;
@@ -975,6 +977,9 @@ public abstract class LogWriterImpl implements InternalLogWriter {
   public abstract void put(int messageLevel, StringId messageId, Object[] parameters,
       Throwable throwable);
 
+  /**
+   * formatText manipulates \n and \r chars but supports Windows and Linux/Unix/Mac
+   */
   static void formatText(PrintWriter writer, String target, int initialLength) {
     BreakIterator boundary = BreakIterator.getLineInstance();
     boundary.setText(target);
@@ -1102,13 +1107,13 @@ public abstract class LogWriterImpl implements InternalLogWriter {
               sb.append("[trace ").append(getTimeStamp()).append("] ");
             }
             StackTraceElement[] els = targetThread.getStackTrace();
-            sb.append("Stack trace for '").append(targetThread).append("'\n");
+            sb.append("Stack trace for '").append(targetThread).append("'").append(LINE_SEPARATOR);
             if (els.length > 0) {
               for (int i = 0; i < els.length; i++) {
-                sb.append("\tat ").append(els[i]).append("\n");
+                sb.append("\tat ").append(els[i]).append(LINE_SEPARATOR);
               }
             } else {
-              sb.append("    no stack\n");
+              sb.append("    no stack").append(LINE_SEPARATOR);
             }
             if (toStdout) {
               System.out.println(sb);
@@ -1126,13 +1131,13 @@ public abstract class LogWriterImpl implements InternalLogWriter {
   public static StringBuilder getStackTrace(Thread targetThread) {
     StringBuilder sb = new StringBuilder(500);
     StackTraceElement[] els = targetThread.getStackTrace();
-    sb.append("Stack trace for '").append(targetThread).append("'\n");
+    sb.append("Stack trace for '").append(targetThread).append("'").append(LINE_SEPARATOR);
     if (els.length > 0) {
       for (int i = 0; i < els.length; i++) {
-        sb.append("\tat ").append(els[i]).append("\n");
+        sb.append("\tat ").append(els[i]).append(LINE_SEPARATOR);
       }
     } else {
-      sb.append("    no stack\n");
+      sb.append("    no stack").append(LINE_SEPARATOR);
     }
     return sb;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/logging/MergeLogFiles.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/logging/MergeLogFiles.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.logging;
 
+import static org.apache.commons.lang.SystemUtils.LINE_SEPARATOR;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -145,7 +147,7 @@ public class MergeLogFiles {
   private static void usage(String s) {
     // note that we don't document the -pids switch because it is tailored
     // to how hydra works and would not be useful for customers
-    err.println("\n** " + s + "\n");
+    err.println(LINE_SEPARATOR + "** " + s + LINE_SEPARATOR);
     err.println(LocalizedStrings.MergeLogFiles_USAGE.toLocalizedString()
         + ": java MergeLogFiles [(directory | logFile)]+");
     err.println("-dirCount n      "

--- a/geode-core/src/main/java/org/apache/geode/internal/logging/SortLogFile.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/logging/SortLogFile.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.logging;
 
+import static org.apache.commons.lang.SystemUtils.LINE_SEPARATOR;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -44,7 +45,6 @@ import org.apache.geode.internal.i18n.LocalizedStrings;
  * @since GemFire 3.0
  */
 public class SortLogFile {
-
   private static PrintStream out = System.out;
   private static PrintStream err = System.err;
 
@@ -91,7 +91,7 @@ public class SortLogFile {
    * Prints usage information about this program
    */
   private static void usage(String s) {
-    err.println("\n** " + s + "\n");
+    err.println(LINE_SEPARATOR + "** " + s + LINE_SEPARATOR);
     err.println(
         LocalizedStrings.SortLogFile_USAGE.toLocalizedString() + ": java SortLogFile logFile");
     err.println("-sortedFile file "


### PR DESCRIPTION
Use org.apache.commons.lang.SystemUtils.LINE_SEPARATOR instead of \n.

These are all of the hardcoded \n I could find in a the internal.logging package (and sub-packages) except for the chars in LogWriterImpl#formatText.

I left LogWriterImpl#formatText alone. This method is iterating over chars and decrementing a count for every \n and \r found. Since this is dealing with char instead of String and it actually works on Windows as written, I left it alone for now. We can eventually rewrite this method with some new unit tests but that's a little more work than just replacing \n with LINE_SEPARATOR.