### PR TITLE
GEODE-5798: Exclude bin directories created by IDE from rat

### DIFF
--- a/gradle/rat.gradle
+++ b/gradle/rat.gradle
@@ -60,6 +60,7 @@ rat {
     '.idea/**',
     '**/tags',
     '**/out/**',
+    '**/bin/**',
 
     // text files
     '**/*.fig',


### PR DESCRIPTION
This fixed the rat failure involving bin directories created by IntelliJ.