### PR TITLE
GEODE-5811: Get gradle to cache tomcat and jetty installs

### DIFF
--- a/geode-assembly/build.gradle
+++ b/geode-assembly/build.gradle
@@ -92,8 +92,7 @@ configurations {
 
   //Configurations used to download and cache web application servers for session module testing
   webServerTomcat6
-  webServerTomcat73
-  webServerTomcat79
+  webServerTomcat7
   webServerTomcat8
   webServerTomcat9
   webServerJetty
@@ -176,14 +175,14 @@ dependencies {
   upgradeTestRuntime group: 'org.codehaus.cargo', name: 'cargo-core-uberjar', version: '1.6.3'
   upgradeTestRuntime 'org.apache.httpcomponents:httpclient:' + project.'httpclient.version'
   upgradeTestRuntime project(':extensions:session-testing-war')
+  upgradeTestRuntime files({ downloadWebServers } )
 
   //Web servers used for session module testing
-  webServerTomcat6 group: 'apache', name: 'tomcat', version: '6.0.37', ext: 'zip'
-  webServerTomcat73 group: 'org.apache.tomcat', name: 'tomcat', version: '7.0.73', ext: 'zip'
-  webServerTomcat79 group: 'org.apache.tomcat', name: 'tomcat', version: '7.0.79', ext: 'zip'
-  webServerTomcat8 group: 'org.apache.tomcat', name: 'tomcat', version: '8.5.15', ext: 'zip'
-  webServerTomcat9 group: 'org.apache.tomcat', name: 'tomcat', version: '9.0.12', ext: 'zip'
-  webServerJetty group: 'org.eclipse.jetty', name: 'jetty-distribution', version: '9.4.8.v20171121', ext: 'zip'
+  webServerTomcat6 group: 'apache', name: 'tomcat', version: project.'tomcat6.version', ext: 'zip'
+  webServerTomcat7 group: 'org.apache.tomcat', name: 'tomcat', version: project.'tomcat7.version', ext: 'zip'
+  webServerTomcat8 group: 'org.apache.tomcat', name: 'tomcat', version: project.'tomcat8.version', ext: 'zip'
+  webServerTomcat9 group: 'org.apache.tomcat', name: 'tomcat', version: project.'tomcat9.version', ext: 'zip'
+  webServerJetty group: 'org.eclipse.jetty', name: 'jetty-distribution', version: project.'jetty.version', ext: 'zip'
 
   gfshDependencies ('org.springframework:spring-web:' + project.'springframework.version'){
     exclude module: 'spring-core'

--- a/geode-assembly/build.gradle
+++ b/geode-assembly/build.gradle
@@ -73,11 +73,44 @@ gradle.taskGraph.whenReady( { graph ->
   }
 })
 
+//This "repository" only exists to download tomcat-6, because the zip for tomcat 6 is
+//not in a maven repo. Later versions of tomcat are.
+repositories {
+  ivy {
+    url 'https://archive.apache.org/'
+    layout 'pattern', {
+      artifact '/dist/tomcat/tomcat-6/v6.0.37/bin/[organisation]-[module]-[revision].[ext]'
+    }
+  }
+}
+
 configurations {
   bundled {
     description 'A dependency that is shipped with geode, but is not required to compile'
   }
   gfshDependencies
+
+  //Configurations used to download and cache web application servers for session module testing
+  webServerTomcat6
+  webServerTomcat73
+  webServerTomcat79
+  webServerTomcat8
+  webServerTomcat9
+  webServerJetty
+}
+
+def webServersDir = "$buildDir/generated-resources/webservers"
+
+sourceSets {
+  distributedTest {
+    output.dir(webServersDir, builtBy: 'downloadWebServers')
+  }
+}
+
+
+task downloadWebServers(type:Copy) {
+  from {configurations.findAll {it.name.startsWith("webServer")}}
+  into webServersDir
 }
 
 dependencies {
@@ -144,6 +177,13 @@ dependencies {
   upgradeTestRuntime 'org.apache.httpcomponents:httpclient:' + project.'httpclient.version'
   upgradeTestRuntime project(':extensions:session-testing-war')
 
+  //Web servers used for session module testing
+  webServerTomcat6 group: 'apache', name: 'tomcat', version: '6.0.37', ext: 'zip'
+  webServerTomcat73 group: 'org.apache.tomcat', name: 'tomcat', version: '7.0.73', ext: 'zip'
+  webServerTomcat79 group: 'org.apache.tomcat', name: 'tomcat', version: '7.0.79', ext: 'zip'
+  webServerTomcat8 group: 'org.apache.tomcat', name: 'tomcat', version: '8.5.15', ext: 'zip'
+  webServerTomcat9 group: 'org.apache.tomcat', name: 'tomcat', version: '9.0.12', ext: 'zip'
+  webServerJetty group: 'org.eclipse.jetty', name: 'jetty-distribution', version: '9.4.8.v20171121', ext: 'zip'
 
   gfshDependencies ('org.springframework:spring-web:' + project.'springframework.version'){
     exclude module: 'spring-core'
@@ -476,3 +516,4 @@ task dumpInstalledJars(dependsOn: installDist) {
     }
   }
 }
+

--- a/geode-assembly/geode-assembly-test/src/main/java/org/apache/geode/session/tests/ContainerInstall.java
+++ b/geode-assembly/geode-assembly-test/src/main/java/org/apache/geode/session/tests/ContainerInstall.java
@@ -42,6 +42,7 @@ import org.w3c.dom.NodeList;
 
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.management.internal.configuration.utils.ZipUtils;
+import org.apache.geode.util.test.TestUtil;
 
 /**
  * Base class for handling downloading and configuring J2EE containers.
@@ -135,11 +136,12 @@ public abstract class ContainerInstall {
 
     clearPreviousInstall(installDir);
 
-    logger.info("Installing container from URL " + downloadURL);
+    String url = "file://" + TestUtil.getResourcePath(getClass(), "/" + downloadURL);
+    logger.info("Installing container from URL " + url);
 
     // Optional step to install the container from a URL pointing to its distribution
     Installer installer =
-        new ZipURLInstaller(new URL(downloadURL), TMP_DIR + "/downloads", installDir);
+        new ZipURLInstaller(new URL(url), TMP_DIR + "/downloads", installDir);
     installer.install();
 
     // Set install home

--- a/geode-assembly/geode-assembly-test/src/main/java/org/apache/geode/session/tests/TomcatInstall.java
+++ b/geode-assembly/geode-assembly-test/src/main/java/org/apache/geode/session/tests/TomcatInstall.java
@@ -43,9 +43,8 @@ public class TomcatInstall extends ContainerInstall {
    */
   public enum TomcatVersion {
     TOMCAT6(6, "tomcat-6.0.37.zip"),
-    TOMCAT7(7, "tomcat-7.0.73.zip"),
-    TOMCAT779(7, "tomcat-7.0.79.zip"),
-    TOMCAT8(8, "tomcat-8.5.15.zip"),
+    TOMCAT7(7, "tomcat-7.0.90.zip"),
+    TOMCAT8(8, "tomcat-8.5.34.zip"),
     TOMCAT9(9, "tomcat-9.0.12.zip");
 
     private final int version;
@@ -93,7 +92,6 @@ public class TomcatInstall extends ContainerInstall {
         case TOMCAT6:
           return null;
         case TOMCAT7:
-        case TOMCAT779:
           return "tomcat.util.scan.DefaultJarScanner.jarsToSkip";
         case TOMCAT8:
         case TOMCAT9:

--- a/geode-assembly/geode-assembly-test/src/main/java/org/apache/geode/session/tests/TomcatInstall.java
+++ b/geode-assembly/geode-assembly-test/src/main/java/org/apache/geode/session/tests/TomcatInstall.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.regex.Pattern;
 
+
 /**
  * Tomcat specific container installation class
  *
@@ -41,18 +42,11 @@ public class TomcatInstall extends ContainerInstall {
    * version, and other properties or XML attributes needed to setup tomcat containers within Cargo
    */
   public enum TomcatVersion {
-    TOMCAT6(6,
-        "http://archive.apache.org/dist/tomcat/tomcat-6/v6.0.37/bin/apache-tomcat-6.0.37.zip"),
-    TOMCAT7(7,
-        "http://archive.apache.org/dist/tomcat/tomcat-7/v7.0.73/bin/apache-tomcat-7.0.73.zip"),
-    TOMCAT755(7,
-        "http://archive.apache.org/dist/tomcat/tomcat-7/v7.0.55/bin/apache-tomcat-7.0.55.zip"),
-    TOMCAT779(7,
-        "http://archive.apache.org/dist/tomcat/tomcat-7/v7.0.79/bin/apache-tomcat-7.0.79.zip"),
-    TOMCAT8(8,
-        "http://archive.apache.org/dist/tomcat/tomcat-8/v8.5.15/bin/apache-tomcat-8.5.15.zip"),
-    TOMCAT9(9,
-        "http://archive.apache.org/dist/tomcat/tomcat-9/v9.0.0.M21/bin/apache-tomcat-9.0.0.M21.zip");
+    TOMCAT6(6, "tomcat-6.0.37.zip"),
+    TOMCAT7(7, "tomcat-7.0.73.zip"),
+    TOMCAT779(7, "tomcat-7.0.79.zip"),
+    TOMCAT8(8, "tomcat-8.5.15.zip"),
+    TOMCAT9(9, "tomcat-9.0.12.zip");
 
     private final int version;
     private final String downloadURL;
@@ -99,7 +93,6 @@ public class TomcatInstall extends ContainerInstall {
         case TOMCAT6:
           return null;
         case TOMCAT7:
-        case TOMCAT755:
         case TOMCAT779:
           return "tomcat.util.scan.DefaultJarScanner.jarsToSkip";
         case TOMCAT8:

--- a/geode-assembly/src/distributedTest/java/org/apache/geode/session/tests/GenericAppServerInstall.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/session/tests/GenericAppServerInstall.java
@@ -41,8 +41,7 @@ public class GenericAppServerInstall extends ContainerInstall {
    * Currently the only supported keyword instance is JETTY9.
    */
   public enum GenericAppServerVersion {
-    JETTY9(9, "http://central.maven.org/maven2/org/eclipse/jetty/jetty-distribution/"
-        + JETTY_VERSION + "/jetty-distribution-" + JETTY_VERSION + ".zip", "jetty");
+    JETTY9(9, "jetty-distribution-" + JETTY_VERSION + ".zip", "jetty");
 
     private final int version;
     private final String downloadURL;

--- a/geode-assembly/src/upgradeTest/java/org/apache/geode/session/tests/TomcatSessionBackwardsCompatibilityTestBase.java
+++ b/geode-assembly/src/upgradeTest/java/org/apache/geode/session/tests/TomcatSessionBackwardsCompatibilityTestBase.java
@@ -114,12 +114,12 @@ public abstract class TomcatSessionBackwardsCompatibilityTestBase {
 
   @Before
   public void setup() throws Exception {
-    tomcat7079AndOldModules = new TomcatInstall(TomcatInstall.TomcatVersion.TOMCAT779,
+    tomcat7079AndOldModules = new TomcatInstall(TomcatInstall.TomcatVersion.TOMCAT7,
         ContainerInstall.ConnectionType.CLIENT_SERVER,
         ContainerInstall.DEFAULT_INSTALL_DIR + "Tomcat7079AndOldModules",
         oldModules.getAbsolutePath(), oldBuild.getAbsolutePath() + "/lib");
 
-    tomcat7079AndCurrentModules = new TomcatInstall(TomcatInstall.TomcatVersion.TOMCAT779,
+    tomcat7079AndCurrentModules = new TomcatInstall(TomcatInstall.TomcatVersion.TOMCAT7,
         ContainerInstall.ConnectionType.CLIENT_SERVER,
         ContainerInstall.DEFAULT_INSTALL_DIR + "Tomcat7079AndCurrentModules");
 

--- a/gradle/dependency-versions.properties
+++ b/gradle/dependency-versions.properties
@@ -105,4 +105,5 @@ tempus-fugit.version = 1.1
 tomcat6.version = 6.0.37
 tomcat7.version = 7.0.90
 tomcat8.version = 8.5.34
+tomcat9.version = 9.0.12
 xercesImpl.version = 2.12.0


### PR DESCRIPTION
We were downloading full installs of tomcat and jetty on every test run.
This occasionally resulted in test failures if the download site was
down. Now we get this installs as gradle dependencies, which will be
cached.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
