### PR TITLE
User Guide: correct version typo (1.8 -> 1.7)

### DIFF
--- a/geode-book/config.yml
+++ b/geode-book/config.yml
@@ -21,14 +21,14 @@ public_host: localhost
 sections:
 - repository:
     name: geode-docs
-  directory: docs/guide/18
+  directory: docs/guide/17
   subnav_template: geode-subnav
 
 template_variables:
   product_name_long: Apache Geode
   product_name: Geode
-  product_version: 1.8
-  product_version_nodot: 18
+  product_version: 1.7
+  product_version_nodot: 17
   min_java_update: 121
   support_url: http://geode.apache.org/community
   product_url: http://geode.apache.org/

--- a/geode-book/redirects.rb
+++ b/geode-book/redirects.rb
@@ -14,5 +14,5 @@
 #permissions and limitations under the License.
 
 r301 %r{/releases/latest/javadoc/(.*)}, 'http://geode.apache.org/releases/latest/javadoc/$1'
-rewrite '/', '/docs/guide/18/about_geode.html'
-rewrite '/index.html', '/docs/guide/18/about_geode.html'
+rewrite '/', '/docs/guide/17/about_geode.html'
+rewrite '/index.html', '/docs/guide/17/about_geode.html'


### PR DESCRIPTION
Placeholder just in case there's a third release candidate for v1.7.0. Would be good to include this fix.
Would also be good to include these two files in the release procedure reminder list:
../geode-book/config.yml
../geode-book/redirects.rb