### PR TITLE
GEODE-5781: split repeatTest into separate tasks

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/RepeatTest.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/RepeatTest.groovy
@@ -12,32 +12,32 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.geode.gradle;
+package org.apache.geode.gradle
 
-import org.gradle.StartParameter;
-import org.gradle.api.file.FileTree;
-import org.gradle.api.internal.DocumentationRegistry;
-import org.gradle.api.internal.tasks.testing.JvmTestExecutionSpec;
+import org.gradle.StartParameter
+import org.gradle.api.file.FileTree
+import org.gradle.api.internal.DocumentationRegistry
+import org.gradle.api.internal.tasks.testing.JvmTestExecutionSpec
 import org.gradle.api.internal.tasks.testing.TestExecuter
-import org.gradle.api.internal.tasks.testing.detection.DefaultTestExecuter;
-import org.gradle.api.internal.tasks.testing.filter.DefaultTestFilter;
-import org.gradle.api.tasks.testing.Test;
-import org.gradle.internal.operations.BuildOperationExecutor;
-import org.gradle.internal.time.Clock;
+import org.gradle.api.internal.tasks.testing.detection.DefaultTestExecuter
+import org.gradle.api.internal.tasks.testing.filter.DefaultTestFilter
+import org.gradle.api.tasks.testing.Test
+import org.gradle.internal.operations.BuildOperationExecutor
+import org.gradle.internal.time.Clock
 import org.gradle.internal.work.WorkerLeaseRegistry
-import org.gradle.process.internal.worker.WorkerProcessFactory;
 
 class RepeatTest extends Test {
-  int times = 1;
+  int times = 1
 
   @Override
   FileTree getCandidateClassFiles() {
-    FileTree candidates = super.getCandidateClassFiles();
-    for (int i = 0; i < times; i++) {
-      candidates = candidates.plus(super.getCandidateClassFiles());
+    FileTree candidates = super.getCandidateClassFiles()
+    int additionalRuns = times - 1
+    for (int i = 0; i < additionalRuns; i++) {
+      candidates = candidates.plus(super.getCandidateClassFiles())
     }
 
-    return candidates;
+    return candidates
   }
 
   /*
@@ -64,7 +64,7 @@ class RepeatTest extends Test {
         getServices().get(StartParameter.class).getMaxWorkerCount(),
         getServices().get(Clock.class),
         getServices().get(DocumentationRegistry.class),
-        (DefaultTestFilter) getFilter());
+        (DefaultTestFilter) getFilter())
   }
 
 }

--- a/ci/scripts/repeat-new-tests.sh
+++ b/ci/scripts/repeat-new-tests.sh
@@ -27,36 +27,60 @@ while [[ -h "$SOURCE" ]]; do # resolve $SOURCE until the file is no longer a sym
 done
 SCRIPTDIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
-CHANGED_FILES=$(cd geode && git diff --name-only HEAD $(git merge-base HEAD origin/develop)  -- */src/test/java */src/integrationTest/java */src/distributedTest/java */src/upgradeTest/java */src/acceptanceTest/java )
+function changes_for_path() {
+  cd geode
+  local path="$1" # only expand once in the line below
+  git diff --name-only HEAD $(git merge-base HEAD origin/develop) -- $path
+}
 
-CHANGED_FILES_ARRAY=( $CHANGED_FILES )
+UNIT_TEST_CHANGES=$(changes_for_path '*/src/test/java')
+INTEGRATION_TEST_CHANGES=$(changes_for_path '*/src/integrationTest/java')
+DISTRIBUTED_TEST_CHANGES=$(changes_for_path '*/src/distributedTest/java')
+ACCEPTANCE_TEST_CHANGES=$(changes_for_path '*/src/acceptanceTest/java')
+UPGRADE_TEST_CHANGES=$(changes_for_path '*/src/upgradeTest/java')
+
+CHANGED_FILES_ARRAY=( $UNIT_TEST_CHANGES $INTEGRATION_TEST_CHANGES $DISTRIBUTED_TEST_CHANGES $ACCEPTANCE_TEST_CHANGES $UPGRADE_TEST_CHANGES )
 NUM_CHANGED_FILES=${#CHANGED_FILES_ARRAY[@]}
-
-TESTS_FLAG=""
 
 echo "${NUM_CHANGED_FILES} changed tests"
 
 if [[  "${NUM_CHANGED_FILES}" -eq 0 ]]
-  then
-    echo "No changed test files, nothing to test."
-    exit 0
+then
+  echo "No changed test files, nothing to test."
+  exit 0
 fi
 
 if [[ "${NUM_CHANGED_FILES}" -gt 25 ]]
-  then
-    echo "${NUM_CHANGED_FILES} is many changed tests to stress test. Allowing this job to pass without stress testing."
-    exit 0
+then
+  echo "${NUM_CHANGED_FILES} is too many changed tests to stress test. Allowing this job to pass without stress testing."
+  exit 0
 fi
 
+TEST_TARGETS=""
 
-for FILENAME in $CHANGED_FILES ; do
-  SHORT_NAME=$(basename $FILENAME)
-  SHORT_NAME="${SHORT_NAME%.java}"
-  TESTS_FLAG="$TESTS_FLAG --tests $SHORT_NAME"
-done
+function append_to_test_targets() {
+  local target="$1"
+  local files="$2"
+  if [[ -n "$files" ]]
+  then
+    TEST_TARGETS="$TEST_TARGETS $target"
+    for FILENAME in $files
+    do
+      SHORT_NAME=$(basename $FILENAME)
+      SHORT_NAME="${SHORT_NAME%.java}"
+      TEST_TARGETS="$TEST_TARGETS --tests $SHORT_NAME"
+    done
+  fi
+}
 
-export GRADLE_TASK='compileTestJava compileIntegrationTestJava compileDistributedTestJava repeatTest'
-export GRADLE_TASK_OPTIONS="--no-parallel -Prepeat=50 -PfailOnNoMatchingTests=false $TESTS_FLAG"
+append_to_test_targets "repeatUnitTest" "$UNIT_TEST_CHANGES"
+append_to_test_targets "repeatIntegrationTest" "$INTEGRATION_TEST_CHANGES"
+append_to_test_targets "repeatDistributedTest" "$DISTRIBUTED_TEST_CHANGES"
+append_to_test_targets "repeatAcceptanceTest" "$ACCEPTANCE_TEST_CHANGES"
+append_to_test_targets "repeatUpgradeTest" "$UPGRADE_TEST_CHANGES"
+
+export GRADLE_TASK="compileTestJava compileIntegrationTestJava compileDistributedTestJava $TEST_TARGETS"
+export GRADLE_TASK_OPTIONS="--no-parallel -Prepeat=50 -PfailOnNoMatchingTests=false"
 
 echo "GRADLE_TASK_OPTIONS=${GRADLE_TASK_OPTIONS}"
 

--- a/geode-assembly/build.gradle
+++ b/geode-assembly/build.gradle
@@ -151,11 +151,6 @@ dependencies {
   }
 }
 
-tasks.withType(Test){
-  dependsOn installDist
-  environment 'GEODE_HOME', "$buildDir/install/${distributions.main.baseName}"
-}
-
 task defaultDistributionConfig(type: JavaExec, dependsOn: classes) {
   outputs.file file("$buildDir/gemfire.properties")
   main 'org.apache.geode.distributed.internal.DefaultPropertiesGenerator'
@@ -437,6 +432,10 @@ distributions {
   }
 }
 
+tasks.withType(Test){
+  dependsOn installDist
+  environment 'GEODE_HOME', "$buildDir/install/${distributions.main.baseName}"
+}
 
 // Make build final task to generate all test and product resources
 build.dependsOn installDist

--- a/geode-assembly/build.gradle
+++ b/geode-assembly/build.gradle
@@ -437,21 +437,6 @@ distributions {
   }
 }
 
