### PR TITLE
Force inclusion of all ci/** files to work around exclude name collision

### DIFF
--- a/geode-assembly/build.gradle
+++ b/geode-assembly/build.gradle
@@ -336,6 +336,9 @@ distributions {
     contents {
       from writeBuildInfo
       from (rootDir) {
+        include 'ci/**'
+      }
+      from (rootDir) {
         exclude 'KEYS'
         exclude '**/gradlew'
         exclude '**/gradlew.bat'


### PR DESCRIPTION
src distribution excludes '**/out/**' which triggers on our concourse
resource script entitled 'out'. This gets the script into the archive
anyway

Co-authored-by: Sean Goller <sgoller@pivotal.io>
Co-authored-by: Robert Houghton <rhoughton@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
