### PR TITLE
Better path resolution for srcDist exclusions

### DIFF
--- a/geode-assembly/build.gradle
+++ b/geode-assembly/build.gradle
@@ -15,6 +15,9 @@
  * limitations under the License.
  */
 
+import java.nio.file.Paths
+import java.nio.file.Path
+
 evaluationDependsOn(":geode-core")
 
 apply plugin: 'distribution'
@@ -320,8 +323,6 @@ distributions {
         exclude '**/gradlew.bat'
         exclude '**/gradle/wrapper/gradle-wrapper.jar'
         exclude '**/.gradle'
-        exclude '**/build/**'
-        exclude '**/out/**'
         exclude '**/.project'
         exclude '**/.classpath'
         exclude '**/.settings/**'
@@ -338,6 +339,17 @@ distributions {
         exclude 'daemon'
         exclude 'native'
         exclude 'wrapper'
+
+        // These exclude the 'build' and 'out' artifact directories from Gradle and IntelliJ for each project
+        exclude 'buildSrc/build'
+        exclude 'buildSrc/out'
+        rootProject.allprojects.each {
+          def relPath = Paths.get(rootDir.getPath()).relativize(Paths.get(it.projectDir.getPath()))
+          def relOut = relPath.resolve("out").toString()
+          def relBuild = relPath.resolve("build").toString()
+          exclude relOut
+          exclude relBuild
+        }
       }
 
     }


### PR DESCRIPTION
Previous exclusion would count executable files named 'build' or 'out'
regardless of path, when we only want to exclude the build-tools output
directories.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