-// Create a configuration closure to configure test targets with the install directory
-def dependOnInstalledProduct = {
-  dependsOn installDist
-  def install = file("$buildDir/install/${distributions.main.baseName}")
-  environment ('GEODE_HOME', install)
-}
-
-// Add the configuration closure to the test targets so they depend on the install directory
-test dependOnInstalledProduct
-acceptanceTest dependOnInstalledProduct
-distributedTest dependOnInstalledProduct
-upgradeTest dependOnInstalledProduct
-integrationTest dependOnInstalledProduct
-uiTest dependOnInstalledProduct
-repeatTest dependOnInstalledProduct
 
 // Make build final task to generate all test and product resources
 build.dependsOn installDist

--- a/gradle/docker.gradle
+++ b/gradle/docker.gradle
@@ -114,12 +114,20 @@ subprojects {
   apply plugin: 'com.github.pedjak.dockerized-test'
 
   if (project.hasProperty('parallelDunit')) {
-    distributedTest.configure(dockerConfig)
-    upgradeTest.configure(dockerConfig)
-    repeatTest.configure(dockerConfig)
-    integrationTest.configure(dockerConfig)
-//    ACCEPTANCE TEST NEEDS DOCKER-COMPOSE TO WORK WITHIN DOCKER FIRST
-//    acceptanceTest.configure(dockerConfig)
     uiTest.configure(dockerConfig)
+    repeatUnitTest.configure(dockerConfig)
+
+    integrationTest.configure(dockerConfig)
+    repeatIntegrationTest.configure(dockerConfig)
+
+    distributedTest.configure(dockerConfig)
+    repeatDistributedTest.configure(dockerConfig)
+
+    upgradeTest.configure(dockerConfig)
+    repeatUpgradeTest.configure(dockerConfig)
+
+    // ACCEPTANCE TEST NEEDS DOCKER-COMPOSE TO WORK WITHIN DOCKER FIRST
+    // acceptanceTest.configure(dockerConfig)
+    // repeatAcceptanceTest.configure(dockerConfig)
   }
 }

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -172,52 +172,40 @@ subprojects {
     }
   }
 
