### PR TITLE
GEODE-5830: Fix `NONE` enum for SSL configuration

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/ConfigurationProperties.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/ConfigurationProperties.java
@@ -1969,7 +1969,7 @@ public interface ConfigurationProperties {
    * the {@link #CLUSTER_SSL_PREFIX} properties. This property will determine which components will
    * use SSL for their communications.
    * </p>
-   * <U>Options</U>: "all","server","cluster","gateway","web","jmx","none" -- As described
+   * <U>Options</U>: "all","server","cluster","gateway","web","jmx","" -- As described
    * {@link org.apache.geode.security.SecurableCommunicationChannels} <U>Since</U>: Geode 1.0
    */
   String SSL_ENABLED_COMPONENTS = "ssl-enabled-components";

--- a/geode-core/src/main/java/org/apache/geode/internal/net/SSLConfigurationFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/SSLConfigurationFactory.java
@@ -188,8 +188,9 @@ public class SSLConfigurationFactory {
   private boolean determineIfSSLEnabledForSSLComponent(final DistributionConfig distributionConfig,
       final SecurableCommunicationChannel sslEnabledComponent) {
     if (ArrayUtils.contains(distributionConfig.getSecurableCommunicationChannels(),
-        SecurableCommunicationChannel.ALL))
+        SecurableCommunicationChannel.ALL)) {
       return true;
+    }
 
     return ArrayUtils.contains(distributionConfig.getSecurableCommunicationChannels(),
         sslEnabledComponent);

--- a/geode-core/src/main/java/org/apache/geode/internal/net/SSLConfigurationFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/SSLConfigurationFactory.java
@@ -181,21 +181,18 @@ public class SSLConfigurationFactory {
     sslConfig.setRequireAuth(distributionConfig.getSSLRequireAuthentication());
     sslConfig.setAlias(distributionConfig.getSSLDefaultAlias());
     sslConfig.setUseDefaultSSLContext(distributionConfig.getSSLUseDefaultContext());
+
     return sslConfig;
   }
 
   private boolean determineIfSSLEnabledForSSLComponent(final DistributionConfig distributionConfig,
       final SecurableCommunicationChannel sslEnabledComponent) {
     if (ArrayUtils.contains(distributionConfig.getSecurableCommunicationChannels(),
-        SecurableCommunicationChannel.NONE)) {
-      return false;
-    }
-    if (ArrayUtils.contains(distributionConfig.getSecurableCommunicationChannels(),
-        SecurableCommunicationChannel.ALL)) {
+        SecurableCommunicationChannel.ALL))
       return true;
-    }
+
     return ArrayUtils.contains(distributionConfig.getSecurableCommunicationChannels(),
-        sslEnabledComponent) ? true : false;
+        sslEnabledComponent);
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/internal/security/SecurableCommunicationChannel.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/security/SecurableCommunicationChannel.java
@@ -26,8 +26,7 @@ public enum SecurableCommunicationChannel {
   JMX(SecurableCommunicationChannels.JMX),
   WEB(SecurableCommunicationChannels.WEB),
   GATEWAY(SecurableCommunicationChannels.GATEWAY),
-  LOCATOR(SecurableCommunicationChannels.LOCATOR),
-  NONE("none");
+  LOCATOR(SecurableCommunicationChannels.LOCATOR);
 
   private final String constant;
 

--- a/geode-core/src/main/java/org/apache/geode/internal/security/SecurableCommunicationChannel.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/security/SecurableCommunicationChannel.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.security;
 
+import java.util.Arrays;
+
 import org.apache.geode.GemFireConfigException;
 import org.apache.geode.security.SecurableCommunicationChannels;
 
@@ -25,23 +27,12 @@ public enum SecurableCommunicationChannel {
   WEB(SecurableCommunicationChannels.WEB),
   GATEWAY(SecurableCommunicationChannels.GATEWAY),
   LOCATOR(SecurableCommunicationChannels.LOCATOR),
-  NONE("NO_COMPONENT");
+  NONE("none");
 
   private final String constant;
 
   SecurableCommunicationChannel(final String constant) {
     this.constant = constant;
-  }
-
-  public static SecurableCommunicationChannel getEnum(String enumString) {
-    for (SecurableCommunicationChannel securableCommunicationChannel : SecurableCommunicationChannel
-        .values()) {
-      if (securableCommunicationChannel.constant.equalsIgnoreCase(enumString)) {
-        return securableCommunicationChannel;
-      }
-    }
-    throw new GemFireConfigException(
-        "There is no registered component for the name: " + enumString);
   }
 
   public String getConstant() {
@@ -51,5 +42,11 @@ public enum SecurableCommunicationChannel {
   @Override
   public String toString() {
     return constant;
+  }
+
+  public static SecurableCommunicationChannel getEnum(String enumString) {
+    return Arrays.stream(values()).filter(ch -> ch.constant.equalsIgnoreCase(enumString)).findAny()
+        .orElseThrow(() -> new GemFireConfigException(
+            "There is no registered component for the name: " + enumString));
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/security/SecurableCommunicationChannelTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/security/SecurableCommunicationChannelTest.java
@@ -29,15 +29,13 @@ public class SecurableCommunicationChannelTest {
 
   @Test
   public void getEnumShouldThrowExceptionWhenTheConstantIsNotKnown() {
-    assertThatThrownBy(() -> SecurableCommunicationChannel.getEnum("unknownComponent"))
+    assertThatThrownBy(() -> SecurableCommunicationChannel.getEnum("none"))
         .isInstanceOf(GemFireConfigException.class)
-        .hasMessage("There is no registered component for the name: unknownComponent");
+        .hasMessage("There is no registered component for the name: none");
   }
 
   @Test
   public void getEnumShouldReturnTheCorrectEnumWhenTheConstantIsKnown() {
-    assertThat(SecurableCommunicationChannel.getEnum("none"))
-        .isEqualTo(SecurableCommunicationChannel.NONE);
     assertThat(SecurableCommunicationChannel.getEnum(SecurableCommunicationChannels.ALL))
         .isEqualTo(SecurableCommunicationChannel.ALL);
     assertThat(SecurableCommunicationChannel.getEnum(SecurableCommunicationChannels.JMX))

--- a/geode-core/src/test/java/org/apache/geode/internal/security/SecurableCommunicationChannelTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/security/SecurableCommunicationChannelTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.GemFireConfigException;
+import org.apache.geode.security.SecurableCommunicationChannels;
+import org.apache.geode.test.junit.categories.SecurityTest;
+
+@Category(SecurityTest.class)
+public class SecurableCommunicationChannelTest {
+
+  @Test
+  public void getEnumShouldThrowExceptionWhenTheConstantIsNotKnown() {
+    assertThatThrownBy(() -> SecurableCommunicationChannel.getEnum("unknownComponent"))
+        .isInstanceOf(GemFireConfigException.class)
+        .hasMessage("There is no registered component for the name: unknownComponent");
+  }
+
+  @Test
+  public void getEnumShouldReturnTheCorrectEnumWhenTheConstantIsKnown() {
+    assertThat(SecurableCommunicationChannel.getEnum("none"))
+        .isEqualTo(SecurableCommunicationChannel.NONE);
+    assertThat(SecurableCommunicationChannel.getEnum(SecurableCommunicationChannels.ALL))
+        .isEqualTo(SecurableCommunicationChannel.ALL);
+    assertThat(SecurableCommunicationChannel.getEnum(SecurableCommunicationChannels.JMX))
+        .isEqualTo(SecurableCommunicationChannel.JMX);
+    assertThat(SecurableCommunicationChannel.getEnum(SecurableCommunicationChannels.WEB))
+        .isEqualTo(SecurableCommunicationChannel.WEB);
+    assertThat(SecurableCommunicationChannel.getEnum(SecurableCommunicationChannels.SERVER))
+        .isEqualTo(SecurableCommunicationChannel.SERVER);
+    assertThat(SecurableCommunicationChannel.getEnum(SecurableCommunicationChannels.CLUSTER))
+        .isEqualTo(SecurableCommunicationChannel.CLUSTER);
+    assertThat(SecurableCommunicationChannel.getEnum(SecurableCommunicationChannels.GATEWAY))
+        .isEqualTo(SecurableCommunicationChannel.GATEWAY);
+    assertThat(SecurableCommunicationChannel.getEnum(SecurableCommunicationChannels.LOCATOR))
+        .isEqualTo(SecurableCommunicationChannel.LOCATOR);
+  }
+}

--- a/geode-docs/managing/security/implementing_ssl.html.md.erb
+++ b/geode-docs/managing/security/implementing_ssl.html.md.erb
@@ -69,7 +69,7 @@ You can use <%=vars.product_name%> configuration properties to enable or disable
 protocols, and to provide the location and credentials for key and trust stores.
 
 <dt>**ssl-enabled-components**</dt>
-<dd>List of components for which to enable SSL. Component list can be "" (disable SSL), "all" or a comma-separated list of components.</dd>
+<dd>List of components for which to enable SSL. Component list can be "" (disable SSL), "all", or a comma-separated list of components.</dd>
 
 <dt>**ssl-endpoint-identification-enabled**</dt>
 <dd> A boolean value that, when set to true, 

--- a/geode-docs/managing/security/implementing_ssl.html.md.erb
+++ b/geode-docs/managing/security/implementing_ssl.html.md.erb
@@ -61,7 +61,7 @@ involve a TCP connection, so SSL does not apply.</dd>
 
 Specifying that a component is enabled for SSL applies to the component's server-socket side and its
 client-socket side.  For example, if you enable SSL for locators, then any process that communicates
-with a locator must also have SSL enabled.
+with a locator must also have SSL enabled.  If you provide "" as the value, SSL is turned off for all components.
 
 ## <a id="ssl_configuration_properties" class="no-quick-link"></a>SSL Configuration Properties
 
@@ -69,7 +69,7 @@ You can use <%=vars.product_name%> configuration properties to enable or disable
 protocols, and to provide the location and credentials for key and trust stores.
 
 <dt>**ssl-enabled-components**</dt>
-<dd>List of components for which to enable SSL. Component list can be "all" or a comma-separated list of components.</dd>
+<dd>List of components for which to enable SSL. Component list can be "" (disable SSL), "all" or a comma-separated list of components.</dd>
 
 <dt>**ssl-endpoint-identification-enabled**</dt>
 <dd> A boolean value that, when set to true, 
@@ -204,7 +204,7 @@ The following table lists the properties you can use to configure SSL on your <%
 
 | Property                           | Description                                                                  | Value |
 |------------------------------------|------------------------------------------------------------------------------|-------|
-| ssl&#8209;enabled&#8209;components | list of components for which to enable SSL | "all" or comma-separated list of components: cluster, gateway, web, jmx, locator, server |
+| ssl&#8209;enabled&#8209;components | list of components for which to enable SSL | "all", "", or comma-separated list of components: cluster, gateway, web, jmx, locator, server |
 | ssl&#8209;endpoint&#8209;identification&#8209;enabled | causes clients to validate server hostname using server certificate | boolean - if true, does validation; defaults to false |
 | ssl-require-authentication         | requires two-way authentication, applies to all components except web | boolean - if true (the default), two-way authentication is required |
 | ssl&#8209;web&#8209;require&#8209;authentication    | requires two-way authentication for web component | boolean - if true, two-way authentication is required. Default is false (one-way authentication only) |


### PR DESCRIPTION
GEODE-5830: Fix `NONE` enum for SSL configuration

The `SecurableCommunicationChannel.NONE` enum instance now references
the correct constant string, `none`, instead of `NO_COMPONENT`.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
