### PR TITLE
GEODE-5829: Do not bind to both localhost and the actual address of the host

### DIFF
--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/wancommand/CreateGatewayReceiverCommandDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/wancommand/CreateGatewayReceiverCommandDUnitTest.java
@@ -357,14 +357,13 @@ public class CreateGatewayReceiverCommandDUnitTest {
   @Test
   public void testCreateGatewayReceiverWithDefaultsAndMultipleBindAddressProperties()
       throws Exception {
-    String extraBindAddress = "localhost";
     String receiverGroup = "receiverGroup";
     Integer locator1Port = locatorSite1.getPort();
     String expectedBindAddress = getBindAddress();
 
     Properties props = new Properties();
     props.setProperty(GROUPS, receiverGroup);
-    props.setProperty(BIND_ADDRESS, extraBindAddress);
+    props.setProperty(BIND_ADDRESS, expectedBindAddress);
     props.setProperty(SERVER_BIND_ADDRESS, expectedBindAddress);
 
     server1 = clusterStartupRule.startServerVM(1, props, locator1Port);


### PR DESCRIPTION
- There is a subtle, low-level networking issue on Windows. See here
  https://stackoverflow.com/questions/52653506/udp-socket-binding-and-sending-behavior-on-windows-1709
  and here
  https://serverfault.com/questions/934207/socket-binding-and-sending-on-different-addresses

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
