### PR TITLE
GEODE-5787: extract ProcessHolder to be an outer class

### DIFF
--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/standalone/DUnitLauncher.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/standalone/DUnitLauncher.java
@@ -124,8 +124,9 @@ public class DUnitLauncher {
   static final String MASTER_PARAM = "DUNIT_MASTER";
 
   public static final String RMI_PORT_PARAM = GEMFIRE_PREFIX + "DUnitLauncher.RMI_PORT";
+  public static final String RMI_HOST_PARAM = GEMFIRE_PREFIX + "DUnitLauncher.RMI_HOST";
   public static final String VM_NUM_PARAM = GEMFIRE_PREFIX + "DUnitLauncher.VM_NUM";
-  static final String VM_VERSION_PARAM = GEMFIRE_PREFIX + "DUnitLauncher.VM_VERSION";
+  public static final String VM_VERSION_PARAM = GEMFIRE_PREFIX + "DUnitLauncher.VM_VERSION";
 
   private static final String LAUNCHED_PROPERTY = GEMFIRE_PREFIX + "DUnitLauncher.LAUNCHED";
 

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/standalone/ProcessHolder.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/standalone/ProcessHolder.java
@@ -1,0 +1,44 @@
+package org.apache.geode.test.dunit.standalone;
+
+
+import java.io.InputStream;
+
+//TODO:: Do we need ProcessHolder?
+public class ProcessHolder {
+  private final Process process;
+  private volatile boolean killed = false;
+
+  public ProcessHolder(Process process) {
+    this.process = process;
+  }
+
+  public void kill() {
+    this.killed = true;
+    process.destroy();
+  }
+
+  public void killForcibly() {
+    this.killed = true;
+    process.destroyForcibly();
+  }
+
+  public void waitFor() throws InterruptedException {
+    process.waitFor();
+  }
+
+  public InputStream getErrorStream() {
+    return process.getErrorStream();
+  }
+
+  public InputStream getInputStream() {
+    return process.getInputStream();
+  }
+
+  public boolean isKilled() {
+    return killed;
+  }
+
+  public boolean isAlive() {
+    return !killed && process.isAlive();
+  }
+}

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/standalone/ProcessHolder.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/standalone/ProcessHolder.java
@@ -1,9 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.apache.geode.test.dunit.standalone;
-
 
 import java.io.InputStream;
 
-//TODO:: Do we need ProcessHolder?
 public class ProcessHolder {
   private final Process process;
   private volatile boolean killed = false;

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/standalone/ProcessManager.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/standalone/ProcessManager.java
@@ -95,8 +95,8 @@ public class ProcessManager {
       pendingVMs++;
       ProcessHolder holder = new ProcessHolder(process);
       processes.put(vmNum, holder);
-      linkStreams(version, vmNum, holder, process.getErrorStream(), System.err);
-      linkStreams(version, vmNum, holder, process.getInputStream(), System.out);
+      linkStreams(version, vmNum, holder, holder.getErrorStream(), System.err);
+      linkStreams(version, vmNum, holder, holder.getInputStream(), System.out);
     } catch (RuntimeException | Error t) {
       t.printStackTrace();
       throw t;
@@ -141,7 +141,7 @@ public class ProcessManager {
       } else {
         holder.kill();
       }
-      holder.getProcess().waitFor();
+      holder.waitFor();
       System.out.println("Old process for vm_" + vmNum + " has exited");
       launchVM(version, vmNum, true);
     } catch (InterruptedException | IOException e) {
@@ -326,37 +326,6 @@ public class ProcessManager {
     }
 
     return true;
-  }
-
-  public static class ProcessHolder {
-    private final Process process;
-    private volatile boolean killed = false;
-
-    public ProcessHolder(Process process) {
-      this.process = process;
-    }
-
-    public void kill() {
-      this.killed = true;
-      process.destroy();
-    }
-
-    public void killForcibly() {
-      this.killed = true;
-      process.destroyForcibly();
-    }
-
-    public Process getProcess() {
-      return process;
-    }
-
-    public boolean isKilled() {
-      return killed;
-    }
-
-    public boolean isAlive() {
-      return !killed && process.isAlive();
-    }
   }
 
   public RemoteDUnitVMIF getStub(int i)


### PR DESCRIPTION
  * Removed getter on ProcessHolder to get underlying  process
  * Added waitFor to ProcessHolder
  * Added getters to get underlying process error & input stream

Signed-off-by: Sai Boorlagadda <sboorlagadda@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
