### PR TITLE
GEODE-5784: Remove unused duplicate condition from AbstractConfig

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/AbstractConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/AbstractConfig.java
@@ -37,7 +37,6 @@ import java.util.StringTokenizer;
 import java.util.TreeSet;
 
 import org.apache.geode.InternalGemFireException;
-import org.apache.geode.UnmodifiableException;
 import org.apache.geode.distributed.internal.FlowControlParams;
 import org.apache.geode.internal.i18n.LocalizedStrings;
 import org.apache.geode.internal.net.SocketCreator;
@@ -224,7 +223,6 @@ public abstract class AbstractConfig implements Config {
       if (valueType.equals(String.class)) {
         attObjectValue = value;
       } else if (valueType.equals(String[].class)) {
-        // TODO:GEODE-5784: DUPLICATE CONDITION with different behavior
         attObjectValue = value.split(",");
       } else if (valueType.equals(Integer.class)) {
         attObjectValue = Integer.valueOf(value);
@@ -251,16 +249,6 @@ public abstract class AbstractConfig implements Config {
           throw new IllegalArgumentException(
               LocalizedStrings.AbstractConfig_0_VALUE_1_MUST_BE_A_VALID_HOST_NAME_2
                   .toLocalizedString(name, value, ex.toString()));
-        }
-      } else if (valueType.equals(String[].class)) {
-        // TODO:GEODE-5784: DUPLICATE CONDITION with different behavior
-        if (value == null || value.length() == 0) {
-          attObjectValue = null;
-        } else {
-          String trimAttName = name.substring(0, name.length() - 1);
-          throw new UnmodifiableException(
-              LocalizedStrings.AbstractConfig_THE_0_CONFIGURATION_ATTRIBUTE_CAN_NOT_BE_SET_FROM_THE_COMMAND_LINE_SET_1_FOR_EACH_INDIVIDUAL_PARAMETER_INSTEAD
-                  .toLocalizedString(name, trimAttName));
         }
       } else if (valueType.equals(FlowControlParams.class)) {
         String[] values = value.split(",");

--- a/geode-core/src/main/java/org/apache/geode/internal/i18n/LocalizedStrings.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/i18n/LocalizedStrings.java
@@ -1888,9 +1888,6 @@ public class LocalizedStrings {
   public static final StringId AbstractConfig_0_VALUE_1_MUST_HAVE_THREE_ELEMENTS_SEPARATED_BY_COMMAS =
       new StringId(2155, "{0}  value \"{1}\" must have three elements separated by commas");
 
-  public static final StringId AbstractConfig_THE_0_CONFIGURATION_ATTRIBUTE_CAN_NOT_BE_SET_FROM_THE_COMMAND_LINE_SET_1_FOR_EACH_INDIVIDUAL_PARAMETER_INSTEAD =
-      new StringId(2157,
-          "The \"{0}\" configuration attribute can not be set from the command line. Set \"{1}\" for each individual parameter instead.");
   public static final StringId AbstractConfig_UNHANDLED_ATTRIBUTE_NAME_0 =
       new StringId(2158, "unhandled attribute name \"{0}\".");
   public static final StringId AbstractConfig_UNHANDLED_ATTRIBUTE_TYPE_0_FOR_1 =

--- a/geode-core/src/test/java/org/apache/geode/internal/AbstractConfigTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/AbstractConfigTest.java
@@ -15,18 +15,83 @@
 package org.apache.geode.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
+import org.junit.Before;
 import org.junit.Test;
-
 
 public class AbstractConfigTest {
 
+  private ConfigSource source;
+  private AbstractConfig abstractConfig;
+
+  private String stringArrayAttributeName;
+
+  @Before
+  public void setUp() {
+    source = mock(ConfigSource.class);
+    abstractConfig = mock(AbstractConfig.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
+
+    stringArrayAttributeName = "stringArray";
+
+    when(abstractConfig.getAttributeType(stringArrayAttributeName)).thenReturn(String[].class);
+  }
+
   @Test
-  public void shouldBeMockable() throws Exception {
-    AbstractConfig mockAbstractConfig = mock(AbstractConfig.class);
-    when(mockAbstractConfig.toString()).thenReturn("STRING");
-    assertThat(mockAbstractConfig.toString()).isEqualTo("STRING");
+  public void toStringCanBeMocked() {
+    when(abstractConfig.toString()).thenReturn("STRING");
+
+    assertThat(abstractConfig.toString()).isEqualTo("STRING");
+  }
+
+  @Test
+  public void setAttributeForStringArrayTypeWithEmpty() {
+    abstractConfig.setAttribute(stringArrayAttributeName, "", source);
+
+    verify(abstractConfig).setAttributeObject(stringArrayAttributeName, new String[] {""}, source);
+  }
+
+  @Test
+  public void setAttributeForStringArrayTypeWithNull() {
+    Throwable thrown =
+        catchThrowable(() -> abstractConfig.setAttribute(stringArrayAttributeName, null, source));
+    assertThat(thrown).isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void setAttributeForStringArrayTypeWithNoCommas() {
+    abstractConfig.setAttribute(stringArrayAttributeName, "value", source);
+
+    verify(abstractConfig).setAttributeObject(stringArrayAttributeName, new String[] {"value"},
+        source);
+  }
+
+  @Test
+  public void setAttributeForStringArrayTypeWithNestedComma() {
+    abstractConfig.setAttribute(stringArrayAttributeName, "value1,value2", source);
+
+    verify(abstractConfig).setAttributeObject(stringArrayAttributeName,
+        new String[] {"value1", "value2"}, source);
+  }
+
+  @Test
+  public void setAttributeForStringArrayTypeStartingWithComma() {
+    abstractConfig.setAttribute(stringArrayAttributeName, ",value", source);
+
+    verify(abstractConfig).setAttributeObject(stringArrayAttributeName, new String[] {"", "value"},
+        source);
+  }
+
+  @Test
+  public void setAttributeForStringArrayTypeEndingWithComma() {
+    abstractConfig.setAttribute(stringArrayAttributeName, "value,", source);
+
+    verify(abstractConfig).setAttributeObject(stringArrayAttributeName, new String[] {"value"},
+        source);
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/AbstractConfigTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/AbstractConfigTest.java
@@ -16,11 +16,10 @@ package org.apache.geode.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
-import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.withSettings;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -35,7 +34,7 @@ public class AbstractConfigTest {
   @Before
   public void setUp() {
     source = mock(ConfigSource.class);
-    abstractConfig = mock(AbstractConfig.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
+    abstractConfig = spy(AbstractConfig.class);
 
     stringArrayAttributeName = "stringArray";
 


### PR DESCRIPTION
Add new characterization tests for AbstractConfig.setAttribute
