### PR TITLE
GEODE-5828: fixes replicates miss transaction commit.

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXCommitMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXCommitMessage.java
@@ -92,7 +92,6 @@ public class TXCommitMessage extends PooledDistributionMessage
   protected int processorId; // 0 unless needsAck is true
   protected TXLockIdImpl lockId;
   protected HashSet farSiders;
-
   protected transient DistributionManager dm; // Used on the sending side of this message
   private transient int sequenceNum = 0;
 
@@ -1837,7 +1836,7 @@ public class TXCommitMessage extends PooledDistributionMessage
 
     @Override
     protected void process(ClusterDistributionManager dm) {
-      final boolean processMsgReceived = txTracker.commitProcessReceived(this.trackerKey, dm);
+      final boolean processMsgReceived = txTracker.commitProcessReceived(this.trackerKey);
       if (!processMsgReceived) {
         if (logger.isDebugEnabled()) {
           logger.debug("CommitProcessQuery did not find {} in the history", this.trackerKey);
@@ -1979,7 +1978,7 @@ public class TXCommitMessage extends PooledDistributionMessage
     if (!getSender().equals(id)) {
       return;
     }
-    this.dm.removeMembershipListener(this);
+    getDm().removeMembershipListener(this);
 
     synchronized (this) {
       if (isProcessing() || this.departureNoticed) {
@@ -1996,7 +1995,7 @@ public class TXCommitMessage extends PooledDistributionMessage
 
     // Send message to fellow FarSiders (aka recipients), if any, to
     // determine if any one of them have received a CommitProcessMessage
-    if (this.farSiders != null && !this.farSiders.isEmpty()) {
+    if (getFarSiders() != null && !getFarSiders().isEmpty()) {
       if (logger.isDebugEnabled()) {
         logger.debug(
             "Member departed: {} sending query for CommitProcess message to other recipients.", id);
@@ -2009,66 +2008,7 @@ public class TXCommitMessage extends PooledDistributionMessage
         // sized thread pool
         @Override
         public void run() {
-          final TXCommitMessage mess = TXCommitMessage.this;
-          Object trackerKey = mess.getTrackerKey();
-          DistributedMember member = getMemberFromTrackerKey(trackerKey);
-          if (!mess.getSender().equals(member)) {
-            /*
-             * Do not send a CommitProcessQueryMessage when the sender of CommitMessage is not the
-             * member in the tracker key. (If this happens we are the redundant node for PR, and the
-             * primary just crashed).
-             */
-            txTracker.removeMessage(mess);
-            return;
-          }
-          CommitProcessQueryReplyProcessor replProc =
-              new CommitProcessQueryReplyProcessor(mess.dm, mess.farSiders);
-          CommitProcessQueryMessage query =
-              new CommitProcessQueryMessage(mess.getTrackerKey(), replProc.getProcessorId());
-          query.setRecipients(mess.farSiders);
-          mess.dm.putOutgoing(query);
-          // Wait for any one positive response or all negative responses.
-          // (while() loop removed for bug 36983 - you can't loop on waitForReplies()
-          TXCommitMessage.this.dm.getCancelCriterion().checkCancelInProgress(null);
-          try {
-            replProc.waitForRepliesUninterruptibly();
-          } catch (ReplyException e) {
-            e.handleCause();
-          }
-          if (replProc.receivedACommitProcessMessage()) {
-            if (logger.isDebugEnabled()) {
-              logger.debug(
-                  "Transaction associated with lockID: {} from orign {} is processing due to a received \"commit process\" message",
-                  mess.lockId, id);
-            }
-
-            try {
-              // Set processor to zero to avoid the ack to the now departed origin
-              mess.processorId = 0;
-              mess.basicProcess();
-            } finally {
-              txTracker.processed(mess);
-            }
-          } else {
-            if (logger.isDebugEnabled()) {
-              logger.debug(
-                  "Transaction associated with lockID: {} from origin {} ignored.  No other recipients received \"commit process\" message",
-                  mess.lockId, id);
-            }
-            txTracker.removeMessage(mess);
-          }
-
-        }
-
-        private DistributedMember getMemberFromTrackerKey(Object trackerKey) {
-          if (trackerKey instanceof TXId) {
-            TXId id1 = (TXId) trackerKey;
-            return id1.getMemberId();
-          } else if (trackerKey instanceof TXLockId) {
-            TXLockId id2 = (TXLockId) trackerKey;
-            return id2.getMemberId();
-          }
-          return null;
+          doCommitProcessQuery(id);
         }
       };
       fellowFarSidersQuery.setDaemon(true);
@@ -2098,6 +2038,73 @@ public class TXCommitMessage extends PooledDistributionMessage
       originDepartedCommit.setDaemon(true);
       originDepartedCommit.start();
     }
+  }
+
+  HashSet getFarSiders() {
+    return farSiders;
+  }
+
+  DistributionManager getDm() {
+    return dm;
+  }
+
+  void doCommitProcessQuery(final InternalDistributedMember id) {
+    final TXCommitMessage message = TXCommitMessage.this;
+
+    CommitProcessQueryReplyProcessor replyProcessor = createReplyProcessor(message);
+    CommitProcessQueryMessage queryMessage = createQueryMessage(message, replyProcessor);
+    queryMessage.setRecipients(message.farSiders);
+    message.getDm().putOutgoing(queryMessage);
+    // Wait for any one positive response or all negative responses.
+    // (while() loop removed for bug 36983 - you can't loop on waitForReplies()
+    message.getDm().getCancelCriterion().checkCancelInProgress(null);
+    try {
+      replyProcessor.waitForRepliesUninterruptibly();
+    } catch (ReplyException e) {
+      e.handleCause();
+    }
+    if (replyProcessor.receivedACommitProcessMessage()) {
+      if (logger.isDebugEnabled()) {
+        logger.debug(
+            "Transaction associated with lockID: {} from orign {} is processing due to a received \"commit process\" message",
+            message.lockId, id);
+      }
+
+      try {
+        // Set processor to zero to avoid the ack to the now departed origin
+        message.processorId = 0;
+        message.basicProcess();
+      } finally {
+        txTracker.processed(message);
+      }
+    } else {
+      if (logger.isDebugEnabled()) {
+        logger.debug(
+            "Transaction associated with lockID: {} from origin {} ignored.  No other recipients received \"commit process\" message",
+            message.lockId, id);
+      }
+      txTracker.removeMessage(message);
+    }
+  }
+
+  CommitProcessQueryReplyProcessor createReplyProcessor(TXCommitMessage message) {
+    return new CommitProcessQueryReplyProcessor(message.dm, message.farSiders);
+  }
+
+  CommitProcessQueryMessage createQueryMessage(TXCommitMessage message,
+      CommitProcessQueryReplyProcessor replProc) {
+    return new CommitProcessQueryMessage(message.getTrackerKey(), replProc.getProcessorId());
+  }
+
+  private DistributedMember getMemberFromTrackerKey(Object trackerKey) {
+    if (trackerKey instanceof TXId) {
+      TXId id1 = (TXId) trackerKey;
+      return id1.getMemberId();
+    } else if (trackerKey instanceof TXLockId) {
+      TXLockId id2 = (TXLockId) trackerKey;
+      return id2.getMemberId();
+    }
+    return null;
   }
 
   void setUpdateLockMembers() {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXFarSideCMTracker.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXFarSideCMTracker.java
@@ -125,10 +125,7 @@ public class TXFarSideCMTracker {
   }
 
   boolean foundTxInProgress(TXCommitMessage message) {
-    if (null != message && message.isProcessing()) {
-      return true;
-    }
-    return false;
+    return null != message && message.isProcessing();
   }
 
   boolean foundFromHistory(Object key) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXFarSideCMTracker.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXFarSideCMTracker.java
@@ -91,38 +91,25 @@ public class TXFarSideCMTracker {
    * Answers fellow "Far Siders" question about an DACK transaction when the transaction originator
    * died before it sent the CommitProcess message.
    */
-  public boolean commitProcessReceived(Object key, DistributionManager dm) {
-    // Assume that after the member has departed that we have all its pending
-    // transaction messages
-    if (key instanceof TXLockId) {
-      TXLockId lk = (TXLockId) key;
-      waitForMemberToDepart(lk.getMemberId(), dm);
-    } else if (key instanceof TXId) {
-      TXId id = (TXId) key;
-      waitForMemberToDepart(id.getMemberId(), dm);
-    } else {
-      Assert.assertTrue(false, "TXTracker received an unknown key class: " + key.getClass());
-    }
-
-    final TXCommitMessage mess;
-    synchronized (this.txInProgress) {
-      mess = (TXCommitMessage) this.txInProgress.get(key);
-      if (null != mess && mess.isProcessing()) {
+  public boolean commitProcessReceived(Object key) {
+    final TXCommitMessage message;
+    synchronized (txInProgress) {
+      message = (TXCommitMessage) getTxInProgress().get(key);
+      if (foundTxInProgress(message)) {
         return true;
       }
-      for (int i = this.txHistory.length - 1; i >= 0; --i) {
-        if (key.equals(this.txHistory[i])) {
-          return true;
-        }
+
+      if (foundFromHistory(key)) {
+        return true;
       }
     }
 
-    if (mess != null) {
-      synchronized (mess) {
-        if (!mess.isProcessing()) {
+    if (message != null) {
+      synchronized (message) {
+        if (!message.isProcessing()) {
           // Prevent any potential future processing
           // of this message
-          mess.setDontProcess();
+          message.setDontProcess();
           return false;
         } else {
           return true;
@@ -130,6 +117,26 @@ public class TXFarSideCMTracker {
       }
     }
 
+    return false;
+  }
+
+  Map getTxInProgress() {
+    return txInProgress;
+  }
+
+  boolean foundTxInProgress(TXCommitMessage message) {
+    if (null != message && message.isProcessing()) {
+      return true;
+    }
+    return false;
+  }
+
+  boolean foundFromHistory(Object key) {
+    for (int i = this.txHistory.length - 1; i >= 0; --i) {
+      if (key.equals(this.txHistory[i])) {
+        return true;
+      }
+    }
     return false;
   }
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/TXCommitMessageTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/TXCommitMessageTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.HashSet;
+
+import org.junit.Test;
+
+import org.apache.geode.CancelCriterion;
+import org.apache.geode.distributed.internal.DistributionManager;
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
+
+public class TXCommitMessageTest {
+
+  @Test
+  public void commitProcessQueryMessageIsSentIfHostDeparted() {
+    DistributionManager manager = mock(DistributionManager.class);
+    InternalDistributedMember member = mock(InternalDistributedMember.class);
+    DistributionManager dm = mock(DistributionManager.class);
+    TXCommitMessage.CommitProcessQueryReplyProcessor processor = mock(
+        TXCommitMessage.CommitProcessQueryReplyProcessor.class);
+    TXCommitMessage.CommitProcessQueryMessage queryMessage =
+        mock(TXCommitMessage.CommitProcessQueryMessage.class);
+    HashSet farSiders = mock(HashSet.class);
+    TXCommitMessage message = spy(new TXCommitMessage());
+    doReturn(dm).when(message).getDm();
+    when(dm.getCancelCriterion()).thenReturn(mock(CancelCriterion.class));
+    doReturn(member).when(message).getSender();
+    doReturn(false).when(message).isProcessing();
+    doReturn(processor).when(message).createReplyProcessor(message);
+    doReturn(farSiders).when(message).getFarSiders();
+    doReturn(queryMessage).when(message).createQueryMessage(message, processor);
+    when(farSiders.isEmpty()).thenReturn(false);
+
+    message.memberDeparted(manager, member, false);
+
+    verify(dm).putOutgoing(queryMessage);
+    verify(processor).waitForRepliesUninterruptibly();
+  }
+
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/TXCommitMessageTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/TXCommitMessageTest.java
@@ -17,6 +17,7 @@ package org.apache.geode.internal.cache;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -41,19 +42,19 @@ public class TXCommitMessageTest {
         mock(TXCommitMessage.CommitProcessQueryMessage.class);
     HashSet farSiders = mock(HashSet.class);
     TXCommitMessage message = spy(new TXCommitMessage());
-    doReturn(dm).when(message).getDm();
+    doReturn(dm).when(message).getDistributionManager();
     when(dm.getCancelCriterion()).thenReturn(mock(CancelCriterion.class));
     doReturn(member).when(message).getSender();
     doReturn(false).when(message).isProcessing();
-    doReturn(processor).when(message).createReplyProcessor(message);
+    doReturn(processor).when(message).createReplyProcessor();
     doReturn(farSiders).when(message).getFarSiders();
-    doReturn(queryMessage).when(message).createQueryMessage(message, processor);
+    doReturn(queryMessage).when(message).createQueryMessage(processor);
     when(farSiders.isEmpty()).thenReturn(false);
 
     message.memberDeparted(manager, member, false);
 
-    verify(dm).putOutgoing(queryMessage);
-    verify(processor).waitForRepliesUninterruptibly();
+    verify(dm, timeout(60000)).putOutgoing(queryMessage);
+    verify(processor, timeout(60000)).waitForRepliesUninterruptibly();
   }
 
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/TXFarSideCMTrackerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/TXFarSideCMTrackerTest.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class TXFarSideCMTrackerTest {
+  private TXCommitMessage message;
+  private TXFarSideCMTracker tracker;
+  private Map txInProcess;
+  private final Object trackerKey = new Object();
+
+  @Before
+  public void setup() {
+    message = mock(TXCommitMessage.class);
+    txInProcess = mock(Map.class);
+    tracker = new TXFarSideCMTracker(100);
+  }
+
+  @Test
+  public void findTxInProgressReturnsTrueIfMessageIsProcessing() {
+    when(message.isProcessing()).thenReturn(true);
+
+    boolean found = tracker.foundTxInProgress(message);
+
+    assertThat(found).isTrue();
+  }
+
+  @Test
+  public void findTxInProgressReturnsFalseIfMessageIsNotProcessing() {
+    when(message.isProcessing()).thenReturn(false);
+
+    boolean found = tracker.foundTxInProgress(message);
+
+    assertThat(found).isFalse();
+  }
+
+  @Test
+  public void findTxInProgressReturnsFalseIfMessageIsNull() {
+    boolean found = tracker.foundTxInProgress(null);
+
+    assertThat(found).isFalse();
+  }
+
+  @Test
+  public void commitProcessReceivedIfFoundInProgress() {
+    TXFarSideCMTracker spy = spy(tracker);
+    doReturn(txInProcess).when(spy).getTxInProgress();
+    when(txInProcess.get(trackerKey)).thenReturn(message);
+    doReturn(true).when(spy).foundTxInProgress(message);
+
+    boolean received = spy.commitProcessReceived(trackerKey);
+
+    assertThat(received).isTrue();
+  }
+
+  @Test
+  public void commitProcessReceivedIfFoundFromHistory() {
+    TXFarSideCMTracker spy = spy(tracker);
+    doReturn(txInProcess).when(spy).getTxInProgress();
+    when(txInProcess.get(trackerKey)).thenReturn(message);
+    doReturn(false).when(spy).foundTxInProgress(message);
+    doReturn(true).when(spy).foundFromHistory(trackerKey);
+
+    boolean received = spy.commitProcessReceived(trackerKey);
+
+    assertThat(received).isTrue();
+  }
+
+  @Test
+  public void commitProcessNotReceivedIfFoundMessageIsNotProcessing() {
+    TXFarSideCMTracker spy = spy(tracker);
+    doReturn(txInProcess).when(spy).getTxInProgress();
+    when(txInProcess.get(trackerKey)).thenReturn(message);
+    doReturn(false).when(spy).foundTxInProgress(message);
+    doReturn(false).when(spy).foundFromHistory(trackerKey);
+    when(message.isProcessing()).thenReturn(false);
+
+    boolean received = spy.commitProcessReceived(trackerKey);
+
+    assertThat(received).isFalse();
+    verify(message).setDontProcess();
+  }
+
+  @Test
+  public void commitProcessNotReceivedIfMessageNotFoundInTxProcessMapAndNotFoundFromHistory() {
+    TXFarSideCMTracker spy = spy(tracker);
+    doReturn(txInProcess).when(spy).getTxInProgress();
+    when(txInProcess.get(trackerKey)).thenReturn(null);
+    doReturn(false).when(spy).foundFromHistory(trackerKey);
+
+    boolean received = spy.commitProcessReceived(trackerKey);
+
+    assertThat(received).isFalse();
+  }
+
+}


### PR DESCRIPTION
 * Always send CommitProcessQueryMessage to other replicates to see if anyone received second 
   message as transaction originator for client transaction will be different from transaction host.
 * Do not wait for transaction originator to depart when processing CommitProcessQueryMessage if 
   transaction host is crashed. Originator may not be the same as the crashed transaction host and 
   never departs from the distributed system.