### PR TITLE
GEODE-5568: Increase wait in testCacheOpAfterQueryCancel

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/ResourceManagerWithQueryMonitorDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/ResourceManagerWithQueryMonitorDUnitTest.java
@@ -75,7 +75,6 @@ import org.apache.geode.internal.cache.control.TestMemoryThresholdListener;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.test.dunit.AsyncInvocation;
 import org.apache.geode.test.dunit.DistributedTestUtils;
-import org.apache.geode.test.dunit.Host;
 import org.apache.geode.test.dunit.IgnoredException;
 import org.apache.geode.test.dunit.Invoke;
 import org.apache.geode.test.dunit.NetworkUtils;
@@ -299,12 +298,13 @@ public class ResourceManagerWithQueryMonitorDUnitTest extends ClientServerTestCa
   }
 
   private void doCriticalMemoryHitTest(final String regionName, boolean createPR,
-      final int criticalThreshold, final boolean disabledQueryMonitorForLowMem,
-      final int queryTimeout, final boolean hitCriticalThreshold) throws Exception {
+      final int criticalThreshold,
+      final boolean disabledQueryMonitorForLowMem,
+      final int queryTimeout, final boolean hitCriticalThreshold)
+      throws Exception {
     // create region on the server
-    final Host host = Host.getHost(0);
-    final VM server = host.getVM(0);
-    final VM client = host.getVM(1);
+    final VM server = VM.getVM(0);
+    final VM client = VM.getVM(1);
     final int numObjects = 200;
     try {
       final int port = AvailablePortHelper.getRandomAvailableTCPPort();
@@ -363,14 +363,16 @@ public class ResourceManagerWithQueryMonitorDUnitTest extends ClientServerTestCa
 
   // test to verify what happens during index creation if memory threshold is hit
   private void doCriticalMemoryHitWithIndexTest(final String regionName, boolean createPR,
-      final int criticalThreshold, final boolean disabledQueryMonitorForLowMem,
-      final int queryTimeout, final boolean hitCriticalThreshold, final String indexType)
+      final int criticalThreshold,
+      final boolean disabledQueryMonitorForLowMem,
+      final int queryTimeout,
+      final boolean hitCriticalThreshold,
+      final String indexType)
       throws Exception {
     // create region on the server
-    final Host host = Host.getHost(0);
-    final VM server1 = host.getVM(0);
-    final VM server2 = host.getVM(2);
-    final VM client = host.getVM(1);
+    final VM server1 = VM.getVM(0);
+    final VM server2 = VM.getVM(2);
+    final VM client = VM.getVM(1);
     final int numObjects = 200;
     try {
       final int[] port = AvailablePortHelper.getRandomAvailableTCPPorts(2);
@@ -419,13 +421,16 @@ public class ResourceManagerWithQueryMonitorDUnitTest extends ClientServerTestCa
   }
 
   private void doCriticalMemoryHitAddResultsTestWithMultipleServers(final String regionName,
-      boolean createPR, final int criticalThreshold, final boolean disabledQueryMonitorForLowMem,
-      final int queryTimeout, final boolean hitCriticalThreshold) throws Exception {
+      boolean createPR,
+      final int criticalThreshold,
+      final boolean disabledQueryMonitorForLowMem,
+      final int queryTimeout,
+      final boolean hitCriticalThreshold)
+      throws Exception {
     // create region on the server
-    final Host host = Host.getHost(0);
-    final VM server1 = host.getVM(0);
-    final VM server2 = host.getVM(1);
-    final VM client = host.getVM(2);
+    final VM server1 = VM.getVM(0);
+    final VM server2 = VM.getVM(1);
+    final VM client = VM.getVM(2);
     final int numObjects = 200;
     try {
       final int[] port = AvailablePortHelper.getRandomAvailableTCPPorts(2);
@@ -500,13 +505,16 @@ public class ResourceManagerWithQueryMonitorDUnitTest extends ClientServerTestCa
 
   // tests low memory hit while gathering partition region results
   private void doCriticalMemoryHitDuringGatherTestWithMultipleServers(final String regionName,
-      boolean createPR, final int criticalThreshold, final boolean disabledQueryMonitorForLowMem,
-      final int queryTimeout, final boolean hitCriticalThreshold) throws Exception {
+      boolean createPR,
+      final int criticalThreshold,
+      final boolean disabledQueryMonitorForLowMem,
+      final int queryTimeout,
+      final boolean hitCriticalThreshold)
+      throws Exception {
     // create region on the server
-    final Host host = Host.getHost(0);
-    final VM server1 = host.getVM(0);
-    final VM server2 = host.getVM(1);
-    final VM client = host.getVM(2);
+    final VM server1 = VM.getVM(0);
+    final VM server2 = VM.getVM(1);
+    final VM client = VM.getVM(2);
     final int numObjects = 200;
     try {
       final int[] port = AvailablePortHelper.getRandomAvailableTCPPorts(2);
@@ -588,13 +596,15 @@ public class ResourceManagerWithQueryMonitorDUnitTest extends ClientServerTestCa
 
   // Executes on client cache with multiple configured servers
   private void doCriticalMemoryHitTestWithMultipleServers(final String regionName, boolean createPR,
-      final int criticalThreshold, final boolean disabledQueryMonitorForLowMem,
-      final int queryTimeout, final boolean hitCriticalThreshold) throws Exception {
+      final int criticalThreshold,
+      final boolean disabledQueryMonitorForLowMem,
+      final int queryTimeout,
+      final boolean hitCriticalThreshold)
+      throws Exception {
     // create region on the server
-    final Host host = Host.getHost(0);
-    final VM server1 = host.getVM(0);
-    final VM server2 = host.getVM(1);
-    final VM client = host.getVM(2);
+    final VM server1 = VM.getVM(0);
+    final VM server2 = VM.getVM(1);
+    final VM client = VM.getVM(2);
     final int numObjects = 200;
 
     try {
@@ -659,12 +669,13 @@ public class ResourceManagerWithQueryMonitorDUnitTest extends ClientServerTestCa
 
   // Executes the query on the server with the RM and QM configured
   private void doCriticalMemoryHitTestOnServer(final String regionName, boolean createPR,
-      final int criticalThreshold, final boolean disabledQueryMonitorForLowMem,
-      final int queryTimeout, final boolean hitCriticalThreshold) throws Exception {
+      final int criticalThreshold,
+      final boolean disabledQueryMonitorForLowMem,
+      final int queryTimeout,
+      final boolean hitCriticalThreshold)
+      throws Exception {
     // create region on the server
-    final Host host = Host.getHost(0);
-    final VM server = host.getVM(0);
-    final VM client = host.getVM(1);
+    final VM server = VM.getVM(0);
     final int numObjects = 200;
     try {
       final int port = AvailablePortHelper.getRandomAvailableTCPPort();
@@ -724,12 +735,15 @@ public class ResourceManagerWithQueryMonitorDUnitTest extends ClientServerTestCa
 
 
   private void executeQueryFromClientWithTimeoutSetAndCriticalThreshold(final String regionName,
-      boolean createPR, final int criticalThreshold, final boolean disabledQueryMonitorForLowMem,
-      final int queryTimeout, final boolean hitCriticalThreshold) throws Exception {
+      boolean createPR,
+      final int criticalThreshold,
+      final boolean disabledQueryMonitorForLowMem,
+      final int queryTimeout,
+      final boolean hitCriticalThreshold)
+      throws Exception {
     // create region on the server
-    final Host host = Host.getHost(0);
-    final VM server = host.getVM(0);
-    final VM client = host.getVM(1);
+    final VM server = VM.getVM(0);
+    final VM client = VM.getVM(1);
     final int numObjects = 200;
     try {
       final int port = AvailablePortHelper.getRandomAvailableTCPPort();
@@ -749,11 +763,14 @@ public class ResourceManagerWithQueryMonitorDUnitTest extends ClientServerTestCa
   }
 
   private void executeQueryWithTimeoutSetAndCriticalThreshold(final String regionName,
-      boolean createPR, final int criticalThreshold, final boolean disabledQueryMonitorForLowMem,
-      final int queryTimeout, final boolean hitCriticalThreshold) throws Exception {
+      boolean createPR,
+      final int criticalThreshold,
+      final boolean disabledQueryMonitorForLowMem,
+      final int queryTimeout,
+      final boolean hitCriticalThreshold)
+      throws Exception {
     // create region on the server
-    final Host host = Host.getHost(0);
-    final VM server = host.getVM(0);
+    final VM server = VM.getVM(0);
     final int numObjects = 200;
     try {
       final int port = AvailablePortHelper.getRandomAvailableTCPPort();
@@ -781,7 +798,8 @@ public class ResourceManagerWithQueryMonitorDUnitTest extends ClientServerTestCa
   // The last part of the test is to execute another query with the system under duress and have it
   // be rejected/cancelled if rm and qm are in use
   private void doTestCriticalHeapAndQueryTimeout(VM server, VM client, final String regionName,
-      final boolean disabledQueryMonitorForLowMem, final int queryTimeout,
+      final boolean disabledQueryMonitorForLowMem,
+      final int queryTimeout,
       final boolean hitCriticalThreshold) {
     createLatchTestHook(server);
 
@@ -820,7 +838,9 @@ public class ResourceManagerWithQueryMonitorDUnitTest extends ClientServerTestCa
   }
 
   private void executeQueryWithCriticalHeapCalledAfterTimeout(VM server, VM client,
-      final String regionName, final int queryTimeout, final boolean hitCriticalThreshold) {
+      final String regionName,
+      final int queryTimeout,
+      final boolean hitCriticalThreshold) {
     createLatchTestHook(server);
     AsyncInvocation queryExecution = executeQueryWithTimeout(client, regionName, queryTimeout);
 
@@ -890,7 +910,8 @@ public class ResourceManagerWithQueryMonitorDUnitTest extends ClientServerTestCa
   }
 
   private AsyncInvocation invokeClientQuery(VM client, final String regionName,
-      final boolean disabledQueryMonitorForLowMem, final int queryTimeout,
+      final boolean disabledQueryMonitorForLowMem,
+      final int queryTimeout,
       final boolean hitCriticalThreshold) {
     return client.invokeAsync(new SerializableCallable("execute query from client") {
       public Object call() throws CacheException {
@@ -931,7 +952,8 @@ public class ResourceManagerWithQueryMonitorDUnitTest extends ClientServerTestCa
   }
 
   private void handleException(Exception e, boolean hitCriticalThreshold,
-      boolean disabledQueryMonitorForLowMem, long queryTimeout) throws CacheException {
+      boolean disabledQueryMonitorForLowMem, long queryTimeout)
+      throws CacheException {
     if (e instanceof QueryExecutionLowMemoryException) {
       if (!(hitCriticalThreshold && disabledQueryMonitorForLowMem == false)) {
         // meaning the query should not be canceled due to low memory
@@ -1103,8 +1125,10 @@ public class ResourceManagerWithQueryMonitorDUnitTest extends ClientServerTestCa
   }
 
   private void startCacheServer(VM server, final int port, final int criticalThreshold,
-      final boolean disableQueryMonitorForLowMemory, final int queryTimeout,
-      final String regionName, final boolean createPR, final int prRedundancy) throws Exception {
+      final boolean disableQueryMonitorForLowMemory,
+      final int queryTimeout,
+      final String regionName, final boolean createPR,
+      final int prRedundancy) throws Exception {
 
     server.invoke(new SerializableCallable() {
       public Object call() throws Exception {
@@ -1242,22 +1266,26 @@ public class ResourceManagerWithQueryMonitorDUnitTest extends ClientServerTestCa
     return new CancelDuringAddResultsHook();
   }
 
-  private class PauseTestHook implements DefaultQuery.TestHook {
+  private static class PauseTestHook implements DefaultQuery.TestHook {
     private CountDownLatch latch = new CountDownLatch(1);
     public boolean rejectedObjects = false;
 
-    public void doTestHook(int spot) {
-      if (spot == 1) {
-        try {
-          if (!latch.await(8, TimeUnit.SECONDS)) {
-            fail("query was never unlatched");
+    @Override
+    public void doTestHook(final SPOTS spot, final DefaultQuery _ignored) {
+      switch (spot) {
+        case BEFORE_QUERY_EXECUTION:
+          try {
+            if (!latch.await(8, TimeUnit.SECONDS)) {
+              fail("query was never unlatched");
+            }
+          } catch (InterruptedException e) {
+            e.printStackTrace();
+            Thread.currentThread().interrupt();
           }
-        } catch (InterruptedException e) {
-          e.printStackTrace();
-          Thread.currentThread().interrupt();
-        }
-      } else if (spot == 2) {
-        rejectedObjects = true;
+          break;
+        case LOW_MEMORY_WHEN_DESERIALIZING_STREAMINGOPERATION:
+          rejectedObjects = true;
+          break;
       }
     }
 
@@ -1266,45 +1294,55 @@ public class ResourceManagerWithQueryMonitorDUnitTest extends ClientServerTestCa
     }
   }
 
+  // non-static class because it needs to call getCache()
   private class CancelDuringGatherHook implements DefaultQuery.TestHook {
     public boolean rejectedObjects = false;
     public boolean triggeredOOME = false;
     private int count = 0;
     private int numObjectsBeforeCancel = 5;
 
-    public void doTestHook(int spot) {
-      if (spot == 2) {
-        rejectedObjects = true;
-      } else if (spot == 3) {
-        if (count++ == numObjectsBeforeCancel) {
-          InternalResourceManager resourceManager =
-              (InternalResourceManager) getCache().getResourceManager();
-          resourceManager.getHeapMonitor().updateStateAndSendEvent(CRITICAL_HEAP_USED);
-          triggeredOOME = true;
-        }
+    @Override
+    public void doTestHook(final SPOTS spot, final DefaultQuery _ignored) {
+      switch (spot) {
+        case LOW_MEMORY_WHEN_DESERIALIZING_STREAMINGOPERATION:
+          rejectedObjects = true;
+          break;
+        case BEFORE_ADD_OR_UPDATE_MAPPING_OR_DESERIALIZING_NTH_STREAMINGOPERATION:
+          if (count++ == numObjectsBeforeCancel) {
+            InternalResourceManager resourceManager =
+                (InternalResourceManager) getCache().getResourceManager();
+            resourceManager.getHeapMonitor().updateStateAndSendEvent(CRITICAL_HEAP_USED);
+            triggeredOOME = true;
+          }
+          break;
       }
     }
   }
 
+  // non-static class because it needs to call getCache()
   private class CancelDuringAddResultsHook implements DefaultQuery.TestHook {
     public boolean triggeredOOME = false;
     public boolean rejectedObjects = false;
 
-    public void doTestHook(int spot) {
-      if (spot == 4) {
-        if (triggeredOOME == false) {
-          InternalResourceManager resourceManager =
-              (InternalResourceManager) getCache().getResourceManager();
-          resourceManager.getHeapMonitor().updateStateAndSendEvent(CRITICAL_HEAP_USED);
-          triggeredOOME = true;
-          try {
-            Thread.sleep(1000);
-          } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
+    @Override
+    public void doTestHook(final SPOTS spot, final DefaultQuery _ignored) {
+      switch (spot) {
+        case BEFORE_BUILD_CUMULATIVE_RESULT:
+          if (triggeredOOME == false) {
+            InternalResourceManager resourceManager =
+                (InternalResourceManager) getCache().getResourceManager();
+            resourceManager.getHeapMonitor().updateStateAndSendEvent(CRITICAL_HEAP_USED);
+            triggeredOOME = true;
+            try {
+              Thread.sleep(1000);
+            } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
+            }
           }
-        }
-      } else if (spot == 5) {
-        rejectedObjects = true;
+          break;
+        case BEFORE_THROW_QUERY_CANCELED_EXCEPTION:
+          rejectedObjects = true;
+          break;
       }
     }
   }

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/PRQueryDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/PRQueryDistributedTest.java
@@ -148,24 +148,29 @@ public class PRQueryDistributedTest implements Serializable {
 
     vm1.invoke(() -> {
       PRQueryTraceTestHook server1TestHookInVM1 = (PRQueryTraceTestHook) DefaultQuery.testHook;
-      assertThat(server1TestHookInVM1.getHooks().get("Pull off PR Query Trace Info")).isTrue();
-      assertThat(server1TestHookInVM1.getHooks().get("Create PR Query Trace String")).isTrue();
-      assertThat(server1TestHookInVM1.getHooks().get("Create PR Query Trace Info From Local Node"))
+      assertThat(server1TestHookInVM1.getHooks().get(TestHook.SPOTS.PULL_OFF_PR_QUERY_TRACE_INFO))
           .isTrue();
+      assertThat(server1TestHookInVM1.getHooks().get(TestHook.SPOTS.CREATE_PR_QUERY_TRACE_STRING))
+          .isTrue();
+      assertThat(server1TestHookInVM1.getHooks()
+          .get(TestHook.SPOTS.CREATE_PR_QUERY_TRACE_INFO_FROM_LOCAL_NODE))
+              .isTrue();
     });
     vm2.invoke(() -> {
       PRQueryTraceTestHook server2TestHookInVM2 = (PRQueryTraceTestHook) DefaultQuery.testHook;
-      assertThat(server2TestHookInVM2.getHooks().get("Populating Trace Info for Remote Query"))
-          .isTrue();
-      assertThat(server2TestHookInVM2.getHooks().get("Create PR Query Trace Info for Remote Query"))
-          .isTrue();
+      assertThat(server2TestHookInVM2.getHooks()
+          .get(DefaultQuery.TestHook.SPOTS.POPULATING_TRACE_INFO_FOR_REMOTE_QUERY))
+              .isTrue();
+      assertThat(server2TestHookInVM2.getHooks()
+          .get(DefaultQuery.TestHook.SPOTS.CREATE_PR_QUERY_TRACE_INFO_FOR_REMOTE_QUERY))
+              .isTrue();
     });
   }
 
   /**
    * Tests trace for PR queries when {@code <trace>} is used and query verbose is set to true on
-   * local but false on remote servers All flags should be true still as the {@code <trace>} is
-   * OR'd with query verbose flag
+   * local but false on remote servers All flags should be true still as the {@code <trace>} is OR'd
+   * with query verbose flag
    */
   @Test
   public void testPartitionRegionDebugMessageQueryTraceOnLocalServerOnly() throws Exception {
@@ -192,24 +197,29 @@ public class PRQueryDistributedTest implements Serializable {
 
     vm1.invoke(() -> {
       PRQueryTraceTestHook server1TestHookInVM1 = (PRQueryTraceTestHook) DefaultQuery.testHook;
-      assertThat(server1TestHookInVM1.getHooks().get("Pull off PR Query Trace Info")).isTrue();
-      assertThat(server1TestHookInVM1.getHooks().get("Create PR Query Trace String")).isTrue();
-      assertThat(server1TestHookInVM1.getHooks().get("Create PR Query Trace Info From Local Node"))
+      assertThat(server1TestHookInVM1.getHooks().get(TestHook.SPOTS.PULL_OFF_PR_QUERY_TRACE_INFO))
           .isTrue();
+      assertThat(server1TestHookInVM1.getHooks().get(TestHook.SPOTS.CREATE_PR_QUERY_TRACE_STRING))
+          .isTrue();
+      assertThat(server1TestHookInVM1.getHooks()
+          .get(TestHook.SPOTS.CREATE_PR_QUERY_TRACE_INFO_FROM_LOCAL_NODE))
+              .isTrue();
     });
     vm2.invoke(() -> {
       PRQueryTraceTestHook server2TestHookInVM2 = (PRQueryTraceTestHook) DefaultQuery.testHook;
-      assertThat(server2TestHookInVM2.getHooks().get("Populating Trace Info for Remote Query"))
-          .isTrue();
-      assertThat(server2TestHookInVM2.getHooks().get("Create PR Query Trace Info for Remote Query"))
-          .isTrue();
+      assertThat(server2TestHookInVM2.getHooks()
+          .get(DefaultQuery.TestHook.SPOTS.POPULATING_TRACE_INFO_FOR_REMOTE_QUERY))
+              .isTrue();
+      assertThat(server2TestHookInVM2.getHooks()
+          .get(DefaultQuery.TestHook.SPOTS.CREATE_PR_QUERY_TRACE_INFO_FOR_REMOTE_QUERY))
+              .isTrue();
     });
   }
 
   /**
-   * Tests trace for PR queries when {@code <trace>} is NOT used and query verbose is set to true
-   * on local but false on remote. The remote should not send a pr query trace info back because
-   * trace was not requested.
+   * Tests trace for PR queries when {@code <trace>} is NOT used and query verbose is set to true on
+   * local but false on remote. The remote should not send a pr query trace info back because trace
+   * was not requested.
    */
   @Test
   public void testPartitionRegionDebugMessageQueryTraceOffLocalServerVerboseOn() throws Exception {
@@ -236,24 +246,30 @@ public class PRQueryDistributedTest implements Serializable {
 
     vm1.invoke(() -> {
       PRQueryTraceTestHook server1TestHookInVM1 = (PRQueryTraceTestHook) DefaultQuery.testHook;
-      assertThat(server1TestHookInVM1.getHooks().get("Pull off PR Query Trace Info")).isNull();
-      assertThat(server1TestHookInVM1.getHooks().get("Create PR Query Trace String")).isTrue();
-      assertThat(server1TestHookInVM1.getHooks().get("Create PR Query Trace Info From Local Node"))
-          .isTrue();
+      assertThat(server1TestHookInVM1.getHooks()
+          .get(DefaultQuery.TestHook.SPOTS.PULL_OFF_PR_QUERY_TRACE_INFO)).isNull();
+      assertThat(server1TestHookInVM1.getHooks()
+          .get(DefaultQuery.TestHook.SPOTS.CREATE_PR_QUERY_TRACE_STRING)).isTrue();
+      assertThat(server1TestHookInVM1.getHooks()
+          .get(DefaultQuery.TestHook.SPOTS.CREATE_PR_QUERY_TRACE_INFO_FROM_LOCAL_NODE))
+              .isTrue();
     });
     vm2.invoke(() -> {
       PRQueryTraceTestHook server2TestHookInVM2 = (PRQueryTraceTestHook) DefaultQuery.testHook;
-      assertThat(server2TestHookInVM2.getHooks().get("Populating Trace Info for Remote Query"))
-          .isNull();
-      assertThat(server2TestHookInVM2.getHooks().get("Create PR Query Trace Info for Remote Query"))
-          .isNull();
+      assertThat(server2TestHookInVM2.getHooks()
+          .get(DefaultQuery.TestHook.SPOTS.POPULATING_TRACE_INFO_FOR_REMOTE_QUERY))
+              .isNull();
+      assertThat(server2TestHookInVM2.getHooks()
+          .get(DefaultQuery.TestHook.SPOTS.CREATE_PR_QUERY_TRACE_INFO_FOR_REMOTE_QUERY))
+              .isNull();
     });
   }
 
   /**
    * Tests trace for PR queries when {@code <trace>} is NOT used and query verbose is set to false
    * on local but true on remote servers We don't output the string or do anything on the local
-   * side, but we still pull off the object due to the remote server generating and sending it over.
+   * side, but we still pull off the object due to the remote server generating and sending it
+   * over.
    */
   @Test
   public void testPartitionRegionDebugMessageQueryTraceOffRemoteServerOnly() throws Exception {
@@ -280,17 +296,22 @@ public class PRQueryDistributedTest implements Serializable {
 
     vm1.invoke(() -> {
       PRQueryTraceTestHook server1TestHookInVM1 = (PRQueryTraceTestHook) DefaultQuery.testHook;
-      assertThat(server1TestHookInVM1.getHooks().get("Pull off PR Query Trace Info")).isTrue();
-      assertThat(server1TestHookInVM1.getHooks().get("Create PR Query Trace String")).isNull();
-      assertThat(server1TestHookInVM1.getHooks().get("Create PR Query Trace Info From Local Node"))
-          .isNull();
+      assertThat(server1TestHookInVM1.getHooks()
+          .get(TestHook.SPOTS.PULL_OFF_PR_QUERY_TRACE_INFO)).isTrue();
+      assertThat(server1TestHookInVM1.getHooks()
+          .get(TestHook.SPOTS.CREATE_PR_QUERY_TRACE_STRING)).isNull();
+      assertThat(server1TestHookInVM1.getHooks()
+          .get(TestHook.SPOTS.CREATE_PR_QUERY_TRACE_INFO_FROM_LOCAL_NODE))
+              .isNull();
     });
     vm2.invoke(() -> {
       PRQueryTraceTestHook server2TestHookInVM2 = (PRQueryTraceTestHook) DefaultQuery.testHook;
-      assertThat(server2TestHookInVM2.getHooks().get("Populating Trace Info for Remote Query"))
-          .isTrue();
-      assertThat(server2TestHookInVM2.getHooks().get("Create PR Query Trace Info for Remote Query"))
-          .isTrue();
+      assertThat(server2TestHookInVM2.getHooks()
+          .get(DefaultQuery.TestHook.SPOTS.POPULATING_TRACE_INFO_FOR_REMOTE_QUERY))
+              .isTrue();
+      assertThat(server2TestHookInVM2.getHooks()
+          .get(DefaultQuery.TestHook.SPOTS.CREATE_PR_QUERY_TRACE_INFO_FOR_REMOTE_QUERY))
+              .isTrue();
     });
   }
 
@@ -323,17 +344,22 @@ public class PRQueryDistributedTest implements Serializable {
 
     vm1.invoke(() -> {
       PRQueryTraceTestHook server1TestHookInVM1 = (PRQueryTraceTestHook) DefaultQuery.testHook;
-      assertThat(server1TestHookInVM1.getHooks().get("Pull off PR Query Trace Info")).isTrue();
-      assertThat(server1TestHookInVM1.getHooks().get("Create PR Query Trace String")).isTrue();
-      assertThat(server1TestHookInVM1.getHooks().get("Create PR Query Trace Info From Local Node"))
+      assertThat(server1TestHookInVM1.getHooks().get(TestHook.SPOTS.PULL_OFF_PR_QUERY_TRACE_INFO))
           .isTrue();
+      assertThat(server1TestHookInVM1.getHooks().get(TestHook.SPOTS.CREATE_PR_QUERY_TRACE_STRING))
+          .isTrue();
+      assertThat(server1TestHookInVM1.getHooks()
+          .get(TestHook.SPOTS.CREATE_PR_QUERY_TRACE_INFO_FROM_LOCAL_NODE))
+              .isTrue();
     });
     vm2.invoke(() -> {
       PRQueryTraceTestHook server2TestHookInVM2 = (PRQueryTraceTestHook) DefaultQuery.testHook;
-      assertThat(server2TestHookInVM2.getHooks().get("Populating Trace Info for Remote Query"))
-          .isTrue();
-      assertThat(server2TestHookInVM2.getHooks().get("Create PR Query Trace Info for Remote Query"))
-          .isTrue();
+      assertThat(server2TestHookInVM2.getHooks()
+          .get(DefaultQuery.TestHook.SPOTS.POPULATING_TRACE_INFO_FOR_REMOTE_QUERY))
+              .isTrue();
+      assertThat(server2TestHookInVM2.getHooks()
+          .get(DefaultQuery.TestHook.SPOTS.CREATE_PR_QUERY_TRACE_INFO_FOR_REMOTE_QUERY))
+              .isTrue();
     });
   }
 
@@ -367,17 +393,22 @@ public class PRQueryDistributedTest implements Serializable {
 
     vm1.invoke(() -> {
       PRQueryTraceTestHook server1TestHookInVM1 = (PRQueryTraceTestHook) DefaultQuery.testHook;
-      assertThat(server1TestHookInVM1.getHooks().get("Pull off PR Query Trace Info")).isTrue();
-      assertThat(server1TestHookInVM1.getHooks().get("Create PR Query Trace String")).isNull();
-      assertThat(server1TestHookInVM1.getHooks().get("Create PR Query Trace Info From Local Node"))
-          .isNull();
+      assertThat(server1TestHookInVM1.getHooks()
+          .get(TestHook.SPOTS.PULL_OFF_PR_QUERY_TRACE_INFO)).isTrue();
+      assertThat(server1TestHookInVM1.getHooks()
+          .get(TestHook.SPOTS.CREATE_PR_QUERY_TRACE_STRING)).isNull();
+      assertThat(server1TestHookInVM1.getHooks()
+          .get(TestHook.SPOTS.CREATE_PR_QUERY_TRACE_INFO_FROM_LOCAL_NODE))
+              .isNull();
     });
     vm2.invoke(() -> {
       PRQueryTraceTestHook server2TestHookInVM2 = (PRQueryTraceTestHook) DefaultQuery.testHook;
-      assertThat(server2TestHookInVM2.getHooks().get("Populating Trace Info for Remote Query"))
-          .isTrue();
-      assertThat(server2TestHookInVM2.getHooks().get("Create PR Query Trace Info for Remote Query"))
-          .isTrue();
+      assertThat(server2TestHookInVM2.getHooks()
+          .get(DefaultQuery.TestHook.SPOTS.POPULATING_TRACE_INFO_FOR_REMOTE_QUERY))
+              .isTrue();
+      assertThat(server2TestHookInVM2.getHooks()
+          .get(DefaultQuery.TestHook.SPOTS.CREATE_PR_QUERY_TRACE_INFO_FOR_REMOTE_QUERY))
+              .isTrue();
     });
   }
 
@@ -410,17 +441,22 @@ public class PRQueryDistributedTest implements Serializable {
 
     vm1.invoke(() -> {
       PRQueryTraceTestHook server1TestHookInVM1 = (PRQueryTraceTestHook) DefaultQuery.testHook;
-      assertThat(server1TestHookInVM1.getHooks().get("Pull off PR Query Trace Info")).isNull();
-      assertThat(server1TestHookInVM1.getHooks().get("Create PR Query Trace String")).isNull();
-      assertThat(server1TestHookInVM1.getHooks().get("Create PR Query Trace Info From Local Node"))
-          .isNull();
+      assertThat(server1TestHookInVM1.getHooks()
+          .get(DefaultQuery.TestHook.SPOTS.PULL_OFF_PR_QUERY_TRACE_INFO)).isNull();
+      assertThat(server1TestHookInVM1.getHooks()
+          .get(DefaultQuery.TestHook.SPOTS.CREATE_PR_QUERY_TRACE_STRING)).isNull();
+      assertThat(server1TestHookInVM1.getHooks()
+          .get(DefaultQuery.TestHook.SPOTS.CREATE_PR_QUERY_TRACE_INFO_FROM_LOCAL_NODE))
+              .isNull();
     });
     vm2.invoke(() -> {
       PRQueryTraceTestHook server2TestHookInVM2 = (PRQueryTraceTestHook) DefaultQuery.testHook;
-      assertThat(server2TestHookInVM2.getHooks().get("Populating Trace Info for Remote Query"))
-          .isNull();
-      assertThat(server2TestHookInVM2.getHooks().get("Create PR Query Trace Info for Remote Query"))
-          .isNull();
+      assertThat(server2TestHookInVM2.getHooks()
+          .get(DefaultQuery.TestHook.SPOTS.POPULATING_TRACE_INFO_FOR_REMOTE_QUERY))
+              .isNull();
+      assertThat(server2TestHookInVM2.getHooks()
+          .get(DefaultQuery.TestHook.SPOTS.CREATE_PR_QUERY_TRACE_INFO_FOR_REMOTE_QUERY))
+              .isNull();
     });
   }
 
@@ -453,17 +489,22 @@ public class PRQueryDistributedTest implements Serializable {
 
     vm1.invoke(() -> {
       PRQueryTraceTestHook server1TestHookInVM1 = (PRQueryTraceTestHook) DefaultQuery.testHook;
-      assertThat(server1TestHookInVM1.getHooks().get("Pull off PR Query Trace Info")).isTrue();
-      assertThat(server1TestHookInVM1.getHooks().get("Create PR Query Trace String")).isTrue();
-      assertThat(server1TestHookInVM1.getHooks().get("Create PR Query Trace Info From Local Node"))
+      assertThat(server1TestHookInVM1.getHooks().get(TestHook.SPOTS.PULL_OFF_PR_QUERY_TRACE_INFO))
           .isTrue();
+      assertThat(server1TestHookInVM1.getHooks().get(TestHook.SPOTS.CREATE_PR_QUERY_TRACE_STRING))
+          .isTrue();
+      assertThat(server1TestHookInVM1.getHooks()
+          .get(TestHook.SPOTS.CREATE_PR_QUERY_TRACE_INFO_FROM_LOCAL_NODE))
+              .isTrue();
     });
     vm2.invoke(() -> {
       PRQueryTraceTestHook server2TestHookInVM2 = (PRQueryTraceTestHook) DefaultQuery.testHook;
-      assertThat(server2TestHookInVM2.getHooks().get("Populating Trace Info for Remote Query"))
-          .isTrue();
-      assertThat(server2TestHookInVM2.getHooks().get("Create PR Query Trace Info for Remote Query"))
-          .isTrue();
+      assertThat(server2TestHookInVM2.getHooks()
+          .get(DefaultQuery.TestHook.SPOTS.POPULATING_TRACE_INFO_FOR_REMOTE_QUERY))
+              .isTrue();
+      assertThat(server2TestHookInVM2.getHooks()
+          .get(DefaultQuery.TestHook.SPOTS.CREATE_PR_QUERY_TRACE_INFO_FOR_REMOTE_QUERY))
+              .isTrue();
     });
   }
 
@@ -527,19 +568,14 @@ public class PRQueryDistributedTest implements Serializable {
 
   private static class PRQueryTraceTestHook implements TestHook, Serializable {
 
-    private final Map<String, Boolean> hooks = new HashMap<>();
+    private final Map<SPOTS, Boolean> hooks = new HashMap<>();
 
-    Map<String, Boolean> getHooks() {
+    Map<SPOTS, Boolean> getHooks() {
       return hooks;
     }
 
     @Override
-    public void doTestHook(int spot) {
-      // nothing
-    }
-
-    @Override
-    public void doTestHook(String spot) {
+    public void doTestHook(final SPOTS spot, final DefaultQuery _ignored) {
       hooks.put(spot, Boolean.TRUE);
     }
   }

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/QueryJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/QueryJUnitTest.java
@@ -50,6 +50,7 @@ import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionFactory;
 import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.cache.query.data.Portfolio;
+import org.apache.geode.cache.query.data.Position;
 import org.apache.geode.cache.query.internal.DefaultQuery;
 import org.apache.geode.cache.query.internal.index.IndexProtocol;
 import org.apache.geode.test.junit.categories.OQLQueryTest;
@@ -247,6 +248,15 @@ public class QueryJUnitTest {
 
   @Test
   public void test008NullCollectionField() {
+
+    /*
+     This test relies on the static Position counter starting at the same value each time.
+     By starting the counter at a well-defined value, this test can be run more than once
+     in the same JVM.
+     Because of its reliance on that static counter, this test cannot be run in parallel.
+      */
+    Position.resetCounter();
+
     Region region = CacheUtils.createRegion("Portfolios", Portfolio.class);
     for (int i = 0; i < 10; i++) {
       Portfolio p = new Portfolio(i);

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/QueryJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/QueryJUnitTest.java
@@ -250,11 +250,11 @@ public class QueryJUnitTest {
   public void test008NullCollectionField() {
 
     /*
-     This test relies on the static Position counter starting at the same value each time.
-     By starting the counter at a well-defined value, this test can be run more than once
-     in the same JVM.
-     Because of its reliance on that static counter, this test cannot be run in parallel.
-      */
+     * This test relies on the static Position counter starting at the same value each time.
+     * By starting the counter at a well-defined value, this test can be run more than once
+     * in the same JVM.
+     * Because of its reliance on that static counter, this test cannot be run in parallel.
+     */
     Position.resetCounter();
 
     Region region = CacheUtils.createRegion("Portfolios", Portfolio.class);

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/QueryJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/QueryJUnitTest.java
@@ -376,7 +376,7 @@ public class QueryJUnitTest {
     }
   }
 
-  public class ScopeThreadingTestHook implements DefaultQuery.TestHook {
+  private static class ScopeThreadingTestHook implements DefaultQuery.TestHook {
     private CyclicBarrier barrier;
     private List<Exception> exceptionsThrown = new LinkedList<Exception>();
 
@@ -385,13 +385,8 @@ public class QueryJUnitTest {
     }
 
     @Override
-    public void doTestHook(int spot) {
-      this.doTestHook(spot + "");
-    }
-
-    @Override
-    public void doTestHook(String spot) {
-      if (spot.equals("1")) {
+    public void doTestHook(final SPOTS spot, final DefaultQuery _ignored) {
+      if (spot == SPOTS.BEFORE_QUERY_EXECUTION) {
         try {
           barrier.await(8, TimeUnit.SECONDS);
         } catch (InterruptedException e) {

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/CompactRangeIndexJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/CompactRangeIndexJUnitTest.java
@@ -341,30 +341,28 @@ public class CompactRangeIndexJUnitTest {
       readyToStartRemoveLatch = new CountDownLatch(1);
     }
 
-    public void doTestHook(int spot) {
-
-    }
-
-    public void doTestHook(String description) {
+    @Override
+    public void doTestHook(final SPOTS spot, final DefaultQuery _ignored) {
       try {
-        if (description.equals("ATTEMPT_REMOVE")) {
-          if (!readyToStartRemoveLatch.await(21, TimeUnit.SECONDS)) {
-            throw new AssertionError("Time ran out waiting for other thread to initiate put");
-          }
-        } else if (description.equals("TRANSITIONED_FROM_REGION_ENTRY_TO_ELEMARRAY")) {
-          readyToStartRemoveLatch.countDown();
-          if (!waitForRemoveLatch.await(21, TimeUnit.SECONDS)) {
-            throw new AssertionError("Time ran out waiting for other thread to initiate remove");
-          }
-        } else if (description.equals("BEGIN_REMOVE_FROM_ELEM_ARRAY")) {
-          waitForRemoveLatch.countDown();
-          if (waitForTransitioned.await(21, TimeUnit.SECONDS)) {
-            throw new AssertionError(
-                "Time ran out waiting for transition from region entry to elem array");
-          }
-        } else if (description.equals("TRANSITIONED_FROM_REGION_ENTRY_TO_ELEMARRAY")) {
-          waitForTransitioned.countDown();
-        } else if (description.equals("REMOVE_CALLED_FROM_ELEM_ARRAY")) {
+        switch (spot) {
+          case ATTEMPT_REMOVE:
+            if (!readyToStartRemoveLatch.await(21, TimeUnit.SECONDS)) {
+              throw new AssertionError("Time ran out waiting for other thread to initiate put");
+            }
+            break;
+          case TRANSITIONED_FROM_REGION_ENTRY_TO_ELEMARRAY:
+            readyToStartRemoveLatch.countDown();
+            if (!waitForRemoveLatch.await(21, TimeUnit.SECONDS)) {
+              throw new AssertionError("Time ran out waiting for other thread to initiate remove");
+            }
+            break;
+          case BEGIN_REMOVE_FROM_ELEM_ARRAY:
+            waitForRemoveLatch.countDown();
+            if (waitForTransitioned.await(21, TimeUnit.SECONDS)) {
+              throw new AssertionError(
+                  "Time ran out waiting for transition from region entry to elem array");
+            }
+            break;
         }
       } catch (InterruptedException e) {
         throw new AssertionError("Interrupted while waiting for test to complete");
@@ -377,7 +375,8 @@ public class CompactRangeIndexJUnitTest {
    * continue to set the token then continue and convert to chs while holding the lock to the elem
    * array still After the conversion of chs, the lock is released and then remove can proceed
    */
-  private class MemoryIndexStoreIndexElemToTokenToConcurrentHashSetTestHook implements TestHook {
+  private static class MemoryIndexStoreIndexElemToTokenToConcurrentHashSetTestHook
+      implements TestHook {
 
     private CountDownLatch waitForRemoveLatch;
     private CountDownLatch waitForTransitioned;
@@ -392,28 +391,30 @@ public class CompactRangeIndexJUnitTest {
     }
 
     @Override
-    public void doTestHook(int spot) {}
-
-    @Override
-    public void doTestHook(String description) {
+    public void doTestHook(final SPOTS spot, final DefaultQuery _ignored) {
       try {
-        if (description.equals("ATTEMPT_REMOVE")) {
-          if (!readyToStartRemoveLatch.await(21, TimeUnit.SECONDS)) {
-            throw new AssertionError("Time ran out waiting for other thread to initiate put");
-          }
-        } else if (description.equals("BEGIN_TRANSITION_FROM_ELEMARRAY_TO_CONCURRENT_HASH_SET")) {
-          readyToStartRemoveLatch.countDown();
-          if (!waitForRemoveLatch.await(21, TimeUnit.SECONDS)) {
-            throw new AssertionError("Time ran out waiting for other thread to initiate remove");
-          }
-        } else if (description.equals("BEGIN_REMOVE_FROM_ELEM_ARRAY")) {
-          waitForRemoveLatch.countDown();
-          if (!waitForTransitioned.await(21, TimeUnit.SECONDS)) {
-            throw new AssertionError(
-                "Time ran out waiting for transition from elem array to token");
-          }
-        } else if (description.equals("TRANSITIONED_FROM_ELEMARRAY_TO_TOKEN")) {
-          waitForTransitioned.countDown();
+        switch (spot) {
+          case ATTEMPT_REMOVE:
+            if (!readyToStartRemoveLatch.await(21, TimeUnit.SECONDS)) {
+              throw new AssertionError("Time ran out waiting for other thread to initiate put");
+            }
+            break;
+          case BEGIN_TRANSITION_FROM_ELEMARRAY_TO_CONCURRENT_HASH_SET:
+            readyToStartRemoveLatch.countDown();
+            if (!waitForRemoveLatch.await(21, TimeUnit.SECONDS)) {
+              throw new AssertionError("Time ran out waiting for other thread to initiate remove");
+            }
+            break;
+          case BEGIN_REMOVE_FROM_ELEM_ARRAY:
+            waitForRemoveLatch.countDown();
+            if (!waitForTransitioned.await(21, TimeUnit.SECONDS)) {
+              throw new AssertionError(
+                  "Time ran out waiting for transition from elem array to token");
+            }
+            break;
+          case TRANSITIONED_FROM_ELEMARRAY_TO_TOKEN:
+            waitForTransitioned.countDown();
+            break;
         }
       } catch (InterruptedException e) {
         throw new AssertionError("Interrupted while waiting for test to complete");

--- a/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/excludedClasses.txt
+++ b/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/excludedClasses.txt
@@ -2,6 +2,7 @@ org/apache/geode/GemFireCacheException
 org/apache/geode/admin/AlertLevel
 org/apache/geode/cache/operations/internal/UpdateOnlyMap
 org/apache/geode/cache/query/internal/index/CompactRangeIndex$1
+org/apache/geode/cache/query/internal/DefaultQuery$TestHook$SPOTS
 org/apache/geode/distributed/LocatorLauncher$Command
 org/apache/geode/distributed/ServerLauncher$Command
 org/apache/geode/distributed/ServerLauncherParameters

--- a/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
+++ b/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
@@ -351,7 +351,7 @@ fromData,16
 toData,16
 
 org/apache/geode/distributed/internal/streaming/StreamingOperation$StreamingReplyMessage,2
-fromData,414
+fromData,420
 toData,85
 
 org/apache/geode/distributed/internal/tcpserver/InfoRequest,2

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/HashIndex.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/HashIndex.java
@@ -188,7 +188,9 @@ public class HashIndex extends AbstractIndex {
 
     try {
       if (DefaultQuery.testHook != null) {
-        DefaultQuery.testHook.doTestHook(3);
+        DefaultQuery.testHook.doTestHook(
+            DefaultQuery.TestHook.SPOTS.BEFORE_ADD_OR_UPDATE_MAPPING_OR_DESERIALIZING_NTH_STREAMINGOPERATION,
+            null);
       }
       Object newKey = TypeUtils.indexKeyFor(key);
       if (newKey.equals(QueryService.UNDEFINED)) {

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/MemoryIndexStore.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/MemoryIndexStore.java
@@ -101,7 +101,9 @@ public class MemoryIndexStore implements IndexStore {
     try {
 
       if (DefaultQuery.testHook != null) {
-        DefaultQuery.testHook.doTestHook(3);
+        DefaultQuery.testHook.doTestHook(
+            DefaultQuery.TestHook.SPOTS.BEFORE_ADD_OR_UPDATE_MAPPING_OR_DESERIALIZING_NTH_STREAMINGOPERATION,
+            null);
       }
 
       // Check if reverse-map is present.
@@ -149,7 +151,8 @@ public class MemoryIndexStore implements IndexStore {
         } else if (regionEntries instanceof RegionEntry) {
           IndexElemArray elemArray = new IndexElemArray();
           if (DefaultQuery.testHook != null) {
-            DefaultQuery.testHook.doTestHook("BEGIN_TRANSITION_FROM_REGION_ENTRY_TO_ELEMARRAY");
+            DefaultQuery.testHook.doTestHook(
+                DefaultQuery.TestHook.SPOTS.BEGIN_TRANSITION_FROM_REGION_ENTRY_TO_ELEMARRAY, null);
           }
           elemArray.add(regionEntries);
           elemArray.add(re);
@@ -157,10 +160,14 @@ public class MemoryIndexStore implements IndexStore {
             retry = true;
           }
           if (DefaultQuery.testHook != null) {
-            DefaultQuery.testHook.doTestHook("TRANSITIONED_FROM_REGION_ENTRY_TO_ELEMARRAY");
+            DefaultQuery.testHook
+                .doTestHook(DefaultQuery.TestHook.SPOTS.TRANSITIONED_FROM_REGION_ENTRY_TO_ELEMARRAY,
+                    null);
           }
           if (DefaultQuery.testHook != null) {
-            DefaultQuery.testHook.doTestHook("COMPLETE_TRANSITION_FROM_REGION_ENTRY_TO_ELEMARRAY");
+            DefaultQuery.testHook.doTestHook(
+                DefaultQuery.TestHook.SPOTS.COMPLETE_TRANSITION_FROM_REGION_ENTRY_TO_ELEMARRAY,
+                null);
           }
         } else if (regionEntries instanceof IndexConcurrentHashSet) {
           // This synchronized is for avoiding conflcts with remove of
@@ -182,8 +189,9 @@ public class MemoryIndexStore implements IndexStore {
               // index then we should add old elements in the new set.
 
               if (DefaultQuery.testHook != null) {
-                DefaultQuery.testHook
-                    .doTestHook("BEGIN_TRANSITION_FROM_ELEMARRAY_TO_CONCURRENT_HASH_SET");
+                DefaultQuery.testHook.doTestHook(
+                    DefaultQuery.TestHook.SPOTS.BEGIN_TRANSITION_FROM_ELEMARRAY_TO_CONCURRENT_HASH_SET,
+                    null);
               }
               // on a remove from the elem array, another thread could start and complete its remove
               // at this point, that is why we need to replace before adding the elem array elements
@@ -195,7 +203,9 @@ public class MemoryIndexStore implements IndexStore {
                 retry = true;
               } else {
                 if (DefaultQuery.testHook != null) {
-                  DefaultQuery.testHook.doTestHook("TRANSITIONED_FROM_ELEMARRAY_TO_TOKEN");
+                  DefaultQuery.testHook
+                      .doTestHook(DefaultQuery.TestHook.SPOTS.TRANSITIONED_FROM_ELEMARRAY_TO_TOKEN,
+                          null);
                 }
                 set.add(re);
                 set.addAll(elemArray);
@@ -209,8 +219,9 @@ public class MemoryIndexStore implements IndexStore {
                       "Unable to transition from index elem to concurrent hash set.  Index needs to be recreated");
                 }
                 if (DefaultQuery.testHook != null) {
-                  DefaultQuery.testHook
-                      .doTestHook("COMPLETE_TRANSITION_FROM_ELEMARRAY_TO_CONCURRENT_HASH_SET");
+                  DefaultQuery.testHook.doTestHook(
+                      DefaultQuery.TestHook.SPOTS.COMPLETE_TRANSITION_FROM_ELEMARRAY_TO_CONCURRENT_HASH_SET,
+                      null);
                 }
               }
             } else {
@@ -293,7 +304,7 @@ public class MemoryIndexStore implements IndexStore {
     try {
       Object newKey = convertToIndexKey(key, entry);
       if (DefaultQuery.testHook != null) {
-        DefaultQuery.testHook.doTestHook("ATTEMPT_REMOVE");
+        DefaultQuery.testHook.doTestHook(DefaultQuery.TestHook.SPOTS.ATTEMPT_REMOVE, null);
       }
       boolean retry = false;
       do {
@@ -301,7 +312,7 @@ public class MemoryIndexStore implements IndexStore {
         Object regionEntries = this.valueToEntriesMap.get(newKey);
         if (regionEntries == TRANSITIONING_TOKEN) {
           if (DefaultQuery.testHook != null) {
-            DefaultQuery.testHook.doTestHook("ATTEMPT_RETRY");
+            DefaultQuery.testHook.doTestHook(DefaultQuery.TestHook.SPOTS.ATTEMPT_RETRY, null);
           }
           retry = true;
           continue;
@@ -320,11 +331,13 @@ public class MemoryIndexStore implements IndexStore {
           } else {
             Collection entries = (Collection) regionEntries;
             if (DefaultQuery.testHook != null) {
-              DefaultQuery.testHook.doTestHook("BEGIN_REMOVE_FROM_ELEM_ARRAY");
+              DefaultQuery.testHook
+                  .doTestHook(DefaultQuery.TestHook.SPOTS.BEGIN_REMOVE_FROM_ELEM_ARRAY, null);
             }
             found = entries.remove(entry);
             if (DefaultQuery.testHook != null) {
-              DefaultQuery.testHook.doTestHook("REMOVE_CALLED_FROM_ELEM_ARRAY");
+              DefaultQuery.testHook
+                  .doTestHook(DefaultQuery.TestHook.SPOTS.REMOVE_CALLED_FROM_ELEM_ARRAY, null);
             }
             // This could be IndexElementArray and might be changing to Set
             // If the remove occurred before changing to a set, then next time it will not be
@@ -351,7 +364,8 @@ public class MemoryIndexStore implements IndexStore {
               }
             }
             if (DefaultQuery.testHook != null) {
-              DefaultQuery.testHook.doTestHook("COMPLETE_REMOVE_FROM_ELEM_ARRAY");
+              DefaultQuery.testHook
+                  .doTestHook(DefaultQuery.TestHook.SPOTS.COMPLETE_REMOVE_FROM_ELEM_ARRAY, null);
             }
           }
         }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/streaming/StreamingOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/streaming/StreamingOperation.java
@@ -542,9 +542,11 @@ public abstract class StreamingOperation {
           for (int i = 0; i < n; i++) {
             // TestHook used in ResourceManagerWithQueryMonitorDUnitTest.
             // will simulate an critical memory event after a certain number of calls to
-            // doTestHook(3)
+            // doTestHook(BEFORE_ADD_OR_UPDATE_MAPPING_OR_DESERIALIZING_NTH_STREAMINGOPERATION)
             if (DefaultQuery.testHook != null) {
-              DefaultQuery.testHook.doTestHook(3);
+              DefaultQuery.testHook.doTestHook(
+                  DefaultQuery.TestHook.SPOTS.BEFORE_ADD_OR_UPDATE_MAPPING_OR_DESERIALIZING_NTH_STREAMINGOPERATION,
+                  null);
             }
             if (isQueryMessageProcessor && QueryMonitor.isLowMemory()) {
               lowMemoryDetected = true;
@@ -566,7 +568,9 @@ public abstract class StreamingOperation {
             isCanceled = true;
             // TestHook to help verify that objects have been rejected.
             if (DefaultQuery.testHook != null) {
-              DefaultQuery.testHook.doTestHook(2);
+              DefaultQuery.testHook.doTestHook(
+                  DefaultQuery.TestHook.SPOTS.LOW_MEMORY_WHEN_DESERIALIZING_STREAMINGOPERATION,
+                  null);
             }
           }
         } finally {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegionQueryEvaluator.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegionQueryEvaluator.java
@@ -211,7 +211,8 @@ public class PartitionedRegionQueryEvaluator extends StreamingPartitionOperation
       Object traceObject = objects.get(0);
       if (traceObject instanceof PRQueryTraceInfo) {
         if (DefaultQuery.testHook != null) {
-          DefaultQuery.testHook.doTestHook("Pull off PR Query Trace Info");
+          DefaultQuery.testHook
+              .doTestHook(DefaultQuery.TestHook.SPOTS.PULL_OFF_PR_QUERY_TRACE_INFO, null);
         }
         PRQueryTraceInfo queryTrace = (PRQueryTraceInfo) objects.remove(0);
         queryTrace.setSender(sender);
@@ -642,7 +643,8 @@ public class PartitionedRegionQueryEvaluator extends StreamingPartitionOperation
     final DistributedMember me = this.pr.getMyId();
 
     if (DefaultQuery.testHook != null) {
-      DefaultQuery.testHook.doTestHook(4);
+      DefaultQuery.testHook
+          .doTestHook(DefaultQuery.TestHook.SPOTS.BEFORE_BUILD_CUMULATIVE_RESULT, null);
     }
 
     boolean localResults = false;
@@ -737,7 +739,8 @@ public class PartitionedRegionQueryEvaluator extends StreamingPartitionOperation
 
     if (prQueryTraceInfoList != null && this.query.isTraced() && logger.isInfoEnabled()) {
       if (DefaultQuery.testHook != null) {
-        DefaultQuery.testHook.doTestHook("Create PR Query Trace String");
+        DefaultQuery.testHook
+            .doTestHook(DefaultQuery.TestHook.SPOTS.CREATE_PR_QUERY_TRACE_STRING, null);
       }
       StringBuilder sb = new StringBuilder();
       sb.append(String.format("Trace Info for Query: %s",
@@ -761,7 +764,8 @@ public class PartitionedRegionQueryEvaluator extends StreamingPartitionOperation
           "Query execution canceled due to low memory while gathering results from partitioned regions";
       query.setCanceled(new QueryExecutionLowMemoryException(reason));
       if (DefaultQuery.testHook != null) {
-        DefaultQuery.testHook.doTestHook(5);
+        DefaultQuery.testHook
+            .doTestHook(DefaultQuery.TestHook.SPOTS.BEFORE_THROW_QUERY_CANCELED_EXCEPTION, null);
       }
       throw query.getQueryCanceledException();
     } else if (query.isCanceled()) {
@@ -986,7 +990,9 @@ public class PartitionedRegionQueryEvaluator extends StreamingPartitionOperation
         // Adds a query trace info object to the results list
         if (query.isTraced() && prQueryTraceInfoList != null) {
           if (DefaultQuery.testHook != null) {
-            DefaultQuery.testHook.doTestHook("Create PR Query Trace Info From Local Node");
+            DefaultQuery.testHook
+                .doTestHook(DefaultQuery.TestHook.SPOTS.CREATE_PR_QUERY_TRACE_INFO_FROM_LOCAL_NODE,
+                    null);
           }
           PRQueryTraceInfo queryTraceInfo = new PRQueryTraceInfo();
           queryTraceInfo.setNumResults(queryTraceInfo.calculateNumberOfResults(resultCollector));

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/QueryMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/QueryMessage.java
@@ -192,7 +192,9 @@ public class QueryMessage extends StreamingPartitionOperation.StreamingPartition
       if (isQueryTraced) {
         this.isTraceInfoIteration = true;
         if (DefaultQuery.testHook != null) {
-          DefaultQuery.testHook.doTestHook("Create PR Query Trace Info for Remote Query");
+          DefaultQuery.testHook
+              .doTestHook(DefaultQuery.TestHook.SPOTS.CREATE_PR_QUERY_TRACE_INFO_FOR_REMOTE_QUERY,
+                  null);
         }
         queryTraceInfo = new PRQueryTraceInfo();
         queryTraceList = Collections.singletonList(queryTraceInfo);
@@ -211,7 +213,8 @@ public class QueryMessage extends StreamingPartitionOperation.StreamingPartition
       // information here rather than the finally block.
       if (isQueryTraced) {
         if (DefaultQuery.testHook != null) {
-          DefaultQuery.testHook.doTestHook("Populating Trace Info for Remote Query");
+          DefaultQuery.testHook
+              .doTestHook(DefaultQuery.TestHook.SPOTS.POPULATING_TRACE_INFO_FOR_REMOTE_QUERY, null);
         }
 
         // calculate the number of rows being sent


### PR DESCRIPTION
Fix intermittently-failing test:
QueryMonitorDUnitTest.testCacheOpAfterQueryCancel()
by increasing timeout to account for GC pauses.

Also did some test refactoring cleanup:

 * clean up DefaultQuery.TestHook interface

 * remove dead code

 * improve test comments

 * remove spurious TODOs

 * camelCase some statics that were SCREAMING_CASE

 * fixed typos in test method names

Co-Authored-By: Bill Burcham <bburcham@pivotal.io>
Co-Authored-By: Galen O'Sullivan <gosullivan@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
