### PR TITLE
GEODE-5799: Restore StatusLogger level to FATAL

### DIFF
--- a/geode-core/src/main/resources/log4j2-cli.xml
+++ b/geode-core/src/main/resources/log4j2-cli.xml
@@ -15,7 +15,7 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<Configuration status="WARN" shutdownHook="disable" packages="org.apache.geode.internal.logging.log4j">
+<Configuration status="FATAL" shutdownHook="disable" packages="org.apache.geode.internal.logging.log4j">
   <Properties>
     <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
   </Properties>

--- a/geode-core/src/main/resources/log4j2.xml
+++ b/geode-core/src/main/resources/log4j2.xml
@@ -15,7 +15,7 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<Configuration status="WARN" shutdownHook="disable" packages="org.apache.geode.internal.logging.log4j">
+<Configuration status="FATAL" shutdownHook="disable" packages="org.apache.geode.internal.logging.log4j">
   <Properties>
     <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
     <Property name="geode-default">true</Property>

--- a/geode-core/src/main/resources/org/apache/geode/internal/logging/log4j/log4j2-legacy.xml
+++ b/geode-core/src/main/resources/org/apache/geode/internal/logging/log4j/log4j2-legacy.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="WARN" shutdownHook="disable" packages="org.apache.geode.internal.logging.log4j">
+<Configuration status="FATAL" shutdownHook="disable" packages="org.apache.geode.internal.logging.log4j">
   <Properties>
     <Property name="geode-pattern">[%level{FATAL=severe,ERROR=error,WARN=warning,INFO=info,DEBUG=fine,TRACE=finest} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
   </Properties>

--- a/geode-core/src/test/resources/org/apache/geode/test/golden/log4j2-test.xml
+++ b/geode-core/src/test/resources/org/apache/geode/test/golden/log4j2-test.xml
@@ -15,7 +15,7 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<Configuration status="WARN" shutdownHook="disable" packages="org.apache.geode.internal.logging.log4j">
+<Configuration status="FATAL" shutdownHook="disable" packages="org.apache.geode.internal.logging.log4j">
   <Properties>
     <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
   </Properties>


### PR DESCRIPTION
When GEODE-2644 is merged to develop, we should be able to change
the StatusLogger level back down to WARN.

This will prevent this noise:
```
2018-10-06 23:19:31,304 DisconnectThread ERROR Attempted to append to non-started appender org.apache.geode.internal.logging.log4j.LogWriterAppender-org.apache.geode
2018-10-06 23:19:31,405 DisconnectThread ERROR Attempted to append to non-started appender org.apache.geode.internal.logging.log4j.LogWriterAppender-org.apache.geode
2018-10-06 23:19:31,405 DisconnectThread ERROR Attempted to append to non-started appender org.apache.geode.internal.logging.log4j.LogWriterAppender-org.apache.geode
2018-10-06 23:27:09,989 vm_15_thr_35_dataStore1_host1_20973 ERROR Attempted to append to non-started appender org.apache.geode.internal.logging.log4j.LogWriterAppender-org.apache.geode
2018-10-06 23:27:09,999 Pooled High Priority Message Processor 6 ERROR Attempted to append to non-started appender org.apache.geode.internal.logging.log4j.LogWriterAppender-org.apache.geode
2018-10-06 23:27:10,000 Pooled High Priority Message Processor 6 ERROR Attempted to append to non-started appender org.apache.geode.internal.logging.log4j.LogWriterAppender-org.apache.geode
2018-10-06 23:27:10,000 Pooled High Priority Message Processor 6 ERROR Attempted to append to non-started appender org.apache.geode.internal.logging.log4j.LogWriterAppender-org.apache.geode
```