### PR TITLE
GEODE-5776: Use HexThreadIdPatternConverter in tests

### DIFF
--- a/geode-core/src/integrationTest/resources/org/apache/geode/internal/logging/log4j/ConsoleAppenderWithLoggerContextRuleIntegrationTest_log4j2.xml
+++ b/geode-core/src/integrationTest/resources/org/apache/geode/internal/logging/log4j/ConsoleAppenderWithLoggerContextRuleIntegrationTest_log4j2.xml
@@ -17,7 +17,7 @@
   -->
 <Configuration status="WARN" shutdownHook="disable" packages="org.apache.geode.internal.logging.log4j,org.apache.logging.log4j.test.appender">
     <Properties>
-        <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%tid] %message%n%throwable%n</Property>
+        <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
     </Properties>
     <Appenders>
         <Console name="STDOUT" target="SYSTEM_OUT">

--- a/geode-core/src/integrationTest/resources/org/apache/geode/internal/logging/log4j/ConsoleAppenderWithSystemOutRuleIntegrationTest_log4j2.xml
+++ b/geode-core/src/integrationTest/resources/org/apache/geode/internal/logging/log4j/ConsoleAppenderWithSystemOutRuleIntegrationTest_log4j2.xml
@@ -17,7 +17,7 @@
   -->
 <Configuration status="ERROR" shutdownHook="disable" packages="org.apache.geode.internal.logging.log4j">
     <Properties>
-        <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%tid] %message%n%throwable%n</Property>
+        <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
     </Properties>
     <Appenders>
         <Console name="STDOUT" target="SYSTEM_OUT">


### PR DESCRIPTION
Use HexThreadIdPatternConverter in two more tests that were introduced after fixing GEODE-5776.