### PR TITLE
GEODE-5800: remove redundant casts for `DataSerializer.readObject()`

### DIFF
--- a/extensions/geode-modules/src/main/java/org/apache/geode/modules/session/catalina/DeltaSession.java
+++ b/extensions/geode-modules/src/main/java/org/apache/geode/modules/session/catalina/DeltaSession.java
@@ -567,7 +567,7 @@ public class DeltaSession extends StandardSession
   }
 
   private void readInAttributes(DataInput in) throws IOException, ClassNotFoundException {
-    ConcurrentHashMap map = (ConcurrentHashMap) DataSerializer.readObject(in);
+    ConcurrentHashMap map = DataSerializer.readObject(in);
     try {
       Field field = getAttributesFieldObject();
       field.set(this, map);

--- a/geode-core/src/distributedTest/java/org/apache/geode/distributed/internal/DateMessage.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/distributed/internal/DateMessage.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.distributed.internal;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -82,7 +84,7 @@ public class DateMessage extends SerialDistributionMessage {
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
 
     super.fromData(in);
-    this.date = (Date) DataSerializer.readObject(in);
+    this.date = readObject(in);
   }
 
   public String toString() {

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/functional/ResultsDataSerializabilityJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/functional/ResultsDataSerializabilityJUnitTest.java
@@ -20,6 +20,7 @@
 
 package org.apache.geode.cache.query.functional;
 
+import static org.apache.geode.DataSerializer.readObject;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -123,7 +124,7 @@ public class ResultsDataSerializabilityJUnitTest {
     out.close();
 
     DataInputStream in = new DataInputStream(new ByteArrayInputStream(baos.toByteArray()));
-    SelectResults res2 = (SelectResults) DataSerializer.readObject(in);
+    SelectResults res2 = readObject(in);
     in.close();
 
     assertEquals(res2.size(), res1.size());

--- a/geode-core/src/integrationTest/java/org/apache/geode/pdx/PdxSerializableJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/pdx/PdxSerializableJUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.pdx;
 
+import static org.apache.geode.DataSerializer.readObject;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -315,7 +316,7 @@ public class PdxSerializableJUnitTest {
     System.out.println("\n");
 
     DataInput in = new DataInputStream(new ByteArrayInputStream(actual));
-    SimpleClass actualVal = (SimpleClass) DataSerializer.readObject(in);
+    SimpleClass actualVal = readObject(in);
     // System.out.println("actualVal..."+actualVal);
     assertTrue(
         "Mismatch in write and read value: Value Write..." + object + " Value Read..." + actualVal,
@@ -426,7 +427,7 @@ public class PdxSerializableJUnitTest {
     System.out.println("\n");
 
     DataInput in = new DataInputStream(new ByteArrayInputStream(actual));
-    SimpleClass1 actualVal = (SimpleClass1) DataSerializer.readObject(in);
+    SimpleClass1 actualVal = readObject(in);
     // System.out.println("actualVal..."+actualVal);
     assertTrue(
         "Mismatch in write and read value: Value Write..." + pdx + " Value Read..." + actualVal,
@@ -435,7 +436,7 @@ public class PdxSerializableJUnitTest {
     cache.setReadSerializedForTest(true);
     try {
       in = new DataInputStream(new ByteArrayInputStream(actual));
-      PdxInstance pi = (PdxInstance) DataSerializer.readObject(in);
+      PdxInstance pi = readObject(in);
       actualVal = (SimpleClass1) pi.getObject();
       assertTrue(
           "Mismatch in write and read value: Value Write..." + pdx + " Value Read..." + actualVal,
@@ -653,7 +654,7 @@ public class PdxSerializableJUnitTest {
     System.out.println("\n");
 
     DataInput in = new DataInputStream(new ByteArrayInputStream(actual));
-    SimpleClass1 actualVal = (SimpleClass1) DataSerializer.readObject(in);
+    SimpleClass1 actualVal = readObject(in);
     // System.out.println("actualVal..."+actualVal);
     assertTrue(
         "Mismatch in write and read value: Value Write..." + pdx + " Value Read..." + actualVal,
@@ -661,7 +662,7 @@ public class PdxSerializableJUnitTest {
     cache.setReadSerializedForTest(true);
     try {
       in = new DataInputStream(new ByteArrayInputStream(actual));
-      PdxInstance pi = (PdxInstance) DataSerializer.readObject(in);
+      PdxInstance pi = readObject(in);
       actualVal = (SimpleClass1) pi.getObject();
       assertTrue(
           "Mismatch in write and read value: Value Write..." + pdx + " Value Read..." + actualVal,
@@ -849,7 +850,7 @@ public class PdxSerializableJUnitTest {
     }
     System.out.println("\n");
     DataInput in = new DataInputStream(new ByteArrayInputStream(actual));
-    NestedPdx actualVal = (NestedPdx) DataSerializer.readObject(in);
+    NestedPdx actualVal = readObject(in);
     // System.out.println("actualVal..."+actualVal);
     assertTrue(
         "Mismatch in write and read value: Value Write..." + pdx + " Value Read..." + actualVal,
@@ -956,7 +957,7 @@ public class PdxSerializableJUnitTest {
     System.out.println("\n");
 
     DataInput in = new DataInputStream(new ByteArrayInputStream(actual));
-    DSInsidePdx actualVal = (DSInsidePdx) DataSerializer.readObject(in);
+    DSInsidePdx actualVal = readObject(in);
     // System.out.println("actualVal..."+actualVal);
     assertTrue(
         "Mismatch in write and read value: Value Write..." + pdx + " Value Read..." + actualVal,
@@ -1029,7 +1030,7 @@ public class PdxSerializableJUnitTest {
     checkBytes(expected, actual);
 
     DataInput in = new DataInputStream(new ByteArrayInputStream(actual));
-    PdxInsideDS actualVal = (PdxInsideDS) DataSerializer.readObject(in);
+    PdxInsideDS actualVal = readObject(in);
     // System.out.println("actualVal..."+actualVal);
     assertTrue(
         "Mismatch in write and read value: Value Write..." + ds + " Value Read..." + actualVal,

--- a/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
+++ b/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
@@ -287,7 +287,7 @@ fromData,62
 toData,62
 
 org/apache/geode/distributed/internal/membership/gms/locator/FindCoordinatorRequest,2
-fromData,97
+fromData,94
 toData,114
 
 org/apache/geode/distributed/internal/membership/gms/locator/FindCoordinatorResponse,2
@@ -529,7 +529,7 @@ fromData,6
 toData,6
 
 org/apache/geode/internal/admin/remote/FetchDistLockInfoResponse,2
-fromData,20
+fromData,17
 toData,14
 
 org/apache/geode/internal/admin/remote/FetchHealthDiagnosisRequest,2
@@ -553,7 +553,7 @@ fromData,16
 toData,16
 
 org/apache/geode/internal/admin/remote/FetchResourceAttributesResponse,2
-fromData,20
+fromData,17
 toData,14
 
 org/apache/geode/internal/admin/remote/FetchStatsRequest,2
@@ -561,7 +561,7 @@ fromData,14
 toData,14
 
 org/apache/geode/internal/admin/remote/FetchStatsResponse,2
-fromData,20
+fromData,17
 toData,14
 
 org/apache/geode/internal/admin/remote/FetchSysCfgRequest,2
@@ -696,7 +696,7 @@ fromData,27
 toData,27
 
 org/apache/geode/internal/admin/remote/RemoteRegionAttributes,2
-fromData,404
+fromData,398
 toData,353
 
 org/apache/geode/internal/admin/remote/RemoteRegionSnapshot,2
@@ -776,7 +776,7 @@ fromData,6
 toData,6
 
 org/apache/geode/internal/admin/remote/SubRegionResponse,2
-fromData,34
+fromData,28
 toData,22
 
 org/apache/geode/internal/admin/remote/TailLogRequest,2
@@ -959,7 +959,7 @@ fromData,197
 toData,165
 
 org/apache/geode/internal/cache/DistributedRegionFunctionStreamingMessage,2
-fromData,171
+fromData,168
 toData,173
 
 org/apache/geode/internal/cache/DistributedRemoveAllOperation$RemoveAllEntryData,1
@@ -1076,7 +1076,7 @@ fromData,224
 toData,234
 
 org/apache/geode/internal/cache/InitialImageOperation$InitialImageVersionedEntryList,2
-fromData,406
+fromData,402
 toData,396
 
 org/apache/geode/internal/cache/InitialImageOperation$RVVReplyMessage,2

--- a/geode-core/src/main/java/org/apache/geode/DataSerializer.java
+++ b/geode-core/src/main/java/org/apache/geode/DataSerializer.java
@@ -94,7 +94,7 @@ import org.apache.geode.pdx.PdxInstance;
  *     this.id = in.readInt();
  *     this.name = in.readUTF();
  *     this.birthday = DataSerializer.readDate(in);
- *     this.employer = (Company) DataSerializer.readObject(in);
+ *     this.employer = DataSerializer.readObject(in);
  *   }
  * }
  *
@@ -158,7 +158,7 @@ public class CompanySerializer extends DataSerializer {
     throws IOException, ClassNotFoundException {
 
     String name = in.readUTF();
-    Address address = (Address) readObject(in);
+    Address address = readObject(in);
     return new Company(name, address);
   }
 }
@@ -194,7 +194,7 @@ public abstract class DataSerializer {
 
   /* Used to prevent standard Java serialization when sending data to a non-Java client */
   protected static final ThreadLocal<Boolean> DISALLOW_JAVA_SERIALIZATION =
-      new ThreadLocal<Boolean>();
+      new ThreadLocal<>();
 
   /**
    * Writes an instance of <code>Class</code> to a <code>DataOutput</code>. This method will handle
@@ -596,7 +596,7 @@ public abstract class DataSerializer {
       logger.trace(LogMarker.SERIALIZER_VERBOSE, "Writing Boolean {}", value);
     }
 
-    out.writeBoolean(value.booleanValue());
+    out.writeBoolean(value);
   }
 
   /**
@@ -607,7 +607,7 @@ public abstract class DataSerializer {
   public static Boolean readBoolean(DataInput in) throws IOException {
     InternalDataSerializer.checkIn(in);
 
-    Boolean value = Boolean.valueOf(in.readBoolean());
+    Boolean value = in.readBoolean();
     if (logger.isTraceEnabled(LogMarker.SERIALIZER_VERBOSE)) {
       logger.trace(LogMarker.SERIALIZER_VERBOSE, "Read Boolean {}", value);
     }
@@ -630,7 +630,7 @@ public abstract class DataSerializer {
       logger.trace(LogMarker.SERIALIZER_VERBOSE, "Writing Character {}", value);
     }
 
-    out.writeChar(value.charValue());
+    out.writeChar(value);
   }
 
   /**
@@ -642,7 +642,7 @@ public abstract class DataSerializer {
 
     InternalDataSerializer.checkIn(in);
 
-    Character value = Character.valueOf(in.readChar());
+    Character value = in.readChar();
     if (logger.isTraceEnabled(LogMarker.SERIALIZER_VERBOSE)) {
       logger.trace(LogMarker.SERIALIZER_VERBOSE, "Read Character {}", value);
     }
@@ -665,7 +665,7 @@ public abstract class DataSerializer {
       logger.trace(LogMarker.SERIALIZER_VERBOSE, "Writing Byte {}", value);
     }
 
-    out.writeByte(value.byteValue());
+    out.writeByte(value);
   }
 
   /**
@@ -676,7 +676,7 @@ public abstract class DataSerializer {
   public static Byte readByte(DataInput in) throws IOException {
     InternalDataSerializer.checkIn(in);
 
-    Byte value = Byte.valueOf(in.readByte());
+    Byte value = in.readByte();
     if (logger.isTraceEnabled(LogMarker.SERIALIZER_VERBOSE)) {
       logger.trace(LogMarker.SERIALIZER_VERBOSE, "Read Byte {}", value);
     }
@@ -699,7 +699,7 @@ public abstract class DataSerializer {
       logger.trace(LogMarker.SERIALIZER_VERBOSE, "Writing Short {}", value);
     }
 
-    out.writeShort(value.shortValue());
+    out.writeShort(value);
   }
 
   /**
@@ -710,7 +710,7 @@ public abstract class DataSerializer {
   public static Short readShort(DataInput in) throws IOException {
     InternalDataSerializer.checkIn(in);
 
-    Short value = Short.valueOf(in.readShort());
+    Short value = in.readShort();
     if (logger.isTraceEnabled(LogMarker.SERIALIZER_VERBOSE)) {
       logger.trace(LogMarker.SERIALIZER_VERBOSE, "Read Short {}", value);
     }
@@ -733,7 +733,7 @@ public abstract class DataSerializer {
       logger.trace(LogMarker.SERIALIZER_VERBOSE, "Writing Integer {}", value);
     }
 
-    out.writeInt(value.intValue());
+    out.writeInt(value);
   }
 
   /**
@@ -744,7 +744,7 @@ public abstract class DataSerializer {
   public static Integer readInteger(DataInput in) throws IOException {
     InternalDataSerializer.checkIn(in);
 
-    Integer value = Integer.valueOf(in.readInt());
+    Integer value = in.readInt();
     if (logger.isTraceEnabled(LogMarker.SERIALIZER_VERBOSE)) {
       logger.trace(LogMarker.SERIALIZER_VERBOSE, "Read Integer {}", value);
     }
@@ -767,7 +767,7 @@ public abstract class DataSerializer {
       logger.trace(LogMarker.SERIALIZER_VERBOSE, "Writing Long {}", value);
     }
 
-    out.writeLong(value.longValue());
+    out.writeLong(value);
   }
 
   /**
@@ -778,7 +778,7 @@ public abstract class DataSerializer {
   public static Long readLong(DataInput in) throws IOException {
     InternalDataSerializer.checkIn(in);
 
-    Long value = Long.valueOf(in.readLong());
+    Long value = in.readLong();
     if (logger.isTraceEnabled(LogMarker.SERIALIZER_VERBOSE)) {
       logger.trace(LogMarker.SERIALIZER_VERBOSE, "Read Long {}", value);
     }
@@ -801,7 +801,7 @@ public abstract class DataSerializer {
       logger.trace(LogMarker.SERIALIZER_VERBOSE, "Writing Float {}", value);
     }
 
-    out.writeFloat(value.floatValue());
+    out.writeFloat(value);
   }
 
   /**
@@ -812,7 +812,7 @@ public abstract class DataSerializer {
   public static Float readFloat(DataInput in) throws IOException {
     InternalDataSerializer.checkIn(in);
 
-    Float value = Float.valueOf(in.readFloat());
+    Float value = in.readFloat();
     if (logger.isTraceEnabled(LogMarker.SERIALIZER_VERBOSE)) {
       logger.trace(LogMarker.SERIALIZER_VERBOSE, "Read Float {}", value);
     }
@@ -835,7 +835,7 @@ public abstract class DataSerializer {
       logger.trace(LogMarker.SERIALIZER_VERBOSE, "Writing Double {}", value);
     }
 
-    out.writeDouble(value.doubleValue());
+    out.writeDouble(value);
   }
 
   /**
@@ -846,7 +846,7 @@ public abstract class DataSerializer {
   public static Double readDouble(DataInput in) throws IOException {
     InternalDataSerializer.checkIn(in);
 
-    Double value = Double.valueOf(in.readDouble());
+    Double value = in.readDouble();
     if (logger.isTraceEnabled(LogMarker.SERIALIZER_VERBOSE)) {
       logger.trace(LogMarker.SERIALIZER_VERBOSE, "Read Double {}", value);
     }
@@ -2005,9 +2005,9 @@ public abstract class DataSerializer {
     if (size == -1) {
       return null;
     } else {
-      ArrayList<E> list = new ArrayList<E>(size);
+      ArrayList<E> list = new ArrayList<>(size);
       for (int i = 0; i < size; i++) {
-        E element = DataSerializer.<E>readObject(in);
+        E element = readObject(in);
         list.add(element);
       }
 
@@ -2071,9 +2071,9 @@ public abstract class DataSerializer {
     if (size == -1) {
       return null;
     } else {
-      Vector<E> list = new Vector<E>(size);
+      Vector<E> list = new Vector<>(size);
       for (int i = 0; i < size; i++) {
-        E element = DataSerializer.<E>readObject(in);
+        E element = readObject(in);
         list.add(element);
       }
 
@@ -2136,9 +2136,9 @@ public abstract class DataSerializer {
     if (size == -1) {
       return null;
     } else {
-      Stack<E> list = new Stack<E>();
+      Stack<E> list = new Stack<>();
       for (int i = 0; i < size; i++) {
-        E element = DataSerializer.<E>readObject(in);
+        E element = readObject(in);
         list.add(element);
       }
 
@@ -2202,9 +2202,9 @@ public abstract class DataSerializer {
     if (size == -1) {
       return null;
     } else {
-      LinkedList<E> list = new LinkedList<E>();
+      LinkedList<E> list = new LinkedList<>();
       for (int i = 0; i < size; i++) {
-        E element = DataSerializer.<E>readObject(in);
+        E element = readObject(in);
         list.add(element);
       }
 
@@ -2251,9 +2251,9 @@ public abstract class DataSerializer {
     if (size == -1) {
       return null;
     } else {
-      HashSet<E> set = new HashSet<E>(size);
+      HashSet<E> set = new HashSet<>(size);
       for (int i = 0; i < size; i++) {
-        E element = DataSerializer.<E>readObject(in);
+        E element = readObject(in);
         set.add(element);
       }
 
@@ -2300,9 +2300,9 @@ public abstract class DataSerializer {
     if (size == -1) {
       return null;
     } else {
-      LinkedHashSet<E> set = new LinkedHashSet<E>(size);
+      LinkedHashSet<E> set = new LinkedHashSet<>(size);
       for (int i = 0; i < size; i++) {
-        E element = DataSerializer.<E>readObject(in);
+        E element = readObject(in);
         set.add(element);
       }
 
@@ -2367,10 +2367,10 @@ public abstract class DataSerializer {
     if (size == -1) {
       return null;
     } else {
-      HashMap<K, V> map = new HashMap<K, V>(size);
+      HashMap<K, V> map = new HashMap<>(size);
       for (int i = 0; i < size; i++) {
-        K key = DataSerializer.<K>readObject(in);
-        V value = DataSerializer.<V>readObject(in);
+        K key = readObject(in);
+        V value = readObject(in);
         map.put(key, value);
       }
 
@@ -2437,10 +2437,10 @@ public abstract class DataSerializer {
     if (size == -1) {
       return null;
     } else {
-      IdentityHashMap<K, V> map = new IdentityHashMap<K, V>(size);
+      IdentityHashMap<K, V> map = new IdentityHashMap<>(size);
       for (int i = 0; i < size; i++) {
-        K key = DataSerializer.<K>readObject(in);
-        V value = DataSerializer.<V>readObject(in);
+        K key = readObject(in);
+        V value = readObject(in);
         map.put(key, value);
       }
 
@@ -2482,7 +2482,7 @@ public abstract class DataSerializer {
       size = -1;
     } else {
       // take a snapshot to fix bug 44562
-      entrySnapshot = new ArrayList<Map.Entry<?, ?>>(map.entrySet());
+      entrySnapshot = new ArrayList<>(map.entrySet());
       size = entrySnapshot.size();
     }
     InternalDataSerializer.writeArrayLength(size, out);
@@ -2517,10 +2517,10 @@ public abstract class DataSerializer {
     if (size == -1) {
       return null;
     } else {
-      ConcurrentHashMap<K, V> map = new ConcurrentHashMap<K, V>(size);
+      ConcurrentHashMap<K, V> map = new ConcurrentHashMap<>(size);
       for (int i = 0; i < size; i++) {
-        K key = DataSerializer.<K>readObject(in);
-        V value = DataSerializer.<V>readObject(in);
+        K key = readObject(in);
+        V value = readObject(in);
         map.put(key, value);
       }
 
@@ -2587,10 +2587,10 @@ public abstract class DataSerializer {
     if (size == -1) {
       return null;
     } else {
-      Hashtable<K, V> map = new Hashtable<K, V>(size);
+      Hashtable<K, V> map = new Hashtable<>(size);
       for (int i = 0; i < size; i++) {
-        K key = DataSerializer.<K>readObject(in);
-        V value = DataSerializer.<V>readObject(in);
+        K key = readObject(in);
+        V value = readObject(in);
         map.put(key, value);
       }
 
@@ -2660,11 +2660,11 @@ public abstract class DataSerializer {
       return null;
     } else {
       Comparator<? super K> c =
-          InternalDataSerializer.<Comparator<? super K>>readNonPdxInstanceObject(in);
-      TreeMap<K, V> map = new TreeMap<K, V>(c);
+          InternalDataSerializer.readNonPdxInstanceObject(in);
+      TreeMap<K, V> map = new TreeMap<>(c);
       for (int i = 0; i < size; i++) {
-        K key = DataSerializer.<K>readObject(in);
-        V value = DataSerializer.<V>readObject(in);
+        K key = readObject(in);
+        V value = readObject(in);
         map.put(key, value);
       }
 
@@ -2730,8 +2730,8 @@ public abstract class DataSerializer {
     } else {
       LinkedHashMap<K, V> map = new LinkedHashMap<>(size);
       for (int i = 0; i < size; i++) {
-        K key = DataSerializer.<K>readObject(in);
-        V value = DataSerializer.<V>readObject(in);
+        K key = readObject(in);
+        V value = readObject(in);
         map.put(key, value);
       }
 
@@ -2800,10 +2800,10 @@ public abstract class DataSerializer {
       return null;
     } else {
       Comparator<? super E> c =
-          InternalDataSerializer.<Comparator<? super E>>readNonPdxInstanceObject(in);
-      TreeSet<E> set = new TreeSet<E>(c);
+          InternalDataSerializer.readNonPdxInstanceObject(in);
+      TreeSet<E> set = new TreeSet<>(c);
       for (int i = 0; i < size; i++) {
-        E element = DataSerializer.<E>readObject(in);
+        E element = readObject(in);
         set.add(element);
       }
 

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/CumulativeNonDistinctResults.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/CumulativeNonDistinctResults.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.cache.query.internal;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -278,7 +280,7 @@ public class CumulativeNonDistinctResults<E> implements SelectResults<E>, DataSe
 
   @Override
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
-    ObjectType elementType = (ObjectType) DataSerializer.readObject(in);
+    ObjectType elementType = readObject(in);
     this.collectionType = new CollectionTypeImpl(CumulativeNonDistinctResults.class, elementType);
     boolean isStruct = elementType.isStructType();
 

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/LinkedResultSet.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/LinkedResultSet.java
@@ -16,6 +16,8 @@ package org.apache.geode.cache.query.internal;
 
 
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -106,7 +108,7 @@ public class LinkedResultSet extends java.util.LinkedHashSet
 
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
     int size = in.readInt();
-    this.elementType = (ObjectType) DataSerializer.readObject(in);
+    this.elementType = readObject(in);
     for (int j = size; j > 0; j--) {
       this.add(DataSerializer.readObject(in));
     }

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/LinkedStructSet.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/LinkedStructSet.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.cache.query.internal;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -172,7 +174,7 @@ public class LinkedStructSet extends LinkedHashSet<Struct>
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
     this.modifiable = in.readBoolean();
     int size = in.readInt();
-    this.structType = (StructTypeImpl) DataSerializer.readObject(in);
+    this.structType = readObject(in);
     for (int j = size; j > 0; j--) {
       Object[] fieldValues = DataSerializer.readObject(in);
       this.add(new StructImpl(this.structType, fieldValues));

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/NWayMergeResults.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/NWayMergeResults.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.cache.query.internal;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -437,7 +439,7 @@ public class NWayMergeResults<E> implements SelectResults<E>, Ordered, DataSeria
 
   @Override
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
-    ObjectType elementType = (ObjectType) DataSerializer.readObject(in);
+    ObjectType elementType = readObject(in);
     this.collectionType = new CollectionTypeImpl(NWayMergeResults.class, elementType);
     boolean isStruct = elementType.isStructType();
     this.isDistinct = DataSerializer.readPrimitiveBoolean(in);

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/ResultsBag.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/ResultsBag.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.cache.query.internal;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -135,7 +137,7 @@ public class ResultsBag extends Bag implements DataSerializableFixedID {
   }
 
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
-    this.elementType = (ObjectType) DataSerializer.readObject(in);
+    this.elementType = readObject(in);
     this.size = in.readInt();
     assert this.size >= 0 : this.size;
     this.map = createMapForFromData();

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/ResultsCollectionWrapper.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/ResultsCollectionWrapper.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.cache.query.internal;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -543,9 +545,9 @@ public class ResultsCollectionWrapper implements SelectResults, DataSerializable
     if (isBagSetView) {
       this.base = (Set) InternalDataSerializer.readSet(in);
     } else {
-      this.base = (Collection) DataSerializer.readObject(in);
+      this.base = readObject(in);
     }
-    this.collectionType = (CollectionType) DataSerializer.readObject(in);
+    this.collectionType = readObject(in);
     this.modifiable = in.readBoolean();
   }
 

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/SortedResultSet.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/SortedResultSet.java
@@ -15,6 +15,8 @@
 
 package org.apache.geode.cache.query.internal;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -119,7 +121,7 @@ public class SortedResultSet extends TreeSet
 
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
     int size = in.readInt();
-    this.elementType = (ObjectType) DataSerializer.readObject(in);
+    this.elementType = readObject(in);
     for (int j = size; j > 0; j--) {
       this.add(DataSerializer.readObject(in));
     }

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/SortedStructSet.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/SortedStructSet.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.cache.query.internal;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -356,7 +358,7 @@ public class SortedStructSet extends TreeSet
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
     this.modifiable = in.readBoolean();
     int size = in.readInt();
-    this.structType = (StructTypeImpl) DataSerializer.readObject(in);
+    this.structType = readObject(in);
     for (int j = size; j > 0; j--) {
       Object[] fieldValues = DataSerializer.readObject(in);
       this.addFieldValues(fieldValues);

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/StructImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/StructImpl.java
@@ -15,6 +15,8 @@
 
 package org.apache.geode.cache.query.internal;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -163,7 +165,7 @@ public class StructImpl implements Struct, DataSerializableFixedID, Serializable
   }
 
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
-    this.type = (StructTypeImpl) DataSerializer.readObject(in);
+    this.type = readObject(in);
     this.values = DataSerializer.readObjectArray(in);
     if (this.values != null) {
       for (Object o : values) {

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/StructSet.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/StructSet.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.cache.query.internal;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -438,7 +440,7 @@ public class StructSet /* extends ObjectOpenCustomHashSet */ implements Set, Sel
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
     this.contents = new ObjectOpenCustomHashSet(new ObjectArrayHashingStrategy());
     int size = in.readInt();
-    this.structType = (StructTypeImpl) DataSerializer.readObject(in);
+    this.structType = readObject(in);
     for (int j = size; j > 0; j--) {
       this.add(DataSerializer.readObject(in));
     }

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/types/CollectionTypeImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/types/CollectionTypeImpl.java
@@ -15,6 +15,8 @@
 
 package org.apache.geode.cache.query.internal.types;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -120,7 +122,7 @@ public class CollectionTypeImpl extends ObjectTypeImpl implements CollectionType
   @Override
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
     super.fromData(in);
-    this.elementType = (ObjectType) DataSerializer.readObject(in);
+    this.elementType = readObject(in);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/types/MapTypeImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/types/MapTypeImpl.java
@@ -15,6 +15,8 @@
 
 package org.apache.geode.cache.query.internal.types;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -90,7 +92,7 @@ public class MapTypeImpl extends CollectionTypeImpl implements MapType {
   @Override
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
     super.fromData(in);
-    this.keyType = (ObjectType) DataSerializer.readObject(in);
+    this.keyType = readObject(in);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/HighPriorityAckedMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/HighPriorityAckedMessage.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.distributed.internal;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -217,7 +219,7 @@ public class HighPriorityAckedMessage extends HighPriorityDistributionMessage
     processorId = in.readInt();
     this.op = operationType.values()[in.readInt()];
     this.useNative = in.readBoolean();
-    this.id = (InternalDistributedMember) DataSerializer.readObject(in);
+    this.id = readObject(in);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/SerialAckedMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/SerialAckedMessage.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.distributed.internal;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -143,7 +145,7 @@ public class SerialAckedMessage extends SerialDistributionMessage implements Mes
 
     super.fromData(in);
     processorId = in.readInt();
-    this.id = (InternalDistributedMember) DataSerializer.readObject(in);
+    this.id = readObject(in);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/ShutdownMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/ShutdownMessage.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.distributed.internal;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -108,7 +110,7 @@ public class ShutdownMessage extends HighPriorityDistributionMessage
 
     super.fromData(in);
     processorId = in.readInt();
-    this.id = (InternalDistributedMember) DataSerializer.readObject(in);
+    this.id = readObject(in);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/StartupResponseMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/StartupResponseMessage.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.distributed.internal;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -259,7 +261,7 @@ public class StartupResponseMessage extends HighPriorityDistributionMessage
       instantiatorIds[i] = in.readInt();
     } // for
 
-    interfaces = (Set) DataSerializer.readObject(in);
+    interfaces = readObject(in);
     distributedSystemId = in.readInt();
     redundancyZone = DataSerializer.readString(in);
   }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/locks/DLockQueryProcessor.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/locks/DLockQueryProcessor.java
@@ -15,6 +15,8 @@
 
 package org.apache.geode.distributed.internal.locks;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -437,7 +439,7 @@ public class DLockQueryProcessor extends ReplyProcessor21 {
       this.replyCode = in.readInt();
       if (this.replyCode == OK) {
         InternalDistributedMember lessee =
-            (InternalDistributedMember) DataSerializer.readObject(in);
+            readObject(in);
         if (lessee != null) {
           this.lesseeThread = new RemoteThread(lessee, in.readInt());
         }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/locks/DLockRecoverGrantorProcessor.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/locks/DLockRecoverGrantorProcessor.java
@@ -15,6 +15,8 @@
 
 package org.apache.geode.distributed.internal.locks;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -279,7 +281,7 @@ public class DLockRecoverGrantorProcessor extends ReplyProcessor21 {
       this.processorId = in.readInt();
       this.grantorSerialNumber = in.readInt();
       this.grantorVersion = in.readLong();
-      this.elder = (InternalDistributedMember) DataSerializer.readObject(in);
+      this.elder = readObject(in);
     }
 
     @Override

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/locks/DLockRemoteToken.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/locks/DLockRemoteToken.java
@@ -15,6 +15,8 @@
 
 package org.apache.geode.distributed.internal.locks;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -81,7 +83,7 @@ public class DLockRemoteToken implements DataSerializableFixedID {
       throws IOException, ClassNotFoundException {
     Object name = DataSerializer.readObject(in);
     RemoteThread lesseeThread = null;
-    InternalDistributedMember lessee = (InternalDistributedMember) DataSerializer.readObject(in);
+    InternalDistributedMember lessee = readObject(in);
     lesseeThread = new RemoteThread(lessee, in.readInt());
     int leaseId = in.readInt();
     long leaseExpireTime = in.readLong();

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/locks/DeposeGrantorProcessor.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/locks/DeposeGrantorProcessor.java
@@ -15,6 +15,8 @@
 
 package org.apache.geode.distributed.internal.locks;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -155,7 +157,7 @@ public class DeposeGrantorProcessor extends ReplyProcessor21 {
       super.fromData(in);
       this.processorId = in.readInt();
       this.serviceName = DataSerializer.readString(in);
-      this.newGrantor = (InternalDistributedMember) DataSerializer.readObject(in);
+      this.newGrantor = readObject(in);
       this.newGrantorVersion = in.readLong();
       this.newGrantorSerialNumber = in.readInt();
     }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/locks/GrantorRequestProcessor.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/locks/GrantorRequestProcessor.java
@@ -15,6 +15,8 @@
 
 package org.apache.geode.distributed.internal.locks;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -529,7 +531,7 @@ public class GrantorRequestProcessor extends ReplyProcessor21 {
       this.processorId = in.readInt();
       this.opCode = in.readByte();
       if (this.opCode == BECOME_OP) {
-        this.oldTurk = (InternalDistributedMember) DataSerializer.readObject(in);
+        this.oldTurk = readObject(in);
       }
     }
 
@@ -614,7 +616,7 @@ public class GrantorRequestProcessor extends ReplyProcessor21 {
     @Override
     public void fromData(DataInput in) throws IOException, ClassNotFoundException {
       super.fromData(in);
-      this.grantor = (InternalDistributedMember) DataSerializer.readObject(in);
+      this.grantor = readObject(in);
       this.elderVersionId = in.readLong();
       this.grantorSerialNumber = in.readInt();
       this.needsRecovery = in.readBoolean();

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/locator/FindCoordinatorRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/locator/FindCoordinatorRequest.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.distributed.internal.membership.gms.locator;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -124,7 +126,7 @@ public class FindCoordinatorRequest extends HighPriorityDistributionMessage
     int size = in.readInt();
     this.rejectedCoordinators = new ArrayList<InternalDistributedMember>(size);
     for (int i = 0; i < size; i++) {
-      this.rejectedCoordinators.add((InternalDistributedMember) DataSerializer.readObject(in));
+      this.rejectedCoordinators.add(readObject(in));
     }
     this.lastViewId = in.readInt();
     this.requestId = in.readInt();

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messages/FinalCheckPassedMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messages/FinalCheckPassedMessage.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.distributed.internal.membership.gms.messages;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -64,7 +66,7 @@ public class FinalCheckPassedMessage extends HighPriorityDistributionMessage {
 
   @Override
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
-    suspect = (InternalDistributedMember) DataSerializer.readObject(in);
+    suspect = readObject(in);
   }
 
   public InternalDistributedMember getSuspect() {

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messages/SuspectMembersMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messages/SuspectMembersMessage.java
@@ -14,6 +14,9 @@
  */
 package org.apache.geode.distributed.internal.membership.gms.messages;
 
+import static org.apache.geode.DataSerializer.readObject;
+import static org.apache.geode.DataSerializer.readString;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -82,7 +85,7 @@ public class SuspectMembersMessage extends HighPriorityDistributionMessage {
     int size = in.readInt();
     for (int i = 0; i < size; i++) {
       SuspectRequest sr = new SuspectRequest(
-          (InternalDistributedMember) DataSerializer.readObject(in), DataSerializer.readString(in));
+          readObject(in), readString(in));
       suspectRequests.add(sr);
     }
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/InternalInstantiator.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/InternalInstantiator.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -931,7 +933,7 @@ public class InternalInstantiator {
       }
 
       this.id = in.readInt();
-      this.eventId = (EventID) DataSerializer.readObject(in);
+      this.eventId = readObject(in);
     }
 
     @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/AddHealthListenerRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/AddHealthListenerRequest.java
@@ -16,6 +16,8 @@
 
 package org.apache.geode.internal.admin.remote;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -75,7 +77,7 @@ public class AddHealthListenerRequest extends AdminRequest {
   @Override
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
     super.fromData(in);
-    this.cfg = (GemFireHealthConfig) DataSerializer.readObject(in);
+    this.cfg = readObject(in);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/BridgeServerRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/BridgeServerRequest.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.admin.remote;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -182,7 +184,7 @@ public class BridgeServerRequest extends AdminRequest {
     super.fromData(in);
     this.cacheId = in.readInt();
     this.operation = in.readInt();
-    this.bridgeInfo = (RemoteBridgeServer) DataSerializer.readObject(in);
+    this.bridgeInfo = readObject(in);
     this.bridgeId = in.readInt();
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/CacheInfoResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/CacheInfoResponse.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.admin.remote;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -68,7 +70,7 @@ public class CacheInfoResponse extends AdminResponse {
   @Override
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
     super.fromData(in);
-    this.info = (RemoteCacheInfo) DataSerializer.readObject(in);
+    this.info = readObject(in);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/DestroyEntryMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/DestroyEntryMessage.java
@@ -15,6 +15,8 @@
 
 package org.apache.geode.internal.admin.remote;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -80,7 +82,7 @@ public class DestroyEntryMessage extends RegionAdminMessage {
   @Override
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
     super.fromData(in);
-    this.action = (ExpirationAction) DataSerializer.readObject(in);
+    this.action = readObject(in);
     this.key = DataSerializer.readObject(in);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/DestroyRegionMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/DestroyRegionMessage.java
@@ -15,6 +15,8 @@
 
 package org.apache.geode.internal.admin.remote;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -77,7 +79,7 @@ public class DestroyRegionMessage extends RegionAdminMessage {
   @Override
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
     super.fromData(in);
-    this.action = (ExpirationAction) DataSerializer.readObject(in);
+    this.action = readObject(in);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/FetchDistLockInfoResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/FetchDistLockInfoResponse.java
@@ -16,6 +16,8 @@
 
 package org.apache.geode.internal.admin.remote;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -83,7 +85,7 @@ public class FetchDistLockInfoResponse extends AdminResponse {
   @Override
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
     super.fromData(in);
-    this.lockInfos = (DLockInfo[]) DataSerializer.readObject(in);
+    this.lockInfos = readObject(in);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/FetchHealthDiagnosisRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/FetchHealthDiagnosisRequest.java
@@ -16,6 +16,9 @@
 
 package org.apache.geode.internal.admin.remote;
 
+import static org.apache.geode.DataSerializer.readObject;
+import static org.apache.geode.admin.GemFireHealth.Health;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -71,7 +74,7 @@ public class FetchHealthDiagnosisRequest extends AdminRequest {
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
     super.fromData(in);
     int i = in.readInt();
-    GemFireHealth.Health oHC = (GemFireHealth.Health) DataSerializer.readObject(in);
+    Health oHC = readObject(in);
     init_(i, oHC);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/FetchHostResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/FetchHostResponse.java
@@ -16,6 +16,8 @@
 
 package org.apache.geode.internal.admin.remote;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.File;
@@ -157,9 +159,9 @@ public class FetchHostResponse extends AdminResponse {
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
     super.fromData(in);
     this.name = DataSerializer.readString(in);
-    this.host = (InetAddress) DataSerializer.readObject(in);
-    this.geodeHomeDir = (File) DataSerializer.readObject(in);
-    this.workingDir = (File) DataSerializer.readObject(in);
+    this.host = readObject(in);
+    this.geodeHomeDir = readObject(in);
+    this.workingDir = readObject(in);
     this.birthDate = in.readLong();
     this.isDedicatedCacheServer = in.readBoolean();
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/FetchResourceAttributesResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/FetchResourceAttributesResponse.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.admin.remote;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -75,7 +77,7 @@ public class FetchResourceAttributesResponse extends AdminResponse {
   @Override
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
     super.fromData(in);
-    stats = (RemoteStat[]) DataSerializer.readObject(in);
+    stats = readObject(in);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/FetchStatsResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/FetchStatsResponse.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.admin.remote;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -85,7 +87,7 @@ public class FetchStatsResponse extends AdminResponse {
   @Override
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
     super.fromData(in);
-    stats = (RemoteStatResource[]) DataSerializer.readObject(in);
+    stats = readObject(in);
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/FetchSysCfgResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/FetchSysCfgResponse.java
@@ -16,6 +16,8 @@
 
 package org.apache.geode.internal.admin.remote;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -66,7 +68,7 @@ public class FetchSysCfgResponse extends AdminResponse {
   @Override
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
     super.fromData(in);
-    this.sc = (Config) DataSerializer.readObject(in);
+    this.sc = readObject(in);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/HealthListenerMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/HealthListenerMessage.java
@@ -16,6 +16,8 @@
 
 package org.apache.geode.internal.admin.remote;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -75,7 +77,7 @@ public class HealthListenerMessage extends PooledDistributionMessage implements 
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
     super.fromData(in);
     this.listenerId = in.readInt();
-    this.status = (GemFireHealth.Health) DataSerializer.readObject(in);
+    this.status = readObject(in);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/LicenseInfoResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/LicenseInfoResponse.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.admin.remote;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -63,7 +65,7 @@ public class LicenseInfoResponse extends AdminResponse {
   @Override
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
     super.fromData(in);
-    this.p = (Properties) DataSerializer.readObject(in);
+    this.p = readObject(in);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/ObjectDetailsResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/ObjectDetailsResponse.java
@@ -16,6 +16,8 @@
 
 package org.apache.geode.internal.admin.remote;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -115,7 +117,7 @@ public class ObjectDetailsResponse extends AdminResponse implements Cancellable 
     super.fromData(in);
     this.objectValue = DataSerializer.readObject(in);
     this.userAttribute = DataSerializer.readObject(in);
-    this.stats = (RemoteCacheStatistics) DataSerializer.readObject(in);
+    this.stats = readObject(in);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/ObjectNamesResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/ObjectNamesResponse.java
@@ -16,6 +16,8 @@
 
 package org.apache.geode.internal.admin.remote;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -92,7 +94,7 @@ public class ObjectNamesResponse extends AdminResponse implements Cancellable {
   @Override
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
     super.fromData(in);
-    this.objectNames = (HashSet) DataSerializer.readObject(in);
+    this.objectNames = readObject(in);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RegionAttributesResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RegionAttributesResponse.java
@@ -16,6 +16,8 @@
 
 package org.apache.geode.internal.admin.remote;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -63,7 +65,7 @@ public class RegionAttributesResponse extends AdminResponse {
   @Override
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
     super.fromData(in);
-    this.attributes = (RemoteRegionAttributes) DataSerializer.readObject(in);
+    this.attributes = readObject(in);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RegionRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RegionRequest.java
@@ -16,6 +16,8 @@
 
 package org.apache.geode.internal.admin.remote;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -141,7 +143,7 @@ public class RegionRequest extends AdminRequest {
     this.cacheId = in.readInt();
     this.path = DataSerializer.readString(in);
     this.newRegionName = DataSerializer.readString(in);
-    this.newRegionAttributes = (RegionAttributes) DataSerializer.readObject(in);
+    this.newRegionAttributes = readObject(in);
     RegionRequest.setFriendlyName(this);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RegionResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RegionResponse.java
@@ -16,6 +16,8 @@
 
 package org.apache.geode.internal.admin.remote;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -138,7 +140,7 @@ public class RegionResponse extends AdminResponse {
     super.fromData(in);
     this.name = DataSerializer.readString(in);
     this.userAttribute = DataSerializer.readString(in);
-    this.exception = (Exception) DataSerializer.readObject(in);
+    this.exception = readObject(in);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RegionStatisticsResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RegionStatisticsResponse.java
@@ -16,6 +16,8 @@
 
 package org.apache.geode.internal.admin.remote;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -63,7 +65,7 @@ public class RegionStatisticsResponse extends AdminResponse {
   @Override
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
     super.fromData(in);
-    this.regionStatistics = (RemoteCacheStatistics) DataSerializer.readObject(in);
+    this.regionStatistics = readObject(in);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RemoteBridgeServer.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RemoteBridgeServer.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.admin.remote;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -205,7 +207,7 @@ public class RemoteBridgeServer extends AbstractCacheServer
     setBindAddress(DataSerializer.readString(in));
     setGroups(DataSerializer.readStringArray(in));
     setHostnameForClients(DataSerializer.readString(in));
-    setLoadProbe((ServerLoadProbe) DataSerializer.readObject(in));
+    setLoadProbe(readObject(in));
     setLoadPollInterval(DataSerializer.readPrimitiveLong(in));
     this.socketBufferSize = in.readInt();
     this.tcpNoDelay = in.readBoolean();

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RemoteCacheInfo.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RemoteCacheInfo.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.admin.remote;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -136,7 +138,7 @@ public class RemoteCacheInfo implements CacheInfo, DataSerializable {
     this.searchTimeout = in.readInt();
     this.upTime = in.readInt();
     this.rootRegionNames = DataSerializer.readStringArray(in);
-    this.perfStats = (RemoteStatResource) DataSerializer.readObject(in);
+    this.perfStats = readObject(in);
     this.bridgeServerIds = DataSerializer.readIntArray(in);
     this.isServer = in.readBoolean();
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RemoteDLockInfo.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RemoteDLockInfo.java
@@ -16,6 +16,8 @@
 
 package org.apache.geode.internal.admin.remote;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -112,7 +114,7 @@ public class RemoteDLockInfo implements DLockInfo, DataSerializable {
     this.lockName = DataSerializer.readString(in);
     this.acquired = in.readBoolean();
     this.recursion = in.readInt();
-    this.owner = (InternalDistributedMember) DataSerializer.readObject(in);
+    this.owner = readObject(in);
     this.startTime = in.readLong();
     this.leaseExpiration = in.readLong();
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RemoteEntrySnapshot.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RemoteEntrySnapshot.java
@@ -15,6 +15,8 @@
 
 package org.apache.geode.internal.admin.remote;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -127,7 +129,7 @@ public class RemoteEntrySnapshot implements EntrySnapshot, DataSerializable {
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
     this.name = DataSerializer.readObject(in);
     this.value = DataSerializer.readObject(in);
-    this.stats = (RemoteCacheStatistics) DataSerializer.readObject(in);
+    this.stats = readObject(in);
     this.userAttribute = DataSerializer.readObject(in);
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RemoteRegionAttributes.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RemoteRegionAttributes.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.admin.remote;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.File;
@@ -414,16 +416,16 @@ public class RemoteRegionAttributes implements RegionAttributes, DataSerializabl
     this.cacheWriterDesc = DataSerializer.readString(in);
     this.cacheListenerDescs = DataSerializer.readStringArray(in);
     this.capacityControllerDesc = DataSerializer.readString(in);
-    this.keyConstraint = (Class) DataSerializer.readObject(in);
-    this.valueConstraint = (Class) DataSerializer.readObject(in);
-    this.rTtl = (ExpirationAttributes) DataSerializer.readObject(in);
-    this.rIdleTimeout = (ExpirationAttributes) DataSerializer.readObject(in);
-    this.eTtl = (ExpirationAttributes) DataSerializer.readObject(in);
+    this.keyConstraint = readObject(in);
+    this.valueConstraint = readObject(in);
+    this.rTtl = readObject(in);
+    this.rIdleTimeout = readObject(in);
+    this.eTtl = readObject(in);
     this.customEttlDesc = DataSerializer.readString(in);
-    this.eIdleTimeout = (ExpirationAttributes) DataSerializer.readObject(in);
+    this.eIdleTimeout = readObject(in);
     this.customEIdleDesc = DataSerializer.readString(in);
-    this.dataPolicy = (DataPolicy) DataSerializer.readObject(in);
-    this.scope = (Scope) DataSerializer.readObject(in);
+    this.dataPolicy = readObject(in);
+    this.scope = readObject(in);
     this.statsEnabled = in.readBoolean();
     this.ignoreJTA = in.readBoolean();
     this.concurrencyLevel = in.readInt();
@@ -435,14 +437,14 @@ public class RemoteRegionAttributes implements RegionAttributes, DataSerializabl
     this.publisher = in.readBoolean();
     this.enableAsyncConflation = in.readBoolean();
 
-    this.diskWriteAttributes = (DiskWriteAttributes) DataSerializer.readObject(in);
-    this.diskDirs = (File[]) DataSerializer.readObject(in);
-    this.diskSizes = (int[]) DataSerializer.readObject(in);
+    this.diskWriteAttributes = readObject(in);
+    this.diskDirs = readObject(in);
+    this.diskSizes = readObject(in);
     this.indexMaintenanceSynchronous = in.readBoolean();
-    this.partitionAttributes = (PartitionAttributes) DataSerializer.readObject(in);
-    this.membershipAttributes = (MembershipAttributes) DataSerializer.readObject(in);
-    this.subscriptionAttributes = (SubscriptionAttributes) DataSerializer.readObject(in);
-    this.evictionAttributes = (EvictionAttributesImpl) DataSerializer.readObject(in);
+    this.partitionAttributes = readObject(in);
+    this.membershipAttributes = readObject(in);
+    this.subscriptionAttributes = readObject(in);
+    this.evictionAttributes = readObject(in);
     this.cloningEnable = in.readBoolean();
     this.diskStoreName = DataSerializer.readString(in);
     this.isDiskSynchronous = in.readBoolean();

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RemoteRegionSnapshot.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RemoteRegionSnapshot.java
@@ -15,6 +15,8 @@
 
 package org.apache.geode.internal.admin.remote;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -151,8 +153,8 @@ public class RemoteRegionSnapshot implements RegionSnapshot, DataSerializable {
 
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
     this.name = DataSerializer.readString(in);
-    this.stats = (RemoteCacheStatistics) DataSerializer.readObject(in);
-    this.attributes = (RemoteRegionAttributes) DataSerializer.readObject(in);
+    this.stats = readObject(in);
+    this.attributes = readObject(in);
     this.entryCount = in.readInt();
     this.subregionCount = in.readInt();
     this.userAttribute = DataSerializer.readObject(in);

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RemoteStat.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RemoteStat.java
@@ -15,6 +15,8 @@
 
 package org.apache.geode.internal.admin.remote;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -113,7 +115,7 @@ public class RemoteStat implements Stat, DataSerializable {
     this.id = in.readInt();
     this.units = DataSerializer.readString(in);
     this.desc = DataSerializer.readString(in);
-    this.value = (Number) DataSerializer.readObject(in);
+    this.value = readObject(in);
     this.isCounter = in.readBoolean();
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/SnapshotResultMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/SnapshotResultMessage.java
@@ -16,6 +16,8 @@
 
 package org.apache.geode.internal.admin.remote;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -76,7 +78,7 @@ public class SnapshotResultMessage extends PooledDistributionMessage implements 
   @Override
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
     super.fromData(in);
-    this.results = (CacheSnapshot) DataSerializer.readObject(in);
+    this.results = readObject(in);
     this.snapshotId = in.readInt();
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/StoreSysCfgRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/StoreSysCfgRequest.java
@@ -16,6 +16,8 @@
 
 package org.apache.geode.internal.admin.remote;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -68,7 +70,7 @@ public class StoreSysCfgRequest extends AdminRequest {
   @Override
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
     super.fromData(in);
-    this.sc = (Config) DataSerializer.readObject(in);
+    this.sc = readObject(in);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/SubRegionResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/SubRegionResponse.java
@@ -16,6 +16,8 @@
 
 package org.apache.geode.internal.admin.remote;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -91,8 +93,8 @@ public class SubRegionResponse extends AdminResponse {
   @Override
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
     super.fromData(in);
-    this.subRegionNames = (String[]) DataSerializer.readObject(in);
-    this.userAttributes = (String[]) DataSerializer.readObject(in);
+    this.subRegionNames = readObject(in);
+    this.userAttributes = readObject(in);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/statalerts/BaseDecoratorImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/statalerts/BaseDecoratorImpl.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.admin.statalerts;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -201,6 +203,6 @@ public abstract class BaseDecoratorImpl implements StatAlertDefinition {
   }
 
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
-    this._def = (StatAlertDefinition) DataSerializer.readObject(in);
+    this._def = readObject(in);
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/statalerts/GaugeThresholdDecoratorImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/statalerts/GaugeThresholdDecoratorImpl.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.admin.statalerts;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -131,8 +133,8 @@ public class GaugeThresholdDecoratorImpl extends BaseDecoratorImpl
   @Override
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
     super.fromData(in);
-    this.lowerLimit = (Number) DataSerializer.readObject(in);
-    this.upperLimit = (Number) DataSerializer.readObject(in);
+    this.lowerLimit = readObject(in);
+    this.upperLimit = readObject(in);
   }
 
   public static final String ID = "GaugeThreshold";

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/statalerts/NumberThresholdDecoratorImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/statalerts/NumberThresholdDecoratorImpl.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.admin.statalerts;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -131,7 +133,7 @@ public class NumberThresholdDecoratorImpl extends BaseDecoratorImpl
   @Override
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
     super.fromData(in);
-    this.threshold = (Number) DataSerializer.readObject(in);
+    this.threshold = readObject(in);
     this.evalForGtThan = DataSerializer.readPrimitiveBoolean(in);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/statalerts/SingleAttrDefinitionImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/statalerts/SingleAttrDefinitionImpl.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.admin.statalerts;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -211,6 +213,6 @@ public class SingleAttrDefinitionImpl implements StatAlertDefinition {
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
     this.name = DataSerializer.readString(in);
     this._id = DataSerializer.readPrimitiveInt(in);
-    this.statisticInfo = (StatisticInfo) DataSerializer.readObject(in);
+    this.statisticInfo = readObject(in);
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/CreateRegionProcessor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/CreateRegionProcessor.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -741,7 +743,7 @@ public class CreateRegionProcessor implements ProfileExchangeProcessor {
     public void fromData(DataInput in) throws IOException, ClassNotFoundException {
       super.fromData(in);
       this.regionPath = DataSerializer.readString(in);
-      this.profile = (CacheProfile) DataSerializer.readObject(in);
+      this.profile = readObject(in);
       this.processorId = in.readInt();
       this.concurrencyChecksEnabled = in.readBoolean();
     }
@@ -801,7 +803,7 @@ public class CreateRegionProcessor implements ProfileExchangeProcessor {
     public void fromData(DataInput in) throws IOException, ClassNotFoundException {
       super.fromData(in);
       if (in.readBoolean()) {
-        this.profile = (CacheProfile) DataSerializer.readObject(in);
+        this.profile = readObject(in);
       }
       int size = in.readInt();
       if (size == 0) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DestroyOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DestroyOperation.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -155,7 +157,7 @@ public class DestroyOperation extends DistributedCacheOperation {
     @Override
     public void fromData(DataInput in) throws IOException, ClassNotFoundException {
       super.fromData(in);
-      this.eventId = (EventID) DataSerializer.readObject(in);
+      this.eventId = readObject(in);
       this.key = DataSerializer.readObject(in);
       Boolean hasTailKey = DataSerializer.readBoolean(in);
       if (hasTailKey.booleanValue()) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DestroyRegionOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DestroyRegionOperation.java
@@ -15,6 +15,8 @@
 
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -435,7 +437,7 @@ public class DestroyRegionOperation extends DistributedCacheOperation {
     @Override
     public void fromData(DataInput in) throws IOException, ClassNotFoundException {
       super.fromData(in);
-      this.eventID = (EventID) DataSerializer.readObject(in);
+      this.eventID = readObject(in);
       this.serialNum = DataSerializer.readPrimitiveInt(in);
       this.notifyOfRegionDeparture = DataSerializer.readPrimitiveBoolean(in);
       this.subregionSerialNumbers = DataSerializer.readHashMap(in);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistTXCommitMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistTXCommitMessage.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -249,7 +251,7 @@ public class DistTXCommitMessage extends TXMessage {
     @Override
     public void fromData(DataInput in) throws IOException, ClassNotFoundException {
       super.fromData(in);
-      this.commitMessage = (TXCommitMessage) DataSerializer.readObject(in);
+      this.commitMessage = readObject(in);
     }
 
     @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistTXPrecommitMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistTXPrecommitMessage.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -253,7 +255,7 @@ public class DistTXPrecommitMessage extends TXMessage {
     @Override
     public void fromData(DataInput in) throws IOException, ClassNotFoundException {
       super.fromData(in);
-      this.commitResponse = (DistTxPrecommitResponse) DataSerializer.readObject(in);
+      this.commitResponse = readObject(in);
     }
 
     @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedClearOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedClearOperation.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -229,9 +231,9 @@ public class DistributedClearOperation extends DistributedCacheOperation {
     public void fromData(DataInput in) throws IOException, ClassNotFoundException {
       super.fromData(in);
       this.clearOp = OperationType.values()[in.readByte()];
-      this.eventID = (EventID) DataSerializer.readObject(in);
-      this.rvv = (RegionVersionVector) DataSerializer.readObject(in);
-      this.operationTag = (VersionTag<?>) DataSerializer.readObject(in);
+      this.eventID = readObject(in);
+      this.rvv = readObject(in);
+      this.operationTag = readObject(in);
     }
 
     @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedPutAllOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedPutAllOperation.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.Externalizable;
@@ -346,7 +348,7 @@ public class DistributedPutAllOperation extends AbstractUpdateOperation {
       this.op = Operation.fromOrdinal(in.readByte());
       this.flags = in.readByte();
       if ((this.flags & FILTER_ROUTING) != 0) {
-        this.filterRouting = (FilterRoutingInfo) DataSerializer.readObject(in);
+        this.filterRouting = readObject(in);
       }
       if ((this.flags & VERSION_TAG) != 0) {
         boolean persistentTag = (this.flags & PERSISTENT_TAG) != 0;
@@ -1194,7 +1196,7 @@ public class DistributedPutAllOperation extends AbstractUpdateOperation {
     public void fromData(DataInput in) throws IOException, ClassNotFoundException {
 
       super.fromData(in);
-      this.eventId = (EventID) DataSerializer.readObject(in);
+      this.eventId = readObject(in);
       this.putAllDataSize = (int) InternalDataSerializer.readUnsignedVL(in);
       this.putAllData = new PutAllEntryData[this.putAllDataSize];
       if (this.putAllDataSize > 0) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegionFunctionStreamingMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegionFunctionStreamingMessage.java
@@ -14,10 +14,11 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
-import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -331,7 +332,7 @@ public class DistributedRegionFunctionStreamingMessage extends DistributionMessa
       this.functionObject = (Function) object;
       this.isFnSerializationReqd = true;
     }
-    this.args = (Serializable) DataSerializer.readObject(in);
+    this.args = readObject(in);
     this.filter = (HashSet) DataSerializer.readHashSet(in);
     this.regionPath = DataSerializer.readString(in);
     this.isReExecute = (flags & IS_REEXECUTE) != 0;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRemoveAllOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRemoveAllOperation.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -320,7 +322,7 @@ public class DistributedRemoveAllOperation extends AbstractUpdateOperation {
       this.op = Operation.fromOrdinal(in.readByte());
       this.flags = in.readByte();
       if ((this.flags & FILTER_ROUTING) != 0) {
-        this.filterRouting = (FilterRoutingInfo) DataSerializer.readObject(in);
+        this.filterRouting = readObject(in);
       }
       if ((this.flags & VERSION_TAG) != 0) {
         boolean persistentTag = (this.flags & PERSISTENT_TAG) != 0;
@@ -977,7 +979,7 @@ public class DistributedRemoveAllOperation extends AbstractUpdateOperation {
     public void fromData(DataInput in) throws IOException, ClassNotFoundException {
 
       super.fromData(in);
-      this.eventId = (EventID) DataSerializer.readObject(in);
+      this.eventId = readObject(in);
       this.removeAllDataSize = (int) InternalDataSerializer.readUnsignedVL(in);
       this.removeAllData = new RemoveAllEntryData[this.removeAllDataSize];
       if (this.removeAllDataSize > 0) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedTombstoneOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedTombstoneOperation.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -195,7 +197,7 @@ public class DistributedTombstoneOperation extends DistributedCacheOperation {
         }
         this.regionGCVersions.put(mbr, Long.valueOf(in.readLong()));
       }
-      this.eventID = (EventID) DataSerializer.readObject(in);
+      this.eventID = readObject(in);
     }
 
     @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/EntryEventImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/EntryEventImpl.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.DataSerializer.readObject;
 import static org.apache.geode.internal.offheap.annotations.OffHeapIdentifier.ENTRY_EVENT_NEW_VALUE;
 import static org.apache.geode.internal.offheap.annotations.OffHeapIdentifier.ENTRY_EVENT_OLD_VALUE;
 
@@ -193,14 +194,14 @@ public class EntryEventImpl implements InternalEntryEvent, InternalCacheEvent,
    * Reads the contents of this message from the given input.
    */
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
-    this.eventID = (EventID) DataSerializer.readObject(in);
+    this.eventID = readObject(in);
     Object key = DataSerializer.readObject(in);
     Object value = DataSerializer.readObject(in);
     this.keyInfo = new KeyInfo(key, value, null);
     this.op = Operation.fromOrdinal(in.readByte());
     this.eventFlags = in.readShort();
     this.keyInfo.setCallbackArg(DataSerializer.readObject(in));
-    this.txId = (TXId) DataSerializer.readObject(in);
+    this.txId = readObject(in);
 
     if (in.readBoolean()) { // isDelta
       assert false : "isDelta should never be true";

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/FindVersionTagOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/FindVersionTagOperation.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -221,7 +223,7 @@ public class FindVersionTagOperation {
     @Override
     public void fromData(DataInput in) throws IOException, ClassNotFoundException {
       super.fromData(in);
-      this.versionTag = (VersionTag) DataSerializer.readObject(in);
+      this.versionTag = readObject(in);
     }
 
     @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InitialImageOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InitialImageOperation.java
@@ -15,6 +15,8 @@
 
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.Externalizable;
@@ -2067,10 +2069,10 @@ public class InitialImageOperation {
       this.keysOnly = in.readBoolean();
       this.targetReinitialized = in.readBoolean();
       this.checkTombstoneVersions = in.readBoolean();
-      this.lostMemberVersionID = (VersionSource) DataSerializer.readObject(in);
-      this.versionVector = (RegionVersionVector) DataSerializer.readObject(in);
-      this.lostMemberID = (InternalDistributedMember) DataSerializer.readObject(in);
-      this.unfinishedKeys = (Set) DataSerializer.readObject(in);
+      this.lostMemberVersionID = readObject(in);
+      this.versionVector = readObject(in);
+      this.lostMemberID = readObject(in);
+      this.unfinishedKeys = readObject(in);
     }
 
     @Override
@@ -3291,7 +3293,7 @@ public class InitialImageOperation {
           logger.trace(LogMarker.INITIAL_IMAGE_VERSIONED_VERBOSE, "reading {} keys", size);
         }
         for (int i = 0; i < size; i++) {
-          super.add((Entry) DataSerializer.readObject(in));
+          super.add(readObject(in));
         }
       }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InvalidateOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InvalidateOperation.java
@@ -15,6 +15,8 @@
 
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -127,7 +129,7 @@ public class InvalidateOperation extends DistributedCacheOperation {
     @Override
     public void fromData(DataInput in) throws IOException, ClassNotFoundException {
       super.fromData(in);
-      this.eventId = (EventID) DataSerializer.readObject(in);
+      this.eventId = readObject(in);
       this.key = DataSerializer.readObject(in);
     }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InvalidateRegionOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InvalidateRegionOperation.java
@@ -15,6 +15,8 @@
 
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -87,7 +89,7 @@ public class InvalidateRegionOperation extends DistributedCacheOperation {
     @Override
     public void fromData(DataInput in) throws IOException, ClassNotFoundException {
       super.fromData(in);
-      this.eventID = (EventID) DataSerializer.readObject(in);
+      this.eventID = readObject(in);
     }
 
     @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/NonLocalRegionEntry.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/NonLocalRegionEntry.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -156,7 +158,7 @@ public class NonLocalRegionEntry implements RegionEntry, VersionStamp {
     this.value = DataSerializer.readObject(in);
     this.lastModified = in.readLong();
     this.isRemoved = in.readBoolean();
-    this.versionTag = (VersionTag) DataSerializer.readObject(in);
+    this.versionTag = readObject(in);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionAttributesImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionAttributesImpl.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -397,8 +399,8 @@ public class PartitionAttributesImpl implements PartitionAttributes, Cloneable, 
     this.localMaxMemory = in.readInt();
     this.totalNumBuckets = in.readInt();
     this.colocatedRegionName = DataSerializer.readString(in);
-    this.localProperties = (Properties) DataSerializer.readObject(in);
-    this.globalProperties = (Properties) DataSerializer.readObject(in);
+    this.localProperties = readObject(in);
+    this.globalProperties = readObject(in);
     this.recoveryDelay = in.readLong();
     this.startupRecoveryDelay = in.readLong();
     this.fixedPAttrs = DataSerializer.readObject(in);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/SearchLoadAndWriteProcessor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/SearchLoadAndWriteProcessor.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -1704,7 +1706,7 @@ public class SearchLoadAndWriteProcessor implements MembershipListener {
       this.isPresent = in.readBoolean();
       this.isSerialized = in.readBoolean();
       this.requestorTimedOut = in.readBoolean();
-      this.versionTag = (VersionTag) DataSerializer.readObject(in);
+      this.versionTag = readObject(in);
     }
 
     @Override
@@ -2362,7 +2364,7 @@ public class SearchLoadAndWriteProcessor implements MembershipListener {
       this.processorId = in.readInt();
       this.result = DataSerializer.readByteArray(in);
       this.aCallbackArgument = DataSerializer.readObject(in);
-      this.e = (Exception) DataSerializer.readObject(in);
+      this.e = readObject(in);
       this.isSerialized = in.readBoolean();
       this.requestorTimedOut = in.readBoolean();
 
@@ -2443,7 +2445,7 @@ public class SearchLoadAndWriteProcessor implements MembershipListener {
       this.processorId = in.readInt();
       this.regionName = in.readUTF();
       this.timeoutMs = in.readInt();
-      this.event = (CacheEvent) DataSerializer.readObject(in);
+      this.event = readObject(in);
       this.action = in.readInt();
     }
 
@@ -2653,7 +2655,7 @@ public class SearchLoadAndWriteProcessor implements MembershipListener {
       super.fromData(in);
       this.processorId = in.readInt();
       this.netWriteSucceeded = in.readBoolean();
-      this.e = (Exception) DataSerializer.readObject(in);
+      this.e = readObject(in);
       this.cacheWriterException = in.readBoolean();
     }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXRemoteCommitMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXRemoteCommitMessage.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -216,7 +218,7 @@ public class TXRemoteCommitMessage extends TXMessage {
     @Override
     public void fromData(DataInput in) throws IOException, ClassNotFoundException {
       super.fromData(in);
-      this.commitMessage = (TXCommitMessage) DataSerializer.readObject(in);
+      this.commitMessage = readObject(in);
     }
 
     @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/UpdateAttributesProcessor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/UpdateAttributesProcessor.java
@@ -15,6 +15,8 @@
 
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -403,7 +405,7 @@ public class UpdateAttributesProcessor {
     @Override
     public void fromData(DataInput in) throws IOException, ClassNotFoundException {
       super.fromData(in);
-      this.profile = (Profile) DataSerializer.readObject(in);
+      this.profile = readObject(in);
     }
 
     @Override
@@ -482,7 +484,7 @@ public class UpdateAttributesProcessor {
       } else {
         Profile[] array = new Profile[length];
         for (int i = 0; i < length; i++) {
-          array[i] = (Profile) DataSerializer.readObject(in);
+          array[i] = readObject(in);
         }
         this.profiles = array;
       }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/UpdateEntryVersionOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/UpdateEntryVersionOperation.java
@@ -15,6 +15,8 @@
 
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -145,7 +147,7 @@ public class UpdateEntryVersionOperation extends DistributedCacheOperation {
     @Override
     public void fromData(DataInput in) throws IOException, ClassNotFoundException {
       super.fromData(in);
-      this.eventId = (EventID) DataSerializer.readObject(in);
+      this.eventId = readObject(in);
       this.key = DataSerializer.readObject(in);
       Boolean hasTailKey = DataSerializer.readBoolean(in);
       if (hasTailKey.booleanValue()) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/event/EventSequenceNumberHolder.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/event/EventSequenceNumberHolder.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache.event;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -97,7 +99,7 @@ public class EventSequenceNumberHolder implements DataSerializable {
 
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
     lastSequenceNumber = in.readLong();
-    versionTag = (VersionTag) DataSerializer.readObject(in);
+    versionTag = readObject(in);
   }
 
   public void toData(DataOutput out) throws IOException {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/locks/TXLockIdImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/locks/TXLockIdImpl.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache.locks;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -114,7 +116,7 @@ public class TXLockIdImpl implements TXLockId, DataSerializableFixedID {
   }
 
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
-    this.memberId = (InternalDistributedMember) DataSerializer.readObject(in);
+    this.memberId = readObject(in);
     this.id = in.readInt();
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/locks/TXOriginatorRecoveryProcessor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/locks/TXOriginatorRecoveryProcessor.java
@@ -15,6 +15,8 @@
 
 package org.apache.geode.internal.cache.locks;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -233,7 +235,7 @@ public class TXOriginatorRecoveryProcessor extends ReplyProcessor21 {
     @Override
     public void fromData(DataInput in) throws IOException, ClassNotFoundException {
       super.fromData(in);
-      this.txLockId = (TXLockId) DataSerializer.readObject(in);
+      this.txLockId = readObject(in);
       this.processorId = in.readInt();
     }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/BucketProfileUpdateMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/BucketProfileUpdateMessage.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache.partitioned;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -151,7 +153,7 @@ public class BucketProfileUpdateMessage extends DistributionMessage implements M
     this.prId = in.readInt();
     this.bucketId = in.readInt();
     this.processorId = in.readInt();
-    this.profile = (BucketAdvisor.BucketProfile) DataSerializer.readObject(in);
+    this.profile = readObject(in);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/DestroyMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/DestroyMessage.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache.partitioned;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -333,8 +335,8 @@ public class DestroyMessage extends PartitionMessageWithDirectReply {
     this.op = Operation.fromOrdinal(in.readByte());
     this.notificationOnly = in.readBoolean();
     this.bridgeContext = ClientProxyMembershipID.readCanonicalized(in);
-    this.originalSender = (InternalDistributedMember) DataSerializer.readObject(in);
-    this.eventId = (EventID) DataSerializer.readObject(in);
+    this.originalSender = readObject(in);
+    this.eventId = readObject(in);
     this.expectedOldValue = DataSerializer.readObject(in);
 
     final boolean hasFilterInfo = ((flags & HAS_FILTER_INFO) != 0);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/DumpB2NRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/DumpB2NRegion.java
@@ -16,6 +16,8 @@
 
 package org.apache.geode.internal.cache.partitioned;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -221,7 +223,7 @@ public class DumpB2NRegion extends PartitionMessage {
     @Override
     public void fromData(DataInput in) throws IOException, ClassNotFoundException {
       super.fromData(in);
-      this.primaryInfo = (PrimaryInfo) DataSerializer.readObject(in);
+      this.primaryInfo = readObject(in);
     }
 
     @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/FetchPartitionDetailsMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/FetchPartitionDetailsMessage.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache.partitioned;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -134,7 +136,7 @@ public class FetchPartitionDetailsMessage extends PartitionMessage {
     super.fromData(in);
     this.internal = in.readBoolean();
     this.fetchOfflineMembers = in.readBoolean();
-    this.loadProbe = (LoadProbe) DataSerializer.readObject(in);
+    this.loadProbe = readObject(in);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/GetMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/GetMessage.java
@@ -15,6 +15,8 @@
 
 package org.apache.geode.internal.cache.partitioned;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -455,7 +457,7 @@ public class GetMessage extends PartitionMessageWithDirectReply {
         this.remoteVersion = InternalDataSerializer.getVersionForDataStreamOrNull(in);
       }
       if (hasVersionTag) {
-        this.versionTag = (VersionTag) DataSerializer.readObject(in);
+        this.versionTag = readObject(in);
       }
     }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/InterestEventMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/InterestEventMessage.java
@@ -15,6 +15,8 @@
 
 package org.apache.geode.internal.cache.partitioned;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -105,7 +107,7 @@ public class InterestEventMessage extends PartitionMessage {
   @Override
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
     super.fromData(in);
-    this.event = (InterestRegistrationEvent) DataSerializer.readObject(in);
+    this.event = readObject(in);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/InvalidateMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/InvalidateMessage.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache.partitioned;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -317,7 +319,7 @@ public class InvalidateMessage extends DestroyMessage {
     @Override
     public void fromData(DataInput in) throws IOException, ClassNotFoundException {
       super.fromData(in);
-      this.versionTag = (VersionTag) DataSerializer.readObject(in);
+      this.versionTag = readObject(in);
     }
 
     @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/MoveBucketMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/MoveBucketMessage.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache.partitioned;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -133,7 +135,7 @@ public class MoveBucketMessage extends PartitionMessage {
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
     super.fromData(in);
     this.bucketId = in.readInt();
-    this.source = (InternalDistributedMember) DataSerializer.readObject(in);
+    this.source = readObject(in);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/PRTombstoneMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/PRTombstoneMessage.java
@@ -15,6 +15,8 @@
 
 package org.apache.geode.internal.cache.partitioned;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -135,7 +137,7 @@ public class PRTombstoneMessage extends PartitionMessageWithDirectReply
     for (int i = 0; i < numKeys; i++) {
       this.keys.add(DataSerializer.readObject(in));
     }
-    this.eventID = (EventID) DataSerializer.readObject(in);
+    this.eventID = readObject(in);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/PRUpdateEntryVersionMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/PRUpdateEntryVersionMessage.java
@@ -15,6 +15,8 @@
 
 package org.apache.geode.internal.cache.partitioned;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -171,7 +173,7 @@ public class PRUpdateEntryVersionMessage extends PartitionMessageWithDirectReply
     super.fromData(in);
     this.key = DataSerializer.readObject(in);
     this.op = Operation.fromOrdinal(in.readByte());
-    this.eventId = (EventID) DataSerializer.readObject(in);
+    this.eventId = readObject(in);
     this.versionTag = DataSerializer.readObject(in);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/PartitionMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/PartitionMessage.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache.partitioned;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -544,7 +546,7 @@ public abstract class PartitionMessage extends DistributionMessage
     if ((s & HAS_TX_ID) != 0)
       this.txUniqId = in.readInt();
     if ((s & HAS_TX_MEMBERID) != 0) {
-      this.txMemberId = (InternalDistributedMember) DataSerializer.readObject(in);
+      this.txMemberId = readObject(in);
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/PutAllPRMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/PutAllPRMessage.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache.partitioned;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -793,7 +795,7 @@ public class PutAllPRMessage extends PartitionMessageWithDirectReply {
     public void fromData(DataInput in) throws IOException, ClassNotFoundException {
       super.fromData(in);
       this.result = in.readBoolean();
-      this.versions = (VersionedObjectList) DataSerializer.readObject(in);
+      this.versions = readObject(in);
     }
 
     @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/PutMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/PutMessage.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache.partitioned;
 
+import static org.apache.geode.DataSerializer.readObject;
 import static org.apache.geode.internal.offheap.annotations.OffHeapIdentifier.ENTRY_EVENT_NEW_VALUE;
 import static org.apache.geode.internal.offheap.annotations.OffHeapIdentifier.ENTRY_EVENT_OLD_VALUE;
 
@@ -494,7 +495,7 @@ public class PutMessage extends PartitionMessageWithDirectReply implements NewVa
       this.bridgeContext = ClientProxyMembershipID.readCanonicalized(in);
     }
     if ((extraFlags & HAS_ORIGINAL_SENDER) != 0) {
-      this.originalSender = (InternalDistributedMember) DataSerializer.readObject(in);
+      this.originalSender = readObject(in);
     }
     this.eventId = new EventID();
     InternalDataSerializer.invokeFromData(this.eventId, in);
@@ -931,7 +932,7 @@ public class PutMessage extends PartitionMessageWithDirectReply implements NewVa
       this.result = in.readBoolean();
       this.op = Operation.fromOrdinal(in.readByte());
       this.oldValue = DataSerializer.readObject(in);
-      this.versionTag = (VersionTag) DataSerializer.readObject(in);
+      this.versionTag = readObject(in);
     }
 
     @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/RemoveAllPRMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/RemoveAllPRMessage.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache.partitioned;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -752,7 +754,7 @@ public class RemoveAllPRMessage extends PartitionMessageWithDirectReply {
     public void fromData(DataInput in) throws IOException, ClassNotFoundException {
       super.fromData(in);
       this.result = in.readBoolean();
-      this.versions = (VersionedObjectList) DataSerializer.readObject(in);
+      this.versions = readObject(in);
     }
 
     @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientDataSerializerMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientDataSerializerMessage.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache.tier.sockets;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -189,7 +191,7 @@ public class ClientDataSerializerMessage extends ClientUpdateMessageImpl {
       this.serializedDataSerializer[i] = DataSerializer.readByteArray(in);
     }
     _membershipId = ClientProxyMembershipID.readCanonicalized(in);
-    _eventIdentifier = (EventID) DataSerializer.readObject(in);
+    _eventIdentifier = readObject(in);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientInstantiatorMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientInstantiatorMessage.java
@@ -15,6 +15,8 @@
 
 package org.apache.geode.internal.cache.tier.sockets;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -174,7 +176,7 @@ public class ClientInstantiatorMessage extends ClientUpdateMessageImpl {
       this.serializedInstantiators[i] = DataSerializer.readByteArray(in);
     }
     _membershipId = ClientProxyMembershipID.readCanonicalized(in);
-    _eventIdentifier = (EventID) DataSerializer.readObject(in);
+    _eventIdentifier = readObject(in);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientInterestMessageImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientInterestMessageImpl.java
@@ -15,6 +15,8 @@
 
 package org.apache.geode.internal.cache.tier.sockets;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -214,7 +216,7 @@ public class ClientInterestMessageImpl implements ClientMessage {
   }
 
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
-    this.eventId = (EventID) DataSerializer.readObject(in);
+    this.eventId = readObject(in);
     this.regionName = DataSerializer.readString(in);
     this.keyOfInterest = DataSerializer.readObject(in);
     this.isDurable = DataSerializer.readPrimitiveBoolean(in);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientMarkerMessageImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientMarkerMessageImpl.java
@@ -15,6 +15,8 @@
 
 package org.apache.geode.internal.cache.tier.sockets;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -89,7 +91,7 @@ public class ClientMarkerMessageImpl implements ClientMessage {
   }
 
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
-    this.eventId = (EventID) DataSerializer.readObject(in);
+    this.eventId = readObject(in);
   }
 
   public EventID getEventId() {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientTombstoneMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientTombstoneMessage.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache.tier.sockets;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -127,7 +129,7 @@ public class ClientTombstoneMessage extends ClientUpdateMessageImpl {
     this.setRegionName(DataSerializer.readString(in));
     this.removalInformation = DataSerializer.readObject(in);
     this._membershipId = ClientProxyMembershipID.readCanonicalized(in);
-    this._eventIdentifier = (EventID) DataSerializer.readObject(in);
+    this._eventIdentifier = readObject(in);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientUpdateMessageImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientUpdateMessageImpl.java
@@ -15,6 +15,8 @@
 
 package org.apache.geode.internal.cache.tier.sockets;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.ByteArrayInputStream;
 import java.io.DataInput;
 import java.io.DataInputStream;
@@ -1280,7 +1282,7 @@ public class ClientUpdateMessageImpl implements ClientUpdateMessage, Sizeable, N
     }
     this._clientInterestListInv = ids;
 
-    this.versionTag = (VersionTag) DataSerializer.readObject(in);
+    this.versionTag = readObject(in);
   }
 
   private Object getOriginalCallbackArgument() {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/HAEventWrapper.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/HAEventWrapper.java
@@ -15,6 +15,8 @@
 
 package org.apache.geode.internal.cache.tier.sockets;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -294,7 +296,7 @@ public class HAEventWrapper implements Conflatable, DataSerializableFixedID, Siz
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
     if (DataSerializer.readPrimitiveBoolean(in)) {
       // Indicates that we have a ClientUpdateMessage along with the HAEW instance in inputstream.
-      this.eventIdentifier = (EventID) DataSerializer.readObject(in);
+      this.eventIdentifier = readObject(in);
       this.clientUpdateMessage = new ClientUpdateMessageImpl();
       InternalDataSerializer.invokeFromData(this.clientUpdateMessage, in);
       ((ClientUpdateMessageImpl) this.clientUpdateMessage).setEventIdentifier(this.eventIdentifier);
@@ -307,7 +309,7 @@ public class HAEventWrapper implements Conflatable, DataSerializableFixedID, Siz
           } else {
             cqMap = new ClientCqConcurrentMap(size, 1.0f, 1);
             for (int i = 0; i < size; i++) {
-              ClientProxyMembershipID key = DataSerializer.<ClientProxyMembershipID>readObject(in);
+              ClientProxyMembershipID key = readObject(in);
               CqNameToOp value;
               {
                 byte typeByte = in.readByte();
@@ -317,16 +319,16 @@ public class HAEventWrapper implements Conflatable, DataSerializableFixedID, Siz
                     throw new IllegalStateException(
                         "The value of a ConcurrentHashMap is not allowed to be null.");
                   } else if (cqNamesSize == 1) {
-                    String cqNamesKey = DataSerializer.<String>readObject(in);
-                    Integer cqNamesValue = DataSerializer.<Integer>readObject(in);
+                    String cqNamesKey = readObject(in);
+                    Integer cqNamesValue = readObject(in);
                     value = new CqNameToOpSingleEntry(cqNamesKey, cqNamesValue);
                   } else if (cqNamesSize == 0) {
                     value = new CqNameToOpSingleEntry(null, 0);
                   } else {
                     value = new CqNameToOpHashMap(cqNamesSize);
                     for (int j = 0; j < cqNamesSize; j++) {
-                      String cqNamesKey = DataSerializer.<String>readObject(in);
-                      Integer cqNamesValue = DataSerializer.<Integer>readObject(in);
+                      String cqNamesKey = readObject(in);
+                      Integer cqNamesValue = readObject(in);
                       value.add(cqNamesKey, cqNamesValue);
                     }
                   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tx/DistTxEntryEvent.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tx/DistTxEntryEvent.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache.tx;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -30,7 +32,6 @@ import org.apache.geode.internal.cache.DistributedPutAllOperation.PutAllEntryDat
 import org.apache.geode.internal.cache.DistributedRemoveAllOperation;
 import org.apache.geode.internal.cache.DistributedRemoveAllOperation.RemoveAllEntryData;
 import org.apache.geode.internal.cache.EntryEventImpl;
-import org.apache.geode.internal.cache.EventID;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.offheap.annotations.Retained;
 
@@ -98,7 +99,7 @@ public class DistTxEntryEvent extends EntryEventImpl {
 
   @Override
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
-    this.eventID = (EventID) DataSerializer.readObject(in);
+    this.eventID = readObject(in);
     this.regionName = DataSerializer.readString(in);
     this.op = Operation.fromOrdinal(in.readByte());
     Object key = DataSerializer.readObject(in);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tx/RemotePutAllMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tx/RemotePutAllMessage.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache.tx;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -222,7 +224,7 @@ public class RemotePutAllMessage extends RemoteOperationMessageWithDirectReply {
   @Override
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
     super.fromData(in);
-    this.eventId = (EventID) DataSerializer.readObject(in);
+    this.eventId = readObject(in);
     this.callbackArg = DataSerializer.readObject(in);
     this.posDup = (flags & POS_DUP) != 0;
     if ((flags & HAS_BRIDGE_CONTEXT) != 0) {
@@ -472,7 +474,7 @@ public class RemotePutAllMessage extends RemoteOperationMessageWithDirectReply {
     @Override
     public void fromData(DataInput in) throws IOException, ClassNotFoundException {
       super.fromData(in);
-      this.versions = (VersionedObjectList) DataSerializer.readObject(in);
+      this.versions = readObject(in);
     }
 
     @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tx/RemoteRemoveAllMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tx/RemoteRemoveAllMessage.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache.tx;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -218,7 +220,7 @@ public class RemoteRemoveAllMessage extends RemoteOperationMessageWithDirectRepl
   @Override
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
     super.fromData(in);
-    this.eventId = (EventID) DataSerializer.readObject(in);
+    this.eventId = readObject(in);
     this.callbackArg = DataSerializer.readObject(in);
     this.posDup = (flags & POS_DUP) != 0;
     if ((flags & HAS_BRIDGE_CONTEXT) != 0) {
@@ -465,7 +467,7 @@ public class RemoteRemoveAllMessage extends RemoteOperationMessageWithDirectRepl
     @Override
     public void fromData(DataInput in) throws IOException, ClassNotFoundException {
       super.fromData(in);
-      this.versions = (VersionedObjectList) DataSerializer.readObject(in);
+      this.versions = readObject(in);
     }
 
     @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/GatewaySenderEventImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/GatewaySenderEventImpl.java
@@ -15,6 +15,8 @@
 
 package org.apache.geode.internal.cache.wan;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -707,7 +709,7 @@ public class GatewaySenderEventImpl
         && InternalDataSerializer.getVersionForDataStream(in) == Version.CURRENT) {
       in = new VersionedDataInputStream((InputStream) in, Version.GFE_701);
     }
-    this.id = (EventID) DataSerializer.readObject(in);
+    this.id = readObject(in);
     // TODO:Asif ; Check if this violates Barry's logic of not assiging VM
     // specific Token.FROM_GATEWAY
     // and retain the serialized Token.FROM_GATEWAY
@@ -716,7 +718,7 @@ public class GatewaySenderEventImpl
     this.valueIsObject = in.readByte();
     deserializeKey(in);
     this.value = DataSerializer.readByteArray(in);
-    this.callbackArgument = (GatewaySenderEventCallbackArgument) DataSerializer.readObject(in);
+    this.callbackArgument = readObject(in);
     this.possibleDuplicate = in.readBoolean();
     this.creationTime = in.readLong();
     this.bucketId = in.readInt();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/serial/BatchDestroyOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/serial/BatchDestroyOperation.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache.wan.serial;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -207,7 +209,7 @@ public class BatchDestroyOperation extends DistributedCacheOperation {
     @Override
     public void fromData(DataInput in) throws IOException, ClassNotFoundException {
       super.fromData(in);
-      this.eventId = (EventID) DataSerializer.readObject(in);
+      this.eventId = readObject(in);
       this.key = DataSerializer.readObject(in);
       Boolean hasTailKey = DataSerializer.readBoolean(in);
       if (hasTailKey.booleanValue()) {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/JmxManagerAdvisor.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/JmxManagerAdvisor.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.management.internal;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -214,7 +216,7 @@ public class JmxManagerAdvisor extends DistributionAdvisor {
     public void fromData(DataInput in) throws IOException, ClassNotFoundException {
       super.fromData(in);
       this.processorId = in.readInt();
-      this.profile = (JmxManagerProfile) DataSerializer.readObject(in);
+      this.profile = readObject(in);
     }
 
     @Override

--- a/geode-core/src/test/java/org/apache/geode/cache/query/internal/QueryObjectSerializationJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/internal/QueryObjectSerializationJUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query.internal;
 
+import static org.apache.geode.DataSerializer.readObject;
 import static org.junit.Assert.assertEquals;
 
 import java.io.ByteArrayInputStream;
@@ -82,7 +83,7 @@ public class QueryObjectSerializationJUnitTest implements Serializable {
     DataSerializer.writeObject(o1, out);
     out.flush();
     DataInput in = getDataInput();
-    assertEquals(o1, DataSerializer.<Object>readObject(in));
+    assertEquals(o1, readObject(in));
     this.baos = new ByteArrayOutputStream();
   }
 
@@ -109,13 +110,7 @@ public class QueryObjectSerializationJUnitTest implements Serializable {
     ResultsBag rbWithData = new ResultsBag(data, (CachePerfStats) null);
     rbWithData.setElementType(elementType); // avoid NPE in equals
     checkRoundTrip(rbWithData);
-    /*
-     * Set rbWithoutDataAsSet = new ResultsBag().asSet(); ResultsCollectionWrapper rcw = new
-     * ResultsCollectionWrapper(elementType, rbWithoutDataAsSet, -1); checkRoundTrip(rcw); Set
-     * rbWithDataAsSet = new ResultsBag(data, (CachePerfStats)null).asSet();
-     * ResultsCollectionWrapper rcwWithData = new ResultsCollectionWrapper(elementType,
-     * rbWithDataAsSet, -1); checkRoundTrip(rcwWithData);
-     */
+
     // SortedResultSet
     SortedResultSet srsWithoutData = new SortedResultSet();
     srsWithoutData.setElementType(elementType); // avoid NPE in equals
@@ -124,9 +119,6 @@ public class QueryObjectSerializationJUnitTest implements Serializable {
     srsWithData.setElementType(elementType); // avoid NPE in equals
     checkRoundTrip(srsWithData);
 
-    // SortedStructSet
-    // SortedStructSet sssWithoutData = new SortedStructSet();
-    // checkRoundTrip(sssWithoutData);
   }
 
   private static class SimpleObjectType implements ObjectType {

--- a/geode-core/src/test/java/org/apache/geode/cache/query/internal/ResultsBagJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/internal/ResultsBagJUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query.internal;
 
+import static org.apache.geode.DataSerializer.readObject;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -105,7 +106,7 @@ public class ResultsBagJUnitTest {
     HeapDataOutputStream hdos = new HeapDataOutputStream(Version.CURRENT);
     DataSerializer.writeObject(w, hdos);
     DataInputStream in = new DataInputStream(hdos.getInputStream());
-    SelectResults setCopy = (SelectResults) DataSerializer.readObject(in);
+    SelectResults setCopy = readObject(in);
 
     assertEquals(4, setCopy.size());
     assertTrue(setCopy.contains(new Integer(4)));

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/StartupMessageDataJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/StartupMessageDataJUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.distributed.internal;
 
+import static org.apache.geode.DataSerializer.readObject;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -30,7 +31,6 @@ import java.util.StringTokenizer;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import org.apache.geode.DataSerializer;
 import org.apache.geode.internal.ByteArrayData;
 import org.apache.geode.internal.admin.remote.DistributionLocatorId;
 import org.apache.geode.internal.net.SocketCreator;
@@ -132,7 +132,7 @@ public class StartupMessageDataJUnitTest {
     assertTrue(testStream.size() > 0);
 
     DataInput in = testStream.getDataInput();
-    Properties props = (Properties) DataSerializer.readObject(in);
+    Properties props = readObject(in);
     assertNull(props);
   }
 
@@ -150,7 +150,7 @@ public class StartupMessageDataJUnitTest {
     assertTrue(testStream.size() > 0);
 
     DataInput in = testStream.getDataInput();
-    Properties props = (Properties) DataSerializer.readObject(in);
+    Properties props = readObject(in);
     assertNull(props);
   }
 
@@ -172,7 +172,7 @@ public class StartupMessageDataJUnitTest {
     assertTrue(testStream.size() > 0);
 
     DataInput in = testStream.getDataInput();
-    Properties props = (Properties) DataSerializer.readObject(in);
+    Properties props = readObject(in);
     assertNotNull(props);
 
     String hostedLocatorsString = props.getProperty(StartupMessageData.HOSTED_LOCATORS);
@@ -199,7 +199,7 @@ public class StartupMessageDataJUnitTest {
     assertTrue(testStream.size() > 0);
 
     DataInput in = testStream.getDataInput();
-    Properties props = (Properties) DataSerializer.readObject(in);
+    Properties props = readObject(in);
     assertNotNull(props);
 
     String hostedLocatorsString = props.getProperty(StartupMessageData.HOSTED_LOCATORS);

--- a/geode-core/src/test/java/org/apache/geode/internal/DataSerializableJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/DataSerializableJUnitTest.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal;
 
+import static org.apache.geode.DataSerializer.readByteArray;
+import static org.apache.geode.DataSerializer.readObject;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
@@ -159,7 +161,7 @@ public class DataSerializableJUnitTest implements Serializable {
     out.flush();
 
     DataInput in = getDataInput();
-    Class c2 = (Class) DataSerializer.readObject(in);
+    Class c2 = readObject(in);
     assertEquals(c, c2);
   }
 
@@ -172,7 +174,7 @@ public class DataSerializableJUnitTest implements Serializable {
     out.flush();
 
     DataInput in = getDataInput();
-    BigInteger o2 = (BigInteger) DataSerializer.readObject(in);
+    BigInteger o2 = readObject(in);
     assertEquals(o, o2);
   }
 
@@ -185,7 +187,7 @@ public class DataSerializableJUnitTest implements Serializable {
     out.flush();
 
     DataInput in = getDataInput();
-    BigDecimal o2 = (BigDecimal) DataSerializer.readObject(in);
+    BigDecimal o2 = readObject(in);
     assertEquals(o, o2);
   }
 
@@ -198,7 +200,7 @@ public class DataSerializableJUnitTest implements Serializable {
     out.flush();
 
     DataInput in = getDataInput();
-    UUID o2 = (UUID) DataSerializer.readObject(in);
+    UUID o2 = readObject(in);
     assertEquals(o, o2);
   }
 
@@ -211,7 +213,7 @@ public class DataSerializableJUnitTest implements Serializable {
     out.flush();
 
     DataInput in = getDataInput();
-    Timestamp o2 = (Timestamp) DataSerializer.readObject(in);
+    Timestamp o2 = readObject(in);
     assertEquals(o, o2);
   }
 
@@ -243,7 +245,7 @@ public class DataSerializableJUnitTest implements Serializable {
     out.flush();
 
     DataInput in = getDataInput();
-    Date date2 = (Date) DataSerializer.readObject(in);
+    Date date2 = readObject(in);
     assertEquals(date, date2);
   }
 
@@ -275,7 +277,7 @@ public class DataSerializableJUnitTest implements Serializable {
     out.flush();
 
     DataInput in = getDataInput();
-    File file2 = (File) DataSerializer.readObject(in);
+    File file2 = readObject(in);
     assertEquals(file, file2);
   }
 
@@ -307,7 +309,7 @@ public class DataSerializableJUnitTest implements Serializable {
     out.flush();
 
     DataInput in = getDataInput();
-    InetAddress address2 = (InetAddress) DataSerializer.readObject(in);
+    InetAddress address2 = readObject(in);
     assertEquals(address, address2);
   }
 
@@ -342,7 +344,7 @@ public class DataSerializableJUnitTest implements Serializable {
     DataInput in = getDataInput();
     String value2 = DataSerializer.readString(in);
     assertEquals(value, value2);
-    value2 = (String) DataSerializer.readObject(in);
+    value2 = readObject(in);
     assertEquals(value, value2);
   }
 
@@ -358,7 +360,7 @@ public class DataSerializableJUnitTest implements Serializable {
     DataInput in = getDataInput();
     String value2 = DataSerializer.readString(in);
     assertEquals(value, value2);
-    value2 = (String) DataSerializer.readObject(in);
+    value2 = readObject(in);
     assertEquals(value, value2);
   }
 
@@ -378,7 +380,7 @@ public class DataSerializableJUnitTest implements Serializable {
     DataInput in = getDataInput();
     String value2 = DataSerializer.readString(in);
     assertEquals(value, value2);
-    value2 = (String) DataSerializer.readObject(in);
+    value2 = readObject(in);
     assertEquals(value, value2);
   }
 
@@ -405,7 +407,7 @@ public class DataSerializableJUnitTest implements Serializable {
     DataInput in = getDataInput();
     String value2 = DataSerializer.readString(in);
     assertEquals(value, value2);
-    value2 = (String) DataSerializer.readObject(in);
+    value2 = readObject(in);
     assertEquals(value, value2);
   }
 
@@ -470,7 +472,7 @@ public class DataSerializableJUnitTest implements Serializable {
     out.flush();
 
     DataInput in = getDataInput();
-    Boolean value2 = (Boolean) DataSerializer.readObject(in);
+    Boolean value2 = readObject(in);
     assertEquals(value, value2);
   }
 
@@ -563,7 +565,7 @@ public class DataSerializableJUnitTest implements Serializable {
     out.flush();
 
     DataInput in = getDataInput();
-    Character value2 = (Character) DataSerializer.readObject(in);
+    Character value2 = readObject(in);
     assertEquals(value, value2);
   }
 
@@ -595,7 +597,7 @@ public class DataSerializableJUnitTest implements Serializable {
     out.flush();
 
     DataInput in = getDataInput();
-    Byte value2 = (Byte) DataSerializer.readObject(in);
+    Byte value2 = readObject(in);
     assertEquals(value, value2);
   }
 
@@ -628,7 +630,7 @@ public class DataSerializableJUnitTest implements Serializable {
     out.flush();
 
     DataInput in = getDataInput();
-    Short value2 = (Short) DataSerializer.readObject(in);
+    Short value2 = readObject(in);
     assertEquals(value, value2);
   }
 
@@ -660,7 +662,7 @@ public class DataSerializableJUnitTest implements Serializable {
     out.flush();
 
     DataInput in = getDataInput();
-    Integer value2 = (Integer) DataSerializer.readObject(in);
+    Integer value2 = readObject(in);
     assertEquals(value, value2);
   }
 
@@ -692,7 +694,7 @@ public class DataSerializableJUnitTest implements Serializable {
     out.flush();
 
     DataInput in = getDataInput();
-    Long value2 = (Long) DataSerializer.readObject(in);
+    Long value2 = readObject(in);
     assertEquals(value, value2);
   }
 
@@ -724,7 +726,7 @@ public class DataSerializableJUnitTest implements Serializable {
     out.flush();
 
     DataInput in = getDataInput();
-    Float value2 = (Float) DataSerializer.readObject(in);
+    Float value2 = readObject(in);
     assertEquals(value, value2);
   }
 
@@ -756,7 +758,7 @@ public class DataSerializableJUnitTest implements Serializable {
     out.flush();
 
     DataInput in = getDataInput();
-    Double value2 = (Double) DataSerializer.readObject(in);
+    Double value2 = readObject(in);
     assertEquals(value, value2);
   }
 
@@ -775,7 +777,7 @@ public class DataSerializableJUnitTest implements Serializable {
     DataInput in = getDataInput();
     for (int idx = 0; idx < 2; idx++) {
       byte[] array2 =
-          (idx == 0) ? DataSerializer.readByteArray(in) : (byte[]) DataSerializer.readObject(in);
+          (idx == 0) ? readByteArray(in) : readObject(in);
       assertEquals(array.length, array2.length);
       for (int i = 0; i < array.length; i++) {
         assertEquals(array[i], array2[i]);
@@ -795,7 +797,7 @@ public class DataSerializableJUnitTest implements Serializable {
     out.flush();
 
     DataInput in = getDataInput();
-    byte[] array2 = (byte[]) DataSerializer.readObject(in);
+    byte[] array2 = readObject(in);
 
     assertEquals(array.length, array2.length);
     for (int i = 0; i < array.length; i++) {
@@ -835,7 +837,7 @@ public class DataSerializableJUnitTest implements Serializable {
     out.flush();
 
     DataInput in = getDataInput();
-    short[] array2 = (short[]) DataSerializer.readObject(in);
+    short[] array2 = readObject(in);
 
     assertEquals(array.length, array2.length);
     for (int i = 0; i < array.length; i++) {
@@ -905,7 +907,7 @@ public class DataSerializableJUnitTest implements Serializable {
     out.flush();
 
     DataInput in = getDataInput();
-    String[] array2 = (String[]) DataSerializer.readObject(in);
+    String[] array2 = readObject(in);
 
     assertEquals(array.length, array2.length);
     for (int i = 0; i < array.length; i++) {
@@ -945,7 +947,7 @@ public class DataSerializableJUnitTest implements Serializable {
     out.flush();
 
     DataInput in = getDataInput();
-    int[] array2 = (int[]) DataSerializer.readObject(in);
+    int[] array2 = readObject(in);
 
     assertEquals(array.length, array2.length);
     for (int i = 0; i < array.length; i++) {
@@ -985,7 +987,7 @@ public class DataSerializableJUnitTest implements Serializable {
     out.flush();
 
     DataInput in = getDataInput();
-    long[] array2 = (long[]) DataSerializer.readObject(in);
+    long[] array2 = readObject(in);
 
     assertEquals(array.length, array2.length);
     for (int i = 0; i < array.length; i++) {
@@ -1025,7 +1027,7 @@ public class DataSerializableJUnitTest implements Serializable {
     out.flush();
 
     DataInput in = getDataInput();
-    float[] array2 = (float[]) DataSerializer.readObject(in);
+    float[] array2 = readObject(in);
 
     assertEquals(array.length, array2.length);
     for (int i = 0; i < array.length; i++) {
@@ -1065,7 +1067,7 @@ public class DataSerializableJUnitTest implements Serializable {
     out.flush();
 
     DataInput in = getDataInput();
-    double[] array2 = (double[]) DataSerializer.readObject(in);
+    double[] array2 = readObject(in);
 
     assertEquals(array.length, array2.length);
     for (int i = 0; i < array.length; i++) {
@@ -1109,7 +1111,7 @@ public class DataSerializableJUnitTest implements Serializable {
     out.flush();
 
     DataInput in = getDataInput();
-    SerializableImpl[] array2 = (SerializableImpl[]) DataSerializer.readObject(in);
+    SerializableImpl[] array2 = readObject(in);
 
     assertEquals(array.length, array2.length);
     for (int i = 0; i < array.length; i++) {
@@ -1235,7 +1237,7 @@ public class DataSerializableJUnitTest implements Serializable {
     out.flush();
 
     DataInput in = getDataInput();
-    ArrayList list2 = (ArrayList) DataSerializer.readObject(in);
+    ArrayList list2 = readObject(in);
     assertEquals(list, list2);
   }
 
@@ -1277,7 +1279,7 @@ public class DataSerializableJUnitTest implements Serializable {
     out.flush();
 
     DataInput in = getDataInput();
-    HashSet set2 = (HashSet) DataSerializer.readObject(in);
+    HashSet set2 = readObject(in);
     assertEquals(set, set2);
   }
 
@@ -1349,7 +1351,7 @@ public class DataSerializableJUnitTest implements Serializable {
     out.flush();
 
     DataInput in = getDataInput();
-    TreeSet set2 = (TreeSet) DataSerializer.readObject(in);
+    TreeSet set2 = readObject(in);
     assertEquals(set, set2);
   }
 
@@ -1395,7 +1397,7 @@ public class DataSerializableJUnitTest implements Serializable {
     out.flush();
 
     DataInput in = getDataInput();
-    HashMap map2 = (HashMap) DataSerializer.readObject(in);
+    HashMap map2 = readObject(in);
     assertEquals(map, map2);
   }
 
@@ -1493,7 +1495,7 @@ public class DataSerializableJUnitTest implements Serializable {
     out.flush();
 
     DataInput in = getDataInput();
-    TreeMap map2 = (TreeMap) DataSerializer.readObject(in);
+    TreeMap map2 = readObject(in);
     assertEquals(map, map2);
   }
 
@@ -1535,7 +1537,7 @@ public class DataSerializableJUnitTest implements Serializable {
     out.flush();
 
     DataInput in = getDataInput();
-    LinkedHashSet set2 = (LinkedHashSet) DataSerializer.readObject(in);
+    LinkedHashSet set2 = readObject(in);
     assertEquals(set, set2);
   }
 
@@ -1581,7 +1583,7 @@ public class DataSerializableJUnitTest implements Serializable {
     out.flush();
 
     DataInput in = getDataInput();
-    Hashtable map2 = (Hashtable) DataSerializer.readObject(in);
+    Hashtable map2 = readObject(in);
     assertEquals(map, map2);
   }
 
@@ -1627,7 +1629,7 @@ public class DataSerializableJUnitTest implements Serializable {
     out.flush();
 
     DataInput in = getDataInput();
-    LinkedHashMap map2 = (LinkedHashMap) DataSerializer.readObject(in);
+    LinkedHashMap map2 = readObject(in);
     assertEquals(map, map2);
   }
 
@@ -1674,7 +1676,7 @@ public class DataSerializableJUnitTest implements Serializable {
     out.flush();
 
     DataInput in = getDataInput();
-    IdentityHashMap map2 = (IdentityHashMap) DataSerializer.readObject(in);
+    IdentityHashMap map2 = readObject(in);
     assertEquals(new HashMap(map), new HashMap(map2));
   }
 
@@ -1716,7 +1718,7 @@ public class DataSerializableJUnitTest implements Serializable {
     out.flush();
 
     DataInput in = getDataInput();
-    Vector list2 = (Vector) DataSerializer.readObject(in);
+    Vector list2 = readObject(in);
     assertEquals(list, list2);
   }
 
@@ -1758,7 +1760,7 @@ public class DataSerializableJUnitTest implements Serializable {
     out.flush();
 
     DataInput in = getDataInput();
-    Stack list2 = (Stack) DataSerializer.readObject(in);
+    Stack list2 = readObject(in);
     assertEquals(list, list2);
   }
 
@@ -2628,7 +2630,7 @@ public class DataSerializableJUnitTest implements Serializable {
     DataSerializer.writeObject(o, out);
     out.flush();
     DataInput in = getDataInput();
-    assertSame(o.getClass(), DataSerializer.<Object>readObject(in).getClass());
+    assertSame(o.getClass(), readObject(in).getClass());
     this.baos = new ByteArrayOutputStream();
   }
 
@@ -3152,8 +3154,8 @@ public class DataSerializableJUnitTest implements Serializable {
         nds.intValue = in.readInt();
         nds.doubleValue = in.readDouble();
         nds.stringValue = in.readUTF();
-        nds.dsValue = (DataSerializable) readObject(in);
-        nds.serValue = (Serializable) readObject(in);
+        nds.dsValue = readObject(in);
+        nds.serValue = readObject(in);
         nds.objectValue = readObject(in);
 
         return nds;
@@ -3267,8 +3269,8 @@ public class DataSerializableJUnitTest implements Serializable {
     @Override
     public void fromData(DataInput in) throws IOException, ClassNotFoundException {
       this.id = in.readInt();
-      this.next = (Link) DataSerializer.readObject(in);
-      this.next2 = (Link) DataSerializer.readObject(in);
+      this.next = readObject(in);
+      this.next2 = readObject(in);
     }
   }
 
@@ -3363,7 +3365,7 @@ public class DataSerializableJUnitTest implements Serializable {
     out.flush();
 
     DataInput in = getDataInput();
-    byte[][] array2 = (byte[][]) DataSerializer.readObject(in);
+    byte[][] array2 = readObject(in);
 
     assertEquals(array.length, array2.length);
     for (int i = 0; i < array.length; i++) {
@@ -3450,7 +3452,7 @@ public class DataSerializableJUnitTest implements Serializable {
     DataInput in = getDataInput();
     String value2 = DataSerializer.readString(in);
     assertEquals(value, value2);
-    value2 = (String) DataSerializer.readObject(in);
+    value2 = readObject(in);
     assertEquals(value, value2);
   }
 
@@ -3511,8 +3513,8 @@ public class DataSerializableJUnitTest implements Serializable {
       out.flush();
 
       DataInput in = getDataInput();
-      DAY_OF_WEEK e2 = (DAY_OF_WEEK) DataSerializer.readObject(in);
-      MONTH m2 = (MONTH) DataSerializer.readObject(in);
+      DAY_OF_WEEK e2 = readObject(in);
+      MONTH m2 = readObject(in);
       assertEquals(e, e2);
       assertEquals(m, m2);
       // Make sure there's nothing left in the stream

--- a/geode-core/src/test/java/org/apache/geode/internal/DataSerializableJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/DataSerializableJUnitTest.java
@@ -81,6 +81,16 @@ import org.apache.geode.test.junit.categories.SerializationTest;
  */
 @Category({SerializationTest.class})
 public class DataSerializableJUnitTest implements Serializable {
+  @Rule
+  public TestName testName = new TestName();
+
+  /**
+   * We need to log the test name for output to be any use in terms of correlation.
+   */
+  @Before
+  public void logTestName() {
+    System.out.println("Before test named " + testName.getMethodName());
+  }
 
   /** A <code>ByteArrayOutputStream</code> that data is serialized to */
   private transient ByteArrayOutputStream baos;

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/versions/RegionVersionVectorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/versions/RegionVersionVectorTest.java
@@ -15,6 +15,7 @@
 package org.apache.geode.internal.cache.versions;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.geode.DataSerializer.readObject;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.Assert.assertEquals;
@@ -285,7 +286,7 @@ public class RegionVersionVectorTest {
     DataSerializer.writeObject(rv2, out);
     ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
     DataInputStream in = new DataInputStream(bais);
-    RegionVersionVector transmittedVector = (RegionVersionVector) DataSerializer.readObject(in);
+    RegionVersionVector transmittedVector = readObject(in);
     // record the provider's rvv in the receiver of the image
     giiReceiverRVV.recordVersions(transmittedVector);
     // removedMembers in the receiver should hold {server4, server3}. Simulate

--- a/geode-junit/src/main/java/com/examples/ds/CompanySerializer.java
+++ b/geode-junit/src/main/java/com/examples/ds/CompanySerializer.java
@@ -59,7 +59,7 @@ public class CompanySerializer extends DataSerializer {
   public Object fromData(DataInput in) throws IOException, ClassNotFoundException {
 
     String name = in.readUTF();
-    Address address = (Address) readObject(in);
+    Address address = readObject(in);
     return new Company(name, address);
   }
 }

--- a/geode-junit/src/main/java/com/examples/ds/Employee.java
+++ b/geode-junit/src/main/java/com/examples/ds/Employee.java
@@ -14,6 +14,8 @@
  */
 package com.examples.ds;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -47,6 +49,6 @@ public class Employee implements DataSerializable {
     this.id = in.readInt();
     this.name = in.readUTF();
     this.birthday = DataSerializer.readDate(in);
-    this.employer = (Company) DataSerializer.readObject(in);
+    this.employer = readObject(in);
   }
 }

--- a/geode-junit/src/main/java/org/apache/geode/cache/query/data/Portfolio.java
+++ b/geode-junit/src/main/java/org/apache/geode/cache/query/data/Portfolio.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.cache.query.data;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -242,10 +244,10 @@ public class Portfolio implements Serializable, DataSerializable {
     }
     this.pkid = DataSerializer.readString(in);
 
-    this.position1 = (Position) DataSerializer.readObject(in);
-    this.position2 = (Position) DataSerializer.readObject(in);
-    this.positions = (HashMap) DataSerializer.readObject(in);
-    this.collectionHolderMap = (HashMap) DataSerializer.readObject(in);
+    this.position1 = readObject(in);
+    this.position2 = readObject(in);
+    this.positions = readObject(in);
+    this.collectionHolderMap = readObject(in);
     this.type = DataSerializer.readString(in);
     this.status = DataSerializer.readString(in);
     this.names = DataSerializer.readStringArray(in);
@@ -257,7 +259,7 @@ public class Portfolio implements Serializable, DataSerializable {
     if (position3Size != 0) {
       this.position3 = new Position[position3Size];
       for (int i = 0; i < position3Size; i++) {
-        this.position3[i] = (Position) DataSerializer.readObject(in);
+        this.position3[i] = readObject(in);
 
       }
     }

--- a/geode-junit/src/main/java/org/apache/geode/codeAnalysis/AnalyzeSerializablesJUnitTestBase.java
+++ b/geode-junit/src/main/java/org/apache/geode/codeAnalysis/AnalyzeSerializablesJUnitTestBase.java
@@ -78,7 +78,8 @@ public abstract class AnalyzeSerializablesJUnitTestBase {
   private static final String FAIL_MESSAGE = NEW_LINE + NEW_LINE
       + "If the class is not persisted or sent over the wire add it to the file " + NEW_LINE + "%s"
       + NEW_LINE + "Otherwise if this doesn't break backward compatibility, copy the file "
-      + NEW_LINE + "%s to " + NEW_LINE + "%s.";
+      + NEW_LINE + "%s to " + NEW_LINE + "%s." + NEW_LINE
+      + "Please note that these files are sorted, so you will need to insert your class in the right place.";
   private static final String EXCLUDED_CLASSES_TXT = "excludedClasses.txt";
   private static final String ACTUAL_DATA_SERIALIZABLES_DAT = "actualDataSerializables.dat";
   private static final String ACTUAL_SERIALIZABLES_DAT = "actualSerializables.dat";

--- a/geode-junit/src/main/java/org/apache/geode/internal/cache/execute/data/OrderId.java
+++ b/geode-junit/src/main/java/org/apache/geode/internal/cache/execute/data/OrderId.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache.execute.data;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -37,7 +39,7 @@ public class OrderId implements DataSerializable {
 
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
     this.orderId = DataSerializer.readInteger(in);
-    this.custId = (CustId) DataSerializer.readObject(in);
+    this.custId = readObject(in);
 
   }
 

--- a/geode-junit/src/main/java/org/apache/geode/internal/cache/execute/data/ShipmentId.java
+++ b/geode-junit/src/main/java/org/apache/geode/internal/cache/execute/data/ShipmentId.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache.execute.data;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -37,7 +39,7 @@ public class ShipmentId implements DataSerializable {
 
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
     this.shipmentId = DataSerializer.readInteger(in);
-    this.orderId = (OrderId) DataSerializer.readObject(in);
+    this.orderId = readObject(in);
   }
 
   public void toData(DataOutput out) throws IOException {

--- a/geode-junit/src/main/java/org/apache/geode/pdx/PdxInsideDS.java
+++ b/geode-junit/src/main/java/org/apache/geode/pdx/PdxInsideDS.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.pdx;
 
+import static org.apache.geode.DataSerializer.readObject;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -47,7 +49,7 @@ class PdxInsideDS implements DataSerializable {
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
     this.myString1 = DataSerializer.readString(in);
     this.myLong = DataSerializer.readPrimitiveLong(in);
-    this.myPdx = (PdxSerializable) DataSerializer.readObject(in);
+    this.myPdx = readObject(in);
     this.myString2 = DataSerializer.readString(in);
   }
 


### PR DESCRIPTION
and remove unused methods on `InternalDataSerializer`.