-  task repeatTest(type: RepeatTest) {
+  task repeatDistributedTest(type: RepeatTest) {
+    classpath = project.sourceSets.distributedTest.runtimeClasspath
+    testClassesDirs = project.sourceSets.distributedTest.output.classesDirs
+  }
+
+  task repeatIntegrationTest(type: RepeatTest) {
+    classpath = project.sourceSets.integrationTest.runtimeClasspath
+    testClassesDirs = project.sourceSets.integrationTest.output.classesDirs
+  }
+
+  task repeatAcceptanceTest(type: RepeatTest) {
+    classpath = project.sourceSets.acceptanceTest.runtimeClasspath
+    testClassesDirs = project.sourceSets.acceptanceTest.output.classesDirs
+  }
+
+  task repeatUpgradeTest(type: RepeatTest) {
+    classpath = project.sourceSets.upgradeTest.runtimeClasspath
+    testClassesDirs = project.sourceSets.upgradeTest.output.classesDirs
+  }
+
+  task repeatUnitTest(type: RepeatTest) {
+    // default classpath works for this one.
+  }
+
+  configure([repeatDistributedTest, repeatIntegrationTest, repeatUpgradeTest, repeatUnitTest, repeatAcceptanceTest]) {
     times = Integer.parseInt(repeat)
-
     useJUnit {}
-
     outputs.upToDateWhen { false }
-
-    classpath += project.sourceSets.distributedTest.runtimeClasspath
-    testClassesDirs += project.sourceSets.distributedTest.output.classesDirs
-    classpath += project.sourceSets.integrationTest.runtimeClasspath
-    testClassesDirs += project.sourceSets.integrationTest.output.classesDirs
-    classpath += project.sourceSets.upgradeTest.runtimeClasspath
-    testClassesDirs += project.sourceSets.upgradeTest.output.classesDirs
-    classpath += project.sourceSets.acceptanceTest.runtimeClasspath
-    testClassesDirs += project.sourceSets.acceptanceTest.output.classesDirs
 
     if (project.hasProperty("failOnNoMatchingTests")) {
       filter {
         setFailOnNoMatchingTests(Boolean.valueOf(project.failOnNoMatchingTests))
       }
     }
-  }
-
-  /*
-   * Don't add tasks for running specific category tests, instead use this
-   * property `testCategory` and set a FQCN of the required category.
-   * Eg: ./gradlew :geode-core:distributedTest -PtestCategory=org.apache.geode.test.junit.categories.GfshTest
-   *
-   * This provides developers a way to choose specific test source and test category.
-   *
-  */
-
-  // By proving a file with an arbitrary list of test classes, we can select only those
-  // tests to run. Activated using -Dcustom.tests=<file> customTest
-  def customTestList = []
-  def customTestFile = System.getProperty('custom.tests')
-  if (customTestFile != null) {
-    new File(customTestFile).eachLine { customTestList << it }
-  }
-
-  task customTest(type: Test) {
-    include { x ->
-      (x.isDirectory() || customTestList.any { y -> x.getName().contains(y) }) ? true : false
-    }
-
-    forkEvery 30
   }
 
   // apply common test configuration
@@ -236,7 +224,6 @@ subprojects {
         }
 
         maxHeapSize '768m'
-//        jvmArgs = ['-XX:+HeapDumpOnOutOfMemoryError', '-ea',"-XX:+PrintGC", "-XX:+PrintGCDetails","-XX:+PrintGCTimeStamps"]
         jvmArgs = ['-XX:+HeapDumpOnOutOfMemoryError', '-ea']
         if (!testJVM.trim().isEmpty()) {
           executable = "${testJVM}/bin/java"
@@ -284,9 +271,9 @@ subprojects {
     description 'Run this task before checking in code to validate changes. It runs tests beyond unitTest'
   }
 
-  combineReports.mustRunAfter check, test, integrationTest, distributedTest, acceptanceTest, repeatTest, upgradeTest
-  [build, check, test, integrationTest, distributedTest, acceptanceTest, repeatTest, upgradeTest].each {
+  tasks.withType(Test).plus([build,check]).each {
     it.finalizedBy combineReports
+    combineReports.mustRunAfter it
   }
 }
 


### PR DESCRIPTION
Because test classpaths can differ between source sets and modules, we should keep them separate, rather than combining them as `repeatTest` was doing before.

This PR removes the original `repeatTest` task and replaces it with one repeat test task per source set.

We tested the PR script by replacing most of `execute_tests.sh` with a single `bash` call and running locally.