### PR TITLE
GEODE-5799: Set StatusLogger level to WARN

### DIFF
--- a/geode-core/src/integrationTest/resources/org/apache/geode/distributed/LocatorLauncherRemoteWithCustomLoggingIntegrationTest_log4j2.xml
+++ b/geode-core/src/integrationTest/resources/org/apache/geode/distributed/LocatorLauncherRemoteWithCustomLoggingIntegrationTest_log4j2.xml
@@ -15,7 +15,7 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<Configuration status="FATAL" shutdownHook="disable" packages="org.apache.geode.internal.logging.log4j.custom">
+<Configuration status="WARN" shutdownHook="disable" packages="org.apache.geode.internal.logging.log4j.custom">
     <Properties>
         <Property name="custom-pattern">CUSTOM: level=%level time=%date{yyyy/MM/dd HH:mm:ss.SSS z} message=%message%nthrowable=%throwable%n
         </Property>

--- a/geode-core/src/integrationTest/resources/org/apache/geode/distributed/ServerLauncherRemoteWithCustomLoggingIntegrationTest_log4j2.xml
+++ b/geode-core/src/integrationTest/resources/org/apache/geode/distributed/ServerLauncherRemoteWithCustomLoggingIntegrationTest_log4j2.xml
@@ -15,7 +15,7 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<Configuration status="FATAL" shutdownHook="disable" packages="org.apache.geode.internal.logging.log4j.custom">
+<Configuration status="WARN" shutdownHook="disable" packages="org.apache.geode.internal.logging.log4j.custom">
     <Properties>
         <Property name="custom-pattern">CUSTOM: level=%level time=%date{yyyy/MM/dd HH:mm:ss.SSS z} message=%message%nthrowable=%throwable%n
         </Property>

--- a/geode-core/src/integrationTest/resources/org/apache/geode/internal/logging/log4j/ConsoleAppenderWithLoggerContextRuleIntegrationTest_log4j2.xml
+++ b/geode-core/src/integrationTest/resources/org/apache/geode/internal/logging/log4j/ConsoleAppenderWithLoggerContextRuleIntegrationTest_log4j2.xml
@@ -17,7 +17,7 @@
   -->
 <Configuration status="WARN" shutdownHook="disable" packages="org.apache.geode.internal.logging.log4j,org.apache.logging.log4j.test.appender">
     <Properties>
-        <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%tid] %message%n%throwable%n</Property>
+        <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
     </Properties>
     <Appenders>
         <Console name="STDOUT" target="SYSTEM_OUT">

--- a/geode-core/src/integrationTest/resources/org/apache/geode/internal/logging/log4j/ConsoleAppenderWithSystemOutRuleIntegrationTest_log4j2.xml
+++ b/geode-core/src/integrationTest/resources/org/apache/geode/internal/logging/log4j/ConsoleAppenderWithSystemOutRuleIntegrationTest_log4j2.xml
@@ -15,9 +15,9 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<Configuration status="ERROR" shutdownHook="disable" packages="org.apache.geode.internal.logging.log4j">
+<Configuration status="WARN" shutdownHook="disable" packages="org.apache.geode.internal.logging.log4j">
     <Properties>
-        <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%tid] %message%n%throwable%n</Property>
+        <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
     </Properties>
     <Appenders>
         <Console name="STDOUT" target="SYSTEM_OUT">

--- a/geode-core/src/integrationTest/resources/org/apache/geode/internal/logging/log4j/custom/CustomConfigWithCacheIntegrationTest_log4j2.xml
+++ b/geode-core/src/integrationTest/resources/org/apache/geode/internal/logging/log4j/custom/CustomConfigWithCacheIntegrationTest_log4j2.xml
@@ -15,7 +15,7 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<Configuration status="FATAL" shutdownHook="disable" packages="org.apache.geode.internal.logging.log4j.custom">
+<Configuration status="WARN" shutdownHook="disable" packages="org.apache.geode.internal.logging.log4j.custom">
     <Properties>
         <Property name="custom-pattern">CUSTOM: level=%level time=%date{yyyy/MM/dd HH:mm:ss.SSS z} message=%message%nthrowable=%throwable%n
         </Property>

--- a/geode-core/src/integrationTest/resources/org/apache/geode/internal/logging/log4j/custom/CustomConfigWithLogServiceIntegrationTest_log4j2.xml
+++ b/geode-core/src/integrationTest/resources/org/apache/geode/internal/logging/log4j/custom/CustomConfigWithLogServiceIntegrationTest_log4j2.xml
@@ -15,7 +15,7 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<Configuration status="FATAL" shutdownHook="disable" packages="org.apache.geode.internal.logging.log4j.custom">
+<Configuration status="WARN" shutdownHook="disable" packages="org.apache.geode.internal.logging.log4j.custom">
     <Properties>
         <Property name="custom-pattern">CUSTOM: level=%level time=%date{yyyy/MM/dd HH:mm:ss.SSS z} message=%message%nthrowable=%throwable%n
         </Property>

