### PR TITLE
GEODE-2644: Improve GfshParserAutoCompletionTest assertions

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/GfshParserAutoCompletionTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/GfshParserAutoCompletionTest.java
@@ -14,8 +14,8 @@
  */
 package org.apache.geode.management.internal.cli;
 
+import static org.apache.commons.lang.SystemUtils.LINE_SEPARATOR;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -27,8 +27,9 @@ import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.test.junit.categories.GfshTest;
 import org.apache.geode.test.junit.rules.GfshParserRule;
 
-@Category({GfshTest.class})
+@Category(GfshTest.class)
 public class GfshParserAutoCompletionTest {
+
   @ClassRule
   public static GfshParserRule parser = new GfshParserRule();
 
@@ -36,254 +37,256 @@ public class GfshParserAutoCompletionTest {
   private GfshParserRule.CommandCandidate candidate;
 
   @Test
-  public void testCompletionDescribe() throws Exception {
+  public void testCompletionDescribe() {
     buffer = "describe";
     candidate = parser.complete(buffer);
-    assertThat(candidate.size()).isEqualTo(8);
+    assertThat(candidate.getCandidates()).hasSize(8);
     assertThat(candidate.getFirstCandidate()).isEqualTo("describe client");
   }
 
   @Test
-  public void testCompletionDescribeWithSpace() throws Exception {
+  public void testCompletionDescribeWithSpace() {
     buffer = "describe ";
     candidate = parser.complete(buffer);
-    assertThat(candidate.size()).isEqualTo(8);
+    assertThat(candidate.getCandidates()).hasSize(8);
     assertThat(candidate.getFirstCandidate()).isEqualTo("describe client");
   }
 
   @Test
-  public void testCompletionDeploy() throws Exception {
+  public void testCompletionDeploy() {
     buffer = "deploy";
     candidate = parser.complete(buffer);
-    assertThat(candidate.size()).isEqualTo(5);
+    assertThat(candidate.getCandidates()).hasSize(5);
     assertThat(candidate.getFirstCandidate()).isEqualTo(buffer + " --dir");
   }
 
   @Test
-  public void testCompletionDeployWithSpace() throws Exception {
+  public void testCompletionDeployWithSpace() {
     buffer = "deploy ";
     candidate = parser.complete(buffer);
-    assertThat(candidate.size()).isEqualTo(5);
+    assertThat(candidate.getCandidates()).hasSize(5);
     assertThat(candidate.getFirstCandidate()).isEqualTo(buffer + "--dir");
   }
 
   @Test
-  public void testCompleteWithRequiredOption() throws Exception {
+  public void testCompleteWithRequiredOption() {
     buffer = "describe config";
     candidate = parser.complete(buffer);
-    assertThat(candidate.size()).isEqualTo(1);
+    assertThat(candidate.getCandidates()).hasSize(1);
     assertThat(candidate.getFirstCandidate()).isEqualTo(buffer + " --member");
   }
 
   @Test
-  public void testCompleteWithRequiredOptionWithSpace() throws Exception {
+  public void testCompleteWithRequiredOptionWithSpace() {
     buffer = "describe config ";
     candidate = parser.complete(buffer);
-    assertThat(candidate.size()).isEqualTo(1);
+    assertThat(candidate.getCandidates()).hasSize(1);
     assertThat(candidate.getFirstCandidate()).isEqualTo(buffer + "--member");
   }
 
   @Test
-  public void testCompleteCommand() throws Exception {
+  public void testCompleteCommand() {
     buffer = "start ser";
     candidate = parser.complete(buffer);
-    assertThat(candidate.size()).isEqualTo(1);
+    assertThat(candidate.getCandidates()).hasSize(1);
     assertThat("start server").isEqualTo(candidate.getFirstCandidate());
   }
 
   @Test
-  public void testCompleteOptionWithOnlyOneCandidate() throws Exception {
+  public void testCompleteOptionWithOnlyOneCandidate() {
     buffer = "start server --nam";
     candidate = parser.complete(buffer);
-    assertThat(candidate.size()).isEqualTo(1);
+    assertThat(candidate.getCandidates()).hasSize(1);
     assertThat(candidate.getFirstCandidate()).isEqualTo(buffer + "e");
   }
 
   @Test
-  public void testCompleteOptionWithMultipleCandidates() throws Exception {
+  public void testCompleteOptionWithMultipleCandidates() {
     buffer = "start server --name=jinmei --loc";
     candidate = parser.complete(buffer);
-    assertThat(candidate.size()).isEqualTo(3);
+    assertThat(candidate.getCandidates()).hasSize(3);
     assertThat(candidate.getFirstCandidate()).isEqualTo(buffer + "ator-wait-time");
     assertThat(candidate.getCandidate(1)).isEqualTo(buffer + "ators");
     assertThat(candidate.getCandidate(2)).isEqualTo(buffer + "k-memory");
   }
 
   @Test
-  public void testCompleteWithExtraSpace() throws Exception {
+  public void testCompleteWithExtraSpace() {
     buffer = "start server --name=name1  --se";
     candidate = parser.complete(buffer);
     assertThat(candidate.getCursor()).isEqualTo("start server --name=name1  ".length());
-    assertThat(candidate.size()).isEqualTo(3);
-    assertTrue(candidate.getCandidates().contains(new Completion("--server-port")));
+    assertThat(candidate.getCandidates()).hasSize(3);
+    assertThat(candidate.getCandidates()).contains(new Completion("--server-port"));
     assertThat(candidate.getFirstCandidate()).isEqualTo(buffer + "curity-properties-file");
   }
 
   @Test
-  public void testCompleteWithDashInTheEnd() throws Exception {
+  public void testCompleteWithDashInTheEnd() {
     buffer = "start server --name=name1 --";
     candidate = parser.complete(buffer);
     assertThat(candidate.getCursor()).isEqualTo(buffer.length() - 2);
-    assertThat(candidate.size()).isEqualTo(53);
-    assertTrue(candidate.getCandidates().contains(new Completion("--properties-file")));
+    assertThat(candidate.getCandidates()).hasSize(53);
+    assertThat(candidate.getCandidates()).contains(new Completion("--properties-file"));
     assertThat(candidate.getFirstCandidate()).isEqualTo(buffer + "J");
   }
 
   @Test
-  public void testCompleteWithSpace() throws Exception {
+  public void testCompleteWithSpace() {
     buffer = "start server --name=name1 ";
     candidate = parser.complete(buffer);
     assertThat(candidate.getCursor()).isEqualTo(buffer.length() - 1);
-    assertThat(candidate.size()).isEqualTo(53);
-    assertTrue(candidate.getCandidates().contains(new Completion(" --properties-file")));
+    assertThat(candidate.getCandidates()).hasSize(53);
+    assertThat(candidate.getCandidates()).contains(new Completion(" --properties-file"));
     assertThat(candidate.getFirstCandidate()).isEqualTo(buffer + "--J");
   }
 
   @Test
-  public void testCompleteWithOutSpace() throws Exception {
+  public void testCompleteWithOutSpace() {
     buffer = "start server --name=name1";
     candidate = parser.complete(buffer);
     assertThat(candidate.getCursor()).isEqualTo(buffer.length());
-    assertThat(candidate.size()).isEqualTo(53);
-    assertTrue(candidate.getCandidates().contains(new Completion(" --properties-file")));
+    assertThat(candidate.getCandidates()).hasSize(53);
+    assertThat(candidate.getCandidates()).contains(new Completion(" --properties-file"));
     assertThat(candidate.getFirstCandidate()).isEqualTo(buffer + " --J");
   }
 
   @Test
-  public void testCompleteJ() throws Exception {
+  public void testCompleteJ() {
     buffer = "start server --name=name1 --J=";
     candidate = parser.complete(buffer);
     assertThat(candidate.getCursor()).isEqualTo(buffer.length() - 3);
-    assertThat(candidate.size()).isEqualTo(1);
+    assertThat(candidate.getCandidates()).hasSize(1);
   }
 
   @Test
-  public void testCompleteWithValue() throws Exception {
+  public void testCompleteWithValue() {
     buffer = "start server --name=name1 --J";
     candidate = parser.complete(buffer);
     assertThat(candidate.getCursor()).isEqualTo(buffer.length() - 3);
-    assertThat(candidate.size()).isEqualTo(1);
+    assertThat(candidate.getCandidates()).hasSize(1);
   }
 
   @Test
-  public void testCompleteWithDash() throws Exception {
+  public void testCompleteWithDash() {
     buffer = "start server --name=name1 --J=-Dfoo.bar --";
     candidate = parser.complete(buffer);
-    assertThat(candidate.size()).isEqualTo(52);
+    assertThat(candidate.getCandidates()).hasSize(52);
   }
 
   @Test
-  public void testCompleteWithMultipleJ() throws Exception {
+  public void testCompleteWithMultipleJ() {
     buffer = "start server --name=name1 --J=-Dme=her --J=-Dfoo=bar --l";
     candidate = parser.complete(buffer);
     assertThat(candidate.getCursor())
         .isEqualTo("start server --name=name1 --J=-Dme=her --J=-Dfoo=bar ".length());
-    assertThat(candidate.size()).isEqualTo(4);
-    assertTrue(candidate.getCandidates().contains(new Completion("--locators")));
+    assertThat(candidate.getCandidates()).hasSize(4);
+    assertThat(candidate.getCandidates()).contains(new Completion("--locators"));
   }
 
   @Test
-  public void testMultiJComplete() throws Exception {
+  public void testMultiJComplete() {
     buffer = "start server --name=name1 --J=-Dtest=test1 --J=-Dfoo=bar";
     candidate = parser.complete(buffer);
     assertThat(candidate.getCursor()).isEqualTo(buffer.length());
-    assertThat(candidate.size()).isEqualTo(52);
+    assertThat(candidate.getCandidates()).hasSize(52);
     assertThat(candidate.getFirstCandidate()).isEqualTo(buffer + " --assign-buckets");
   }
 
   @Test
-  public void testMultiJCompleteWithDifferentOrder() throws Exception {
+  public void testMultiJCompleteWithDifferentOrder() {
     buffer = "start server --J=-Dtest=test1 --J=-Dfoo=bar --name=name1";
     candidate = parser.complete(buffer);
     assertThat(candidate.getCursor()).isEqualTo(buffer.length());
-    assertThat(candidate.size()).isEqualTo(52);
+    assertThat(candidate.getCandidates()).hasSize(52);
     assertThat(candidate.getFirstCandidate()).isEqualTo(buffer + " --assign-buckets");
   }
 
   @Test
-  public void testJComplete3() throws Exception {
+  public void testJComplete3() {
     buffer = "start server --name=name1 --locators=localhost --J=-Dfoo=bar";
     candidate = parser.complete(buffer);
     assertThat(candidate.getCursor()).isEqualTo(buffer.length());
-    assertThat(candidate.size()).isEqualTo(51);
+    assertThat(candidate.getCandidates()).hasSize(51);
     assertThat(candidate.getFirstCandidate()).isEqualTo(buffer + " --assign-buckets");
   }
 
   @Test
-  public void testJComplete4() throws Exception {
+  public void testJComplete4() {
     buffer = "start server --name=name1 --locators=localhost  --J=-Dfoo=bar --";
     candidate = parser.complete(buffer);
     assertThat(candidate.getCursor()).isEqualTo(buffer.length() - 2);
-    assertThat(candidate.size()).isEqualTo(51);
+    assertThat(candidate.getCandidates()).hasSize(51);
     assertThat(candidate.getFirstCandidate()).isEqualTo(buffer + "assign-buckets");
   }
 
   @Test
-  public void testCompletRegionType() throws Exception {
+  public void testCompleteRegionType() {
     buffer = "create region --name=test --type";
     candidate = parser.complete(buffer);
-    assertThat(candidate.size()).isEqualTo(23);
+    assertThat(candidate.getCandidates()).hasSize(23);
     assertThat(candidate.getFirstCandidate()).isEqualTo(buffer + "=LOCAL");
   }
 
   @Test
-  public void testCompletPartialRegionType() throws Exception {
+  public void testCompletePartialRegionType() {
     buffer = "create region --name=test --type=LO";
     candidate = parser.complete(buffer);
-    assertThat(candidate.size()).isEqualTo(5);
+    assertThat(candidate.getCandidates()).hasSize(5);
     assertThat(candidate.getFirstCandidate()).isEqualTo(buffer + "CAL");
   }
 
   @Test
-  public void testCompletWithRegionTypeWithNoSpace() throws Exception {
+  public void testCompleteWithRegionTypeWithNoSpace() {
     buffer = "create region --name=test --type=REPLICATE";
     candidate = parser.complete(buffer);
-    assertThat(candidate.size()).isEqualTo(5);
+    assertThat(candidate.getCandidates()).hasSize(5);
     assertThat(candidate.getFirstCandidate()).isEqualTo(buffer + "_HEAP_LRU");
   }
 
   @Test
-  public void testCompletWithRegionTypeWithSpace() throws Exception {
+  public void testCompleteWithRegionTypeWithSpace() {
     buffer = "create region --name=test --type=REPLICATE ";
     candidate = parser.complete(buffer);
-    assertThat(candidate.size()).isEqualTo(45);
+    assertThat(candidate.getCandidates()).hasSize(45);
     assertThat(candidate.getFirstCandidate()).isEqualTo(buffer + "--async-event-queue-id");
   }
 
   @Test
-  public void testCompletLogLevel() throws Exception {
+  public void testCompleteLogLevel() {
     buffer = "change loglevel --loglevel";
     candidate = parser.complete(buffer);
-    assertThat(candidate.size()).isEqualTo(8);
+    assertThat(candidate.getCandidates()).hasSize(8);
     assertThat(candidate.getFirstCandidate()).isEqualTo(buffer + "=ALL");
   }
 
   @Test
-  public void testCompletLogLevelWithEqualSign() throws Exception {
+  public void testCompleteLogLevelWithEqualSign() {
     buffer = "change loglevel --loglevel=";
     candidate = parser.complete(buffer);
-    assertThat(candidate.size()).isEqualTo(8);
+    assertThat(candidate.getCandidates()).hasSize(8);
     assertThat(candidate.getFirstCandidate()).isEqualTo(buffer + "ALL");
   }
 
   @Test
   public void testObtainHelp() {
     String command = CliStrings.START_PULSE;
-    String helpString = ("NAME\n" + "start pulse\n" + "IS AVAILABLE\n" + "true\n" + "SYNOPSIS\n"
-        + "Open a new window in the default Web browser with the URL for the Pulse application.\n"
-        + "SYNTAX\n" + "start pulse [--url=value]\n" + "PARAMETERS\n" + "url\n"
-        + "URL of the Pulse Web application.\n" + "Required: false\n"
-        + "Default (if the parameter is not specified): http://localhost:7070/pulse\n").replace(
-            "\n", System.lineSeparator());
+    String helpString = "NAME" + LINE_SEPARATOR + "start pulse" + LINE_SEPARATOR + "IS AVAILABLE"
+        + LINE_SEPARATOR + "true" + LINE_SEPARATOR + "SYNOPSIS" + LINE_SEPARATOR
+        + "Open a new window in the default Web browser with the URL for the Pulse application."
+        + LINE_SEPARATOR
+        + "SYNTAX" + LINE_SEPARATOR + "start pulse [--url=value]" + LINE_SEPARATOR + "PARAMETERS"
+        + LINE_SEPARATOR + "url" + LINE_SEPARATOR
+        + "URL of the Pulse Web application." + LINE_SEPARATOR + "Required: false" + LINE_SEPARATOR
+        + "Default (if the parameter is not specified): http://localhost:7070/pulse"
+        + LINE_SEPARATOR;
     assertThat(parser.getCommandManager().obtainHelp(command)).isEqualTo(helpString);
   }
 
   @Test
-  public void testIndexType() throws Exception {
+  public void testIndexType() {
     buffer = "create index --type=";
     candidate = parser.complete(buffer);
-    assertThat(candidate.size()).isEqualTo(IndexType.values().length);
+    assertThat(candidate.getCandidates()).hasSize(IndexType.values().length);
     assertThat(candidate.getFirstCandidate()).isEqualTo(buffer + "hash");
   }
-
 }


### PR DESCRIPTION
Improve assertions so that failures in this test can be
diagnosed without using the IDE debugger.

This test is failing on my branch for GEODE-2644 but
the failure messages are very cryptic. This simple change
makes the assertion messages easy to understand. Since
this is valuable on develop, I'd like to merge the test change
to develop.