### PR TITLE
GEODE-5501: Disconnect only current test's server

### DIFF
--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/Disconnect.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/Disconnect.java
@@ -34,14 +34,16 @@ public class Disconnect {
   public static void disconnectFromDS() {
     GemFireCacheImpl.testCacheXml = null;
 
-    for (;;) {
-      DistributedSystem ds = InternalDistributedSystem.getConnectedInstance();
-      if (ds == null) {
-        break;
-      }
-      try {
-        ds.disconnect();
-      } catch (Exception ignore) {
+    DistributedSystem ds = InternalDistributedSystem.getConnectedInstance();
+    if (ds != null) {
+      for (;;) {
+        try {
+          ds.disconnect();
+          if (InternalDistributedSystem.getConnectedInstance() == null) {
+            break;
+          }
+        } catch (Exception ignore) {
+        }
       }
     }
 


### PR DESCRIPTION
* Disconnect would wait until there was a system, then disconnect it.
Sometimes it would wait until the next test started a new instance, then
immediately disconnect it.

* Wait for the member to finish disconnecting before ending the test.

* Remove the listener at the end of the test, so that it does not
respond to events in later tests.

Signed-Off-By: Helena Bales <hbales@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