--- a/geode-core/src/main/resources/log4j2-cli.xml
+++ b/geode-core/src/main/resources/log4j2-cli.xml
@@ -15,7 +15,7 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<Configuration status="FATAL" shutdownHook="disable" packages="org.apache.geode.internal.logging.log4j">
+<Configuration status="WARN" shutdownHook="disable" packages="org.apache.geode.internal.logging.log4j">
   <Properties>
     <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
   </Properties>

--- a/geode-core/src/main/resources/log4j2.xml
+++ b/geode-core/src/main/resources/log4j2.xml
@@ -15,7 +15,7 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<Configuration status="FATAL" shutdownHook="disable" packages="org.apache.geode.internal.logging.log4j">
+<Configuration status="WARN" shutdownHook="disable" packages="org.apache.geode.internal.logging.log4j">
   <Properties>
     <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
     <Property name="geode-default">true</Property>

--- a/geode-core/src/main/resources/org/apache/geode/internal/logging/log4j/log4j2-legacy.xml
+++ b/geode-core/src/main/resources/org/apache/geode/internal/logging/log4j/log4j2-legacy.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="FATAL" shutdownHook="disable" packages="org.apache.geode.internal.logging.log4j">
+<Configuration status="WARN" shutdownHook="disable" packages="org.apache.geode.internal.logging.log4j">
   <Properties>
     <Property name="geode-pattern">[%level{FATAL=severe,ERROR=error,WARN=warning,INFO=info,DEBUG=fine,TRACE=finest} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
   </Properties>

--- a/geode-core/src/test/resources/org/apache/geode/internal/logging/log4j/marker/log4j2-gemfire_verbose-accept.xml
+++ b/geode-core/src/test/resources/org/apache/geode/internal/logging/log4j/marker/log4j2-gemfire_verbose-accept.xml
@@ -15,7 +15,7 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<Configuration status="FATAL" shutdownHook="disable" packages="org.apache.geode.internal.logging.log4j">
+<Configuration status="WARN" shutdownHook="disable" packages="org.apache.geode.internal.logging.log4j">
   <Properties>
     <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
     <Property name="geode-default">true</Property>

--- a/geode-core/src/test/resources/org/apache/geode/internal/logging/log4j/marker/log4j2-gemfire_verbose-deny.xml
+++ b/geode-core/src/test/resources/org/apache/geode/internal/logging/log4j/marker/log4j2-gemfire_verbose-deny.xml
@@ -15,7 +15,7 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<Configuration status="FATAL" shutdownHook="disable" packages="org.apache.geode.internal.logging.log4j">
+<Configuration status="WARN" shutdownHook="disable" packages="org.apache.geode.internal.logging.log4j">
   <Properties>
     <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
     <Property name="geode-default">true</Property>

--- a/geode-core/src/test/resources/org/apache/geode/internal/logging/log4j/marker/log4j2-geode_verbose-accept.xml
+++ b/geode-core/src/test/resources/org/apache/geode/internal/logging/log4j/marker/log4j2-geode_verbose-accept.xml
@@ -15,7 +15,7 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<Configuration status="FATAL" shutdownHook="disable" packages="org.apache.geode.internal.logging.log4j">
+<Configuration status="WARN" shutdownHook="disable" packages="org.apache.geode.internal.logging.log4j">
   <Properties>
     <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
     <Property name="geode-default">true</Property>

--- a/geode-core/src/test/resources/org/apache/geode/internal/logging/log4j/marker/log4j2-geode_verbose-deny.xml
+++ b/geode-core/src/test/resources/org/apache/geode/internal/logging/log4j/marker/log4j2-geode_verbose-deny.xml
@@ -15,7 +15,7 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<Configuration status="FATAL" shutdownHook="disable" packages="org.apache.geode.internal.logging.log4j">
+<Configuration status="WARN" shutdownHook="disable" packages="org.apache.geode.internal.logging.log4j">
   <Properties>
     <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
     <Property name="geode-default">true</Property>

--- a/geode-core/src/test/resources/org/apache/geode/test/golden/log4j2-test.xml
+++ b/geode-core/src/test/resources/org/apache/geode/test/golden/log4j2-test.xml
@@ -15,7 +15,7 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<Configuration status="ERROR" shutdownHook="disable" packages="org.apache.geode.internal.logging.log4j">
+<Configuration status="WARN" shutdownHook="disable" packages="org.apache.geode.internal.logging.log4j">
   <Properties>
     <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
   </Properties>


### PR DESCRIPTION
This changes the level from FATAL to WARN. WARN is the default.

StatusLogger is the internal Log4J2 logger used by Appenders,
PatternConverters, etc. WARN level is the default and it will be
silent unless we introduce a bug into one of the custom Appenders
or PatternConverters in Geode.