### PR TITLE
GEODE-5711: Gfsh prompt for JNDI username and password

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/CreateJndiBindingCommandDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/CreateJndiBindingCommandDUnitTest.java
@@ -61,7 +61,7 @@ public class CreateJndiBindingCommandDUnitTest {
 
     // create the binding
     gfsh.executeAndAssertThat(
-        "create jndi-binding --name=jndi1 --type=SIMPLE --jdbc-driver-class=org.apache.derby.jdbc.EmbeddedDriver --connection-url=\"jdbc:derby:newDB;create=true\"")
+        "create jndi-binding --name=jndi1 --username=myuser --password=mypass --type=SIMPLE --jdbc-driver-class=org.apache.derby.jdbc.EmbeddedDriver --connection-url=\"jdbc:derby:newDB;create=true\"")
         .statusIsSuccess().tableHasColumnOnlyWithValues("Member", "server-1", "server-2");
 
     // verify cluster config is updated
@@ -69,10 +69,14 @@ public class CreateJndiBindingCommandDUnitTest {
       InternalConfigurationPersistenceService ccService =
           ClusterStartupRule.getLocator().getConfigurationPersistenceService();
       Configuration configuration = ccService.getConfiguration("cluster");
-      Document document = XmlUtils.createDocumentFromXml(configuration.getCacheXmlContent());
+      String xmlContent = configuration.getCacheXmlContent();
+
+      Document document = XmlUtils.createDocumentFromXml(xmlContent);
       NodeList jndiBindings = document.getElementsByTagName("jndi-binding");
 
-      assertThat(jndiBindings.getLength()).isGreaterThan(0);
+      assertThat(jndiBindings.getLength()).isEqualTo(1);
+      assertThat(xmlContent).contains("user-name=\"myuser\"");
+      assertThat(xmlContent).contains("password=\"mypass\"");
 
       boolean found = false;
       for (int i = 0; i < jndiBindings.getLength(); i++) {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/GfshParseResult.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/GfshParseResult.java
@@ -95,6 +95,10 @@ public class GfshParseResult extends ParseResult {
     return userInput;
   }
 
+  public void setUserInput(String userText) {
+    userInput = userText;
+  }
+
   public Object getParamValue(String param) {
     return paramValueMap.get(param);
   }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateJndiBindingCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateJndiBindingCommand.java
@@ -95,7 +95,8 @@ public class CreateJndiBindingCommand extends SingleGfshCommand {
       "Properties for the custom XADataSource driver. Append json string containing (name, type, value) to set any property. Eg: --datasource-config-properties={'name':'name1','type':'type1','value':'value1'},{'name':'name2','type':'type2','value':'value2'}";
 
   @CliCommand(value = CREATE_JNDIBINDING, help = CREATE_JNDIBINDING__HELP)
-  @CliMetaData(relatedTopic = CliStrings.TOPIC_GEODE_REGION)
+  @CliMetaData(relatedTopic = CliStrings.TOPIC_GEODE_REGION,
+      interceptor = "org.apache.geode.management.internal.cli.commands.UsernamePasswordInterceptor")
   @ResourceOperation(resource = ResourcePermission.Resource.CLUSTER,
       operation = ResourcePermission.Operation.MANAGE)
   public ResultModel createJDNIBinding(
@@ -115,10 +116,10 @@ public class CreateJndiBindingCommand extends SingleGfshCommand {
       @CliOption(key = MANAGED_CONN_FACTORY_CLASS,
           help = MANAGED_CONN_FACTORY_CLASS__HELP) String managedConnFactory,
       @CliOption(key = MAX_POOL_SIZE, help = MAX_POOL_SIZE__HELP) Integer maxPoolSize,
+      @CliOption(key = USERNAME, help = USERNAME__HELP) String username,
       @CliOption(key = PASSWORD, help = PASSWORD__HELP) String password,
       @CliOption(key = TRANSACTION_TYPE, help = TRANSACTION_TYPE__HELP) String transactionType,
       @CliOption(key = TYPE, mandatory = true, help = TYPE__HELP) DATASOURCE_TYPE type,
-      @CliOption(key = USERNAME, help = USERNAME__HELP) String username,
       @CliOption(key = XA_DATASOURCE_CLASS, help = XA_DATASOURCE_CLASS__HELP) String xaDataSource,
       @CliOption(key = CliStrings.IFNOTEXISTS, help = IFNOTEXISTS__HELP,
           specifiedDefaultValue = "true", unspecifiedDefaultValue = "false") boolean ifNotExists,

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/UsernamePasswordInterceptor.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/UsernamePasswordInterceptor.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.management.internal.cli.commands;
+
+import org.apache.commons.lang.StringUtils;
+
+import org.apache.geode.management.internal.cli.AbstractCliAroundInterceptor;
+import org.apache.geode.management.internal.cli.GfshParseResult;
+import org.apache.geode.management.internal.cli.i18n.CliStrings;
+import org.apache.geode.management.internal.cli.result.model.ResultModel;
+import org.apache.geode.management.internal.cli.shell.Gfsh;
+
+public class UsernamePasswordInterceptor extends AbstractCliAroundInterceptor {
+  @Override
+  public ResultModel preExecution(GfshParseResult parseResult) {
+    Gfsh gfsh = Gfsh.getCurrentInstance();
+    if (gfsh == null || !gfsh.isConnectedAndReady()) {
+      return new ResultModel();
+    }
+
+    String userInput = parseResult.getUserInput();
+
+    String username = parseResult.getParamValueAsString("username");
+    String password = parseResult.getParamValueAsString("password");
+
+    if (!StringUtils.isBlank(password) && StringUtils.isBlank(username)) {
+      username = gfsh.readText(CliStrings.INTERCEPTOR_USERNAME);
+      userInput = userInput + " --username=" + username;
+      parseResult.setUserInput(userInput);
+    } else if (!StringUtils.isBlank(username) && StringUtils.isBlank(password)) {
+      password = gfsh.readPassword(CliStrings.INTERCEPTOR_PASSWORD);
+      userInput = userInput + " --password=" + password;
+      parseResult.setUserInput(userInput);
+    }
+
+    return new ResultModel();
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/i18n/CliStrings.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/i18n/CliStrings.java
@@ -1595,6 +1595,9 @@ public class CliStrings {
   public static final String IMPORT_DATA__INVOKE_CALLBACKS__HELP =
       "Whether callbacks should be invoked";
 
+  public static final String INTERCEPTOR_PASSWORD = "Password: ";
+  public static final String INTERCEPTOR_USERNAME = "Username: ";
+
   /* 'list async-event-queues' command */
   public static final String LIST_ASYNC_EVENT_QUEUES = "list async-event-queues";
   public static final String LIST_ASYNC_EVENT_QUEUES__HELP =

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/UsernamePasswordInterceptorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/UsernamePasswordInterceptorTest.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.management.internal.cli.commands;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import org.apache.geode.management.internal.cli.GfshParseResult;
+import org.apache.geode.management.internal.cli.shell.Gfsh;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({Gfsh.class})
+public class UsernamePasswordInterceptorTest {
+  private Gfsh gfsh;
+  private GfshParseResult parseResult;
+
+  @Before
+  public void setUp() throws Exception {
+    gfsh = mock(Gfsh.class);
+    parseResult = mock(GfshParseResult.class);
+
+    PowerMockito.mockStatic(Gfsh.class);
+    PowerMockito.when(Gfsh.getCurrentInstance()).thenReturn(gfsh);
+  }
+
+  @Test
+  public void WithConnectedGfshWithNoUsernameAndNoPasswordWillPrompt_interactive()
+      throws Exception {
+    when(gfsh.readText("Username: ")).thenReturn("user");
+    when(gfsh.readPassword("Password: ")).thenReturn("pass");
+    when(gfsh.isConnectedAndReady()).thenReturn(true);
+
+    when(parseResult.getUserInput()).thenReturn("command");
+    when(parseResult.getParamValueAsString("username")).thenReturn("");
+    when(parseResult.getParamValueAsString("password")).thenReturn("");
+
+    UsernamePasswordInterceptor interceptor = new UsernamePasswordInterceptor();
+    interceptor.preExecution(parseResult);
+
+    verify(gfsh, times(0)).readText(any());
+    verify(gfsh, times(0)).readPassword(any());
+    verify(parseResult, times(0)).setUserInput("command");
+  }
+
+  @Test
+  public void WithConnectedGfshWithUsernameButNoPasswordWillPrompt_interactive()
+      throws Exception {
+    when(gfsh.readPassword("Password: ")).thenReturn("pass");
+    when(gfsh.isConnectedAndReady()).thenReturn(true);
+
+    when(parseResult.getUserInput()).thenReturn("command --username=user");
+    when(parseResult.getParamValueAsString("username")).thenReturn("user");
+    when(parseResult.getParamValueAsString("password")).thenReturn("");
+
+    UsernamePasswordInterceptor interceptor = new UsernamePasswordInterceptor();
+    interceptor.preExecution(parseResult);
+
+    verify(gfsh, times(0)).readText(any());
+    verify(gfsh, times(1)).readPassword(any());
+    verify(parseResult, times(1)).setUserInput("command --username=user --password=pass");
+  }
+
+  @Test
+  public void WithConnectedGfshWithUsernameAndPasswordWillNotPrompt_interactive()
+      throws Exception {
+    when(gfsh.isConnectedAndReady()).thenReturn(true);
+
+    when(parseResult.getUserInput()).thenReturn("command --username=user --password=pass");
+    when(parseResult.getParamValueAsString("username")).thenReturn("user");
+    when(parseResult.getParamValueAsString("password")).thenReturn("pass");
+
+    UsernamePasswordInterceptor interceptor = new UsernamePasswordInterceptor();
+    interceptor.preExecution(parseResult);
+
+    verify(gfsh, times(0)).readText(any());
+    verify(gfsh, times(0)).readPassword(any());
+    verify(parseResult, times(0)).setUserInput("command --username=user --password=pass");
+  }
+
+  @Test
+  public void WithConnectedGfshWithPasswordButNoUsernameWillPrompt_interactive()
+      throws Exception {
+    when(gfsh.readText("Username: ")).thenReturn("user");
+    when(gfsh.isConnectedAndReady()).thenReturn(true);
+
+    when(parseResult.getUserInput()).thenReturn("command --password=pass");
+    when(parseResult.getParamValueAsString("username")).thenReturn("");
+    when(parseResult.getParamValueAsString("password")).thenReturn("pass");
+
+    UsernamePasswordInterceptor interceptor = new UsernamePasswordInterceptor();
+    interceptor.preExecution(parseResult);
+
+    verify(gfsh, times(1)).readText(any());
+    verify(gfsh, times(0)).readPassword(any());
+    verify(parseResult, times(1)).setUserInput("command --password=pass --username=user");
+  }
+
+  @Test
+  public void WithNonConnectedGfshWithoutUsernameAndPasswordWillNotPrompt_interactive()
+      throws Exception {
+    when(gfsh.isConnectedAndReady()).thenReturn(false);
+
+    when(parseResult.getUserInput()).thenReturn("command");
+    when(parseResult.getParamValueAsString("username")).thenReturn("");
+    when(parseResult.getParamValueAsString("password")).thenReturn("");
+
+    UsernamePasswordInterceptor interceptor = new UsernamePasswordInterceptor();
+    interceptor.preExecution(parseResult);
+
+    verify(gfsh, times(0)).readText(any());
+    verify(gfsh, times(0)).readPassword(any());
+    verify(parseResult, times(0)).setUserInput(any());
+  }
+}


### PR DESCRIPTION
Added Intercepter to CreateJndiCommand to prompt for user name and
password.

Modified GfshParseResult to allow update of the user input text.
When the command parsing occurs again on the remote side, the
modified user input will be used to determine function parms.

Added tests to cover new interceptor and modified tests to cover
new funcitonality for GfshExecutionStrategy and
CreateJndiBindingCommand.

Co-authored-by: Scott Jewell <sjewell@pivotal.io>
Co-authored-by: Jianxia Chen <jchen@pivotal.io>
Co-authored-by: Ben Ross <bross@pivotal.io>
Co-authored-by: Rob Day-Reynolds <rdayreynolds@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
