### PR TITLE
GEODE-5739: Use Launchers in StarterRules

### DIFF
--- a/extensions/geode-modules/src/integrationTest/java/org/apache/geode/modules/util/ModuleFunctionsSecurityTest.java
+++ b/extensions/geode-modules/src/integrationTest/java/org/apache/geode/modules/util/ModuleFunctionsSecurityTest.java
@@ -33,7 +33,7 @@ import org.apache.geode.test.junit.rules.ConnectionConfiguration;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({SecurityTest.class})
+@Category(SecurityTest.class)
 public class ModuleFunctionsSecurityTest {
 
   private static final String RESULT_HEADER = "Message";
@@ -62,13 +62,10 @@ public class ModuleFunctionsSecurityTest {
 
   @Test
   @ConnectionConfiguration(user = "user", password = "user")
-  public void functionRequireExpectedPermission() throws Exception {
-    functionStringMap.entrySet().stream().forEach(entry -> {
-      Function function = entry.getKey();
-      String permission = entry.getValue();
-      gfsh.executeAndAssertThat("execute function --region=AuthRegion --id=" + function.getId())
-          .tableHasRowCount(RESULT_HEADER, 1)
-          .tableHasColumnWithValuesContaining(RESULT_HEADER, permission).statusIsError();
-    });
+  public void functionRequireExpectedPermission() {
+    functionStringMap.forEach((function, permission) -> gfsh
+        .executeAndAssertThat("execute function --region=AuthRegion --id=" + function.getId())
+        .tableHasRowCount(RESULT_HEADER, 1)
+        .tableHasColumnWithValuesContaining(RESULT_HEADER, permission).statusIsError());
   }
 }

--- a/geode-assembly/src/integrationTest/java/org/apache/geode/rest/internal/web/RestSecurityIntegrationTest.java
+++ b/geode-assembly/src/integrationTest/java/org/apache/geode/rest/internal/web/RestSecurityIntegrationTest.java
@@ -15,9 +15,7 @@
 package org.apache.geode.rest.internal.web;
 
 import static org.apache.geode.test.junit.rules.HttpResponseAssert.assertResponse;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.BeforeClass;
@@ -38,7 +36,7 @@ import org.apache.geode.test.junit.rules.ServerStarterRule;
 @Category({SecurityTest.class, RestAPITest.class})
 public class RestSecurityIntegrationTest {
 
-  protected static final String REGION_NAME = "AuthRegion";
+  private static final String REGION_NAME = "AuthRegion";
 
   @ClassRule
   public static ServerStarterRule serverStarter = new ServerStarterRule()
@@ -57,7 +55,7 @@ public class RestSecurityIntegrationTest {
   }
 
   @Test
-  public void testListFunctions() throws Exception {
+  public void testListFunctions() {
     assertResponse(restClient.doGet("/functions", "user", "wrongPswd")).hasStatusCode(401);
     assertResponse(restClient.doGet("/functions", "user", "user")).hasStatusCode(403);
     assertResponse(restClient.doGet("/functions", "dataRead", "dataRead"))
@@ -66,7 +64,7 @@ public class RestSecurityIntegrationTest {
   }
 
   @Test
-  public void executeNotRegisteredFunction() throws Exception {
+  public void executeNotRegisteredFunction() {
     assertResponse(restClient.doPost("/functions/invalid-function-id", "user", "wrongPswd", ""))
         .hasStatusCode(401);
     assertResponse(restClient.doPost("/functions/invalid-function-id", "user", "user", ""))
@@ -74,7 +72,7 @@ public class RestSecurityIntegrationTest {
   }
 
   @Test
-  public void testQueries() throws Exception {
+  public void testQueries() {
     restClient.doGetAndAssert("/queries", "user", "wrongPswd")
         .hasStatusCode(401);
     restClient.doGetAndAssert("/queries", "user", "user")
@@ -85,7 +83,7 @@ public class RestSecurityIntegrationTest {
   }
 
   @Test
-  public void testAdhocQuery() throws Exception {
+  public void testAdhocQuery() {
     restClient.doGetAndAssert("/queries/adhoc?q=", "user", "wrongPswd")
         .hasStatusCode(401);
     restClient.doGetAndAssert("/queries/adhoc?q=", "user", "user")
@@ -97,7 +95,7 @@ public class RestSecurityIntegrationTest {
   }
 
   @Test
-  public void testPostQuery() throws Exception {
+  public void testPostQuery() {
     assertResponse(restClient.doPost("/queries?id=0&q=", "user", "wrongPswd", ""))
         .hasStatusCode(401);
     assertResponse(restClient.doPost("/queries?id=0&q=", "user", "user", ""))
@@ -107,7 +105,7 @@ public class RestSecurityIntegrationTest {
   }
 
   @Test
-  public void testPostQuery2() throws Exception {
+  public void testPostQuery2() {
     assertResponse(restClient.doPost("/queries/id", "user", "wrongPswd", "{\"id\" : \"foo\"}"))
         .hasStatusCode(401);
     assertResponse(restClient.doPost("/queries/id", "user", "user", "{\"id\" : \"foo\"}"))
@@ -117,7 +115,7 @@ public class RestSecurityIntegrationTest {
   }
 
   @Test
-  public void testPutQuery() throws Exception {
+  public void testPutQuery() {
     assertResponse(restClient.doPut("/queries/id", "user", "wrongPswd", "{\"id\" : \"foo\"}"))
         .hasStatusCode(401);
     assertResponse(restClient.doPut("/queries/id", "user", "user", "{\"id\" : \"foo\"}"))
@@ -127,7 +125,7 @@ public class RestSecurityIntegrationTest {
   }
 
   @Test
-  public void testDeleteQuery() throws Exception {
+  public void testDeleteQuery() {
     assertResponse(restClient.doDelete("/queries/id", "user", "wrongPswd"))
         .hasStatusCode(401);
     assertResponse(restClient.doDelete("/queries/id", "stranger", "stranger"))
@@ -137,7 +135,7 @@ public class RestSecurityIntegrationTest {
   }
 
   @Test
-  public void testServers() throws Exception {
+  public void testServers() {
     assertResponse(restClient.doGet("/servers", "user", "wrongPswd"))
         .hasStatusCode(401);
     assertResponse(restClient.doGet("/servers", "stranger", "stranger"))
@@ -152,7 +150,7 @@ public class RestSecurityIntegrationTest {
    * should not be able to determine whether a user/password combination is good
    */
   @Test
-  public void testPing() throws Exception {
+  public void testPing() {
     assertResponse(restClient.doHEAD("/ping", "stranger", "stranger"))
         .hasStatusCode(200);
     assertResponse(restClient.doGet("/ping", "stranger", "stranger"))
@@ -174,12 +172,12 @@ public class RestSecurityIntegrationTest {
         .getJsonObject();
 
     JsonNode regions = jsonObject.get("regions");
-    assertNotNull(regions);
-    assertTrue(regions.size() > 0);
+    assertThat(regions).isNotNull();
+    assertThat(regions.size() > 0).isTrue();
 
     JsonNode region = regions.get(0);
-    assertEquals("AuthRegion", region.get("name").asText());
-    assertEquals("REPLICATE", region.get("type").asText());
+    assertThat(region.get("name").asText()).isEqualTo("AuthRegion");
+    assertThat(region.get("type").asText()).isEqualTo("REPLICATE");
 
     // List regions with an unknown user - 401
     assertResponse(restClient.doGet("", "user", "wrongPswd"))
@@ -194,7 +192,7 @@ public class RestSecurityIntegrationTest {
    * Test permissions on getting a region
    */
   @Test
-  public void getRegion() throws Exception {
+  public void getRegion() {
     // Test an unknown user - 401 error
     assertResponse(restClient.doGet("/" + REGION_NAME, "user", "wrongPswd"))
         .hasStatusCode(401);
@@ -212,7 +210,7 @@ public class RestSecurityIntegrationTest {
    * Test permissions on HEAD region
    */
   @Test
-  public void headRegion() throws Exception {
+  public void headRegion() {
     // Test an unknown user - 401 error
     assertResponse(restClient.doHEAD("/" + REGION_NAME, "user", "wrongPswd"))
         .hasStatusCode(401);
@@ -230,7 +228,7 @@ public class RestSecurityIntegrationTest {
    * Test permissions on deleting a region
    */
   @Test
-  public void deleteRegion() throws Exception {
+  public void deleteRegion() {
     // Test an unknown user - 401 error
     assertResponse(restClient.doDelete("/" + REGION_NAME, "user", "wrongPswd"))
         .hasStatusCode(401);
@@ -244,7 +242,7 @@ public class RestSecurityIntegrationTest {
    * Test permissions on getting a region's keys
    */
   @Test
-  public void getRegionKeys() throws Exception {
+  public void getRegionKeys() {
     // Test an authorized user
     assertResponse(restClient.doGet("/" + REGION_NAME + "/keys", "data", "data"))
         .hasStatusCode(200).hasContentType(MediaType.APPLICATION_JSON_UTF8_VALUE);
@@ -257,7 +255,7 @@ public class RestSecurityIntegrationTest {
    * Test permissions on retrieving a key from a region
    */
   @Test
-  public void getRegionKey() throws Exception {
+  public void getRegionKey() {
     // Test an authorized user
     assertResponse(restClient.doGet("/" + REGION_NAME + "/key1", "dataReadAuthRegionKey1",
         "dataReadAuthRegionKey1"))
@@ -272,7 +270,7 @@ public class RestSecurityIntegrationTest {
    * Test permissions on deleting a region's key(s)
    */
   @Test
-  public void deleteRegionKey() throws Exception {
+  public void deleteRegionKey() {
     // Test an unknown user - 401 error
     assertResponse(restClient.doDelete("/" + REGION_NAME + "/key1", "user", "wrongPswd"))
         .hasStatusCode(401);
@@ -291,7 +289,7 @@ public class RestSecurityIntegrationTest {
    * Test permissions on deleting a region's key(s)
    */
   @Test
-  public void postRegionKey() throws Exception {
+  public void postRegionKey() {
     // Test an unknown user - 401 error
     assertResponse(restClient.doPost("/" + REGION_NAME + "?key9", "user", "wrongPswd",
         "{ \"key9\" : \"foo\" }"))
@@ -312,7 +310,7 @@ public class RestSecurityIntegrationTest {
    * Test permissions on deleting a region's key(s)
    */
   @Test
-  public void putRegionKey() throws Exception {
+  public void putRegionKey() {
 
     String json =
         "{\"@type\":\"com.gemstone.gemfire.web.rest.domain.Order\",\"purchaseOrderNo\":1121,\"customerId\":1012,\"description\":\"Order for  XYZ Corp\",\"orderDate\":\"02/10/2014\",\"deliveryDate\":\"02/20/2014\",\"contact\":\"Jelly Bean\",\"email\":\"jelly.bean@example.com\",\"phone\":\"01-2048096\",\"items\":[{\"itemNo\":1,\"description\":\"Product-100\",\"quantity\":12,\"unitPrice\":5,\"totalPrice\":60}],\"totalPrice\":225}";

--- a/geode-assembly/src/integrationTest/java/org/apache/geode/rest/internal/web/RestSecurityPostProcessorTest.java
+++ b/geode-assembly/src/integrationTest/java/org/apache/geode/rest/internal/web/RestSecurityPostProcessorTest.java
@@ -17,8 +17,7 @@ package org.apache.geode.rest.internal.web;
 import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_MANAGER;
 import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_POST_PROCESSOR;
 import static org.apache.geode.test.junit.rules.HttpResponseAssert.assertResponse;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.URLEncoder;
 
@@ -59,9 +58,10 @@ public class RestSecurityPostProcessorTest {
   public RequiresGeodeHome requiresGeodeHome = new RequiresGeodeHome();
 
   @BeforeClass
-  public static void before() throws Exception {
-    Region region =
-        serverStarter.getCache().createRegionFactory(RegionShortcut.REPLICATE).create("customers");
+  public static void before() {
+    Region<String, Customer> region =
+        serverStarter.getCache().<String, Customer>createRegionFactory(RegionShortcut.REPLICATE)
+            .create("customers");
     region.put("1", new Customer(1L, "John", "Doe", "555555555"));
     region.put("2", new Customer(2L, "Richard", "Roe", "222533554"));
     region.put("3", new Customer(3L, "Jane", "Doe", "555223333"));
@@ -80,8 +80,8 @@ public class RestSecurityPostProcessorTest {
             .hasContentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
             .getJsonObject();
 
-    assertEquals("*********", jsonNode.get("socialSecurityNumber").asText());
-    assertEquals(1L, jsonNode.get("customerId").asLong());
+    assertThat(jsonNode.get("socialSecurityNumber").asText()).isEqualTo("*********");
+    assertThat(jsonNode.get("customerId").asLong()).isEqualTo(1L);
 
     // Try with super-user
     jsonNode =
@@ -89,8 +89,8 @@ public class RestSecurityPostProcessorTest {
             .hasStatusCode(200)
             .hasContentType(MediaType.APPLICATION_JSON_UTF8_VALUE)
             .getJsonObject();
-    assertEquals("555555555", jsonNode.get("socialSecurityNumber").asText());
-    assertEquals(1L, jsonNode.get("customerId").asLong());
+    assertThat(jsonNode.get("socialSecurityNumber").asText()).isEqualTo("555555555");
+    assertThat(jsonNode.get("customerId").asLong()).isEqualTo(1L);
   }
 
   // Test multiple keys
@@ -104,13 +104,13 @@ public class RestSecurityPostProcessorTest {
 
     JsonNode customers = jsonNode.get("customers");
     final int length = customers.size();
-    assertEquals(2, length);
+    assertThat(length).isEqualTo(2);
     JsonNode customer = customers.get(0);
-    assertEquals("*********", customer.get("socialSecurityNumber").asText());
-    assertEquals(1, customer.get("customerId").asLong());
+    assertThat(customer.get("socialSecurityNumber").asText()).isEqualTo("*********");
+    assertThat(customer.get("customerId").asLong()).isEqualTo(1);
     customer = customers.get(1);
-    assertEquals("*********", customer.get("socialSecurityNumber").asText());
-    assertEquals(3, customer.get("customerId").asLong());
+    assertThat(customer.get("socialSecurityNumber").asText()).isEqualTo("*********");
+    assertThat(customer.get("customerId").asLong()).isEqualTo(3);
   }
 
   @Test
@@ -124,8 +124,8 @@ public class RestSecurityPostProcessorTest {
     final int length = customers.size();
     for (int index = 0; index < length; ++index) {
       JsonNode customer = customers.get(index);
-      assertEquals("*********", customer.get("socialSecurityNumber").asText());
-      assertEquals((long) index + 1, customer.get("customerId").asLong());
+      assertThat(customer.get("socialSecurityNumber").asText()).isEqualTo("*********");
+      assertThat(customer.get("customerId").asLong()).isEqualTo((long) index + 1);
     }
   }
 
@@ -141,8 +141,8 @@ public class RestSecurityPostProcessorTest {
     final int length = jsonArray.size();
     for (int index = 0; index < length; ++index) {
       JsonNode customer = jsonArray.get(index);
-      assertEquals("*********", customer.get("socialSecurityNumber").asText());
-      assertEquals((long) index + 1, customer.get("customerId").asLong());
+      assertThat(customer.get("socialSecurityNumber").asText()).isEqualTo("*********");
+      assertThat(customer.get("customerId").asLong()).isEqualTo((long) index + 1);
     }
   }
 
@@ -170,9 +170,9 @@ public class RestSecurityPostProcessorTest {
                 .hasStatusCode(200)
                 .getJsonObject();
 
-    assertTrue(jsonArray.size() == 1);
+    assertThat(jsonArray.size() == 1).isTrue();
     JsonNode customer = jsonArray.get(0);
-    assertEquals("*********", customer.get("socialSecurityNumber").asText());
-    assertEquals(1L, customer.get("customerId").asLong());
+    assertThat(customer.get("socialSecurityNumber").asText()).isEqualTo("*********");
+    assertThat(customer.get("customerId").asLong()).isEqualTo(1L);
   }
 }

--- a/geode-assembly/src/integrationTest/java/org/apache/geode/rest/internal/web/RestServersIntegrationTest.java
+++ b/geode-assembly/src/integrationTest/java/org/apache/geode/rest/internal/web/RestServersIntegrationTest.java
@@ -33,7 +33,7 @@ import org.apache.geode.test.junit.rules.GeodeDevRestClient;
 import org.apache.geode.test.junit.rules.RequiresGeodeHome;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({RestAPITest.class})
+@Category(RestAPITest.class)
 public class RestServersIntegrationTest {
 
   private static GeodeDevRestClient restClient;
@@ -41,12 +41,11 @@ public class RestServersIntegrationTest {
   @ClassRule
   public static ServerStarterRule serverStarter = new ServerStarterRule().withRestService(true);
 
-
   @Rule
   public RequiresGeodeHome requiresGeodeHome = new RequiresGeodeHome();
 
   @BeforeClass
-  public static void before() throws Exception {
+  public static void before() {
     assumeTrue(
         "Default port was unavailable for testing.  Please ensure the testing environment is clean.",
         AvailablePort.isPortAvailable(DEFAULT_HTTP_SERVICE_PORT, AvailablePort.SOCKET));
@@ -56,7 +55,7 @@ public class RestServersIntegrationTest {
   }
 
   @Test
-  public void testGet() throws Exception {
+  public void testGet() {
     assertResponse(restClient.doGet("/", null, null))
         .hasStatusCode(HttpStatus.SC_OK);
   }

--- a/geode-assembly/src/integrationTest/java/org/apache/geode/rest/internal/web/SwaggerVerificationIntegrationTest.java
+++ b/geode-assembly/src/integrationTest/java/org/apache/geode/rest/internal/web/SwaggerVerificationIntegrationTest.java
@@ -64,6 +64,5 @@ public class SwaggerVerificationIntegrationTest {
     JsonNode license = info.get("license");
     assertThat(license.get("name").asText(), is("Apache License, version 2.0"));
     assertThat(license.get("url").asText(), is("http://www.apache.org/licenses/"));
-
   }
 }

--- a/geode-assembly/src/integrationTest/java/org/apache/geode/tools/pulse/PulseConnectivityTest.java
+++ b/geode-assembly/src/integrationTest/java/org/apache/geode/tools/pulse/PulseConnectivityTest.java
@@ -38,7 +38,7 @@ import org.apache.geode.test.junit.rules.LocatorStarterRule;
 import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactory;
 import org.apache.geode.tools.pulse.internal.data.Cluster;
 
-@Category({PulseTest.class})
+@Category(PulseTest.class)
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
 public class PulseConnectivityTest {
@@ -60,11 +60,11 @@ public class PulseConnectivityTest {
     if ("localhost".equals(nonDefaultJmxBindAddress)) {
       nonDefaultJmxBindAddress = InetAddress.getLocalHost().getHostAddress();
     }
-    return Arrays.asList(new String[] {"localhost", nonDefaultJmxBindAddress});
+    return Arrays.asList("localhost", nonDefaultJmxBindAddress);
   }
 
   @Before
-  public void setUp() throws Exception {
+  public void setUp() {
     Properties locatorProperties = new Properties();
     if (!"localhost".equals(jmxBindAddress))
       locatorProperties.setProperty(JMX_MANAGER_BIND_ADDRESS, jmxBindAddress);
@@ -81,7 +81,7 @@ public class PulseConnectivityTest {
   }
 
   @Test
-  public void testConnectToJmx() throws Exception {
+  public void testConnectToJmx() {
     pulse.useJmxManager(jmxBindAddress, locator.getJmxPort());
     Cluster cluster = pulse.getRepository().getCluster("admin", null);
     assertThat(cluster.isConnectedFlag()).isTrue();
@@ -89,7 +89,7 @@ public class PulseConnectivityTest {
   }
 
   @Test
-  public void testConnectToLocator() throws Exception {
+  public void testConnectToLocator() {
     pulse.useLocatorPort(locator.getPort());
     Cluster cluster = pulse.getRepository().getCluster("admin", null);
     assertThat(cluster.isConnectedFlag()).isTrue();

--- a/geode-assembly/src/integrationTest/java/org/apache/geode/tools/pulse/PulseDataExportTest.java
+++ b/geode-assembly/src/integrationTest/java/org/apache/geode/tools/pulse/PulseDataExportTest.java
@@ -29,7 +29,7 @@ import org.apache.geode.test.junit.categories.PulseTest;
 import org.apache.geode.test.junit.rules.GeodeHttpClientRule;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({PulseTest.class})
+@Category(PulseTest.class)
 public class PulseDataExportTest {
 
   @Rule
@@ -41,8 +41,8 @@ public class PulseDataExportTest {
   public GeodeHttpClientRule client = new GeodeHttpClientRule(server::getHttpPort);
 
   @Before
-  public void before() throws Exception {
-    Region region = server.getCache().getRegion("regionA");
+  public void before() {
+    Region<String, String> region = server.getCache().getRegion("regionA");
     region.put("key1", "value1");
     region.put("key2", "value2");
     region.put("key3", "value3");

--- a/geode-assembly/src/integrationTest/java/org/apache/geode/tools/pulse/PulseSecurityIntegrationTest.java
+++ b/geode-assembly/src/integrationTest/java/org/apache/geode/tools/pulse/PulseSecurityIntegrationTest.java
@@ -42,7 +42,7 @@ public class PulseSecurityIntegrationTest {
   public EmbeddedPulseRule pulse = new EmbeddedPulseRule();
 
   @Test
-  public void getAttributesWithSecurityManager() throws Exception {
+  public void getAttributesWithSecurityManager() {
     pulse.useJmxPort(locator.getJmxPort());
 
     ManagementService service =

--- a/geode-assembly/src/integrationTest/java/org/apache/geode/tools/pulse/PulseSecurityTest.java
+++ b/geode-assembly/src/integrationTest/java/org/apache/geode/tools/pulse/PulseSecurityTest.java
@@ -49,7 +49,6 @@ public class PulseSecurityTest {
   @Rule
   public GeodeHttpClientRule client = new GeodeHttpClientRule(server::getHttpPort);
 
-
   @Test
   public void loginWithIncorrectPassword() throws Exception {
     HttpResponse response = client.loginToPulse("data", "wrongPassword");
@@ -98,7 +97,7 @@ public class PulseSecurityTest {
   }
 
   @Test
-  public void queryUsingEmbededPulseWillHaveAuthorizationEnabled() throws Exception {
+  public void queryUsingEmbededPulseWillHaveAuthorizationEnabled() {
     pulse.useJmxPort(server.getJmxPort());
     // using "cluster" to connect to jmx manager will not get authorized to execute query
     Cluster cluster = pulse.getRepository().getCluster("cluster", "cluster");

--- a/geode-assembly/src/integrationTest/java/org/apache/geode/tools/pulse/PulseSecurityWithSSLTest.java
+++ b/geode-assembly/src/integrationTest/java/org/apache/geode/tools/pulse/PulseSecurityWithSSLTest.java
@@ -100,6 +100,7 @@ public class PulseSecurityWithSSLTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void loginWithDeprecatedSSLOptions() throws Exception {
     Properties securityProps = new Properties();
     securityProps.setProperty(CLUSTER_SSL_ENABLED, "true");

--- a/geode-connectors/src/integrationTest/java/org/apache/geode/connectors/jdbc/internal/cli/JDBCConnectorFunctionsSecurityTest.java
+++ b/geode-connectors/src/integrationTest/java/org/apache/geode/connectors/jdbc/internal/cli/JDBCConnectorFunctionsSecurityTest.java
@@ -42,7 +42,7 @@ class InheritsDefaultPermissionsJDBCFunction extends CliFunction<String> {
 
   @Override
   public CliFunctionResult executeFunction(FunctionContext<String> context) {
-    return new CliFunctionResult("some-member", true, "some-message");
+    return new CliFunctionResult("some-member", CliFunctionResult.StatusState.OK, "some-message");
   }
 }
 
@@ -73,15 +73,12 @@ public class JDBCConnectorFunctionsSecurityTest {
 
   @Test
   @ConnectionConfiguration(user = "user", password = "user")
-  public void functionRequireExpectedPermission() throws Exception {
-    functionStringMap.entrySet().stream().forEach(entry -> {
-      Function function = entry.getKey();
-      String permission = entry.getValue();
-      gfsh.executeAndAssertThat("execute function --id=" + function.getId())
-          .tableHasRowCount("Message", 1)
-          .tableHasRowWithValues("Message",
-              "Exception: user not authorized for " + permission)
-          .statusIsError();
-    });
+  public void functionRequireExpectedPermission() {
+    functionStringMap.forEach((function, permission) -> gfsh
+        .executeAndAssertThat("execute function --id=" + function.getId())
+        .tableHasRowCount("Message", 1)
+        .tableHasRowWithValues("Message",
+            "Exception: user not authorized for " + permission)
+        .statusIsError());
   }
 }

--- a/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/ConcurrentDeployDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/ConcurrentDeployDUnitTest.java
@@ -76,12 +76,12 @@ public class ConcurrentDeployDUnitTest {
     gfsh3.invoke(() -> gfsh.close());
   }
 
-  public static void connectToLocator(int locatorPort) throws Exception {
+  private static void connectToLocator(int locatorPort) throws Exception {
     gfsh = new GfshCommandRule();
     gfsh.connectAndVerify(locatorPort, GfshCommandRule.PortType.locator);
   }
 
-  public static void loopThroughDeployAndUndeploys(File jar1) throws Exception {
+  private static void loopThroughDeployAndUndeploys(File jar1) {
     int numTimesToExecute = 50;
     String command;
 
@@ -94,8 +94,6 @@ public class ConcurrentDeployDUnitTest {
 
       command = "undeploy --jar=" + jar1.getName();
       gfsh.executeAndAssertThat(command).statusIsSuccess();
-
     }
   }
-
 }

--- a/geode-core/src/distributedTest/java/org/apache/geode/management/internal/security/DistributedSystemMXBeanSecurityTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/internal/security/DistributedSystemMXBeanSecurityTest.java
@@ -33,7 +33,7 @@ import org.apache.geode.test.junit.rules.ConnectionConfiguration;
 import org.apache.geode.test.junit.rules.MBeanServerConnectionRule;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({SecurityTest.class})
+@Category(SecurityTest.class)
 public class DistributedSystemMXBeanSecurityTest {
 
   private DistributedSystemMXBean bean;
@@ -54,14 +54,14 @@ public class DistributedSystemMXBeanSecurityTest {
 
   @Test
   @ConnectionConfiguration(user = "dataRead", password = "dataRead")
-  public void testDataReadAccess() throws Exception {
+  public void testDataReadAccess() {
     assertThatThrownBy(() -> bean.backupAllMembers(null, null))
         .isInstanceOf(NotAuthorizedException.class);
   }
 
   @Test
   @ConnectionConfiguration(user = "clusterManageDisk", password = "clusterManageDisk")
-  public void testDiskManageAccess() throws Exception {
+  public void testDiskManageAccess() {
     assertThatThrownBy(() -> bean.backupAllMembers(null, null))
         .isInstanceOf(NotAuthorizedException.class);
   }
@@ -69,7 +69,7 @@ public class DistributedSystemMXBeanSecurityTest {
   @Test
   @ConnectionConfiguration(user = "dataRead,clusterWriteDisk",
       password = "dataRead,clusterWriteDisk")
-  public void testBothAccess() throws Exception {
+  public void testBothAccess() {
     assertThatThrownBy(() -> bean.backupAllMembers(null, null))
         .isNotInstanceOf(NotAuthorizedException.class);
   }

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/ClientAuthDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/ClientAuthDUnitTest.java
@@ -16,6 +16,7 @@ package org.apache.geode.security;
 
 import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_CLIENT_AUTH_INIT;
 import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_MANAGER;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
@@ -43,7 +44,7 @@ import org.apache.geode.test.junit.categories.SecurityTest;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactory;
 
-@Category({SecurityTest.class})
+@Category(SecurityTest.class)
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
 public class ClientAuthDUnitTest {
@@ -74,9 +75,10 @@ public class ClientAuthDUnitTest {
 
     clientVM.invoke(() -> {
       ClientCache clientCache = ClusterStartupRule.getClientCache();
-      ClientRegionFactory clientRegionFactory =
+      assertThat(clientCache).isNotNull();
+      ClientRegionFactory<String, String> clientRegionFactory =
           clientCache.createClientRegionFactory(ClientRegionShortcut.PROXY);
-      Region region = clientRegionFactory.create("region");
+      Region<String, String> region = clientRegionFactory.create("region");
       region.put("A", "A");
     });
   }
@@ -106,6 +108,7 @@ public class ClientAuthDUnitTest {
 
     clientVM.invoke(() -> {
       ClientCache clientCache = ClusterStartupRule.getClientCache();
+      assertThat(clientCache).isNotNull();
       ClientRegionFactory clientRegionFactory =
           clientCache.createClientRegionFactory(ClientRegionShortcut.PROXY);
       assertThatThrownBy(() -> clientRegionFactory.create("region"))
@@ -125,9 +128,10 @@ public class ClientAuthDUnitTest {
 
     clientVM.invoke(() -> {
       ClientCache clientCache = ClusterStartupRule.getClientCache();
-      ClientRegionFactory clientRegionFactory =
+      assertThat(clientCache).isNotNull();
+      ClientRegionFactory<String, String> clientRegionFactory =
           clientCache.createClientRegionFactory(ClientRegionShortcut.PROXY);
-      Region region = clientRegionFactory.create("region");
+      Region<String, String> region = clientRegionFactory.create("region");
       assertThatThrownBy(() -> region.put("A", "A")).isInstanceOf(ServerOperationException.class)
           .hasCauseInstanceOf(AuthenticationFailedException.class);
     });

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/ClientDestroyRegionAuthDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/ClientDestroyRegionAuthDUnitTest.java
@@ -31,14 +31,14 @@ import org.apache.geode.test.dunit.internal.JUnit4DistributedTestCase;
 import org.apache.geode.test.junit.categories.SecurityTest;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({SecurityTest.class})
+@Category(SecurityTest.class)
 public class ClientDestroyRegionAuthDUnitTest extends JUnit4DistributedTestCase {
   private static String REGION_NAME = "testRegion";
 
   final Host host = Host.getHost(0);
-  final VM client1 = host.getVM(1);
-  final VM client2 = host.getVM(2);
-  final VM client3 = host.getVM(3);
+  final VM client1 = VM.getVM(1);
+  final VM client2 = VM.getVM(2);
+  private final VM client3 = VM.getVM(3);
 
   @Rule
   public ServerStarterRule server =
@@ -48,14 +48,14 @@ public class ClientDestroyRegionAuthDUnitTest extends JUnit4DistributedTestCase 
           .withRegion(RegionShortcut.REPLICATE, REGION_NAME);
 
   @Test
-  public void testDestroyRegion() throws InterruptedException {
+  public void testDestroyRegion() {
     client1.invoke(() -> {
       ClientCache cache =
           SecurityTestUtil.createClientCache("dataWriter", "1234567", server.getPort());
 
       Region region =
           cache.createClientRegionFactory(ClientRegionShortcut.PROXY).create(REGION_NAME);
-      SecurityTestUtil.assertNotAuthorized(() -> region.destroyRegion(), "DATA:MANAGE");
+      SecurityTestUtil.assertNotAuthorized(region::destroyRegion, "DATA:MANAGE");
     });
 
     client2.invoke(() -> {
@@ -64,7 +64,7 @@ public class ClientDestroyRegionAuthDUnitTest extends JUnit4DistributedTestCase 
 
       Region region =
           cache.createClientRegionFactory(ClientRegionShortcut.PROXY).create(REGION_NAME);
-      SecurityTestUtil.assertNotAuthorized(() -> region.destroyRegion(), "DATA:MANAGE");
+      SecurityTestUtil.assertNotAuthorized(region::destroyRegion, "DATA:MANAGE");
     });
 
     client3.invoke(() -> {

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/ClientExecuteRegionFunctionAuthDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/ClientExecuteRegionFunctionAuthDUnitTest.java
@@ -41,12 +41,11 @@ import org.apache.geode.test.dunit.internal.JUnit4DistributedTestCase;
 import org.apache.geode.test.junit.categories.SecurityTest;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({SecurityTest.class})
+@Category(SecurityTest.class)
 public class ClientExecuteRegionFunctionAuthDUnitTest extends JUnit4DistributedTestCase {
-
   final Host host = Host.getHost(0);
-  final VM client1 = host.getVM(1);
-  final VM client2 = host.getVM(2);
+  final VM client1 = VM.getVM(1);
+  final VM client2 = VM.getVM(2);
 
   private Function readFunction;
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/ClientGetAllAuthDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/ClientGetAllAuthDUnitTest.java
@@ -15,10 +15,9 @@
 package org.apache.geode.security;
 
 import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_MANAGER;
-import static org.apache.geode.internal.Assert.assertTrue;
 import static org.apache.geode.security.SecurityTestUtil.createClientCache;
 import static org.apache.geode.security.SecurityTestUtil.createProxyRegion;
-import static org.jgroups.util.Util.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -36,14 +35,13 @@ import org.apache.geode.test.dunit.internal.JUnit4DistributedTestCase;
 import org.apache.geode.test.junit.categories.SecurityTest;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({SecurityTest.class})
+@Category(SecurityTest.class)
 public class ClientGetAllAuthDUnitTest extends JUnit4DistributedTestCase {
-
   private static String REGION_NAME = "AuthRegion";
 
   final Host host = Host.getHost(0);
-  final VM client1 = host.getVM(1);
-  final VM client2 = host.getVM(2);
+  final VM client1 = VM.getVM(1);
+  final VM client2 = VM.getVM(2);
 
   @Rule
   public ServerStarterRule server =
@@ -53,13 +51,14 @@ public class ClientGetAllAuthDUnitTest extends JUnit4DistributedTestCase {
           .withRegion(RegionShortcut.REPLICATE, REGION_NAME);
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testGetAll() {
     client1.invoke("logging in Stranger", () -> {
       ClientCache cache = createClientCache("stranger", "1234567", server.getPort());
 
       Region region = createProxyRegion(cache, REGION_NAME);
       Map emptyMap = region.getAll(Arrays.asList("key1", "key2", "key3", "key4"));
-      assertTrue(emptyMap.isEmpty());
+      assertThat(emptyMap.isEmpty()).isTrue();
     });
 
     client2.invoke("logging in authRegionReader", () -> {
@@ -67,8 +66,9 @@ public class ClientGetAllAuthDUnitTest extends JUnit4DistributedTestCase {
 
       Region region = createProxyRegion(cache, REGION_NAME);
       Map filledMap = region.getAll(Arrays.asList("key1", "key2", "key3", "key4"));
-      assertEquals("Map should contain 4 entries", 4, filledMap.size());
-      assertTrue(filledMap.containsKey("key1"));
+
+      assertThat(filledMap.size()).as("Map should contain 4 entries").isEqualTo(4);
+      assertThat(filledMap.containsKey("key1")).isTrue();
     });
   }
 }

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/ClientGetEntryAuthDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/ClientGetEntryAuthDUnitTest.java
@@ -35,14 +35,13 @@ import org.apache.geode.test.dunit.internal.JUnit4DistributedTestCase;
 import org.apache.geode.test.junit.categories.SecurityTest;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({SecurityTest.class})
+@Category(SecurityTest.class)
 public class ClientGetEntryAuthDUnitTest extends JUnit4DistributedTestCase {
-
   private static String REGION_NAME = "AuthRegion";
 
   final Host host = Host.getHost(0);
-  final VM client1 = host.getVM(1);
-  final VM client2 = host.getVM(2);
+  final VM client1 = VM.getVM(1);
+  final VM client2 = VM.getVM(2);
 
   @Rule
   public ServerStarterRule server =
@@ -53,8 +52,9 @@ public class ClientGetEntryAuthDUnitTest extends JUnit4DistributedTestCase {
 
   @Before
   public void before() throws Exception {
-    Region region =
-        server.getCache().createRegionFactory(RegionShortcut.REPLICATE).create(REGION_NAME);
+    Region<String, String> region =
+        server.getCache().<String, String>createRegionFactory(RegionShortcut.REPLICATE)
+            .create(REGION_NAME);
     for (int i = 0; i < 5; i++) {
       region.put("key" + i, "value" + i);
     }
@@ -74,7 +74,6 @@ public class ClientGetEntryAuthDUnitTest extends JUnit4DistributedTestCase {
       } finally {
         transactionManager.commit();
       }
-
     });
 
     AsyncInvocation ai2 = client2.invokeAsync(() -> {
@@ -88,11 +87,9 @@ public class ClientGetEntryAuthDUnitTest extends JUnit4DistributedTestCase {
       } finally {
         transactionManager.commit();
       }
-
     });
 
     ai1.await();
     ai2.await();
-
   }
 }

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/ClientGetPutAuthDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/ClientGetPutAuthDUnitTest.java
@@ -18,7 +18,7 @@ import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_MANA
 import static org.apache.geode.security.SecurityTestUtil.assertNotAuthorized;
 import static org.apache.geode.security.SecurityTestUtil.createClientCache;
 import static org.apache.geode.security.SecurityTestUtil.createProxyRegion;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -41,15 +41,14 @@ import org.apache.geode.test.dunit.internal.JUnit4DistributedTestCase;
 import org.apache.geode.test.junit.categories.SecurityTest;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({SecurityTest.class})
+@Category(SecurityTest.class)
 public class ClientGetPutAuthDUnitTest extends JUnit4DistributedTestCase {
-
   private static String REGION_NAME = "AuthRegion";
 
   final Host host = Host.getHost(0);
-  final VM client1 = host.getVM(1);
-  final VM client2 = host.getVM(2);
-  final VM client3 = host.getVM(3);
+  final VM client1 = VM.getVM(1);
+  final VM client2 = VM.getVM(2);
+  private final VM client3 = VM.getVM(3);
 
   @Rule
   public ServerStarterRule server =
@@ -60,16 +59,18 @@ public class ClientGetPutAuthDUnitTest extends JUnit4DistributedTestCase {
 
   @Before
   public void before() throws Exception {
-    Region region =
-        server.getCache().createRegionFactory(RegionShortcut.REPLICATE).create(REGION_NAME);
+    Region<String, String> region =
+        server.getCache().<String, String>createRegionFactory(RegionShortcut.REPLICATE)
+            .create(REGION_NAME);
     for (int i = 0; i < 5; i++) {
       region.put("key" + i, "value" + i);
     }
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testGetPutAuthorization() throws InterruptedException {
-    Map<String, String> allValues = new HashMap<String, String>();
+    Map<String, String> allValues = new HashMap<>();
     allValues.put("key1", "value1");
     allValues.put("key2", "value2");
 
@@ -90,9 +91,9 @@ public class ClientGetPutAuthDUnitTest extends JUnit4DistributedTestCase {
 
       // not authorized for either keys, get no record back
       Map keyValues = region.getAll(keys);
-      assertEquals(0, keyValues.size());
+      assertThat(keyValues.size()).isEqualTo(0);
 
-      assertNotAuthorized(() -> region.keySetOnServer(), "DATA:READ:AuthRegion");
+      assertNotAuthorized(region::keySetOnServer, "DATA:READ:AuthRegion");
     });
 
 
@@ -102,18 +103,18 @@ public class ClientGetPutAuthDUnitTest extends JUnit4DistributedTestCase {
       Region region = createProxyRegion(cache, REGION_NAME);
 
       region.put("key3", "value3");
-      assertEquals("value3", region.get("key3"));
+      assertThat(region.get("key3")).isEqualTo("value3");
 
       // put all
       region.putAll(allValues);
 
       // get all
       Map keyValues = region.getAll(keys);
-      assertEquals(2, keyValues.size());
+      assertThat(keyValues.size()).isEqualTo(2);
 
       // keyset
       Set keySet = region.keySetOnServer();
-      assertEquals(5, keySet.size());
+      assertThat(keySet.size()).isEqualTo(5);
     });
 
     // client3 connects to user as a user authorized to use key1 in AuthRegion region
@@ -128,10 +129,10 @@ public class ClientGetPutAuthDUnitTest extends JUnit4DistributedTestCase {
 
       // only authorized for one recrod
       Map keyValues = region.getAll(keys);
-      assertEquals(1, keyValues.size());
+      assertThat(keyValues.size()).isEqualTo(1);
 
       // keyset
-      assertNotAuthorized(() -> region.keySetOnServer(), "DATA:READ:AuthRegion");
+      assertNotAuthorized(region::keySetOnServer, "DATA:READ:AuthRegion");
     });
 
     ai1.join();
@@ -142,5 +143,4 @@ public class ClientGetPutAuthDUnitTest extends JUnit4DistributedTestCase {
     ai2.checkException();
     ai3.checkException();
   }
-
 }

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/ClientRegionClearAuthDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/ClientRegionClearAuthDUnitTest.java
@@ -33,14 +33,13 @@ import org.apache.geode.test.dunit.internal.JUnit4DistributedTestCase;
 import org.apache.geode.test.junit.categories.SecurityTest;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({SecurityTest.class})
+@Category(SecurityTest.class)
 public class ClientRegionClearAuthDUnitTest extends JUnit4DistributedTestCase {
-
   private static String REGION_NAME = "AuthRegion";
 
   final Host host = Host.getHost(0);
-  final VM client1 = host.getVM(1);
-  final VM client2 = host.getVM(2);
+  final VM client1 = VM.getVM(1);
+  final VM client2 = VM.getVM(2);
 
   @Rule
   public ServerStarterRule server =
@@ -50,14 +49,14 @@ public class ClientRegionClearAuthDUnitTest extends JUnit4DistributedTestCase {
           .withRegion(RegionShortcut.REPLICATE, REGION_NAME);
 
   @Test
-  public void testRegionClear() throws InterruptedException {
+  public void testRegionClear() {
     // Verify that an unauthorized user can't clear the region
     SerializableRunnable clearUnauthorized = new SerializableRunnable() {
       @Override
       public void run() {
         ClientCache cache = createClientCache("stranger", "1234567", server.getPort());
         Region region = createProxyRegion(cache, REGION_NAME);
-        assertNotAuthorized(() -> region.clear(), "DATA:WRITE:AuthRegion");
+        assertNotAuthorized(region::clear, "DATA:WRITE:AuthRegion");
       }
     };
     client1.invoke(clearUnauthorized);

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/ClientRegisterInterestAuthDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/ClientRegisterInterestAuthDUnitTest.java
@@ -39,17 +39,17 @@ import org.apache.geode.test.dunit.internal.JUnit4DistributedTestCase;
 import org.apache.geode.test.junit.categories.SecurityTest;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({SecurityTest.class})
+@Category(SecurityTest.class)
 public class ClientRegisterInterestAuthDUnitTest extends JUnit4DistributedTestCase {
-
   private static String REGION_NAME = "AuthRegion";
 
   final Host host = Host.getHost(0);
-  final VM client1 = host.getVM(1);
-  final VM client2 = host.getVM(2);
-  final VM client3 = host.getVM(3);
+  final VM client1 = VM.getVM(1);
+  final VM client2 = VM.getVM(2);
+  private final VM client3 = VM.getVM(3);
 
   @Rule
+  @SuppressWarnings("deprecation")
   public ServerStarterRule server =
       new ServerStarterRule().withProperty(SECURITY_MANAGER, TestSecurityManager.class.getName())
           .withProperty(TestSecurityManager.SECURITY_JSON,
@@ -58,6 +58,7 @@ public class ClientRegisterInterestAuthDUnitTest extends JUnit4DistributedTestCa
           .withRegion(RegionShortcut.REPLICATE, REGION_NAME);
 
   @Test
+  @SuppressWarnings({"deprecation", "unchecked"})
   public void testRegisterInterest() throws Exception {
     final Properties extraProperties = new Properties();
     extraProperties.setProperty(SECURITY_CLIENT_DHALGO, "AES:128");
@@ -92,6 +93,7 @@ public class ClientRegisterInterestAuthDUnitTest extends JUnit4DistributedTestCa
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void testRegisterInterestRegex() throws Exception {
     final Properties extraProperties = new Properties();
     extraProperties.setProperty(SECURITY_CLIENT_DHALGO, "AES:128");
@@ -133,6 +135,7 @@ public class ClientRegisterInterestAuthDUnitTest extends JUnit4DistributedTestCa
   }
 
   @Test
+  @SuppressWarnings({"deprecation", "unchecked"})
   public void testRegisterInterestList() throws Exception {
     final Properties extraProperties = new Properties();
     extraProperties.setProperty(SECURITY_CLIENT_DHALGO, "AES:128");
@@ -175,5 +178,4 @@ public class ClientRegisterInterestAuthDUnitTest extends JUnit4DistributedTestCa
     ai2.await();
     ai3.await();
   }
-
 }

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/ClientRemoveAllAuthDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/ClientRemoveAllAuthDUnitTest.java
@@ -18,7 +18,7 @@ import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_MANA
 import static org.apache.geode.security.SecurityTestUtil.assertNotAuthorized;
 import static org.apache.geode.security.SecurityTestUtil.createClientCache;
 import static org.apache.geode.security.SecurityTestUtil.createProxyRegion;
-import static org.junit.Assert.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 
@@ -36,14 +36,13 @@ import org.apache.geode.test.dunit.internal.JUnit4DistributedTestCase;
 import org.apache.geode.test.junit.categories.SecurityTest;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({SecurityTest.class})
+@Category(SecurityTest.class)
 public class ClientRemoveAllAuthDUnitTest extends JUnit4DistributedTestCase {
-
   private static String REGION_NAME = "AuthRegion";
 
   final Host host = Host.getHost(0);
-  final VM client1 = host.getVM(1);
-  final VM client2 = host.getVM(2);
+  final VM client1 = VM.getVM(1);
+  final VM client2 = VM.getVM(2);
 
   @Rule
   public ServerStarterRule server =
@@ -53,6 +52,7 @@ public class ClientRemoveAllAuthDUnitTest extends JUnit4DistributedTestCase {
           .withRegion(RegionShortcut.REPLICATE, REGION_NAME);
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testRemoveAll() throws Exception {
 
     AsyncInvocation ai1 = client1.invokeAsync(() -> {
@@ -68,11 +68,11 @@ public class ClientRemoveAllAuthDUnitTest extends JUnit4DistributedTestCase {
 
       Region region = createProxyRegion(cache, REGION_NAME);
       region.removeAll(Arrays.asList("key1", "key2", "key3", "key4"));
-      assertFalse(region.containsKey("key1"));
+      assertThat(region.containsKey("key1")).isFalse();
       assertNotAuthorized(() -> region.containsKeyOnServer("key1"), "DATA:READ:AuthRegion:key1");
     });
+
     ai1.await();
     ai2.await();
   }
-
 }

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/ClientUnregisterInterestAuthDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/ClientUnregisterInterestAuthDUnitTest.java
@@ -32,14 +32,13 @@ import org.apache.geode.test.dunit.internal.JUnit4DistributedTestCase;
 import org.apache.geode.test.junit.categories.SecurityTest;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({SecurityTest.class})
+@Category(SecurityTest.class)
 public class ClientUnregisterInterestAuthDUnitTest extends JUnit4DistributedTestCase {
-
   private static String REGION_NAME = "AuthRegion";
 
   final Host host = Host.getHost(0);
-  final VM client1 = host.getVM(1);
-  final VM client2 = host.getVM(2);
+  final VM client1 = VM.getVM(1);
+  final VM client2 = VM.getVM(2);
 
   @Rule
   public ServerStarterRule server =
@@ -49,6 +48,7 @@ public class ClientUnregisterInterestAuthDUnitTest extends JUnit4DistributedTest
           .withRegion(RegionShortcut.REPLICATE, REGION_NAME);
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testUnregisterInterest() throws Exception {
     // client2 connects to user as a user authorized to use AuthRegion region
     AsyncInvocation ai1 = client2.invokeAsync(() -> {
@@ -58,6 +58,7 @@ public class ClientUnregisterInterestAuthDUnitTest extends JUnit4DistributedTest
       region.registerInterest("key3");
       region.unregisterInterest("key3"); // DATA:READ:AuthRegion:key3;
     });
+
     ai1.await();
   }
 }

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/ClusterConfigWithoutSecurityDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/ClusterConfigWithoutSecurityDUnitTest.java
@@ -17,8 +17,8 @@ package org.apache.geode.security;
 import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_MANAGER;
 import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_POST_PROCESSOR;
 import static org.apache.geode.distributed.ConfigurationProperties.USE_CLUSTER_CONFIGURATION;
+import static org.assertj.core.api.Java6Assertions.assertThat;
 import static org.assertj.core.api.Java6Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertEquals;
 
 import java.util.Properties;
 
@@ -35,7 +35,7 @@ import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.junit.categories.SecurityTest;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({SecurityTest.class})
+@Category(SecurityTest.class)
 public class ClusterConfigWithoutSecurityDUnitTest {
 
   @Rule
@@ -46,13 +46,10 @@ public class ClusterConfigWithoutSecurityDUnitTest {
 
   @Before
   public void before() throws Exception {
-    IgnoredException
-        .addIgnoredException(
-            "A server cannot specify its own security-manager or security-post-processor when using cluster configuration"
-                .toString());
-    IgnoredException
-        .addIgnoredException(
-            "A server must use cluster configuration when joining a secured cluster.".toString());
+    IgnoredException.addIgnoredException(
+        "A server cannot specify its own security-manager or security-post-processor when using cluster configuration");
+    IgnoredException.addIgnoredException(
+        "A server must use cluster configuration when joining a secured cluster.");
     this.lsRule.startLocatorVM(0, new Properties());
   }
 
@@ -66,7 +63,7 @@ public class ClusterConfigWithoutSecurityDUnitTest {
    * manager if use-cluster-config is false
    */
   @Test
-  public void serverShouldBeAllowedToStartWithSecurityIfNotUsingClusterConfig() throws Exception {
+  public void serverShouldBeAllowedToStartWithSecurityIfNotUsingClusterConfig() {
     Properties props = new Properties();
     props.setProperty(SECURITY_MANAGER, SimpleTestSecurityManager.class.getName());
     props.setProperty(SECURITY_POST_PROCESSOR, PDXPostProcessor.class.getName());
@@ -78,17 +75,18 @@ public class ClusterConfigWithoutSecurityDUnitTest {
 
     // after cache is created, the configuration won't chagne
     Properties secProps = ds.getSecurityProperties();
-    assertEquals(2, secProps.size());
-    assertEquals(SimpleTestSecurityManager.class.getName(),
-        secProps.getProperty("security-manager"));
-    assertEquals(PDXPostProcessor.class.getName(), secProps.getProperty("security-post-processor"));
+    assertThat(secProps.size()).isEqualTo(2);
+    assertThat(secProps.getProperty("security-manager"))
+        .isEqualTo(SimpleTestSecurityManager.class.getName());
+    assertThat(secProps.getProperty("security-post-processor"))
+        .isEqualTo(PDXPostProcessor.class.getName());
   }
 
   /**
    * when locator is not secured, server should not be secured if use-cluster-config is true
    */
   @Test
-  public void serverShouldNotBeAllowedToStartWithSecurityIfUsingClusterConfig() throws Exception {
+  public void serverShouldNotBeAllowedToStartWithSecurityIfUsingClusterConfig() {
     Properties props = new Properties();
     props.setProperty(SECURITY_MANAGER, SimpleTestSecurityManager.class.getName());
     props.setProperty(USE_CLUSTER_CONFIGURATION, "true");
@@ -100,7 +98,7 @@ public class ClusterConfigWithoutSecurityDUnitTest {
   }
 
   @Test
-  public void nonExistentSecurityManagerThrowsGemFireSecurityException() throws Exception {
+  public void nonExistentSecurityManagerThrowsGemFireSecurityException() {
     Properties props = new Properties();
     props.setProperty(SECURITY_MANAGER, "mySecurityManager");
     props.setProperty(USE_CLUSTER_CONFIGURATION, "true");
@@ -109,5 +107,4 @@ public class ClusterConfigWithoutSecurityDUnitTest {
         .getPort())).isInstanceOf(GemFireSecurityException.class).hasMessage(
             "Instance could not be obtained, java.lang.ClassNotFoundException: mySecurityManager");
   }
-
 }

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/ClusterConfigurationSecurityDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/ClusterConfigurationSecurityDUnitTest.java
@@ -31,7 +31,7 @@ import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.junit.categories.SecurityTest;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({SecurityTest.class})
+@Category(SecurityTest.class)
 public class ClusterConfigurationSecurityDUnitTest {
 
   @ClassRule
@@ -44,21 +44,21 @@ public class ClusterConfigurationSecurityDUnitTest {
   private static MemberVM locator;
 
   @BeforeClass
-  public static void beforeClass() throws Exception {
+  public static void beforeClass() {
     Properties properties = new Properties();
     properties.put(SECURITY_MANAGER, SimpleTestSecurityManager.class.getName());
     locator = lsRule.startLocatorVM(0, properties);
   }
 
   @Test
-  public void startServerWithNoCredentialWouldFail() throws Exception {
+  public void startServerWithNoCredentialWouldFail() {
     assertThatThrownBy(() -> serverStarter.startServer(new Properties(), locator.getPort()))
         .isInstanceOf(AuthenticationRequiredException.class)
         .hasMessageContaining("Failed to find credentials");
   }
 
   @Test
-  public void startServerWithInvalidCredentialWouldfail() throws Exception {
+  public void startServerWithInvalidCredentialWouldFail() {
     Properties properties = new Properties();
     properties.put("security-username", "test");
     properties.put("security-password", "invalidPassword");
@@ -68,7 +68,7 @@ public class ClusterConfigurationSecurityDUnitTest {
   }
 
   @Test
-  public void startServerWithInsufficientCredential() throws Exception {
+  public void startServerWithInsufficientCredential() {
     Properties properties = new Properties();
     properties.put("security-username", "test");
     properties.put("security-password", "test");
@@ -78,7 +78,7 @@ public class ClusterConfigurationSecurityDUnitTest {
   }
 
   @Test
-  public void startServerWithValidCredential() throws Exception {
+  public void startServerWithValidCredential() {
     Properties properties = new Properties();
     properties.put("security-username", "clusterManage");
     properties.put("security-password", "clusterManage");

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/IntegratedSecurityPeerAuthDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/IntegratedSecurityPeerAuthDUnitTest.java
@@ -20,7 +20,6 @@ import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_MANA
 import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_PEER_AUTH_INIT;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.io.IOException;
 import java.util.Properties;
 
 import org.junit.BeforeClass;
@@ -41,7 +40,7 @@ import org.apache.geode.test.junit.rules.ServerStarterRule;
  * other than security-username and security-password. But this will be doable only in peer/client
  * case. For gfsh/rest, we still expected the credentials to be wrapped as expected.
  */
-@Category({SecurityTest.class})
+@Category(SecurityTest.class)
 public class IntegratedSecurityPeerAuthDUnitTest {
 
   @ClassRule
@@ -50,14 +49,14 @@ public class IntegratedSecurityPeerAuthDUnitTest {
   private static MemberVM locator;
 
   @BeforeClass
-  public static void beforeClass() throws Exception {
+  public static void beforeClass() {
     Properties properties = new Properties();
     properties.put(SECURITY_MANAGER, MySecurityManager.class.getName());
     locator = cluster.startLocatorVM(0, properties);
   }
 
   @Test
-  public void startServer1WithPeerAuthInit_success() throws IOException {
+  public void startServer1WithPeerAuthInit_success() {
     Properties props = new Properties();
     props.setProperty(SECURITY_PEER_AUTH_INIT, MyAuthInit.class.getName());
     props.setProperty("security-name", "server-1");
@@ -73,7 +72,7 @@ public class IntegratedSecurityPeerAuthDUnitTest {
     cluster.getVM(2).invoke(() -> {
       ServerStarterRule server = new ServerStarterRule();
       server.withProperties(props).withConnectionToLocator(locatorPort).withAutoStart();
-      assertThatThrownBy(() -> server.before()).isInstanceOf(GemFireSecurityException.class)
+      assertThatThrownBy(server::before).isInstanceOf(GemFireSecurityException.class)
           .hasMessageContaining("server-2 not authorized for CLUSTER:MANAGE");
     });
   }
@@ -87,7 +86,7 @@ public class IntegratedSecurityPeerAuthDUnitTest {
     cluster.getVM(3).invoke(() -> {
       ServerStarterRule server = new ServerStarterRule();
       server.withProperties(props).withConnectionToLocator(locatorPort).withAutoStart();
-      assertThatThrownBy(() -> server.before()).isInstanceOf(GemFireSecurityException.class)
+      assertThatThrownBy(server::before).isInstanceOf(GemFireSecurityException.class)
           .hasMessageContaining("Authentication error");
     });
   }

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/PeerAuthenticatorDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/PeerAuthenticatorDUnitTest.java
@@ -16,7 +16,6 @@
 package org.apache.geode.security;
 
 import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_PEER_AUTHENTICATOR;
-import static org.apache.geode.test.dunit.Host.getHost;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Properties;
@@ -32,12 +31,13 @@ import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.junit.categories.SecurityTest;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({SecurityTest.class})
+@Category(SecurityTest.class)
 public class PeerAuthenticatorDUnitTest {
   @Rule
   public ClusterStartupRule lsRule = new ClusterStartupRule();
 
   @Before
+  @SuppressWarnings("deprecation")
   public void before() throws Exception {
     Properties props = new Properties();
     props.setProperty(SECURITY_PEER_AUTHENTICATOR, DummyAuthenticator.class.getName());
@@ -45,27 +45,23 @@ public class PeerAuthenticatorDUnitTest {
   }
 
   @Test
-  public void testPeerAuthenticator() throws Exception {
-
+  public void testPeerAuthenticator() {
     int locatorPort = lsRule.getMember(0).getPort();
     Properties server1Props = new Properties();
     server1Props.setProperty("security-username", "user");
     server1Props.setProperty("security-password", "user");
     lsRule.startServerVM(1, server1Props, locatorPort);
 
-
     Properties server2Props = new Properties();
     server2Props.setProperty("security-username", "bogus");
     server2Props.setProperty("security-password", "user");
-    VM server2 = getHost(0).getVM(2);
+    VM server2 = VM.getVM(2);
 
     server2.invoke(() -> {
       ServerStarterRule serverStarter = new ServerStarterRule();
       ClusterStartupRule.memberStarter = serverStarter;
       assertThatThrownBy(() -> serverStarter.startServer(server2Props, locatorPort))
           .isInstanceOf(GemFireSecurityException.class).hasMessageContaining("Invalid user name");
-
     });
   }
-
 }

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/PeerSecurityWithEmbeddedLocatorDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/PeerSecurityWithEmbeddedLocatorDUnitTest.java
@@ -17,7 +17,6 @@ package org.apache.geode.security;
 
 import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_MANAGER;
 import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_PEER_AUTHENTICATOR;
-import static org.apache.geode.test.dunit.Host.getHost;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Properties;
@@ -33,22 +32,20 @@ import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.junit.categories.SecurityTest;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({SecurityTest.class})
+@Category(SecurityTest.class)
 public class PeerSecurityWithEmbeddedLocatorDUnitTest {
 
   @Rule
   public ClusterStartupRule lsRule = new ClusterStartupRule();
 
-
   @Test
-  public void testPeerSecurityManager() throws Exception {
+  public void testPeerSecurityManager() {
     int locatorPort = AvailablePortHelper.getRandomAvailableTCPPort();
 
     Properties server0Props = new Properties();
     server0Props.setProperty(SECURITY_MANAGER, SimpleTestSecurityManager.class.getName());
     server0Props.setProperty("start-locator", "localhost[" + locatorPort + "]");
     lsRule.startServerVM(0, server0Props);
-
 
     Properties server1Props = new Properties();
     server1Props.setProperty("security-username", "cluster");
@@ -59,7 +56,7 @@ public class PeerSecurityWithEmbeddedLocatorDUnitTest {
     server2Props.setProperty("security-username", "user");
     server2Props.setProperty("security-password", "wrongPwd");
 
-    VM server2 = getHost(0).getVM(2);
+    VM server2 = VM.getVM(2);
     server2.invoke(() -> {
       ServerStarterRule serverStarter = new ServerStarterRule();
       ClusterStartupRule.memberStarter = serverStarter;
@@ -69,10 +66,9 @@ public class PeerSecurityWithEmbeddedLocatorDUnitTest {
     });
   }
 
-
-
   @Test
-  public void testPeerAuthenticator() throws Exception {
+  @SuppressWarnings("deprecation")
+  public void testPeerAuthenticator() {
     int locatorPort = AvailablePortHelper.getRandomAvailableTCPPort();
 
     Properties server0Props = new Properties();
@@ -90,7 +86,7 @@ public class PeerSecurityWithEmbeddedLocatorDUnitTest {
     server2Props.setProperty("security-username", "bogus");
     server2Props.setProperty("security-password", "user");
 
-    VM server2 = getHost(0).getVM(2);
+    VM server2 = VM.getVM(2);
     server2.invoke(() -> {
       ServerStarterRule serverStarter = new ServerStarterRule();
       ClusterStartupRule.memberStarter = serverStarter;
@@ -98,5 +94,4 @@ public class PeerSecurityWithEmbeddedLocatorDUnitTest {
           .isInstanceOf(GemFireSecurityException.class).hasMessageContaining("Invalid user name");
     });
   }
-
 }

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/SecurityClusterConfigDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/SecurityClusterConfigDUnitTest.java
@@ -37,7 +37,7 @@ import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.junit.categories.SecurityTest;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({SecurityTest.class})
+@Category(SecurityTest.class)
 public class SecurityClusterConfigDUnitTest {
 
   @Rule
@@ -49,10 +49,8 @@ public class SecurityClusterConfigDUnitTest {
   @Before
   public void before() throws Exception {
     addIgnoredException(
-        "A server cannot specify its own security-manager or security-post-processor when using cluster configuration"
-            .toString());
-    addIgnoredException(
-        "A server must use cluster configuration when joining a secured cluster.".toString());
+        "A server cannot specify its own security-manager or security-post-processor when using cluster configuration");
+    addIgnoredException("A server must use cluster configuration when joining a secured cluster.");
 
     Properties props = new Properties();
     props.setProperty(JMX_MANAGER, "false");
@@ -65,7 +63,7 @@ public class SecurityClusterConfigDUnitTest {
   }
 
   @Test
-  public void testStartServerWithClusterConfig() throws Exception {
+  public void testStartServerWithClusterConfig() {
     Properties props = new Properties();
 
     // the following are needed for peer-to-peer authentication
@@ -86,7 +84,7 @@ public class SecurityClusterConfigDUnitTest {
   }
 
   @Test
-  public void testStartServerWithSameSecurityManager() throws Exception {
+  public void testStartServerWithSameSecurityManager() {
     Properties props = new Properties();
 
     // the following are needed for peer-to-peer authentication
@@ -108,8 +106,7 @@ public class SecurityClusterConfigDUnitTest {
   }
 
   @Test
-  public void serverWithDifferentSecurityManagerShouldThrowGemFireConfigException()
-      throws Exception {
+  public void serverWithDifferentSecurityManagerShouldThrowGemFireConfigException() {
     Properties props = new Properties();
 
     // the following are needed for peer-to-peer authentication
@@ -126,7 +123,7 @@ public class SecurityClusterConfigDUnitTest {
   }
 
   @Test
-  public void serverWithDifferentPostProcessorShouldThrowGemFireConfigException() throws Exception {
+  public void serverWithDifferentPostProcessorShouldThrowGemFireConfigException() {
     Properties props = new Properties();
 
     // the following are needed for peer-to-peer authentication
@@ -144,7 +141,7 @@ public class SecurityClusterConfigDUnitTest {
   }
 
   @Test
-  public void serverConnectingToSecuredLocatorMustUseClusterConfig() throws Exception {
+  public void serverConnectingToSecuredLocatorMustUseClusterConfig() {
     Properties props = new Properties();
 
     // the following are needed for peer-to-peer authentication

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/SecurityWithoutClusterConfigDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/SecurityWithoutClusterConfigDUnitTest.java
@@ -18,8 +18,7 @@ package org.apache.geode.security;
 import static org.apache.geode.distributed.ConfigurationProperties.ENABLE_CLUSTER_CONFIGURATION;
 import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_MANAGER;
 import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_POST_PROCESSOR;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Properties;
 
@@ -35,7 +34,7 @@ import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.junit.categories.SecurityTest;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({SecurityTest.class})
+@Category(SecurityTest.class)
 
 public class SecurityWithoutClusterConfigDUnitTest {
 
@@ -51,11 +50,10 @@ public class SecurityWithoutClusterConfigDUnitTest {
   public void before() throws Exception {
     IgnoredException
         .addIgnoredException(
-            "A server cannot specify its own security-manager or security-post-processor when using cluster configuration"
-                .toString());
+            "A server cannot specify its own security-manager or security-post-processor when using cluster configuration");
     IgnoredException
         .addIgnoredException(
-            "A server must use cluster configuration when joining a secured cluster.".toString());
+            "A server must use cluster configuration when joining a secured cluster.");
     Properties props = new Properties();
     props.setProperty(SECURITY_MANAGER, SimpleTestSecurityManager.class.getName());
     props.setProperty(SECURITY_POST_PROCESSOR, PDXPostProcessor.class.getName());
@@ -67,7 +65,7 @@ public class SecurityWithoutClusterConfigDUnitTest {
   // if a secured locator is started without cluster config service, the server is free to use any
   // security manager
   // or no security manager at all. Currently this is valid, but not recommended.
-  public void testStartServerWithClusterConfig() throws Exception {
+  public void testStartServerWithClusterConfig() {
 
     Properties props = new Properties();
     // the following are needed for peer-to-peer authentication
@@ -79,12 +77,13 @@ public class SecurityWithoutClusterConfigDUnitTest {
     // initial security properties should only contain initial set of values
     serverStarter.withProperties(props).withConnectionToLocator(locator.getPort()).startServer();
     DistributedSystem ds = serverStarter.getCache().getDistributedSystem();
-    assertEquals(3, ds.getSecurityProperties().size());
+    assertThat(ds.getSecurityProperties().size()).isEqualTo(3);
 
     // after cache is created, we got the security props passed in by cluster config
     Properties secProps = ds.getSecurityProperties();
-    assertEquals(3, secProps.size());
-    assertEquals(TestSecurityManager.class.getName(), secProps.getProperty("security-manager"));
-    assertFalse(secProps.containsKey("security-post-processor"));
+    assertThat(secProps.size()).isEqualTo(3);
+    assertThat(secProps.getProperty("security-manager"))
+        .isEqualTo(TestSecurityManager.class.getName());
+    assertThat(secProps.containsKey("security-post-processor")).isFalse();
   }
 }

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/StartServerAuthorizationTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/StartServerAuthorizationTest.java
@@ -31,7 +31,7 @@ import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.junit.categories.SecurityTest;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({SecurityTest.class})
+@Category(SecurityTest.class)
 public class StartServerAuthorizationTest {
 
   @ClassRule
@@ -42,14 +42,14 @@ public class StartServerAuthorizationTest {
   public ServerStarterRule serverStarter = new ServerStarterRule();
 
   @BeforeClass
-  public static void beforeClass() throws Exception {
+  public static void beforeClass() {
     Properties props = new Properties();
     props.setProperty(SECURITY_MANAGER, SimpleTestSecurityManager.class.getName());
     locator = lsRule.startLocatorVM(0, props);
   }
 
   @Test
-  public void testStartServerWithInvalidCredential() throws Exception {
+  public void testStartServerWithInvalidCredential() {
     Properties props = new Properties();
     // the following are needed for peer-to-peer authentication
     props.setProperty("security-username", "user");
@@ -61,7 +61,7 @@ public class StartServerAuthorizationTest {
   }
 
   @Test
-  public void testStartServerWithInsufficientPrevilage() throws Exception {
+  public void testStartServerWithInsufficientPrivileges() {
     Properties props = new Properties();
 
     // the following are needed for peer-to-peer authentication
@@ -74,7 +74,7 @@ public class StartServerAuthorizationTest {
   }
 
   @Test
-  public void testStartServerWithSufficientPrevilage() throws Exception {
+  public void testStartServerWithSufficientPrivileges() {
     Properties props = new Properties();
 
     // the following are needed for peer-to-peer authentication
@@ -83,5 +83,4 @@ public class StartServerAuthorizationTest {
 
     lsRule.startServerVM(1, props);
   }
-
 }

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/query/PartitionedQuerySecurityRestrictedButMethodsDoNotExistQueriesDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/query/PartitionedQuerySecurityRestrictedButMethodsDoNotExistQueriesDUnitTest.java
@@ -26,7 +26,7 @@ import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactor
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
 public class PartitionedQuerySecurityRestrictedButMethodsDoNotExistQueriesDUnitTest
-    extends QuerySecurityRetrictedButMethodsDoNotExistDUnitTest {
+    extends QuerySecurityRestrictedButMethodsDoNotExistDUnitTest {
 
   public RegionShortcut getRegionType() {
     return RegionShortcut.PARTITION;

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/query/PdxQuerySecurityAllowedQueriesDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/query/PdxQuerySecurityAllowedQueriesDUnitTest.java
@@ -14,7 +14,7 @@
  */
 package org.apache.geode.security.query;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Before;
@@ -27,7 +27,7 @@ import org.apache.geode.security.query.data.PdxQueryTestObject;
 import org.apache.geode.test.junit.categories.SecurityTest;
 import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactory;
 
-@Category({SecurityTest.class})
+@Category(SecurityTest.class)
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
 public class PdxQuerySecurityAllowedQueriesDUnitTest extends QuerySecurityBase {
@@ -53,7 +53,7 @@ public class PdxQuerySecurityAllowedQueriesDUnitTest extends QuerySecurityBase {
   @Test
   public void checkUserAuthorizationsForSelectOnPublicFieldQuery() {
     String query = "select * from /" + regionName + " r where r.id = 3";
-    List<Object> expectedResults = Arrays.asList(values[1]);
+    List<Object> expectedResults = Collections.singletonList(values[1]);
     executeQueryWithCheckForAccessPermissions(specificUserClient, query, regionName,
         expectedResults);
   }
@@ -62,7 +62,7 @@ public class PdxQuerySecurityAllowedQueriesDUnitTest extends QuerySecurityBase {
   public void checkUserAuthorizationsForSelectWithPdxFieldNamedGetQuery() {
     server.getCache().setReadSerializedForTest(true);
     String query = "select * from /" + regionName + " r where r.getName = 'Beth'";
-    List<Object> expectedResults = Arrays.asList(values[1]);
+    List<Object> expectedResults = Collections.singletonList(values[1]);
     executeQueryWithCheckForAccessPermissions(specificUserClient, query, regionName,
         expectedResults);
   }

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/query/PdxQuerySecurityRestrictedQueriesDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/query/PdxQuerySecurityRestrictedQueriesDUnitTest.java
@@ -24,7 +24,7 @@ import org.apache.geode.security.query.data.PdxQueryTestObject;
 import org.apache.geode.test.junit.categories.SecurityTest;
 import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactory;
 
-@Category({SecurityTest.class})
+@Category(SecurityTest.class)
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
 public class PdxQuerySecurityRestrictedQueriesDUnitTest extends QuerySecurityBase {

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/query/QuerySecurityAllowedQueriesDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/query/QuerySecurityAllowedQueriesDUnitTest.java
@@ -15,6 +15,7 @@
 package org.apache.geode.security.query;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -29,7 +30,7 @@ import org.apache.geode.security.query.data.QueryTestObject;
 import org.apache.geode.test.junit.categories.SecurityTest;
 import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactory;
 
-@Category({SecurityTest.class})
+@Category(SecurityTest.class)
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
 public class QuerySecurityAllowedQueriesDUnitTest extends QuerySecurityBase {
@@ -66,7 +67,7 @@ public class QuerySecurityAllowedQueriesDUnitTest extends QuerySecurityBase {
   @Test
   public void checkUserAuthorizationsForSelectByPublicFieldQuery() {
     String query = "select * from /" + regionName + " r where r.id = 1";
-    List<Object> expectedResults = Arrays.asList(values[0]);
+    List<Object> expectedResults = Collections.singletonList(values[0]);
     executeQueryWithCheckForAccessPermissions(specificUserClient, query, regionName,
         expectedResults);
   }
@@ -82,7 +83,7 @@ public class QuerySecurityAllowedQueriesDUnitTest extends QuerySecurityBase {
   @Test
   public void checkUserAuthorizationsForSelectCountOfPublicFieldQuery() {
     String query = "select count(r.id) from /" + regionName + " r";
-    List<Object> expectedResults = Arrays.asList(2);
+    List<Object> expectedResults = Collections.singletonList(2);
     executeQueryWithCheckForAccessPermissions(specificUserClient, query, regionName,
         expectedResults);
   }
@@ -90,7 +91,7 @@ public class QuerySecurityAllowedQueriesDUnitTest extends QuerySecurityBase {
   @Test
   public void checkUserAuthorizationsForSelectMaxOfPublicFieldQuery() {
     String query = "select max(r.id) from /" + regionName + " r";
-    List<Object> expectedResults = Arrays.asList(3);
+    List<Object> expectedResults = Collections.singletonList(3);
     executeQueryWithCheckForAccessPermissions(specificUserClient, query, regionName,
         expectedResults);
   }
@@ -98,7 +99,7 @@ public class QuerySecurityAllowedQueriesDUnitTest extends QuerySecurityBase {
   @Test
   public void checkUserAuthorizationsForSelectMinOfPublicFieldQuery() {
     String query = "select min(r.id) from /" + regionName + " r";
-    List<Object> expectedResults = Arrays.asList(1);
+    List<Object> expectedResults = Collections.singletonList(1);
     executeQueryWithCheckForAccessPermissions(specificUserClient, query, regionName,
         expectedResults);
   }
@@ -115,7 +116,7 @@ public class QuerySecurityAllowedQueriesDUnitTest extends QuerySecurityBase {
   @Test
   public void checkUserAuthorizationsForSelectRegionContainsKeyQuery() {
     String query = "select * from /" + regionName + ".containsKey('" + keys[0] + "')";
-    List<Object> expectedResults = Arrays.asList(true);
+    List<Object> expectedResults = Collections.singletonList(true);
     executeQueryWithCheckForAccessPermissions(specificUserClient, query, regionName,
         expectedResults);
   }

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/query/QuerySecurityAuthorizedUserBindParameterDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/query/QuerySecurityAuthorizedUserBindParameterDUnitTest.java
@@ -25,7 +25,7 @@ import org.apache.geode.cache.Region;
 import org.apache.geode.security.query.data.QueryTestObject;
 import org.apache.geode.test.junit.categories.SecurityTest;
 
-@Category({SecurityTest.class})
+@Category(SecurityTest.class)
 public class QuerySecurityAuthorizedUserBindParameterDUnitTest extends QuerySecurityBase {
 
   @Before
@@ -44,7 +44,7 @@ public class QuerySecurityAuthorizedUserBindParameterDUnitTest extends QuerySecu
     String query = "select v from $1 r, r.values() v";
     specificUserClient.invoke(() -> {
       Region region = getClientCache().getRegion(regionName);
-      HashSet hashset = new HashSet();
+      HashSet<Region> hashset = new HashSet<>();
       hashset.add(region);
       assertQueryResults(getClientCache(), query, new Object[] {hashset}, Arrays.asList(values));
     });

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/query/QuerySecurityRestrictedButMethodsDoNotExistDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/query/QuerySecurityRestrictedButMethodsDoNotExistDUnitTest.java
@@ -15,6 +15,7 @@
 package org.apache.geode.security.query;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Before;
@@ -28,10 +29,10 @@ import org.apache.geode.security.query.data.QueryTestObject;
 import org.apache.geode.test.junit.categories.SecurityTest;
 import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactory;
 
-@Category({SecurityTest.class})
+@Category(SecurityTest.class)
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
-public class QuerySecurityRetrictedButMethodsDoNotExistDUnitTest extends QuerySecurityBase {
+public class QuerySecurityRestrictedButMethodsDoNotExistDUnitTest extends QuerySecurityBase {
 
   @Parameterized.Parameters
   public static Object[] usersAllowed() {
@@ -63,7 +64,7 @@ public class QuerySecurityRetrictedButMethodsDoNotExistDUnitTest extends QuerySe
   @Test
   public void cloneExecutedOnQRegionWillReturnEmptyResults() {
     String query = "select * from /" + regionName + ".clone";
-    List<Object> expectedResults = Arrays.asList();
+    List<Object> expectedResults = Collections.emptyList();
     executeQueryWithCheckForAccessPermissions(specificUserClient, query, regionName,
         expectedResults);
   }
@@ -71,13 +72,13 @@ public class QuerySecurityRetrictedButMethodsDoNotExistDUnitTest extends QuerySe
   @Test
   public void executingMethodThatDoesNotExistOnQRegionWillReturnEmptyResult() {
     String query = "select * from /" + regionName + ".getKey('" + keys[0] + "')";
-    List<Object> expectedResults = Arrays.asList();
+    List<Object> expectedResults = Collections.emptyList();
     executeQueryWithCheckForAccessPermissions(specificUserClient, query, regionName,
         expectedResults);
   }
 
   @Test
-  public void executingCreateOnRegionWillResultInUndefinedButNotModifyRegion() throws Exception {
+  public void executingCreateOnRegionWillResultInUndefinedButNotModifyRegion() {
     String query = "select r.create('key2', 15) from /" + regionName + " r";
     List<Object> expectedResults = Arrays.asList(QueryService.UNDEFINED, QueryService.UNDEFINED);
     executeQueryWithCheckForAccessPermissions(specificUserClient, query, regionName,
@@ -86,29 +87,27 @@ public class QuerySecurityRetrictedButMethodsDoNotExistDUnitTest extends QuerySe
   }
 
   @Test
-  public void executingDestroyKeyOnRegionWillReturnEmptyResultsAndNotModifyRegion()
-      throws Exception {
+  public void executingDestroyKeyOnRegionWillReturnEmptyResultsAndNotModifyRegion() {
     String query = "select * from /" + regionName + ".destroyKey('" + keys[0] + "')";
-    List<Object> expectedResults = Arrays.asList();
+    List<Object> expectedResults = Collections.emptyList();
     executeQueryWithCheckForAccessPermissions(specificUserClient, query, regionName,
         expectedResults);
     executeAndConfirmRegionMatches(specificUserClient, regionName, Arrays.asList(values));
   }
 
   @Test
-  public void executingPutIfAbsentOnRegionWillReturnEmptyResultsAndNotModifyRegion()
-      throws Exception {
+  public void executingPutIfAbsentOnRegionWillReturnEmptyResultsAndNotModifyRegion() {
     String query = "select * from /" + regionName + ".putIfAbsent('key-2', 'something')";
-    List<Object> expectedResults = Arrays.asList();
+    List<Object> expectedResults = Collections.emptyList();
     executeQueryWithCheckForAccessPermissions(specificUserClient, query, regionName,
         expectedResults);
     executeAndConfirmRegionMatches(specificUserClient, regionName, Arrays.asList(values));
   }
 
   @Test
-  public void executingReplaceOnRegionWillReturnEmptyResultsAndNotModifyRegion() throws Exception {
+  public void executingReplaceOnRegionWillReturnEmptyResultsAndNotModifyRegion() {
     String query = "select * from /" + regionName + ".replace('key-0', 'something')";
-    List<Object> expectedResults = Arrays.asList();
+    List<Object> expectedResults = Collections.emptyList();
     executeQueryWithCheckForAccessPermissions(specificUserClient, query, regionName,
         expectedResults);
     executeAndConfirmRegionMatches(specificUserClient, regionName, Arrays.asList(values));
@@ -121,5 +120,4 @@ public class QuerySecurityRetrictedButMethodsDoNotExistDUnitTest extends QuerySe
     executeQueryWithCheckForAccessPermissions(specificUserClient, query, regionName,
         expectedResults);
   }
-
 }

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/query/QuerySecurityRestrictedQueriesDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/query/QuerySecurityRestrictedQueriesDUnitTest.java
@@ -14,7 +14,7 @@
  */
 package org.apache.geode.security.query;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.Arrays;
 
@@ -32,7 +32,7 @@ import org.apache.geode.security.query.data.QueryTestObject;
 import org.apache.geode.test.junit.categories.SecurityTest;
 import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactory;
 
-@Category({SecurityTest.class})
+@Category(SecurityTest.class)
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
 public class QuerySecurityRestrictedQueriesDUnitTest extends QuerySecurityBase {
@@ -56,7 +56,7 @@ public class QuerySecurityRestrictedQueriesDUnitTest extends QuerySecurityBase {
     putIntoRegion(superUserClient, keys, values, regionName);
   }
 
-  protected String regexForExpectedExceptions = ".*Unauthorized access.*";
+  private String regexForExpectedExceptions = ".*Unauthorized access.*";
 
 
   /* ----- Implicit Getter Tests ----- */
@@ -162,7 +162,7 @@ public class QuerySecurityRestrictedQueriesDUnitTest extends QuerySecurityBase {
       QueryService queryService = getClientCache().getQueryService();
       try {
         queryService.newQuery(query).execute();
-        fail();
+        fail("An exception should have been thrown.");
       } catch (Exception e) {
         e.printStackTrace();
         if (!e.getMessage().matches(regexForExpectedExceptions)) {
@@ -174,15 +174,14 @@ public class QuerySecurityRestrictedQueriesDUnitTest extends QuerySecurityBase {
             cause = cause.getCause();
           }
           e.printStackTrace();
-          fail();
+          fail("Expression " + regexForExpectedExceptions + " not found within the stack trace.");
         }
       }
     });
   }
 
   @Test
-  public void usersWhoCanExecuteQueryShouldNotInvokeRegionCreateForSelectRegionCreateQuery()
-      throws Exception {
+  public void usersWhoCanExecuteQueryShouldNotInvokeRegionCreateForSelectRegionCreateQuery() {
     String query = "select * from /" + regionName + ".create('key2', 15)";
     executeQueryWithCheckForAccessPermissions(specificUserClient, query, regionName,
         regexForExpectedExceptions);
@@ -203,8 +202,7 @@ public class QuerySecurityRestrictedQueriesDUnitTest extends QuerySecurityBase {
   }
 
   @Test
-  public void usersWhoCanExecuteQueryShouldNotInvokeRegionPutForSelectRegionPutQuery()
-      throws Exception {
+  public void usersWhoCanExecuteQueryShouldNotInvokeRegionPutForSelectRegionPutQuery() {
     String query = "select * from /" + regionName + ".put('key-2', 'something')";
     executeQueryWithCheckForAccessPermissions(specificUserClient, query, regionName,
         regexForExpectedExceptions);
@@ -213,8 +211,7 @@ public class QuerySecurityRestrictedQueriesDUnitTest extends QuerySecurityBase {
 
   @Test
   @Parameters(method = "getAllUsersWhoCanExecuteQuery")
-  public void usersWhoCanExecuteQueryShouldNotInvokedRegionRemoveForSelectRegionRemoveQuery()
-      throws Exception {
+  public void usersWhoCanExecuteQueryShouldNotInvokedRegionRemoveForSelectRegionRemoveQuery() {
     String query = "select * from /" + regionName + ".remove('key-0')";
     executeQueryWithCheckForAccessPermissions(specificUserClient, query, regionName,
         regexForExpectedExceptions);

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/query/QuerySecurityUnauthorizedUserBindParameterDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/query/QuerySecurityUnauthorizedUserBindParameterDUnitTest.java
@@ -21,11 +21,12 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import org.apache.geode.cache.Region;
+import org.apache.geode.cache.query.internal.QRegion;
 import org.apache.geode.cache.query.internal.index.DummyQRegion;
 import org.apache.geode.security.query.data.QueryTestObject;
 import org.apache.geode.test.junit.categories.SecurityTest;
 
-@Category({SecurityTest.class})
+@Category(SecurityTest.class)
 public class QuerySecurityUnauthorizedUserBindParameterDUnitTest extends QuerySecurityBase {
 
   @Before
@@ -45,13 +46,12 @@ public class QuerySecurityUnauthorizedUserBindParameterDUnitTest extends QuerySe
     String regexForExpectedException = ".*DATA:READ.*";
     specificUserClient.invoke(() -> {
       Region region = getClientCache().getRegion(regionName);
-      HashSet hashset = new HashSet();
+      HashSet<Region> hashset = new HashSet<>();
       hashset.add(region);
       assertExceptionOccurred(getClientCache().getQueryService(), query, new Object[] {hashset},
           regexForExpectedException);
     });
   }
-
 
   // If DummyQRegion is ever serializable, then this test will fail and a security hole with query
   // will have been opened
@@ -63,7 +63,7 @@ public class QuerySecurityUnauthorizedUserBindParameterDUnitTest extends QuerySe
     String regexForExpectedException = ".*failed serializing object.*";
     specificUserClient.invoke(() -> {
       Region region = getClientCache().getRegion(regionName);
-      HashSet hashset = new HashSet();
+      HashSet<QRegion> hashset = new HashSet<>();
       hashset.add(new DummyQRegion(region));
       assertExceptionOccurred(getClientCache().getQueryService(), query, new Object[] {hashset},
           regexForExpectedException);

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/execute/CoreFunctionSecurityTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/execute/CoreFunctionSecurityTest.java
@@ -157,10 +157,8 @@ public class CoreFunctionSecurityTest {
 
   @Test
   @ConnectionConfiguration(user = "user", password = "user")
-  public void functionRequireExpectedPermission() throws Exception {
-    functionStringMap.entrySet().stream().forEach(entry -> {
-      Function function = entry.getKey();
-      String permission = entry.getValue();
+  public void functionRequireExpectedPermission() {
+    functionStringMap.forEach((function, permission) -> {
       System.out.println("function: " + function.getId() + ", permission: " + permission);
       gfsh.executeAndAssertThat("execute function --id=" + function.getId())
           .tableHasRowCount(RESULT_HEADER, 1)

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/CompactRangeIndexQueryIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/CompactRangeIndexQueryIntegrationTest.java
@@ -14,8 +14,7 @@
  */
 package org.apache.geode.cache.query.internal.index;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -36,7 +35,7 @@ import org.apache.geode.cache.query.data.PortfolioPdx;
 import org.apache.geode.test.junit.categories.OQLIndexTest;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({OQLIndexTest.class})
+@Category(OQLIndexTest.class)
 public class CompactRangeIndexQueryIntegrationTest {
 
   @Rule
@@ -46,7 +45,8 @@ public class CompactRangeIndexQueryIntegrationTest {
   public void multipleNotEqualsClausesOnAPartitionedRegionShouldReturnCorrectResults()
       throws Exception {
     Cache cache = serverStarterRule.getCache();
-    Region region = cache.createRegionFactory(RegionShortcut.PARTITION).create("portfolios");
+    Region<String, PortfolioPdx> region = cache
+        .<String, PortfolioPdx>createRegionFactory(RegionShortcut.PARTITION).create("portfolios");
     int numMatching = 10;
     QueryService qs = cache.getQueryService();
     qs.createIndex("statusIndex", "p.status", "/portfolios p");
@@ -61,19 +61,21 @@ public class CompactRangeIndexQueryIntegrationTest {
     Query q = qs.newQuery(
         "select * from /portfolios p where p.pk <> '0' and p.status <> '0' and p.status <> '1' and p.status <> '2'");
     SelectResults rs = (SelectResults) q.execute();
-    assertEquals(numMatching, rs.size());
+    assertThat(rs.size()).isEqualTo(numMatching);
   }
 
   @Test
   public void whenAuxFilterWithAnIterableFilterShouldNotCombineFiltersIntoAndJunction()
       throws Exception {
     Cache cache = serverStarterRule.getCache();
-    Region region = cache.createRegionFactory(RegionShortcut.PARTITION).create("ExampleRegion");
+    Region<String, Map<String, Object>> region =
+        cache.<String, Map<String, Object>>createRegionFactory(RegionShortcut.PARTITION)
+            .create("ExampleRegion");
     QueryService qs = cache.getQueryService();
     qs.createIndex("ExampleRegionIndex", "er['codeNumber','origin']", "/ExampleRegion er");
 
     for (int i = 0; i < 10; i++) {
-      Map<String, Object> data = new HashMap<String, Object>();
+      Map<String, Object> data = new HashMap<>();
       data.put("codeNumber", 1);
       if ((i % 3) == 0) {
         data.put("origin", "src_common");
@@ -89,7 +91,7 @@ public class CompactRangeIndexQueryIntegrationTest {
     Query q = qs.newQuery(
         "select * from /ExampleRegion E where E['codeNumber']=1 and E['origin']='src_common' and (E['country']='JPY' or E['ccountrycy']='USD')");
     SelectResults rs = (SelectResults) q.execute();
-    assertEquals(4, rs.size());
+    assertThat(rs.size()).isEqualTo(4);
   }
 
   @Test
@@ -98,9 +100,9 @@ public class CompactRangeIndexQueryIntegrationTest {
     String regionName = "portfolio";
 
     Cache cache = serverStarterRule.getCache();
-    assertNotNull(cache);
-    Region region =
-        cache.createRegionFactory().setDataPolicy(DataPolicy.REPLICATE).create(regionName);
+    assertThat(cache).isNotNull();
+    Region<Integer, Portfolio> region = cache.<Integer, Portfolio>createRegionFactory()
+        .setDataPolicy(DataPolicy.REPLICATE).create(regionName);
 
     Portfolio p = new Portfolio(1);
     region.put(1, p);
@@ -114,6 +116,6 @@ public class CompactRangeIndexQueryIntegrationTest {
     SelectResults results = (SelectResults) queryService
         .newQuery("select * from /portfolio where status = 4 AND ID = 'StringID'").execute();
 
-    assertNotNull(results);
+    assertThat(results).isNotNull();
   }
 }

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/partitioned/PRColocatedEquiJoinTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/partitioned/PRColocatedEquiJoinTest.java
@@ -34,7 +34,7 @@ import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.test.junit.categories.OQLQueryTest;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({OQLQueryTest.class})
+@Category(OQLQueryTest.class)
 public class PRColocatedEquiJoinTest {
   private static final int count = 100;
 
@@ -42,6 +42,7 @@ public class PRColocatedEquiJoinTest {
   public ServerStarterRule server = new ServerStarterRule().withAutoStart();
 
   @Test
+  @SuppressWarnings("unchecked")
   public void prQueryWithHeteroIndex() throws Exception {
     InternalCache cache = server.getCache();
     QueryService qs = cache.getQueryService();
@@ -64,10 +65,10 @@ public class PRColocatedEquiJoinTest {
     NewPortfolio[] newPortfolio = createNewPortfoliosAndPositions(count);
 
     for (int i = 0; i < count; i++) {
-      r1.put(new Integer(i), portfolio[i]);
-      r2.put(new Integer(i), newPortfolio[i]);
-      r3.put(new Integer(i), portfolio[i]);
-      r4.put(new Integer(i), newPortfolio[i]);
+      r1.put(i, portfolio[i]);
+      r2.put(i, newPortfolio[i]);
+      r3.put(i, portfolio[i]);
+      r4.put(i, newPortfolio[i]);
     }
 
     ArrayList results[][] = new ArrayList[whereClauses.length][2];

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache30/ShorteningExpirationTimeRegressionTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache30/ShorteningExpirationTimeRegressionTest.java
@@ -49,8 +49,7 @@ public class ShorteningExpirationTimeRegressionTest {
   private static final String KEY = "key";
 
   @ClassRule
-  public static ServerStarterRule server =
-      new ServerStarterRule().withNoCacheServer().withAutoStart();
+  public static ServerStarterRule server = new ServerStarterRule().withAutoStart();
 
   @ClassRule
   public static RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
@@ -81,7 +80,7 @@ public class ShorteningExpirationTimeRegressionTest {
   }
 
   @Test
-  public void customEntryIdleTimeoutCanBeShortened() throws Exception {
+  public void customEntryIdleTimeoutCanBeShortened() {
     RegionFactory<String, String> rf = server.getCache().createRegionFactory(RegionShortcut.LOCAL);
     rf.setCustomEntryIdleTimeout(new CustomExpiryTestClass<>());
     rf.setStatisticsEnabled(true);

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/CacheConfigIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/CacheConfigIntegrationTest.java
@@ -35,11 +35,9 @@ public class CacheConfigIntegrationTest {
   @Rule
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
-  private File xmlFile;
-
   @Test
   public void testXmlCreatedByCacheConfigCanBeUsedToStartupServer() throws Exception {
-    xmlFile = temporaryFolder.newFile("cache.xml");
+    File xmlFile = temporaryFolder.newFile("cache.xml");
     CacheConfig cacheConfig = new CacheConfig();
     cacheConfig.setVersion("1.0");
     JAXBService service = new JAXBService(CacheConfig.class);
@@ -49,5 +47,4 @@ public class CacheConfigIntegrationTest {
     server.withProperty("cache-xml-file", xmlFile.getAbsolutePath());
     server.startServer();
   }
-
 }

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ClusterConfigurationLoaderIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ClusterConfigurationLoaderIntegrationTest.java
@@ -116,9 +116,9 @@ public class ClusterConfigurationLoaderIntegrationTest {
 
   class CustomAnswer implements Answer {
     public int calls;
-    public int mockLimit;
+    int mockLimit;
 
-    public CustomAnswer(int mockLimit) {
+    CustomAnswer(int mockLimit) {
       this.calls = 0;
       this.mockLimit = mockLimit;
     }

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/PartitionedRegionAttributesMutatorTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/PartitionedRegionAttributesMutatorTest.java
@@ -14,7 +14,7 @@
 
 package org.apache.geode.internal.cache;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -54,6 +54,7 @@ public class PartitionedRegionAttributesMutatorTest {
   private PartitionedRegion pr;
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testChangeCacheLoaderDuringBucketCreation()
       throws InterruptedException, TimeoutException, ExecutionException {
     createRegion();
@@ -66,10 +67,12 @@ public class PartitionedRegionAttributesMutatorTest {
     mutationMade.countDown();
     createBucket.get(DEFAULT_WAIT_DURATION, DEFAULT_WAIT_UNIT);
 
-    getAllBucketRegions(pr).forEach(region -> assertEquals(loader, region.getCacheLoader()));
+    getAllBucketRegions(pr)
+        .forEach(region -> assertThat(region.getCacheLoader()).isEqualTo(loader));
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testChangeCustomEntryTtlDuringBucketCreation()
       throws InterruptedException, ExecutionException {
     createRegion();
@@ -83,10 +86,11 @@ public class PartitionedRegionAttributesMutatorTest {
     createBucket.get();
 
     getAllBucketRegions(pr)
-        .forEach(region -> assertEquals(customExpiry, region.customEntryTimeToLive));
+        .forEach(region -> assertThat(region.customEntryTimeToLive).isEqualTo(customExpiry));
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testChangeCustomEntryIdleTimeoutDuringBucketCreation()
       throws InterruptedException, ExecutionException {
     createRegion();
@@ -100,7 +104,7 @@ public class PartitionedRegionAttributesMutatorTest {
     createBucket.get();
 
     getAllBucketRegions(pr)
-        .forEach(region -> assertEquals(customExpiry, region.customEntryIdleTimeout));
+        .forEach(region -> assertThat(region.customEntryIdleTimeout).isEqualTo(customExpiry));
   }
 
   @Test
@@ -118,7 +122,8 @@ public class PartitionedRegionAttributesMutatorTest {
     createBucket.get();
 
     getAllBucketRegions(pr)
-        .forEach(region -> assertEquals(expirationAttributes, region.getEntryIdleTimeout()));
+        .forEach(
+            region -> assertThat(region.getEntryIdleTimeout()).isEqualTo(expirationAttributes));
   }
 
   @Test
@@ -136,7 +141,7 @@ public class PartitionedRegionAttributesMutatorTest {
     createBucket.get();
 
     getAllBucketRegions(pr)
-        .forEach(region -> assertEquals(expirationAttributes, region.getEntryTimeToLive()));
+        .forEach(region -> assertThat(region.getEntryTimeToLive()).isEqualTo(expirationAttributes));
   }
 
   private void createRegion() {

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/FederatingManagerIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/FederatingManagerIntegrationTest.java
@@ -34,7 +34,7 @@ import org.apache.geode.management.internal.SystemManagementService;
 import org.apache.geode.test.junit.categories.JMXTest;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({JMXTest.class})
+@Category(JMXTest.class)
 public class FederatingManagerIntegrationTest {
 
   @Rule

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/beans/ManagementAdapterTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/beans/ManagementAdapterTest.java
@@ -52,8 +52,8 @@ public class ManagementAdapterTest {
   @Before
   public void before() {
     cache = serverRule.getCache();
-    doReturn(new DiskStoreStats(cache.getInternalDistributedSystem(), "disk-stats"))
-        .when(diskStore).getStats();
+    doReturn(new DiskStoreStats(cache.getInternalDistributedSystem(), "disk-stats")).when(diskStore)
+        .getStats();
     doReturn(new File[] {}).when(diskStore).getDiskDirs();
   }
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/AlterRegionCommandIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/AlterRegionCommandIntegrationTest.java
@@ -25,7 +25,7 @@ import org.apache.geode.test.junit.categories.RegionsTest;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({RegionsTest.class})
+@Category(RegionsTest.class)
 public class AlterRegionCommandIntegrationTest {
   @ClassRule
   public static ServerStarterRule server =
@@ -40,34 +40,34 @@ public class AlterRegionCommandIntegrationTest {
   }
 
   @Test
-  public void validateGroup() throws Exception {
+  public void validateGroup() {
     gfsh.executeAndAssertThat("alter region --name=/REPLICATED --group=unknown").statusIsError()
         .containsOutput("Group(s) \"[unknown]\" are invalid.");
   }
 
   @Test
-  public void invalidCacheListener() throws Exception {
+  public void invalidCacheListener() {
     gfsh.executeAndAssertThat("alter region --name=/REPLICATED --cache-listener=abc-def")
         .statusIsError().containsOutput(
             "java.lang.IllegalArgumentException: Failed to convert 'abc-def' to type ClassName[] for option 'cache-listener'");
   }
 
   @Test
-  public void invalidCacheLoader() throws Exception {
+  public void invalidCacheLoader() {
     gfsh.executeAndAssertThat("alter region --name=/REPLICATED --cache-loader=abc-def")
         .statusIsError().containsOutput(
             "java.lang.IllegalArgumentException: Failed to convert 'abc-def' to type ClassName for option 'cache-loader'");
   }
 
   @Test
-  public void invalidCacheWriter() throws Exception {
+  public void invalidCacheWriter() {
     gfsh.executeAndAssertThat("alter region --name=/REPLICATED --cache-writer=abc-def")
         .statusIsError().containsOutput(
             "java.lang.IllegalArgumentException: Failed to convert 'abc-def' to type ClassName for option 'cache-writer'");
   }
 
   @Test
-  public void invalidEvictionMax() throws Exception {
+  public void invalidEvictionMax() {
     gfsh.executeAndAssertThat("alter region --name=/REPLICATED --eviction-max=-1").statusIsError()
         .containsOutput("Specify 0 or a positive integer value for eviction-max");
   }

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/ConfigurePDXCommandIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/ConfigurePDXCommandIntegrationTest.java
@@ -21,11 +21,11 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import org.apache.geode.test.junit.categories.ClientServerTest;
+import org.apache.geode.test.junit.categories.GfshTest;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
 import org.apache.geode.test.junit.rules.LocatorStarterRule;
 
-@Category({ClientServerTest.class})
+@Category(GfshTest.class)
 public class ConfigurePDXCommandIntegrationTest {
   private static final String BASE_COMMAND_STRING = "configure pdx ";
 
@@ -34,7 +34,7 @@ public class ConfigurePDXCommandIntegrationTest {
 
   @Rule
   public LocatorStarterRule locator =
-      new LocatorStarterRule().withWorkingDir().withAutoStart().withJMXManager();;
+      new LocatorStarterRule().withWorkingDir().withAutoStart().withJMXManager();
 
   @Before
   public void before() throws Exception {

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/CreateRegionCommandIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/CreateRegionCommandIntegrationTest.java
@@ -39,7 +39,7 @@ import org.apache.geode.test.junit.categories.RegionsTest;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({RegionsTest.class})
+@Category(RegionsTest.class)
 public class CreateRegionCommandIntegrationTest {
 
   private static String CREATE_REGION = "create region --type=REPLICATE ";
@@ -47,7 +47,7 @@ public class CreateRegionCommandIntegrationTest {
   public static class TestCacheListener extends CacheListenerAdapter {
   }
 
-  public static class TestConstraint {
+  private static class TestConstraint {
   }
 
   @ClassRule
@@ -63,25 +63,25 @@ public class CreateRegionCommandIntegrationTest {
   }
 
   @Test
-  public void parentRegionDoesNotExist() throws Exception {
+  public void parentRegionDoesNotExist() {
     gfsh.executeAndAssertThat(CREATE_REGION + "--name=/A/B").statusIsError()
         .containsOutput("Parent region for \"/A/B\" doesnt exist");
   }
 
   @Test
-  public void groupDoesNotExist() throws Exception {
+  public void groupDoesNotExist() {
     gfsh.executeAndAssertThat(CREATE_REGION + "--name=/FOO --groups=unknown").statusIsError()
         .containsOutput("Group(s) \"unknown\" are invalid");
   }
 
   @Test
-  public void templateRegionDoesNotExist() throws Exception {
+  public void templateRegionDoesNotExist() {
     gfsh.executeAndAssertThat("create region --name=/FOO --template-region=/BAR").statusIsError()
         .containsOutput("Specify a valid region path for template-region");
   }
 
   @Test
-  public void conflictingPartitionAttributesWithTemplate() throws Exception {
+  public void conflictingPartitionAttributesWithTemplate() {
     gfsh.executeAndAssertThat(
         "create region --name=/FOO --template-region=REPLICATED --redundant-copies=2")
         .statusIsError().containsOutput(
@@ -89,52 +89,52 @@ public class CreateRegionCommandIntegrationTest {
   }
 
   @Test
-  public void conflictingPartitionAttributesWithShortCut() throws Exception {
+  public void conflictingPartitionAttributesWithShortCut() {
     gfsh.executeAndAssertThat("create region --name=/FOO --type=REPLICATE --redundant-copies=2")
         .statusIsError().containsOutput(
             "Parameter(s) \"[redundant-copies]\" can be used only for creating a Partitioned Region");
   }
 
   @Test
-  public void colocatedWithRegionDoesNotExist() throws Exception {
+  public void colocatedWithRegionDoesNotExist() {
     gfsh.executeAndAssertThat("create region --type=PARTITION --name=/FOO --colocated-with=/BAR")
         .statusIsError().containsOutput("Specify a valid region path for colocated-with");
   }
 
   @Test
-  public void colocatedWithRegionIsNotPartitioned() throws Exception {
+  public void colocatedWithRegionIsNotPartitioned() {
     gfsh.executeAndAssertThat(
         "create region --type=PARTITION --name=/FOO --colocated-with=/REPLICATED").statusIsError()
         .containsOutput("colocated-with \"/REPLICATED\" is not a Partitioned Region");
   }
 
   @Test
-  public void negativeLocalMaxMemory() throws Exception {
+  public void negativeLocalMaxMemory() {
     gfsh.executeAndAssertThat("create region --type=PARTITION --name=/FOO --local-max-memory=-1")
         .statusIsError().containsOutput("PartitionAttributes localMaxMemory must not be negative");
   }
 
   @Test
-  public void zeroLocalMaxMemoryIsOK() throws Exception {
+  public void zeroLocalMaxMemoryIsOK() {
     gfsh.executeAndAssertThat("create region --type=PARTITION --name=/FOO --local-max-memory=0")
         .statusIsSuccess().containsOutput("Region \"/FOO\" created");
     gfsh.executeAndAssertThat("destroy region --name=/FOO").statusIsSuccess();
   }
 
   @Test
-  public void negativeTotalMaxMemory() throws Exception {
+  public void negativeTotalMaxMemory() {
     gfsh.executeAndAssertThat("create region --type=PARTITION --name=/FOO --total-max-memory=-1")
         .statusIsError().containsOutput("Total size of partition region must be > 0");
   }
 
   @Test
-  public void zeroTotalMaxMemory() throws Exception {
+  public void zeroTotalMaxMemory() {
     gfsh.executeAndAssertThat("create region --type=PARTITION --name=/FOO --total-max-memory=0")
         .statusIsError().containsOutput("Total size of partition region must be > 0");
   }
 
   @Test
-  public void redundantCopies() throws Exception {
+  public void redundantCopies() {
     gfsh.executeAndAssertThat("create region --name=/FOO --type=PARTITION --redundant-copies=2")
         .statusIsSuccess().containsOutput("Region \"/FOO\" created");
 
@@ -142,26 +142,26 @@ public class CreateRegionCommandIntegrationTest {
   }
 
   @Test
-  public void tooManyredundantCopies() throws Exception {
+  public void tooManyRedundantCopies() {
     gfsh.executeAndAssertThat("create region --name=/FOO --type=PARTITION --redundant-copies=4")
         .statusIsError().containsOutput("redundant-copies \"4\" is not valid");
   }
 
   @Test
-  public void keyConstraint() throws Exception {
+  public void keyConstraint() {
     gfsh.executeAndAssertThat("create region --name=/FOO --type=REPLICATE --key-constraint=abc-def")
         .statusIsError().containsOutput("Specify a valid class name for key-constraint");
   }
 
   @Test
-  public void valueConstraint() throws Exception {
+  public void valueConstraint() {
     gfsh.executeAndAssertThat(
         "create region --name=/FOO --type=REPLICATE --value-constraint=abc-def").statusIsError()
         .containsOutput("Specify a valid class name for value-constraint");
   }
 
   @Test
-  public void ifNotExistsIsIdempotent() throws Exception {
+  public void ifNotExistsIsIdempotent() {
     gfsh.executeAndAssertThat(
         "create region --if-not-exists --type=PARTITION --name=/FOO --local-max-memory=0")
         .statusIsSuccess().containsOutput("Region \"/FOO\" created");
@@ -178,28 +178,28 @@ public class CreateRegionCommandIntegrationTest {
   }
 
   @Test
-  public void invalidCacheListener() throws Exception {
+  public void invalidCacheListener() {
     gfsh.executeAndAssertThat("create region --name=/FOO --type=REPLICATE --cache-listener=abc-def")
         .statusIsError().containsOutput(
             "java.lang.IllegalArgumentException: Failed to convert 'abc-def' to type ClassName");
   }
 
   @Test
-  public void invalidCacheLoader() throws Exception {
+  public void invalidCacheLoader() {
     gfsh.executeAndAssertThat("create region --name=/FOO --type=REPLICATE --cache-loader=abc-def")
         .statusIsError().containsOutput(
             "java.lang.IllegalArgumentException: Failed to convert 'abc-def' to type ClassName");
   }
 
   @Test
-  public void invalidCacheWriter() throws Exception {
+  public void invalidCacheWriter() {
     gfsh.executeAndAssertThat("create region --name=/FOO --type=REPLICATE --cache-writer=abc-def")
         .statusIsError().containsOutput(
             "java.lang.IllegalArgumentException: Failed to convert 'abc-def' to type ClassName");
   }
 
   @Test
-  public void invalidGatewaySenders() throws Exception {
+  public void invalidGatewaySenders() {
     gfsh.executeAndAssertThat(
         "create region --name=/FOO --type=REPLICATE --gateway-sender-id=unknown").statusIsError()
         .containsOutput("There are no GatewaySenders defined currently in the system");
@@ -208,21 +208,21 @@ public class CreateRegionCommandIntegrationTest {
   // TODO: Write test for invalid gateway name (gateways already need to exist).
 
   @Test
-  public void invalidConcurrencyLevel() throws Exception {
+  public void invalidConcurrencyLevel() {
     gfsh.executeAndAssertThat(
         "create region --name=/FOO --template-region=/REPLICATED --concurrency-level=-1")
         .statusIsError().containsOutput("Specify positive integer value for concurrency-level");
   }
 
   @Test
-  public void nonPersistentRegionWithdiskStore() throws Exception {
+  public void nonPersistentRegionWithDiskStore() {
     gfsh.executeAndAssertThat("create region --name=/FOO --type=REPLICATE --disk-store=unknown")
         .statusIsError()
         .containsOutput("Only regions with persistence or overflow to disk can specify DiskStore");
   }
 
   @Test
-  public void nonPersistentTemplateWithdiskStore() throws Exception {
+  public void nonPersistentTemplateWithdiskStore() {
     gfsh.executeAndAssertThat(
         "create region --name=/FOO --template-region=/REPLICATED --disk-store=unknown")
         .statusIsError().containsOutput("template-region region \"/REPLICATED\" is not persistent")
@@ -231,7 +231,7 @@ public class CreateRegionCommandIntegrationTest {
 
 
   @Test
-  public void invalidDiskStore() throws Exception {
+  public void invalidDiskStore() {
     gfsh.executeAndAssertThat(
         "create region --name=/FOO --type=REPLICATE_PERSISTENT --disk-store=unknown")
         .statusIsError()
@@ -239,14 +239,14 @@ public class CreateRegionCommandIntegrationTest {
   }
 
   @Test
-  public void entryIdleTimeWithoutStatisticsEnabled() throws Exception {
+  public void entryIdleTimeWithoutStatisticsEnabled() {
     gfsh.executeAndAssertThat(
         "create region --name=/FOO --type=REPLICATE --entry-idle-time-expiration=1").statusIsError()
         .containsOutput("Statistics must be enabled for expiration");
   }
 
   @Test
-  public void invalidCompressor() throws Exception {
+  public void invalidCompressor() {
     gfsh.executeAndAssertThat(
         "create region --name=/FOO --type=REPLICATE --compressor=java.lang.String").statusIsError()
         .containsOutput(
@@ -254,7 +254,7 @@ public class CreateRegionCommandIntegrationTest {
   }
 
   @Test
-  public void validateDefaultExpirationAttributes() throws Exception {
+  public void validateDefaultExpirationAttributes() {
     gfsh.executeAndAssertThat("create region --name=/A --type=REPLICATE").statusIsSuccess();
 
     Region region = server.getCache().getRegion("/A");
@@ -281,7 +281,7 @@ public class CreateRegionCommandIntegrationTest {
   }
 
   @Test
-  public void validateNonDefaultBinaryOptions() throws Exception {
+  public void validateNonDefaultBinaryOptions() {
     gfsh.executeAndAssertThat("create region --name=/FOO --type=REPLICATE"
         + " --enable-async-conflation" + " --enable-cloning" + " --enable-concurrency-checks=false"
         + " --enable-multicast" + " --enable-statistics" + " --enable-subscription-conflation"
@@ -301,7 +301,7 @@ public class CreateRegionCommandIntegrationTest {
   }
 
   @Test
-  public void validateExpirationOptions() throws Exception {
+  public void validateExpirationOptions() {
     gfsh.executeAndAssertThat("create region --name=/FOO --type=REPLICATE" + " --enable-statistics"
         + " --entry-idle-time-expiration=3" + " --entry-idle-time-expiration-action=DESTROY"
         + " --entry-time-to-live-expiration=5" + " --entry-time-to-live-expiration-action=DESTROY"
@@ -329,7 +329,8 @@ public class CreateRegionCommandIntegrationTest {
   }
 
   @Test
-  public void validatePartitionRegionOptions() throws Exception {
+  @SuppressWarnings("deprecation")
+  public void validatePartitionRegionOptions() {
     gfsh.executeAndAssertThat("create region --name=/FOO --type=PARTITION_REDUNDANT"
         + " --local-max-memory=1001" + " --recovery-delay=7" + " --redundant-copies=1"
         + " --startup-recovery-delay=5" + " --total-max-memory=2001" + " --total-num-buckets=11"
@@ -351,7 +352,7 @@ public class CreateRegionCommandIntegrationTest {
   }
 
   @Test
-  public void validateCallbackOptions() throws Exception {
+  public void validateCallbackOptions() {
     gfsh.executeAndAssertThat(
         "create region --name=/FOO --type=PARTITION_REDUNDANT --cache-listener="
             + TestCacheListener.class.getName() + " --cache-loader="
@@ -375,7 +376,7 @@ public class CreateRegionCommandIntegrationTest {
   }
 
   @Test
-  public void validateConstraints() throws Exception {
+  public void validateConstraints() {
     gfsh.executeAndAssertThat("create region --name=/FOO --type=REPLICATE" + " --key-constraint="
         + TestConstraint.class.getName() + " --value-constraint=" + TestConstraint.class.getName())
         .statusIsSuccess();
@@ -391,7 +392,7 @@ public class CreateRegionCommandIntegrationTest {
   }
 
   @Test
-  public void validateEntryIdleTimeExpiration() throws Exception {
+  public void validateEntryIdleTimeExpiration() {
     gfsh.executeAndAssertThat(
         "create region --name=/FOO --type=REPLICATE --entry-idle-time-expiration=7 --enable-statistics")
         .statusIsSuccess();
@@ -402,7 +403,7 @@ public class CreateRegionCommandIntegrationTest {
   }
 
   @Test
-  public void validateTemplateRegionAttributesForReplicate() throws Exception {
+  public void validateTemplateRegionAttributesForReplicate() {
     gfsh.executeAndAssertThat("create region --name=/TEMPLATE --type=REPLICATE"
         + " --enable-async-conflation" + " --enable-cloning" + " --enable-concurrency-checks=false"
         + " --enable-multicast" + " --enable-statistics" + " --enable-subscription-conflation"
@@ -460,7 +461,8 @@ public class CreateRegionCommandIntegrationTest {
   }
 
   @Test
-  public void validateTemplateRegionAttributesForPartitionRedundant() throws Exception {
+  @SuppressWarnings("deprecation")
+  public void validateTemplateRegionAttributesForPartitionRedundant() {
     gfsh.executeAndAssertThat("create region --name=/TEMPLATE --type=PARTITION_REDUNDANT"
         + " --enable-async-conflation" + " --enable-cloning" + " --enable-concurrency-checks=false"
         + " --enable-multicast" + " --enable-statistics" + " --enable-subscription-conflation"
@@ -524,7 +526,7 @@ public class CreateRegionCommandIntegrationTest {
   }
 
   @Test
-  public void testEvictionAttributesForLRUHeap() throws Exception {
+  public void testEvictionAttributesForLRUHeap() {
     gfsh.executeAndAssertThat(
         "create region --name=FOO --type=REPLICATE --eviction-action=local-destroy")
         .statusIsSuccess();
@@ -539,7 +541,7 @@ public class CreateRegionCommandIntegrationTest {
   }
 
   @Test
-  public void testEvictionAttributesForLRUHeapWithObjectSizer() throws Exception {
+  public void testEvictionAttributesForLRUHeapWithObjectSizer() {
     gfsh.executeAndAssertThat(
         "create region --name=FOO --type=REPLICATE --eviction-action=local-destroy --eviction-object-sizer="
             + TestObjectSizer.class.getName())
@@ -557,7 +559,7 @@ public class CreateRegionCommandIntegrationTest {
   }
 
   @Test
-  public void testEvictionAttributesForLRUEntry() throws Exception {
+  public void testEvictionAttributesForLRUEntry() {
     gfsh.executeAndAssertThat(
         "create region --name=FOO --type=REPLICATE --eviction-entry-count=1001 --eviction-action=overflow-to-disk")
         .statusIsSuccess();
@@ -573,7 +575,7 @@ public class CreateRegionCommandIntegrationTest {
   }
 
   @Test
-  public void testEvictionAttributesForLRUMemory() throws Exception {
+  public void testEvictionAttributesForLRUMemory() {
     gfsh.executeAndAssertThat(
         "create region --name=FOO --type=REPLICATE --eviction-max-memory=1001 --eviction-action=overflow-to-disk")
         .statusIsSuccess();
@@ -589,7 +591,7 @@ public class CreateRegionCommandIntegrationTest {
   }
 
   @Test
-  public void testEvictionAttributesForObjectSizer() throws Exception {
+  public void testEvictionAttributesForObjectSizer() {
     gfsh.executeAndAssertThat(
         "create region --name=FOO --type=REPLICATE --eviction-max-memory=1001 --eviction-action=overflow-to-disk --eviction-object-sizer="
             + TestObjectSizer.class.getName())
@@ -607,7 +609,7 @@ public class CreateRegionCommandIntegrationTest {
   }
 
   @Test
-  public void testEvictionAttributesForNonDeclarableObjectSizer() throws Exception {
+  public void testEvictionAttributesForNonDeclarableObjectSizer() {
     gfsh.executeAndAssertThat(
         "create region --name=FOO --type=REPLICATE --eviction-max-memory=1001 --eviction-action=overflow-to-disk --eviction-object-sizer="
             + TestObjectSizerNotDeclarable.class.getName())

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/DescribeConfigCommandIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/DescribeConfigCommandIntegrationTest.java
@@ -25,7 +25,7 @@ import org.apache.geode.test.junit.rules.GfshCommandRule;
 import org.apache.geode.test.junit.rules.GfshCommandRule.PortType;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({ConfigurationTest.class})
+@Category(ConfigurationTest.class)
 public class DescribeConfigCommandIntegrationTest {
   private static final String[] EXPECTED_BASE_CONFIGURATION_DATA = {"Configuration of member :",
       "JVM command line arguments", "GemFire properties defined using the API"};
@@ -41,13 +41,13 @@ public class DescribeConfigCommandIntegrationTest {
   public GfshCommandRule gfsh = new GfshCommandRule(server::getJmxPort, PortType.jmxManager);
 
   @Test
-  public void describeConfig() throws Exception {
+  public void describeConfig() {
     gfsh.executeAndAssertThat("describe config --member=" + server.getName()).statusIsSuccess()
         .containsOutput(EXPECTED_BASE_CONFIGURATION_DATA);
   }
 
   @Test
-  public void describeConfigAndShowDefaults() throws Exception {
+  public void describeConfigAndShowDefaults() {
     gfsh.executeAndAssertThat("describe config --hide-defaults=false --member=" + server.getName())
         .statusIsSuccess().containsOutput(EXPECTED_BASE_CONFIGURATION_DATA)
         .containsOutput(EXPECTED_EXPANDED_CONFIGURATION_DATA);
@@ -61,7 +61,7 @@ public class DescribeConfigCommandIntegrationTest {
   }
 
   @Test
-  public void describeConfigOnInvalidMember() throws Exception {
+  public void describeConfigOnInvalidMember() {
     String invalidMemberName = "invalid-member-name";
     String expectedErrorString = String.format("Member %s could not be found", invalidMemberName);
     gfsh.executeAndAssertThat("describe config --member=" + invalidMemberName).statusIsError()

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/DescribeConnectionCommandIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/DescribeConnectionCommandIntegrationTest.java
@@ -26,7 +26,7 @@ import org.apache.geode.test.junit.rules.GfshCommandRule;
 import org.apache.geode.test.junit.rules.GfshCommandRule.PortType;
 import org.apache.geode.test.junit.rules.LocatorStarterRule;
 
-@Category({GfshTest.class})
+@Category(GfshTest.class)
 public class DescribeConnectionCommandIntegrationTest {
   public static Logger logger = LogService.getLogger();
 
@@ -44,9 +44,8 @@ public class DescribeConnectionCommandIntegrationTest {
   }
 
   @Test
-  public void executeWhileNotConnected() throws Exception {
+  public void executeWhileNotConnected() {
     gfsh.executeAndAssertThat("describe connection")
         .tableHasColumnWithValuesContaining("Connection Endpoints", "Not connected");
   }
-
 }

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/DescribeDiskStoreCommandIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/DescribeDiskStoreCommandIntegrationTest.java
@@ -29,7 +29,7 @@ import org.apache.geode.test.junit.rules.GfshCommandRule;
 import org.apache.geode.test.junit.rules.GfshCommandRule.PortType;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({PersistenceTest.class})
+@Category(PersistenceTest.class)
 public class DescribeDiskStoreCommandIntegrationTest {
   private static final String REGION_NAME = "test-region";
   private static final String MEMBER_NAME = "testServer";
@@ -57,7 +57,7 @@ public class DescribeDiskStoreCommandIntegrationTest {
   public static GfshCommandRule gfsh = new GfshCommandRule().withTimeout(1);
 
   @Test
-  public void commandFailsWithoutOptions() throws Exception {
+  public void commandFailsWithoutOptions() {
     String cmd = "describe disk-store";
     gfsh.executeAndAssertThat(cmd).statusIsError().containsOutput("You should specify option (",
         "--name", "--member", ") for this command");
@@ -65,35 +65,35 @@ public class DescribeDiskStoreCommandIntegrationTest {
   }
 
   @Test
-  public void commandFailsWithOnlyMember() throws Exception {
+  public void commandFailsWithOnlyMember() {
     String cmd = "describe disk-store --member=" + MEMBER_NAME;
     gfsh.executeAndAssertThat(cmd).statusIsError().containsOutput("You should specify option (",
         "--name", ") for this command");
   }
 
   @Test
-  public void commandFailsWithOnlyName() throws Exception {
+  public void commandFailsWithOnlyName() {
     String cmd = "describe disk-store --name=" + DISK_STORE_NAME;
     gfsh.executeAndAssertThat(cmd).statusIsError().containsOutput("You should specify option (",
         "--member", ") for this command");
   }
 
   @Test
-  public void commandFailsWithBadMember() throws Exception {
+  public void commandFailsWithBadMember() {
     String cmd = "describe disk-store --member=invalid-member-name --name=" + DISK_STORE_NAME;
     gfsh.executeAndAssertThat(cmd).statusIsError().containsOutput("Member",
         "could not be found.  Please verify the member name or ID and try again.");
   }
 
   @Test
-  public void commandFailsWithBadName() throws Exception {
+  public void commandFailsWithBadName() {
     String cmd = "describe disk-store --name=invalid-diskstore-name --member=" + MEMBER_NAME;
     gfsh.executeAndAssertThat(cmd).statusIsError().containsOutput("A disk store with name",
         "was not found on member");
   }
 
   @Test
-  public void commandSucceedsWithNameAndMember() throws Exception {
+  public void commandSucceedsWithNameAndMember() {
     String cmd = "describe disk-store --name=" + DISK_STORE_NAME + " --member=" + MEMBER_NAME;
     gfsh.executeAndAssertThat(cmd).statusIsSuccess()
         .containsOutput(expectedData.toArray(new String[0]));

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/DescribeRegionIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/DescribeRegionIntegrationTest.java
@@ -26,7 +26,7 @@ import org.apache.geode.test.junit.rules.GfshCommandRule;
 import org.apache.geode.test.junit.rules.GfshCommandRule.PortType;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({RegionsTest.class})
+@Category(RegionsTest.class)
 public class DescribeRegionIntegrationTest {
   private static String MEMBER_NAME = "test-server";
   private static String REGION_NAME = "test-region";
@@ -49,13 +49,13 @@ public class DescribeRegionIntegrationTest {
   }
 
   @Test
-  public void commandFailsWithBadNameOption() throws Exception {
+  public void commandFailsWithBadNameOption() {
     String cmd = "describe region --name=invalid-region-name";
     gfsh.executeAndAssertThat(cmd).statusIsError().containsOutput("invalid-region-name not found");
   }
 
   @Test
-  public void commandSucceedsWithGoodNameOption() throws Exception {
+  public void commandSucceedsWithGoodNameOption() {
     String cmd = "describe region --name=" + REGION_NAME;
     gfsh.executeAndAssertThat(cmd).statusIsSuccess().containsOutput("Name", "Data Policy",
         "Hosting Members");

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/ExportDataIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/ExportDataIntegrationTest.java
@@ -17,7 +17,6 @@
 package org.apache.geode.management.internal.cli.commands;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertFalse;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -60,14 +59,14 @@ public class ExportDataIntegrationTest {
   public void setup() throws Exception {
     gfsh.connectAndVerify(server.getEmbeddedLocatorPort(), GfshCommandRule.PortType.locator);
     region = server.getCache().getRegion(TEST_REGION_NAME);
-    loadRegion("value");
+    IntStream.range(0, DATA_POINTS).forEach(i -> region.put("key" + i, "value"));
     Path basePath = tempDir.getRoot().toPath();
     snapshotFile = basePath.resolve(SNAPSHOT_FILE);
     snapshotDir = basePath.resolve(SNAPSHOT_DIR);
   }
 
   @Test
-  public void testExport() throws Exception {
+  public void testExport() {
     String exportCommand = buildBaseExportCommand()
         .addOption(CliStrings.EXPORT_DATA__FILE, snapshotFile.toString()).getCommandString();
     gfsh.executeAndAssertThat(exportCommand).statusIsSuccess();
@@ -75,7 +74,7 @@ public class ExportDataIntegrationTest {
   }
 
   @Test
-  public void testParallelExport() throws Exception {
+  public void testParallelExport() {
     String exportCommand =
         buildBaseExportCommand().addOption(CliStrings.EXPORT_DATA__DIR, snapshotDir.toString())
             .addOption(CliStrings.EXPORT_DATA__PARALLEL, "true").getCommandString();
@@ -84,7 +83,7 @@ public class ExportDataIntegrationTest {
   }
 
   @Test
-  public void testInvalidMember() throws Exception {
+  public void testInvalidMember() {
     String invalidMemberName = "invalidMember";
     String invalidMemberCommand = new CommandStringBuilder(CliStrings.EXPORT_DATA)
         .addOption(CliStrings.MEMBER, invalidMemberName)
@@ -95,7 +94,7 @@ public class ExportDataIntegrationTest {
   }
 
   @Test
-  public void testNonExistentRegion() throws Exception {
+  public void testNonExistentRegion() {
     String nonExistentRegionCommand = new CommandStringBuilder(CliStrings.EXPORT_DATA)
         .addOption(CliStrings.MEMBER, server.getName())
         .addOption(CliStrings.EXPORT_DATA__REGION, "/nonExistentRegion")
@@ -105,7 +104,7 @@ public class ExportDataIntegrationTest {
   }
 
   @Test
-  public void testInvalidFile() throws Exception {
+  public void testInvalidFile() {
     String invalidFileCommand = buildBaseExportCommand()
         .addOption(CliStrings.EXPORT_DATA__FILE, snapshotFile.toString() + ".invalid")
         .getCommandString();
@@ -115,7 +114,7 @@ public class ExportDataIntegrationTest {
   }
 
   @Test
-  public void testMissingRegion() throws Exception {
+  public void testMissingRegion() {
     String missingRegionCommand = new CommandStringBuilder(CliStrings.EXPORT_DATA)
         .addOption(CliStrings.MEMBER, server.getName())
         .addOption(CliStrings.EXPORT_DATA__FILE, snapshotFile.toString()).getCommandString();
@@ -124,14 +123,14 @@ public class ExportDataIntegrationTest {
   }
 
   @Test
-  public void testMissingFileAndDirectory() throws Exception {
+  public void testMissingFileAndDirectory() {
     String missingFileAndDirCommand = buildBaseExportCommand().getCommandString();
     gfsh.executeCommand(missingFileAndDirCommand);
     assertThat(gfsh.getGfshOutput()).contains("Must specify a location to save snapshot");
   }
 
   @Test
-  public void testParallelExportWithOnlyFile() throws Exception {
+  public void testParallelExportWithOnlyFile() {
     String exportCommand =
         buildBaseExportCommand().addOption(CliStrings.EXPORT_DATA__FILE, snapshotFile.toString())
             .addOption(CliStrings.EXPORT_DATA__PARALLEL, "true").getCommandString();
@@ -140,7 +139,7 @@ public class ExportDataIntegrationTest {
   }
 
   @Test
-  public void testSpecifyingDirectoryAndFileCommands() throws Exception {
+  public void testSpecifyingDirectoryAndFileCommands() {
     String exportCommand =
         buildBaseExportCommand().addOption(CliStrings.EXPORT_DATA__FILE, snapshotFile.toString())
             .addOption(CliStrings.EXPORT_DATA__DIR, snapshotDir.toString()).getCommandString();
@@ -148,11 +147,7 @@ public class ExportDataIntegrationTest {
     assertThat(gfsh.getGfshOutput())
         .contains("Options \"file\" and \"dir\" cannot be specified at the same time");
 
-    assertFalse(Files.exists(snapshotDir));
-  }
-
-  private void loadRegion(String value) {
-    IntStream.range(0, DATA_POINTS).forEach(i -> region.put("key" + i, value));
+    assertThat(Files.exists(snapshotDir)).isFalse();
   }
 
   private CommandStringBuilder buildBaseExportCommand() {

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/GetCommandIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/GetCommandIntegrationTest.java
@@ -16,8 +16,6 @@
 package org.apache.geode.management.internal.cli.commands;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 
 import java.io.Serializable;
 import java.util.Formatter;
@@ -48,8 +46,7 @@ import org.apache.geode.test.junit.rules.ServerStarterRule;
 
 
 public class GetCommandIntegrationTest {
-
-  private static final Map<String, User> userDataStore = new HashMap<String, User>(5);
+  private static final Map<String, User> userDataStore = new HashMap<>(5);
 
   static {
     userDataStore.put("jackhandy", new User("jackhandy"));
@@ -69,7 +66,7 @@ public class GetCommandIntegrationTest {
   public static RuleChain chain = RuleChain.outerRule(server).around(gfsh);
 
   @BeforeClass
-  public static void beforeClass() throws Exception {
+  public static void beforeClass() {
     InternalCache cache = server.getCache();
 
     // Region containing POJOs
@@ -79,8 +76,8 @@ public class GetCommandIntegrationTest {
     Region<String, User> users = userRegionFactory.create("Users");
 
     users.put("jonbloom", new User("jonbloom"));
-    assertFalse(users.isEmpty());
-    assertEquals(1, users.size());
+    assertThat(users.isEmpty()).isFalse();
+    assertThat(users.size()).isEqualTo(1);
 
     // Region containing PdxInstances
     RegionFactory<String, PdxInstance> userPdxRegionFactory =
@@ -96,22 +93,22 @@ public class GetCommandIntegrationTest {
     Region<String, String> usersString = userStringRegionFactory.create("UsersString");
 
     usersString.put("jonbloom", "6a6f6e626c6f6f6d");
-    assertFalse(usersString.isEmpty());
-    assertEquals(1, usersString.size());
+    assertThat(usersString.isEmpty()).isFalse();
+    assertThat(usersString.size()).isEqualTo(1);
   }
 
   @Test
-  public void get() throws Exception {
+  public void get() {
     gfsh.executeAndAssertThat("get --region=Users --key=jonbloom").statusIsSuccess();
   }
 
   @Test
-  public void getWithSlashedRegionName() throws Exception {
+  public void getWithSlashedRegionName() {
     gfsh.executeAndAssertThat("get --region=/Users --key=jonbloom").statusIsSuccess();
   }
 
   @Test
-  public void getOnCacheMissForRegularRegion() throws Exception {
+  public void getOnCacheMissForRegularRegion() {
     CommandResult result = gfsh.executeCommand("get --region=Users --key=jonbloom");
     assertThat(result.getStatus()).isEqualTo(Result.Status.OK);
 
@@ -173,7 +170,7 @@ public class GetCommandIntegrationTest {
   }
 
   @Test
-  public void getOnCacheMissForStringRegion() throws Exception {
+  public void getOnCacheMissForStringRegion() {
     CommandResult result = gfsh.executeCommand("get --region=UsersString --key=jonbloom");
     assertThat(result.getStatus()).isEqualTo(Result.Status.OK);
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/GfshCommandIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/GfshCommandIntegrationTest.java
@@ -24,7 +24,7 @@ import org.apache.geode.test.junit.categories.GfshTest;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
 import org.apache.geode.test.junit.rules.LocatorStarterRule;
 
-@Category({GfshTest.class})
+@Category(GfshTest.class)
 public class GfshCommandIntegrationTest {
   @ClassRule
   public static LocatorStarterRule locator = new LocatorStarterRule().withAutoStart();
@@ -33,7 +33,7 @@ public class GfshCommandIntegrationTest {
   public GfshCommandRule gfsh = new GfshCommandRule();
 
   @Test
-  public void invalidCommandWhenNotConnected() throws Exception {
+  public void invalidCommandWhenNotConnected() {
     gfsh.executeAndAssertThat("abc").statusIsError().containsOutput("Command 'abc' not found");
   }
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/ImportDataIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/ImportDataIntegrationTest.java
@@ -17,7 +17,6 @@
 package org.apache.geode.management.internal.cli.commands;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -68,7 +67,7 @@ public class ImportDataIntegrationTest {
   }
 
   @Test
-  public void testExportImport() throws Exception {
+  public void testExportImport() {
     String exportCommand = buildBaseExportCommand()
         .addOption(CliStrings.EXPORT_DATA__FILE, snapshotFile.toString()).getCommandString();
     gfsh.executeAndAssertThat(exportCommand).statusIsSuccess();
@@ -99,7 +98,7 @@ public class ImportDataIntegrationTest {
   }
 
   @Test
-  public void testParallelExportImport() throws Exception {
+  public void testParallelExportImport() {
     String exportCommand =
         buildBaseExportCommand().addOption(CliStrings.EXPORT_DATA__DIR, snapshotDir.toString())
             .addOption(CliStrings.EXPORT_DATA__PARALLEL, "true").getCommandString();
@@ -117,7 +116,7 @@ public class ImportDataIntegrationTest {
   }
 
   @Test
-  public void testInvalidMember() throws Exception {
+  public void testInvalidMember() {
     String invalidMemberName = "invalidMember";
     String invalidMemberCommand = new CommandStringBuilder(CliStrings.EXPORT_DATA)
         .addOption(CliStrings.MEMBER, invalidMemberName)
@@ -129,7 +128,7 @@ public class ImportDataIntegrationTest {
   }
 
   @Test
-  public void testNonExistentRegion() throws Exception {
+  public void testNonExistentRegion() {
     String nonExistentRegionCommand = new CommandStringBuilder(CliStrings.EXPORT_DATA)
         .addOption(CliStrings.MEMBER, server.getName())
         .addOption(CliStrings.IMPORT_DATA__REGION, "/nonExistentRegion")
@@ -139,7 +138,7 @@ public class ImportDataIntegrationTest {
   }
 
   @Test
-  public void testInvalidFile() throws Exception {
+  public void testInvalidFile() {
     String invalidFileCommand = buildBaseImportCommand()
         .addOption(CliStrings.IMPORT_DATA__FILE, snapshotFile.toString() + ".invalid")
         .getCommandString();
@@ -149,14 +148,14 @@ public class ImportDataIntegrationTest {
   }
 
   @Test
-  public void testMissingFileAndDirectory() throws Exception {
+  public void testMissingFileAndDirectory() {
     String missingFileAndDirCommand = buildBaseImportCommand().getCommandString();
     gfsh.executeCommand(missingFileAndDirCommand);
     assertThat(gfsh.getGfshOutput()).contains("Must specify a location to load snapshot from");
   }
 
   @Test
-  public void testParallelWithOnlyFile() throws Exception {
+  public void testParallelWithOnlyFile() {
     String importCommand =
         buildBaseImportCommand().addOption(CliStrings.IMPORT_DATA__FILE, snapshotFile.toString())
             .addOption(CliStrings.IMPORT_DATA__PARALLEL, "true").getCommandString();
@@ -166,7 +165,7 @@ public class ImportDataIntegrationTest {
   }
 
   @Test
-  public void testSpecifyingDirectoryAndFileCommands() throws Exception {
+  public void testSpecifyingDirectoryAndFileCommands() {
     String importCommand =
         buildBaseImportCommand().addOption(CliStrings.IMPORT_DATA__FILE, snapshotFile.toString())
             .addOption(CliStrings.IMPORT_DATA__DIR, snapshotDir.toString()).getCommandString();
@@ -176,7 +175,8 @@ public class ImportDataIntegrationTest {
   }
 
   private void validateImport(String value) {
-    IntStream.range(0, DATA_POINTS).forEach(i -> assertEquals(value, region.get("key" + i)));
+    IntStream.range(0, DATA_POINTS)
+        .forEach(i -> assertThat(region.get("key" + i)).isEqualTo(value));
   }
 
   private void loadRegion(String value) {

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/ListDiskStoreCommandIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/ListDiskStoreCommandIntegrationTest.java
@@ -28,7 +28,7 @@ import org.apache.geode.test.junit.rules.GfshCommandRule;
 import org.apache.geode.test.junit.rules.GfshCommandRule.PortType;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({PersistenceTest.class})
+@Category(PersistenceTest.class)
 public class ListDiskStoreCommandIntegrationTest {
   private static final String REGION_NAME = "test-region";
   private static final String MEMBER_NAME = "testServer";
@@ -56,7 +56,7 @@ public class ListDiskStoreCommandIntegrationTest {
   }
 
   @Test
-  public void commandFailsWhenNotConnected() throws Exception {
+  public void commandFailsWhenNotConnected() {
     gfsh.executeAndAssertThat("list disk-stores").statusIsError().containsOutput("Command",
         "was found but is not currently available");
   }

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/ListRegionIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/ListRegionIntegrationTest.java
@@ -26,7 +26,7 @@ import org.apache.geode.test.junit.rules.GfshCommandRule;
 import org.apache.geode.test.junit.rules.GfshCommandRule.PortType;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({RegionsTest.class})
+@Category(RegionsTest.class)
 public class ListRegionIntegrationTest {
   private static String MEMBER_NAME = "test-server";
   private static String REGION_NAME = "test-region";
@@ -49,28 +49,28 @@ public class ListRegionIntegrationTest {
   }
 
   @Test
-  public void memberAndGroupAreMutuallyExclusive() throws Exception {
+  public void memberAndGroupAreMutuallyExclusive() {
     String cmd = "list regions --member=" + MEMBER_NAME + " --group=" + GROUP_NAME;
     gfsh.executeAndAssertThat(cmd).statusIsError()
         .containsOutput("Please provide either \"member\" or \"group\" option.");
   }
 
   @Test
-  public void commandWithNoOptionsSucceeds() throws Exception {
+  public void commandWithNoOptionsSucceeds() {
     String cmd = "list regions";
     gfsh.executeAndAssertThat(cmd).statusIsSuccess()
         .tableHasColumnWithValuesContaining(OUTPUT_HEADER, REGION_NAME);
   }
 
   @Test
-  public void commandWithMemberSucceeds() throws Exception {
+  public void commandWithMemberSucceeds() {
     String cmd = "list regions --member=" + MEMBER_NAME;
     gfsh.executeAndAssertThat(cmd).statusIsSuccess()
         .tableHasColumnWithValuesContaining(OUTPUT_HEADER, REGION_NAME);
   }
 
   @Test
-  public void commandWithGroupSucceeds() throws Exception {
+  public void commandWithGroupSucceeds() {
     String cmd = "list regions --group=" + GROUP_NAME;
     gfsh.executeAndAssertThat(cmd).statusIsSuccess()
         .tableHasColumnWithValuesContaining(OUTPUT_HEADER, REGION_NAME);

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/PutCommandIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/PutCommandIntegrationTest.java
@@ -39,8 +39,7 @@ import org.apache.geode.test.junit.categories.GfshTest;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-
-@Category({GfshTest.class})
+@Category(GfshTest.class)
 public class PutCommandIntegrationTest {
 
   private static ServerStarterRule server =
@@ -60,7 +59,7 @@ public class PutCommandIntegrationTest {
   }
 
   @Test
-  public void putWithoutSlash() throws Exception {
+  public void putWithoutSlash() {
     gfsh.executeAndAssertThat("put --region=testRegion --key=key1 --value=value1")
         .statusIsSuccess();
     assertThat(server.getCache().getRegion("testRegion").get("key1")).isEqualTo("value1");
@@ -68,14 +67,14 @@ public class PutCommandIntegrationTest {
 
 
   @Test
-  public void putWithSlash() throws Exception {
+  public void putWithSlash() {
     gfsh.executeAndAssertThat("put --region=/testRegion --key=key1 --value=value1")
         .statusIsSuccess().containsKeyValuePair("Result", "true");
     assertThat(server.getCache().getRegion("testRegion").get("key1")).isEqualTo("value1");
   }
 
   @Test
-  public void putIfNotExists() throws Exception {
+  public void putIfNotExists() {
     gfsh.executeAndAssertThat("put --region=/testRegion --key=key1 --value=value1")
         .statusIsSuccess().containsKeyValuePair("Result", "true");
     assertThat(server.getCache().getRegion("testRegion").get("key1")).isEqualTo("value1");
@@ -99,7 +98,7 @@ public class PutCommandIntegrationTest {
 
   @Test
   // Bug : 51587 : GFSH command failing when ; is present in either key or value in put operation
-  public void putWithSemicolon() throws Exception {
+  public void putWithSemicolon() {
     gfsh.executeAndAssertThat("put --region=/testRegion --key=key1;key1 --value=value1;value1")
         .statusIsSuccess().containsKeyValuePair("Result", "true");
     assertThat(server.getCache().getRegion("testRegion").get("key1;key1"))
@@ -107,7 +106,7 @@ public class PutCommandIntegrationTest {
   }
 
   @Test
-  public void putIfAbsent() throws Exception {
+  public void putIfAbsent() {
     // skip-if-exists is deprecated.
     gfsh.executeAndAssertThat("help put").statusIsSuccess()
         .containsOutput("(Deprecated: Use --if-not-exists).");
@@ -136,7 +135,7 @@ public class PutCommandIntegrationTest {
   }
 
   @Test
-  public void putWithSimpleJson() throws Exception {
+  public void putWithSimpleJson() {
     CommandResult result = gfsh.executeCommand(
         "put --region=testRegion --key=('key':'1') --value=('value':'1') " + "--key-class="
             + Key.class.getCanonicalName() + " --value-class=" + Value.class.getCanonicalName());
@@ -146,7 +145,7 @@ public class PutCommandIntegrationTest {
   }
 
   @Test
-  public void putWithCorrectJsonSyntax() throws Exception {
+  public void putWithCorrectJsonSyntax() {
     CommandResult result = gfsh.executeCommand(
         "put --region=testRegion --key={\"key\":\"1\"} --value={\"value\":\"1\"} " + "--key-class="
             + Key.class.getCanonicalName() + " --value-class=" + Value.class.getCanonicalName());
@@ -156,7 +155,7 @@ public class PutCommandIntegrationTest {
   }
 
   @Test
-  public void putWithInvalidJson() throws Exception {
+  public void putWithInvalidJson() {
     gfsh.executeAndAssertThat(
         "put --region=testRegion --key=('key':'1') --value=(value:2) " + "--key-class="
             + Key.class.getCanonicalName() + " --value-class=" + Value.class.getCanonicalName())
@@ -164,7 +163,7 @@ public class PutCommandIntegrationTest {
   }
 
   @Test
-  public void putWithComplicatedJson() throws Exception {
+  public void putWithComplicatedJson() {
     String keyJson = "('id':'1','name':'name1')";
     String stateJson =
         "('stateName':'State1','population':10,'capitalCity':'capital1','areaInSqKm':100)";

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/ShowMetricsCommandIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/ShowMetricsCommandIntegrationTest.java
@@ -36,7 +36,7 @@ import org.apache.geode.test.junit.rules.GfshCommandRule;
 import org.apache.geode.test.junit.rules.GfshCommandRule.PortType;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({GfshTest.class})
+@Category(GfshTest.class)
 public class ShowMetricsCommandIntegrationTest {
   private static final Logger logger = LogService.getLogger();
   private static final String REGION_NAME = "test-region";
@@ -51,7 +51,7 @@ public class ShowMetricsCommandIntegrationTest {
   public GfshCommandRule gfsh = new GfshCommandRule(server::getJmxPort, PortType.jmxManager);
 
   @Test
-  public void everyCategoryHasAUseCase() throws Exception {
+  public void everyCategoryHasAUseCase() {
     Set<ShowMetricsCommand.Category> categoriesUsed = new HashSet<>();
     categoriesUsed.addAll(ShowMetricsCommand.REGION_METRIC_CATEGORIES);
     categoriesUsed.addAll(ShowMetricsCommand.MEMBER_METRIC_CATEGORIES);
@@ -74,7 +74,7 @@ public class ShowMetricsCommandIntegrationTest {
   }
 
   @Test
-  public void getRegionMetricsShowsExactlyDefaultCategories() throws Exception {
+  public void getRegionMetricsShowsExactlyDefaultCategories() {
     // Use --region and --member to get RegionMetricsFromMember
     String cmd = "show metrics --region=/" + REGION_NAME + " --member=" + MEMBER_NAME;
     List<String> expectedCategories =
@@ -87,7 +87,7 @@ public class ShowMetricsCommandIntegrationTest {
   }
 
   @Test
-  public void getSystemRegionMetricsShowsExactlyDefaultCategories() throws Exception {
+  public void getSystemRegionMetricsShowsExactlyDefaultCategories() {
     // Use --region alone to get SystemRegionMetrics
     String cmd = "show metrics --region=/" + REGION_NAME;
     List<String> expectedCategories =
@@ -101,7 +101,7 @@ public class ShowMetricsCommandIntegrationTest {
   }
 
   @Test
-  public void getMemberMetricsShowsExactlyDefaultCategories() throws Exception {
+  public void getMemberMetricsShowsExactlyDefaultCategories() {
     // Use --member to get member metrics
     String cmd = "show metrics --member=" + MEMBER_NAME;
     List<String> expectedCategories =
@@ -115,7 +115,7 @@ public class ShowMetricsCommandIntegrationTest {
   }
 
   @Test
-  public void getMemberWithPortMetricsShowsExactlyDefaultCategories() throws Exception {
+  public void getMemberWithPortMetricsShowsExactlyDefaultCategories() {
     // Use --member and --port to get member metrics with port info
     String cmd = "show metrics --member=" + MEMBER_NAME + " --port=" + server.getPort();
     List<String> expectedCategories =
@@ -129,7 +129,7 @@ public class ShowMetricsCommandIntegrationTest {
   }
 
   @Test
-  public void getSystemMetricsShowsExactlyDefaultCategories() throws Exception {
+  public void getSystemMetricsShowsExactlyDefaultCategories() {
     // No specified options yield system-wide metrics
     String cmd = "show metrics";
     List<String> expectedCategories =
@@ -143,7 +143,7 @@ public class ShowMetricsCommandIntegrationTest {
   }
 
   @Test
-  public void invalidCategoryGetsReported() throws Exception {
+  public void invalidCategoryGetsReported() {
     String cmd =
         "show metrics --categories=\"cluster,cache,some_invalid_category,another_invalid_category\"";
 
@@ -153,7 +153,7 @@ public class ShowMetricsCommandIntegrationTest {
   }
 
   @Test
-  public void categoryOptionAbridgesOutput() throws Exception {
+  public void categoryOptionAbridgesOutput() {
     String cmd = "show metrics --categories=\"cluster,cache\"";
     List<String> expectedCategories = Arrays.asList("cluster", "cache", "");
     logger.info("Expecting categories: " + String.join(", ", expectedCategories));
@@ -163,7 +163,7 @@ public class ShowMetricsCommandIntegrationTest {
   }
 
   @Test
-  public void getRegionMetricsForPartitionedRegionWithStatistics() throws Exception {
+  public void getRegionMetricsForPartitionedRegionWithStatistics() {
     String cmd = "create region --name=region2 --type=PARTITION --enable-statistics";
     gfsh.executeAndAssertThat(cmd).statusIsSuccess();
     String cmd2 = "show metrics --member=" + MEMBER_NAME + " --region=region2";

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/VersionCommandJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/VersionCommandJUnitTest.java
@@ -38,7 +38,7 @@ import org.apache.geode.test.junit.categories.GfshTest;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
 import org.apache.geode.test.junit.rules.LocatorStarterRule;
 
-@Category({GfshTest.class})
+@Category(GfshTest.class)
 @RunWith(JUnitParamsRunner.class)
 public class VersionCommandJUnitTest {
   private static final String[] EXPECTED_FULL_DATA =

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/lifecycle/GfshStatusCommandsIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/lifecycle/GfshStatusCommandsIntegrationTest.java
@@ -45,31 +45,31 @@ public class GfshStatusCommandsIntegrationTest {
   }
 
   @Test
-  public void statusLocatorWithBadPortReportsNotResponding() throws Exception {
+  public void statusLocatorWithBadPortReportsNotResponding() {
     CommandResult result = gfsh.executeCommand("status locator --host=localhost --port="
         + String.valueOf(locator.getLocator().getPort() - 1));
     assertThat(result.getMessageFromContent()).contains("not responding");
   }
 
   @Test
-  public void statusLocatorWithActivePortReportsOnline() throws Exception {
+  public void statusLocatorWithActivePortReportsOnline() {
     CommandResult result = gfsh.executeCommand(
         "status locator --host=localhost --port=" + String.valueOf(locator.getLocator().getPort()));
     assertThat(result.getMessageFromContent()).contains("is currently online");
   }
 
   @Test
-  public void statusServerWithWithNoOptions() throws Exception {
+  public void statusServerWithWithNoOptions() {
     File serverDir = new File(temporaryFolder.getRoot(), "serverDir");
-    serverDir.mkdirs();
+    assertThat(serverDir.mkdirs()).isTrue();
     CommandResult result = gfsh.executeCommand("status server");
     assertThat(result.getMessageFromContent()).contains("not responding");
   }
 
   @Test
-  public void statusServerWithInvalidDirReturnsMeangingfulMessage() throws Exception {
+  public void statusServerWithInvalidDirReturnsMeangingfulMessage() {
     File serverDir = new File(temporaryFolder.getRoot(), "serverDir");
-    serverDir.mkdirs();
+    assertThat(serverDir.mkdirs()).isTrue();
     CommandResult result = gfsh.executeCommand("status server --dir=" + serverDir.toString());
     assertThat(result.getMessageFromContent()).contains("not responding");
   }

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/domain/IndexDetailsIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/domain/IndexDetailsIntegrationTest.java
@@ -35,7 +35,7 @@ public class IndexDetailsIntegrationTest {
   private static final String INDEX_REGION_NAME = "/REGION1";
   private static final String INDEX_1 = "INDEX1";
 
-  private Region region;
+  private Region<Integer, Stock> region;
 
   @Rule
   public ServerStarterRule serverRule =
@@ -66,7 +66,9 @@ public class IndexDetailsIntegrationTest {
     assertThat(details.getMemberName()).isEqualTo(member.getName());
     assertThat(details.getFromClause()).isEqualTo(INDEX_REGION_NAME);
     assertThat(details.getIndexedExpression()).isEqualTo("key");
-    assertThat(details.getIndexType()).isEqualTo(IndexType.FUNCTIONAL);
+    @SuppressWarnings("deprecation")
+    IndexType functionalIndexType = IndexType.FUNCTIONAL;
+    assertThat(details.getIndexType()).isEqualTo(functionalIndexType);
     assertThat(details.getProjectionAttributes()).isEqualTo("*");
     assertThat(details.getIsValid()).isEqualTo(true);
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/functions/DataCommandFunctionWithPDXJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/functions/DataCommandFunctionWithPDXJUnitTest.java
@@ -39,7 +39,7 @@ import org.apache.geode.pdx.PdxWriter;
 import org.apache.geode.test.junit.categories.GfshTest;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({GfshTest.class})
+@Category(GfshTest.class)
 public class DataCommandFunctionWithPDXJUnitTest {
   private static final String PARTITIONED_REGION = "part_region";
 
@@ -61,7 +61,7 @@ public class DataCommandFunctionWithPDXJUnitTest {
     dan = new CustomerWithPhone("3", "Dan", "Dickinson", "(333) 333-3333");
 
     cache = server.getCache();
-    Region region = cache.getRegion(PARTITIONED_REGION);
+    Region<Integer, Customer> region = cache.getRegion(PARTITIONED_REGION);
     region.put(0, alice);
     region.put(1, bob);
     region.put(2, charlie);

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/functions/ExportLogsFunctionIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/functions/ExportLogsFunctionIntegrationTest.java
@@ -18,6 +18,7 @@ package org.apache.geode.management.internal.cli.functions;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
+import java.nio.charset.Charset;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;
@@ -28,7 +29,7 @@ import org.junit.experimental.categories.Category;
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.execute.FunctionContext;
 import org.apache.geode.cache.execute.ResultSender;
-import org.apache.geode.internal.cache.GemFireCacheImpl;
+import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.execute.FunctionContextImpl;
 import org.apache.geode.test.junit.categories.GfshTest;
 import org.apache.geode.test.junit.categories.LoggingTest;
@@ -51,12 +52,14 @@ public class ExportLogsFunctionIntegrationTest {
   @Test
   public void exportLogsFunctionDoesNotBlowUp() throws Throwable {
     File logFile1 = new File(serverWorkingDir, "server1.log");
-    FileUtils.writeStringToFile(logFile1, "some log for server1 \n some other log line");
+    FileUtils.writeStringToFile(logFile1, "some log for server1 \n some other log line",
+        Charset.defaultCharset());
     File logFile2 = new File(serverWorkingDir, "server2.log");
-    FileUtils.writeStringToFile(logFile2, "some log for server2 \n some other log line");
+    FileUtils.writeStringToFile(logFile2, "some log for server2 \n some other log line",
+        Charset.defaultCharset());
 
     File notALogFile = new File(serverWorkingDir, "foo.txt");
-    FileUtils.writeStringToFile(notALogFile, "some text");
+    FileUtils.writeStringToFile(notALogFile, "some text", Charset.defaultCharset());
 
     verifyExportLogsFunctionDoesNotBlowUp(serverStarterRule.getCache());
 
@@ -66,14 +69,14 @@ public class ExportLogsFunctionIntegrationTest {
 
   @Test
   public void createOrGetExistingExportLogsRegionDoesNotBlowUp() throws Exception {
-    GemFireCacheImpl cache = GemFireCacheImpl.getInstance();
+    InternalCache cache = serverStarterRule.getCache();
     ExportLogsFunction.createOrGetExistingExportLogsRegion(false, cache);
     assertThat(cache.getRegion(ExportLogsFunction.EXPORT_LOGS_REGION)).isNotNull();
   }
 
   @Test
   public void destroyExportLogsRegionWorksAsExpectedForInitiatingMember() throws Exception {
-    GemFireCacheImpl cache = GemFireCacheImpl.getInstance();
+    InternalCache cache = serverStarterRule.getCache();
     ExportLogsFunction.createOrGetExistingExportLogsRegion(true, cache);
     assertThat(cache.getRegion(ExportLogsFunction.EXPORT_LOGS_REGION)).isNotNull();
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/shell/GfshMultilineCommandTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/shell/GfshMultilineCommandTest.java
@@ -29,7 +29,7 @@ import org.apache.geode.test.junit.rules.GfshCommandRule;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
 
-@Category({GfshTest.class})
+@Category(GfshTest.class)
 public class GfshMultilineCommandTest {
 
   @Rule
@@ -53,5 +53,4 @@ public class GfshMultilineCommandTest {
     gfsh.executeAndAssertThat(csb.getCommandString()).statusIsSuccess();
     assertThat(gfsh.getGfshOutput().trim()).isEqualTo(NO_MEMBERS_FOUND_MESSAGE);
   }
-
 }

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/util/LogExporterIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/util/LogExporterIntegrationTest.java
@@ -48,11 +48,9 @@ import org.apache.geode.test.junit.rules.ServerStarterRule;
 
 @Category({GfshTest.class, LoggingTest.class})
 public class LogExporterIntegrationTest {
-
-  private final LogFilter filter = new LogFilter(Level.INFO, null, null);
-
-  private LogExporter logExporter;
   private Properties properties;
+  private LogExporter logExporter;
+  private final LogFilter filter = new LogFilter(Level.INFO, null, null);
 
   @Rule
   public ServerStarterRule server = new ServerStarterRule().withWorkingDir();

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/security/AccessControlMBeanJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/security/AccessControlMBeanJUnitTest.java
@@ -29,7 +29,7 @@ import org.apache.geode.test.junit.rules.ConnectionConfiguration;
 import org.apache.geode.test.junit.rules.MBeanServerConnectionRule;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({SecurityTest.class})
+@Category(SecurityTest.class)
 public class AccessControlMBeanJUnitTest {
 
   private AccessControlMXBean bean;
@@ -55,7 +55,7 @@ public class AccessControlMBeanJUnitTest {
    */
   @Test
   @ConnectionConfiguration(user = "stranger", password = "1234567")
-  public void testAnyAccess() throws Exception {
+  public void testAnyAccess() {
     assertThat(bean.authorize("DATA", "READ")).isEqualTo(false);
     assertThat(bean.authorize("CLUSTER", "READ")).isEqualTo(false);
   }

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/security/CacheServerMBeanAuthenticationJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/security/CacheServerMBeanAuthenticationJUnitTest.java
@@ -44,6 +44,7 @@ public class CacheServerMBeanAuthenticationJUnitTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   @ConnectionConfiguration(user = "data,cluster", password = "data,cluster")
   public void testAllAccess() throws Exception {
     bean.removeIndex("foo");

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/security/CacheServerMBeanAuthorizationJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/security/CacheServerMBeanAuthorizationJUnitTest.java
@@ -31,7 +31,7 @@ import org.apache.geode.test.junit.rules.ConnectionConfiguration;
 import org.apache.geode.test.junit.rules.MBeanServerConnectionRule;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({SecurityTest.class})
+@Category(SecurityTest.class)
 public class CacheServerMBeanAuthorizationJUnitTest {
   private CacheServerMXBean bean;
 
@@ -52,6 +52,7 @@ public class CacheServerMBeanAuthorizationJUnitTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   @ConnectionConfiguration(user = "data-admin", password = "1234567")
   public void testDataAdmin() throws Exception {
     bean.removeIndex("foo");
@@ -68,8 +69,9 @@ public class CacheServerMBeanAuthorizationJUnitTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   @ConnectionConfiguration(user = "cluster-admin", password = "1234567")
-  public void testClusterAdmin() throws Exception {
+  public void testClusterAdmin() {
     assertThatThrownBy(() -> bean.removeIndex("foo"))
         .hasMessageContaining(ResourcePermissions.DATA_MANAGE.toString());
     assertThatThrownBy(() -> bean.executeContinuousQuery("bar"))
@@ -79,6 +81,7 @@ public class CacheServerMBeanAuthorizationJUnitTest {
 
 
   @Test
+  @SuppressWarnings("deprecation")
   @ConnectionConfiguration(user = "data-user", password = "1234567")
   public void testDataUser() throws Exception {
     assertThatThrownBy(() -> bean.removeIndex("foo"))
@@ -89,8 +92,9 @@ public class CacheServerMBeanAuthorizationJUnitTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   @ConnectionConfiguration(user = "stranger", password = "1234567")
-  public void testNoAccess() throws Exception {
+  public void testNoAccess() {
     SoftAssertions softly = new SoftAssertions();
 
     softly.assertThatThrownBy(() -> bean.removeIndex("foo"))

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/security/CacheServerMBeanWithShiroIniIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/security/CacheServerMBeanWithShiroIniIntegrationTest.java
@@ -29,7 +29,7 @@ import org.apache.geode.test.junit.rules.ConnectionConfiguration;
 import org.apache.geode.test.junit.rules.MBeanServerConnectionRule;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({SecurityTest.class})
+@Category(SecurityTest.class)
 public class CacheServerMBeanWithShiroIniIntegrationTest {
   private CacheServerMXBean bean;
 
@@ -47,6 +47,7 @@ public class CacheServerMBeanWithShiroIniIntegrationTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   @ConnectionConfiguration(user = "root", password = "secret")
   public void testAllAccess() throws Exception {
     bean.removeIndex("foo");
@@ -60,8 +61,9 @@ public class CacheServerMBeanWithShiroIniIntegrationTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   @ConnectionConfiguration(user = "guest", password = "guest")
-  public void testNoAccess() throws Exception {
+  public void testNoAccess() {
     assertThatThrownBy(() -> bean.removeIndex("foo"))
         .hasMessageContaining(ResourcePermissions.DATA_MANAGE.toString());
     assertThatThrownBy(() -> bean.executeContinuousQuery("bar"))
@@ -81,20 +83,21 @@ public class CacheServerMBeanWithShiroIniIntegrationTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   @ConnectionConfiguration(user = "regionAReader", password = "password")
-  public void testRegionAccess() throws Exception {
+  public void testRegionAccess() {
     assertThatThrownBy(() -> bean.removeIndex("foo"))
         .hasMessageContaining(ResourcePermissions.DATA_MANAGE.toString());
     assertThatThrownBy(() -> bean.fetchLoadProbe())
         .hasMessageContaining(ResourcePermissions.CLUSTER_READ.toString());
     assertThatThrownBy(() -> bean.getActiveCQCount())
         .hasMessageContaining(ResourcePermissions.CLUSTER_READ.toString());
-
     assertThatThrownBy(() -> bean.executeContinuousQuery("bar"))
         .hasMessageContaining(ResourcePermissions.DATA_READ.toString());
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   @ConnectionConfiguration(user = "dataReader", password = "12345")
   public void testDataRead() throws Exception {
     assertThatThrownBy(() -> bean.removeIndex("foo"))

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/security/CliCommandsSecurityTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/security/CliCommandsSecurityTest.java
@@ -34,7 +34,7 @@ import org.apache.geode.test.junit.rules.ConnectionConfiguration;
 import org.apache.geode.test.junit.rules.MBeanServerConnectionRule;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({SecurityTest.class})
+@Category(SecurityTest.class)
 public class CliCommandsSecurityTest {
   private MemberMXBean bean;
 
@@ -79,7 +79,7 @@ public class CliCommandsSecurityTest {
 
   @Test
   @ConnectionConfiguration(user = "super-user", password = "1234567")
-  public void testAdminUser() throws Exception {
+  public void testAdminUser() {
     for (TestCommand command : commands) {
       LogService.getLogger().info("processing: " + command.getCommand());
       bean.processCommand(command.getCommand());

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/security/DataCommandsSecurityTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/security/DataCommandsSecurityTest.java
@@ -33,7 +33,7 @@ import org.apache.geode.test.junit.rules.ConnectionConfiguration;
 import org.apache.geode.test.junit.rules.MBeanServerConnectionRule;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({SecurityTest.class})
+@Category(SecurityTest.class)
 public class DataCommandsSecurityTest {
   private MemberMXBean bean;
 
@@ -45,7 +45,7 @@ public class DataCommandsSecurityTest {
       .withAutoStart();
 
   @BeforeClass
-  public static void beforeClass() throws Exception {
+  public static void beforeClass() {
     Cache cache = server.getCache();
     cache.createRegionFactory().create("region1");
     cache.createRegionFactory().create("region2");
@@ -63,7 +63,7 @@ public class DataCommandsSecurityTest {
 
   @Test
   @ConnectionConfiguration(user = "region1-user", password = "1234567")
-  public void testDataUser() throws Exception {
+  public void testDataUser() {
     bean.processCommand("locate entry --key=k1 --region=region1");
 
     // can't operate on secureRegion
@@ -100,5 +100,4 @@ public class DataCommandsSecurityTest {
     assertThatThrownBy(() -> bean.processCommand("get --key=key1 --region=region2"))
         .isInstanceOf(GemFireSecurityException.class).hasMessageContaining("DATA:READ:region2");
   }
-
 }

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/security/DeployCommandsSecurityTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/security/DeployCommandsSecurityTest.java
@@ -35,7 +35,7 @@ import org.apache.geode.test.junit.rules.ConnectionConfiguration;
 import org.apache.geode.test.junit.rules.MBeanServerConnectionRule;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({SecurityTest.class})
+@Category(SecurityTest.class)
 public class DeployCommandsSecurityTest {
 
   private MemberMXBean bean;
@@ -47,11 +47,10 @@ public class DeployCommandsSecurityTest {
   @ClassRule
   public static TemporaryFolder temporaryFolder = new TemporaryFolder();
   private static String deployCommand = null;
-  private static String zipFileName = "functions.jar";
 
   @BeforeClass
   public static void beforeClass() throws Exception {
-    File zipFile = temporaryFolder.newFile(zipFileName);
+    File zipFile = temporaryFolder.newFile("functions.jar");
     deployCommand = "deploy --jar=" + zipFile.getAbsolutePath();
   }
 
@@ -63,7 +62,6 @@ public class DeployCommandsSecurityTest {
   public void setUp() throws Exception {
     bean = connectionRule.getProxyMXBean(MemberMXBean.class);
   }
-
 
   @Test // regular user can't deploy
   @ConnectionConfiguration(user = "user", password = "user")

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/security/DiskStoreMXBeanSecurityJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/security/DiskStoreMXBeanSecurityJUnitTest.java
@@ -30,7 +30,7 @@ import org.apache.geode.test.junit.rules.ConnectionConfiguration;
 import org.apache.geode.test.junit.rules.MBeanServerConnectionRule;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({SecurityTest.class})
+@Category(SecurityTest.class)
 public class DiskStoreMXBeanSecurityJUnitTest {
   private DiskStoreMXBean bean;
 
@@ -51,7 +51,7 @@ public class DiskStoreMXBeanSecurityJUnitTest {
 
   @Test
   @ConnectionConfiguration(user = "clusterRead", password = "clusterRead")
-  public void testClusterReadAccess() throws Exception {
+  public void testClusterReadAccess() {
     assertThatThrownBy(() -> bean.flush()).hasMessageContaining(TestCommand.diskManage.toString());
     assertThatThrownBy(() -> bean.forceCompaction())
         .hasMessageContaining(TestCommand.diskManage.toString());
@@ -71,7 +71,7 @@ public class DiskStoreMXBeanSecurityJUnitTest {
 
   @Test
   @ConnectionConfiguration(user = "clusterManageDisk", password = "clusterManageDisk")
-  public void testDiskManageAccess() throws Exception {
+  public void testDiskManageAccess() {
     assertThatThrownBy(() -> bean.getCompactionThreshold())
         .hasMessageContaining(ResourcePermissions.CLUSTER_READ.toString());
     assertThatThrownBy(() -> bean.getDiskDirectories())
@@ -92,7 +92,7 @@ public class DiskStoreMXBeanSecurityJUnitTest {
 
   @Test
   @ConnectionConfiguration(user = "data,cluster", password = "data,cluster")
-  public void testAllAccess() throws Exception {
+  public void testAllAccess() {
     bean.flush();
     bean.forceCompaction();
     bean.forceRoll();
@@ -107,7 +107,7 @@ public class DiskStoreMXBeanSecurityJUnitTest {
 
   @Test
   @ConnectionConfiguration(user = "noAccess", password = "noAccess")
-  public void testNoAccess() throws Exception {
+  public void testNoAccess() {
     SoftAssertions softly = new SoftAssertions();
 
     softly.assertThatThrownBy(() -> bean.flush())

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/security/FileUploaderMBeanSecurityTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/security/FileUploaderMBeanSecurityTest.java
@@ -33,7 +33,7 @@ import org.apache.geode.test.junit.rules.ConnectionConfiguration;
 import org.apache.geode.test.junit.rules.MBeanServerConnectionRule;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({SecurityTest.class})
+@Category(SecurityTest.class)
 public class FileUploaderMBeanSecurityTest {
 
   private FileUploaderMBean bean;
@@ -54,13 +54,13 @@ public class FileUploaderMBeanSecurityTest {
 
   @Test
   @ConnectionConfiguration(user = "clusterManageDeploy", password = "clusterManageDeploy")
-  public void testClusterManageDeployAccess() throws Exception {
+  public void testClusterManageDeployAccess() {
     assertThatThrownBy(() -> bean.uploadFile(null)).isNotInstanceOf(NotAuthorizedException.class);
   }
 
   @Test
   @ConnectionConfiguration(user = "clusterManage", password = "clusterManage")
-  public void testClusterManageAccess() throws Exception {
+  public void testClusterManageAccess() {
     assertThatThrownBy(() -> bean.uploadFile(null)).isNotInstanceOf(NotAuthorizedException.class);
   }
 }

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/security/GatewayReceiverMBeanSecurityTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/security/GatewayReceiverMBeanSecurityTest.java
@@ -36,9 +36,8 @@ import org.apache.geode.test.junit.rules.ConnectionConfiguration;
 import org.apache.geode.test.junit.rules.MBeanServerConnectionRule;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({SecurityTest.class})
+@Category(SecurityTest.class)
 public class GatewayReceiverMBeanSecurityTest {
-
   private static GatewayReceiverMXBean mock = mock(GatewayReceiverMXBean.class);
   private static ObjectName mockBeanName = null;
   private static ManagementService service = null;
@@ -85,7 +84,7 @@ public class GatewayReceiverMBeanSecurityTest {
 
   @Test
   @ConnectionConfiguration(user = "user", password = "user")
-  public void testNoAccess() throws Exception {
+  public void testNoAccess() {
     SoftAssertions softly = new SoftAssertions();
     softly.assertThatThrownBy(() -> bean.getTotalConnectionsTimedOut())
         .hasMessageContaining(ResourcePermissions.CLUSTER_READ.toString());
@@ -95,5 +94,4 @@ public class GatewayReceiverMBeanSecurityTest {
         .hasMessageContaining(TestCommand.clusterManageGateway.toString());
     softly.assertAll();
   }
-
 }

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/security/GatewaySenderMBeanSecurityTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/security/GatewaySenderMBeanSecurityTest.java
@@ -37,7 +37,7 @@ import org.apache.geode.test.junit.rules.ConnectionConfiguration;
 import org.apache.geode.test.junit.rules.MBeanServerConnectionRule;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({SecurityTest.class})
+@Category(SecurityTest.class)
 public class GatewaySenderMBeanSecurityTest {
   private static GatewaySenderMBean mock = mock(GatewaySenderMBean.class);
   private static ObjectName mockBeanName = null;
@@ -74,7 +74,7 @@ public class GatewaySenderMBeanSecurityTest {
 
   @Test
   @ConnectionConfiguration(user = "data,cluster", password = "data,cluster")
-  public void testAllAccess() throws Exception {
+  public void testAllAccess() {
     bean.getAlertThreshold();
     bean.getAverageDistributionTimePerBatch();
     bean.getBatchSize();
@@ -91,7 +91,7 @@ public class GatewaySenderMBeanSecurityTest {
 
   @Test
   @ConnectionConfiguration(user = "stranger", password = "stranger")
-  public void testNoAccess() throws Exception {
+  public void testNoAccess() {
     SoftAssertions softly = new SoftAssertions();
 
     softly.assertThatThrownBy(() -> bean.getAlertThreshold())
@@ -121,5 +121,4 @@ public class GatewaySenderMBeanSecurityTest {
 
     softly.assertAll();
   }
-
 }

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/security/GfshCommandsPostProcessorTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/security/GfshCommandsPostProcessorTest.java
@@ -31,7 +31,7 @@ import org.apache.geode.test.junit.rules.ConnectionConfiguration;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({SecurityTest.class})
+@Category(SecurityTest.class)
 public class GfshCommandsPostProcessorTest {
 
   @ClassRule
@@ -44,13 +44,13 @@ public class GfshCommandsPostProcessorTest {
       new GfshCommandRule(serverStarter::getJmxPort, GfshCommandRule.PortType.jmxManager);
 
   @BeforeClass
-  public static void beforeClass() throws Exception {
+  public static void beforeClass() {
     serverStarter.getCache().createRegionFactory(RegionShortcut.REPLICATE).create("region1");
   }
 
   @Test
   @ConnectionConfiguration(user = "dataWrite,dataRead", password = "dataWrite,dataRead")
-  public void testGetPostProcess() throws Exception {
+  public void testGetPostProcess() {
     gfshConnection.executeCommand("put --region=region1 --key=key1 --value=value1");
     gfshConnection.executeCommand("put --region=region1 --key=key2 --value=value2");
     gfshConnection.executeCommand("put --region=region1 --key=key3 --value=value3");

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/security/JavaRmiServerNameTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/security/JavaRmiServerNameTest.java
@@ -16,7 +16,7 @@
 
 package org.apache.geode.management.internal.security;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.After;
 import org.junit.ClassRule;
@@ -37,12 +37,11 @@ public class JavaRmiServerNameTest {
    */
   @Test
   public void testThatJavaRmiServerNameGetsSet() {
-    assertEquals(JMX_HOST, System.getProperty("java.rmi.server.hostname"));
+    assertThat(System.getProperty("java.rmi.server.hostname")).isEqualTo(JMX_HOST);
   }
 
   @After
   public void after() {
     System.setProperty("java.rmi.server.hostname", "");
   }
-
 }

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/security/JmxPasswordFileTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/security/JmxPasswordFileTest.java
@@ -43,9 +43,8 @@ public class JmxPasswordFileTest {
   public void connectWhenJmxManagerSecuredWithPasswordFile() throws Exception {
     File passwordFile = temporaryFolder.newFile("password.properties");
     FileUtils.writeLines(passwordFile, Collections.singleton("user user"));
-    locator.withProperty("jmx-manager-password-file", passwordFile.getAbsolutePath());
-
-    locator.startLocator();
+    locator.withProperty("jmx-manager-password-file", passwordFile.getAbsolutePath())
+        .startLocator();
 
     gfsh.secureConnectAndVerify(locator.getJmxPort(), jmxManager, "user", "user");
   }

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/security/LockServiceMBeanAuthorizationJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/security/LockServiceMBeanAuthorizationJUnitTest.java
@@ -35,7 +35,7 @@ import org.apache.geode.test.junit.rules.ConnectionConfiguration;
 import org.apache.geode.test.junit.rules.MBeanServerConnectionRule;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({SecurityTest.class})
+@Category(SecurityTest.class)
 public class LockServiceMBeanAuthorizationJUnitTest {
   private LockServiceMXBean lockServiceMBean;
 
@@ -67,7 +67,7 @@ public class LockServiceMBeanAuthorizationJUnitTest {
   @Test
   @ConnectionConfiguration(user = "clusterRead,clusterManage",
       password = "clusterRead,clusterManage")
-  public void testAllAccess() throws Exception {
+  public void testAllAccess() {
     lockServiceMBean.becomeLockGrantor();
     lockServiceMBean.fetchGrantorMember();
     lockServiceMBean.getMemberCount();
@@ -77,7 +77,7 @@ public class LockServiceMBeanAuthorizationJUnitTest {
 
   @Test
   @ConnectionConfiguration(user = "clusterManage", password = "clusterManage")
-  public void testClusterManage() throws Exception {
+  public void testClusterManage() {
     SoftAssertions softly = new SoftAssertions();
     lockServiceMBean.becomeLockGrantor(); // c:m
     softly.assertThatThrownBy(() -> lockServiceMBean.fetchGrantorMember())
@@ -93,7 +93,7 @@ public class LockServiceMBeanAuthorizationJUnitTest {
 
   @Test
   @ConnectionConfiguration(user = "clusterRead", password = "clusterRead")
-  public void testClusterRead() throws Exception {
+  public void testClusterRead() {
     SoftAssertions softly = new SoftAssertions();
     softly.assertThatThrownBy(() -> lockServiceMBean.becomeLockGrantor())
         .hasMessageContaining(ResourcePermissions.CLUSTER_MANAGE.toString());
@@ -106,7 +106,7 @@ public class LockServiceMBeanAuthorizationJUnitTest {
 
   @Test
   @ConnectionConfiguration(user = "user", password = "user")
-  public void testNoAccess() throws Exception {
+  public void testNoAccess() {
     SoftAssertions softly = new SoftAssertions();
 
     softly.assertThatThrownBy(() -> lockServiceMBean.becomeLockGrantor())

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/security/MBeanSecurityJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/security/MBeanSecurityJUnitTest.java
@@ -45,7 +45,7 @@ import org.apache.geode.test.junit.rules.ConnectionConfiguration;
 import org.apache.geode.test.junit.rules.MBeanServerConnectionRule;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({SecurityTest.class})
+@Category(SecurityTest.class)
 public class MBeanSecurityJUnitTest {
 
   @ClassRule
@@ -100,7 +100,7 @@ public class MBeanSecurityJUnitTest {
    * throwing the SecurityExceptions
    */
   @Test
-  public void testLocalCalls() throws Exception {
+  public void testLocalCalls() {
     MBeanServer server = MBeanJMXAdapter.mbeanServer;
     assertThatThrownBy(
         () -> server.createMBean("FakeClassName", new ObjectName("GemFire", "name", "foo")))

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/security/ManagerMBeanAuthorizationJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/security/ManagerMBeanAuthorizationJUnitTest.java
@@ -37,7 +37,7 @@ import org.apache.geode.test.junit.rules.ConnectionConfiguration;
 import org.apache.geode.test.junit.rules.MBeanServerConnectionRule;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({SecurityTest.class})
+@Category(SecurityTest.class)
 public class ManagerMBeanAuthorizationJUnitTest {
   private ManagerMXBean managerMXBean;
 
@@ -76,7 +76,7 @@ public class ManagerMBeanAuthorizationJUnitTest {
 
   @Test
   @ConnectionConfiguration(user = "data-admin", password = "1234567")
-  public void testSomeAccess() throws Exception {
+  public void testSomeAccess() {
     SoftAssertions softly = new SoftAssertions();
 
     softly.assertThatThrownBy(() -> managerMXBean.start())

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/security/MemberMBeanSecurityJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/security/MemberMBeanSecurityJUnitTest.java
@@ -31,7 +31,7 @@ import org.apache.geode.test.junit.rules.ConnectionConfiguration;
 import org.apache.geode.test.junit.rules.MBeanServerConnectionRule;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({SecurityTest.class})
+@Category(SecurityTest.class)
 public class MemberMBeanSecurityJUnitTest {
 
   private MemberMXBean bean;
@@ -57,7 +57,7 @@ public class MemberMBeanSecurityJUnitTest {
 
   @Test
   @ConnectionConfiguration(user = "super-user", password = "1234567")
-  public void testAllAccess() throws Exception {
+  public void testAllAccess() {
     bean.shutDownMember();
     bean.compactAllDiskStores();
     bean.createManager();
@@ -74,7 +74,7 @@ public class MemberMBeanSecurityJUnitTest {
 
   @Test
   @ConnectionConfiguration(user = "cluster-admin", password = "1234567")
-  public void testClusterAdmin() throws Exception {
+  public void testClusterAdmin() {
     bean.compactAllDiskStores();
     bean.shutDownMember();
     bean.createManager();
@@ -91,7 +91,7 @@ public class MemberMBeanSecurityJUnitTest {
 
   @Test
   @ConnectionConfiguration(user = "data-admin", password = "1234567")
-  public void testDataAdmin() throws Exception {
+  public void testDataAdmin() {
     assertThatThrownBy(() -> bean.compactAllDiskStores())
         .hasMessageContaining(TestCommand.clusterManageDisk.toString());
     assertThatThrownBy(() -> bean.shutDownMember())
@@ -104,7 +104,7 @@ public class MemberMBeanSecurityJUnitTest {
 
   @Test
   @ConnectionConfiguration(user = "data-user", password = "1234567")
-  public void testDataUser() throws Exception {
+  public void testDataUser() {
     SoftAssertions softly = new SoftAssertions();
 
     softly.assertThatThrownBy(() -> bean.shutDownMember())

--- a/geode-core/src/main/java/org/apache/geode/distributed/AbstractLauncher.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/AbstractLauncher.java
@@ -254,7 +254,7 @@ public abstract class AbstractLauncher<T extends Comparable<T>> implements Runna
    *
    * @return a File reference to the path of the log file for the process.
    */
-  protected File getLogFile() {
+  public File getLogFile() {
     return new File(getWorkingDirectory(), getLogFileName());
   }
 
@@ -265,7 +265,8 @@ public abstract class AbstractLauncher<T extends Comparable<T>> implements Runna
    */
   protected String getLogFileCanonicalPath() {
     try {
-      return getLogFile().getCanonicalPath();
+      File logFile = getLogFile();
+      return logFile != null ? logFile.getCanonicalPath() : "";
     } catch (IOException handled) {
       return getLogFileName();
     }

--- a/geode-core/src/main/java/org/apache/geode/distributed/LocatorLauncher.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/LocatorLauncher.java
@@ -1097,11 +1097,11 @@ public class LocatorLauncher extends AbstractLauncher<String> {
     return new LocatorState(this, Status.NOT_RESPONDING, errorMessage);
   }
 
-  private Properties getOverriddenDefaults() throws IOException {
+  private Properties getOverriddenDefaults() {
     Properties overriddenDefaults = new Properties();
 
     overriddenDefaults.put(ProcessLauncherContext.OVERRIDDEN_DEFAULTS_PREFIX.concat(LOG_FILE),
-        getLogFile().getCanonicalPath());
+        getLogFileCanonicalPath());
 
     for (String key : System.getProperties().stringPropertyNames()) {
       if (key.startsWith(ProcessLauncherContext.OVERRIDDEN_DEFAULTS_PREFIX)) {

--- a/geode-core/src/main/java/org/apache/geode/distributed/ServerLauncher.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/ServerLauncher.java
@@ -337,7 +337,7 @@ public class ServerLauncher extends AbstractLauncher<String> {
    * @return a reference to the Cache created by the GemFire Server start operation.
    * @see org.apache.geode.cache.Cache
    */
-  Cache getCache() {
+  public Cache getCache() {
     if (this.cache != null) {
       boolean isReconnecting = this.cache.isReconnecting();
       if (isReconnecting) {
@@ -1282,11 +1282,11 @@ public class ServerLauncher extends AbstractLauncher<String> {
     return new ServerState(this, Status.NOT_RESPONDING, errorMessage);
   }
 
-  private Properties getOverriddenDefaults() throws IOException {
+  private Properties getOverriddenDefaults() {
     final Properties overriddenDefaults = new Properties();
 
     overriddenDefaults.put(ProcessLauncherContext.OVERRIDDEN_DEFAULTS_PREFIX.concat(LOG_FILE),
-        getLogFile().getCanonicalPath());
+        getLogFileCanonicalPath());
 
     for (String key : System.getProperties().stringPropertyNames()) {
       if (key.startsWith(ProcessLauncherContext.OVERRIDDEN_DEFAULTS_PREFIX)) {

--- a/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/CqSecurityAuthorizedUserDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/CqSecurityAuthorizedUserDUnitTest.java
@@ -14,9 +14,8 @@
  */
 package org.apache.geode.cache.query.cq.dunit;
 
-import static org.apache.geode.internal.Assert.assertTrue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.concurrent.TimeUnit;
 
@@ -39,7 +38,7 @@ import org.apache.geode.security.query.data.QueryTestObject;
 import org.apache.geode.test.junit.categories.SecurityTest;
 import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactory;
 
-@Category({SecurityTest.class})
+@Category(SecurityTest.class)
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
 public class CqSecurityAuthorizedUserDUnitTest extends QuerySecurityBase {
@@ -68,8 +67,7 @@ public class CqSecurityAuthorizedUserDUnitTest extends QuerySecurityBase {
   private String regexForExpectedExceptions = ".*Unauthorized access.*";
 
   @Test
-  public void cqExecuteNoMethodInvocationWithUsersWithCqPermissionsWithPrepopulatedRegionShouldBeAllowed()
-      throws Exception {
+  public void cqExecuteNoMethodInvocationWithUsersWithCqPermissionsWithPrepopulatedRegionShouldBeAllowed() {
     putIntoRegion(superUserClient, keys, values, regionName);
     String query = "select * from /" + regionName + " r where r.id = 0";
     specificUserClient.invoke(() -> {
@@ -83,10 +81,8 @@ public class CqSecurityAuthorizedUserDUnitTest extends QuerySecurityBase {
     putIntoRegion(superUserClient, keys, new Object[] {new QueryTestObject(0, "Bethany")},
         regionName);
 
-    specificUserClient.invoke(() -> {
-      Awaitility.await().atMost(30, TimeUnit.SECONDS)
-          .untilAsserted(() -> assertEquals(1, cqListener.getNumEvent()));
-    });
+    specificUserClient.invoke(() -> Awaitility.await().atMost(30, TimeUnit.SECONDS)
+        .untilAsserted(() -> assertThat(cqListener.getNumEvent()).isEqualTo(1)));
   }
 
   @Test
@@ -104,8 +100,7 @@ public class CqSecurityAuthorizedUserDUnitTest extends QuerySecurityBase {
   }
 
   @Test
-  public void cqExecuteWithInitialResultsWithMethodInvocationWithUsersWithCqPermissionsWithPrepopulatedRegionShouldBeDeniedBecauseOfInvocation()
-      throws Exception {
+  public void cqExecuteWithInitialResultsWithMethodInvocationWithUsersWithCqPermissionsWithPrepopulatedRegionShouldBeDeniedBecauseOfInvocation() {
     putIntoRegion(superUserClient, keys, values, regionName);
     String query = "select * from /" + regionName + " r where r.name = 'Beth'";
 
@@ -120,8 +115,7 @@ public class CqSecurityAuthorizedUserDUnitTest extends QuerySecurityBase {
 
 
   @Test
-  public void cqExecuteWithInitialResultsWithMethodInvocationWithUnpopulatedRegionAndFollowedByAPutShouldTriggerCqError()
-      throws Exception {
+  public void cqExecuteWithInitialResultsWithMethodInvocationWithUnpopulatedRegionAndFollowedByAPutShouldTriggerCqError() {
     String query = "select * from /" + regionName + " r where r.name = 'Beth'";
 
     specificUserClient.invoke(() -> {
@@ -136,16 +130,13 @@ public class CqSecurityAuthorizedUserDUnitTest extends QuerySecurityBase {
     Object[] values = {new QueryTestObject(1, "Mary")};
     putIntoRegion(superUserClient, keys, values, regionName);
 
-    specificUserClient.invoke(() -> {
-      Awaitility.await().atMost(30, TimeUnit.SECONDS)
-          .untilAsserted(() -> assertEquals(1, cqListener.getNumErrors()));
-    });
+    specificUserClient.invoke(() -> Awaitility.await().atMost(30, TimeUnit.SECONDS)
+        .untilAsserted(() -> assertThat(cqListener.getNumErrors()).isEqualTo(1)));
   }
 
   @Test
-  public void cqExecuteWithMethodInvocationWithUnpopulatedRegionAndFollowedByAPutShouldTriggerCqError()
-      throws Exception {
-    String query = "select * from /" + regionName + " r where r.name = 'Beth'";;
+  public void cqExecuteWithMethodInvocationWithUnpopulatedRegionAndFollowedByAPutShouldTriggerCqError() {
+    String query = "select * from /" + regionName + " r where r.name = 'Beth'";
 
     specificUserClient.invoke(() -> {
       QueryService queryService = getClientCache().getQueryService();
@@ -159,14 +150,12 @@ public class CqSecurityAuthorizedUserDUnitTest extends QuerySecurityBase {
     Object[] values = {new QueryTestObject(1, "Mary")};
     putIntoRegion(superUserClient, keys, values, regionName);
 
-    specificUserClient.invoke(() -> {
-      Awaitility.await().atMost(30, TimeUnit.SECONDS)
-          .untilAsserted(() -> assertEquals(1, cqListener.getNumErrors()));
-    });
+    specificUserClient.invoke(() -> Awaitility.await().atMost(30, TimeUnit.SECONDS)
+        .untilAsserted(() -> assertThat(cqListener.getNumErrors()).isEqualTo(1)));
   }
 
   @Test
-  public void cqCanBeClosedByTheCreator() throws Exception {
+  public void cqCanBeClosedByTheCreator() {
     String query = "select * from /" + regionName + " r where r.id = 0";
 
     specificUserClient.invoke(() -> {
@@ -176,21 +165,20 @@ public class CqSecurityAuthorizedUserDUnitTest extends QuerySecurityBase {
       CqQuery cq = createCq(queryService, query, cqListener);
       cq.execute();
       cq.close();
-      assertTrue(cq.isClosed());
+      assertThat(cq.isClosed()).isTrue();
     });
-    assertEquals(0, server.getCache().getCqService().getAllCqs().size());
+    assertThat(server.getCache().getCqService().getAllCqs().size()).isEqualTo(0);
   }
 
-
-  protected CqQuery createCq(QueryService queryService, String query, CqListener cqListener)
+  CqQuery createCq(QueryService queryService, String query, CqListener cqListener)
       throws CqException {
     CqAttributesFactory cqaf = new CqAttributesFactory();
     cqaf.addCqListener(cqListener);
-    CqQuery cq = queryService.newCq(query, cqaf.create());
-    return cq;
+
+    return queryService.newCq(query, cqaf.create());
   }
 
-  protected void executeCqButExpectException(CqQuery cq, String user,
+  private void executeCqButExpectException(CqQuery cq, String user,
       String regexForExpectedException) {
     try {
       cq.execute();
@@ -247,17 +235,15 @@ public class CqSecurityAuthorizedUserDUnitTest extends QuerySecurityBase {
       numErrors++;
     }
 
-    public int getNumEvent() {
+    int getNumEvent() {
       return numEvents;
     }
 
-    public int getNumErrors() {
+    int getNumErrors() {
       return numErrors;
     }
 
     @Override
-    public void close() {
-
-    }
+    public void close() {}
   }
 }

--- a/geode-cq/src/distributedTest/java/org/apache/geode/security/ClientCQAuthDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/security/ClientCQAuthDUnitTest.java
@@ -38,9 +38,8 @@ import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.junit.categories.SecurityTest;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({SecurityTest.class})
+@Category(SecurityTest.class)
 public class ClientCQAuthDUnitTest {
-
   private static final String REGION_NAME = "AuthRegion";
 
   private VM client1;

--- a/geode-cq/src/distributedTest/java/org/apache/geode/security/ClientQueryAuthDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/security/ClientQueryAuthDUnitTest.java
@@ -28,20 +28,15 @@ import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.cache.client.ClientCache;
 import org.apache.geode.cache.client.Pool;
 import org.apache.geode.cache.client.PoolManager;
-import org.apache.geode.test.dunit.Host;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.internal.JUnit4DistributedTestCase;
 import org.apache.geode.test.junit.categories.SecurityTest;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({SecurityTest.class})
+@Category(SecurityTest.class)
 public class ClientQueryAuthDUnitTest extends JUnit4DistributedTestCase {
-
   private static String REGION_NAME = "AuthRegion";
-  final Host host = Host.getHost(0);
-  final VM client1 = host.getVM(1);
-  final VM client2 = host.getVM(2);
-  final VM client3 = host.getVM(3);
+  private final VM client1 = VM.getVM(1);
 
   @Rule
   public ServerStarterRule server =

--- a/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/rules/tests/MemberStarterRuleAwaitIntegrationTest.java
+++ b/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/rules/tests/MemberStarterRuleAwaitIntegrationTest.java
@@ -27,7 +27,6 @@ import java.util.function.UnaryOperator;
 
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.awaitility.core.ConditionTimeoutException;
-import org.awaitility.core.Predicate;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -42,11 +41,10 @@ import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactor
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
 public class MemberStarterRuleAwaitIntegrationTest {
-
   private static MemberStarterRule locatorStarterRule = new LocatorStarterRule();
   private static MemberStarterRule serverStarterRule = new ServerStarterRule();
 
-  @Parameter(0)
+  @Parameter
   public MemberStarterRule ruleToUse;
 
   @Parameter(1)
@@ -61,7 +59,7 @@ public class MemberStarterRuleAwaitIntegrationTest {
   }
 
   @Test
-  public void testWithDefaultPresentation() throws Exception {
+  public void testWithDefaultPresentation() {
     Supplier<Boolean> alwaysFalseProvider = () -> false;
     String description = "Awaiting until boolean becomes true.";
 
@@ -73,9 +71,8 @@ public class MemberStarterRuleAwaitIntegrationTest {
   }
 
   @Test
-  public void waitCanAcceptNullsIfPredicateAcceptsNulls() throws Exception {
+  public void waitCanAcceptNullsIfPredicateAcceptsNulls() {
     Supplier<Boolean> alwaysNullProvider = () -> null;
-    Predicate<Boolean> booleanIdentityPredicate = b -> b != null && b.equals(true);
     String description = "Awaiting until boolean becomes not null and also true.";
     assertThatThrownBy(printExceptionWrapper(() -> ruleToUse.waitUntilEqual(alwaysNullProvider,
         UnaryOperator.identity(), true, description, 1, TimeUnit.SECONDS)))
@@ -85,9 +82,9 @@ public class MemberStarterRuleAwaitIntegrationTest {
   }
 
   @Test
-  public void waitCanPrintMoreComplexResults() throws Exception {
+  public void waitCanPrintMoreComplexResults() {
     Supplier<List<String>> abcListProvider = () -> Arrays.asList("A", "B", "C");
-    Function<List<String>, Integer> examiner = list -> list.size();
+    Function<List<String>, Integer> examiner = List::size;
     String description = "Awaiting until list becomes empty.";
     assertThatThrownBy(printExceptionWrapper(() -> ruleToUse.waitUntilEqual(abcListProvider,
         examiner, 0, description, 1, TimeUnit.SECONDS)))
@@ -101,7 +98,7 @@ public class MemberStarterRuleAwaitIntegrationTest {
       try {
         throwingCallable.call();
       } catch (Exception e) {
-        System.out.println(e);
+        e.printStackTrace(System.out);
         throw (e);
       }
     };

--- a/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/rules/tests/MemberStarterRuleIntegrationTest.java
+++ b/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/rules/tests/MemberStarterRuleIntegrationTest.java
@@ -27,8 +27,6 @@ import org.apache.geode.test.junit.rules.LocatorStarterRule;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
 public class MemberStarterRuleIntegrationTest {
-
-
   private LocatorStarterRule locator;
   private ServerStarterRule server;
 
@@ -54,7 +52,6 @@ public class MemberStarterRuleIntegrationTest {
     assertThat(locator.getPort()).isEqualTo(targetPort);
     // This is the actual, live member's port.
     assertThat(internalMember.getPort()).isEqualTo(targetPort);
-
   }
 
   @Test
@@ -69,6 +66,5 @@ public class MemberStarterRuleIntegrationTest {
     assertThat(server.getPort()).isEqualTo(targetPort);
     // This is the actual, live member's port.
     assertThat(internalMember.getPort()).isEqualTo(targetPort);
-
   }
 }

--- a/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/rules/tests/MemberStarterRuleTest.java
+++ b/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/rules/tests/MemberStarterRuleTest.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 import org.apache.geode.test.junit.rules.LocatorStarterRule;
 
 public class MemberStarterRuleTest {
-
   private LocatorStarterRule locator;
 
   @After
@@ -88,7 +87,7 @@ public class MemberStarterRuleTest {
   }
 
   @Test
-  public void workingDirNotCreatedByDefault() throws Exception {
+  public void workingDirNotCreatedByDefault() {
     String userDir = System.getProperty("user.dir");
     locator = new LocatorStarterRule();
     locator.before();
@@ -97,7 +96,7 @@ public class MemberStarterRuleTest {
   }
 
   @Test
-  public void logFileDoesNotCreatesWorkingDir() throws Exception {
+  public void logFileDoesNotCreatesWorkingDir() {
     locator = new LocatorStarterRule().withLogFile();
     locator.before();
 
@@ -106,7 +105,7 @@ public class MemberStarterRuleTest {
   }
 
   @Test
-  public void workDirCreatesWorkDir() throws Exception {
+  public void workDirCreatesWorkDir() {
     locator = new LocatorStarterRule().withWorkingDir();
     locator.before();
 

--- a/geode-dunit/src/main/java/org/apache/geode/management/internal/cli/commands/QueryCommandIntegrationTestBase.java
+++ b/geode-dunit/src/main/java/org/apache/geode/management/internal/cli/commands/QueryCommandIntegrationTestBase.java
@@ -45,7 +45,7 @@ import org.apache.geode.test.junit.rules.GfshCommandRule;
 import org.apache.geode.test.junit.rules.Server;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({GfshTest.class})
+@Category(GfshTest.class)
 public class QueryCommandIntegrationTestBase {
 
   private final String DEFAULT_FETCH_SIZE = String.valueOf(Gfsh.DEFAULT_APP_FETCH_SIZE);
@@ -87,14 +87,14 @@ public class QueryCommandIntegrationTestBase {
   }
 
   @Test
-  public void doesShowLimitIfLimitNotInQuery() throws Exception {
+  public void doesShowLimitIfLimitNotInQuery() {
     gfsh.executeAndAssertThat("query --query='select * from /simpleRegion'")
         .containsKeyValuePair("Rows", DEFAULT_FETCH_SIZE)
         .containsKeyValuePair("Limit", DEFAULT_FETCH_SIZE).hasResult();
   }
 
   @Test
-  public void doesNotShowLimitIfLimitInQuery() throws Exception {
+  public void doesNotShowLimitIfLimitInQuery() {
     gfsh.executeAndAssertThat("query --query='select * from /simpleRegion limit 50'")
         .containsKeyValuePair("Rows", "50").doesNotContainOutput("Limit").hasResult();
   }
@@ -208,7 +208,7 @@ public class QueryCommandIntegrationTestBase {
   }
 
   @Test
-  public void queryWithInvalidRegionNameGivesDescriptiveErrorMessage() throws Exception {
+  public void queryWithInvalidRegionNameGivesDescriptiveErrorMessage() {
     gfsh.executeAndAssertThat("query --query='select * from /nonExistentRegion'")
         .containsKeyValuePair("Result", "false")
         .containsOutput("Cannot find regions <[/nonExistentRegion]> in any of the members");
@@ -281,5 +281,4 @@ public class QueryCommandIntegrationTestBase {
       this.city = city;
     }
   }
-
 }

--- a/geode-dunit/src/main/java/org/apache/geode/management/internal/security/GfshCommandsSecurityTestBase.java
+++ b/geode-dunit/src/main/java/org/apache/geode/management/internal/security/GfshCommandsSecurityTestBase.java
@@ -38,7 +38,7 @@ import org.apache.geode.test.junit.rules.ConnectionConfiguration;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({SecurityTest.class})
+@Category(SecurityTest.class)
 public class GfshCommandsSecurityTestBase {
   @ClassRule
   public static ServerStarterRule serverStarter =
@@ -51,83 +51,83 @@ public class GfshCommandsSecurityTestBase {
       new GfshCommandRule(serverStarter::getJmxPort, GfshCommandRule.PortType.jmxManager);
 
   @BeforeClass
-  public static void beforeClass() throws Exception {
+  public static void beforeClass() {
     serverStarter.getCache().createRegionFactory(RegionShortcut.REPLICATE).create("region1");
   }
 
   @Test
   @ConnectionConfiguration(user = "data", password = "wrongPwd")
-  public void testInvalidCredentials() throws Exception {
+  public void testInvalidCredentials() {
     assertThat(gfshConnection.isConnected()).isFalse();
   }
 
   @Test
   @ConnectionConfiguration(user = "data", password = "data")
-  public void testValidCredentials() throws Exception {
+  public void testValidCredentials() {
     assertThat(gfshConnection.isConnected()).isTrue();
   }
 
   @Test
   @ConnectionConfiguration(user = "clusterRead", password = "clusterRead")
-  public void testClusterReader() throws Exception {
+  public void testClusterReader() {
     runCommandsPermittedAndForbiddenBy("CLUSTER:READ");
   }
 
   @Test
   @ConnectionConfiguration(user = "clusterWrite", password = "clusterWrite")
-  public void testClusterWriter() throws Exception {
+  public void testClusterWriter() {
     runCommandsPermittedAndForbiddenBy("CLUSTER:WRITE");
   }
 
   @Test
   @ConnectionConfiguration(user = "clusterManage", password = "clusterManage")
-  public void testClusterManager() throws Exception {
+  public void testClusterManager() {
     runCommandsPermittedAndForbiddenBy("CLUSTER:MANAGE");
   }
 
   @Test
   @ConnectionConfiguration(user = "dataRead", password = "dataRead")
-  public void testDataReader() throws Exception {
+  public void testDataReader() {
     runCommandsPermittedAndForbiddenBy("DATA:READ");
   }
 
   @Test
   @ConnectionConfiguration(user = "dataWrite", password = "dataWrite")
-  public void testDataWriter() throws Exception {
+  public void testDataWriter() {
     runCommandsPermittedAndForbiddenBy("DATA:WRITE");
   }
 
   @Test
   @ConnectionConfiguration(user = "dataManage", password = "dataManage")
-  public void testDataManager() throws Exception {
+  public void testDataManager() {
     runCommandsPermittedAndForbiddenBy("DATA:MANAGE");
   }
 
   @Test
   @ConnectionConfiguration(user = "dataReadRegionA", password = "dataReadRegionA")
-  public void testRegionAReader() throws Exception {
+  public void testRegionAReader() {
     runCommandsPermittedAndForbiddenBy("DATA:READ:RegionA");
   }
 
   @Test
   @ConnectionConfiguration(user = "dataWriteRegionA", password = "dataWriteRegionA")
-  public void testRegionAWriter() throws Exception {
+  public void testRegionAWriter() {
     runCommandsPermittedAndForbiddenBy("DATA:WRITE:RegionA");
   }
 
   @Test
   @ConnectionConfiguration(user = "dataManageRegionA", password = "dataManageRegionA")
-  public void testRegionAManager() throws Exception {
+  public void testRegionAManager() {
     runCommandsPermittedAndForbiddenBy("DATA:MANAGE:RegionA");
   }
 
   @Test
   @ConnectionConfiguration(user = "data,cluster", password = "data,cluster")
-  public void testRegionSuperUser() throws Exception {
+  public void testRegionSuperUser() {
     runCommandsPermittedAndForbiddenBy("*");
   }
 
-  private void runCommandsPermittedAndForbiddenBy(String permission) throws Exception {
+  private void runCommandsPermittedAndForbiddenBy(String permission) {
     List<TestCommand> allPermitted =
         TestCommand.getPermittedCommands(new WildcardPermission(permission, true));
 
@@ -168,7 +168,7 @@ public class GfshCommandsSecurityTestBase {
 
   @Test
   @ConnectionConfiguration(user = "data", password = "data")
-  public void testGetPostProcess() throws Exception {
+  public void testGetPostProcess() {
     gfshConnection.executeCommand("put --region=region1 --key=key2 --value=value2");
     gfshConnection.executeCommand("put --region=region1 --key=key2 --value=value2");
     gfshConnection.executeCommand("put --region=region1 --key=key3 --value=value3");
@@ -179,7 +179,7 @@ public class GfshCommandsSecurityTestBase {
 
   @Test
   @ConnectionConfiguration(user = "data", password = "data")
-  public void createDiskStore() throws Exception {
+  public void createDiskStore() {
     CommandResult result =
         gfshConnection.executeCommand("create disk-store --name=disk1 --dir=disk1");
 
@@ -189,14 +189,14 @@ public class GfshCommandsSecurityTestBase {
   @Test
   @ConnectionConfiguration(user = "dataManage,clusterWriteDisk",
       password = "dataManage,clusterWriteDisk")
-  public void createPartitionedPersistentRegionWithCorrectPermissions() throws Exception {
+  public void createPartitionedPersistentRegionWithCorrectPermissions() {
     gfshConnection.executeAndAssertThat("create region --name=region2 --type=PARTITION_PERSISTENT")
         .statusIsSuccess();
   }
 
   @Test
   @ConnectionConfiguration(user = "dataManage", password = "dataManage")
-  public void createPartitionedPersistentRegionWithoutClusterWriteDisk() throws Exception {
+  public void createPartitionedPersistentRegionWithoutClusterWriteDisk() {
     CommandResult result =
         gfshConnection.executeCommand("create region --name=region2 --type=PARTITION_PERSISTENT");
 
@@ -205,7 +205,7 @@ public class GfshCommandsSecurityTestBase {
 
   @Test
   @ConnectionConfiguration(user = "clusterWriteDisk", password = "clusterWriteDisk")
-  public void createPartitionedPersistentRegionWithoutDataManage() throws Exception {
+  public void createPartitionedPersistentRegionWithoutDataManage() {
     CommandResult result =
         gfshConnection.executeCommand("create region --name=region2 --type=PARTITION_PERSISTENT");
 

--- a/geode-lucene/src/integrationTest/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexCommandsIntegrationTest.java
+++ b/geode-lucene/src/integrationTest/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexCommandsIntegrationTest.java
@@ -16,8 +16,6 @@ package org.apache.geode.cache.lucene.internal.cli;
 
 import static org.apache.geode.cache.lucene.test.LuceneTestUtilities.INDEX_NAME;
 import static org.apache.geode.cache.lucene.test.LuceneTestUtilities.REGION_NAME;
-import static org.apache.geode.test.dunit.Assert.assertArrayEquals;
-import static org.apache.geode.test.dunit.Assert.assertEquals;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.Serializable;
@@ -88,7 +86,7 @@ public class LuceneIndexCommandsIntegrationTest {
   }
 
   @Test
-  public void listIndexShouldReturnExistingIndexWithStats() throws Exception {
+  public void listIndexShouldReturnExistingIndexWithStats() {
     createIndex();
 
     CommandStringBuilder csb = new CommandStringBuilder(LuceneCliStrings.LUCENE_LIST_INDEX);
@@ -99,7 +97,7 @@ public class LuceneIndexCommandsIntegrationTest {
   }
 
   @Test
-  public void listIndexShouldReturnExistingIndexWithoutStats() throws Exception {
+  public void listIndexShouldReturnExistingIndexWithoutStats() {
     createIndex();
     CommandStringBuilder csb = new CommandStringBuilder(LuceneCliStrings.LUCENE_LIST_INDEX);
     gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess().containsOutput(INDEX_NAME)
@@ -107,13 +105,13 @@ public class LuceneIndexCommandsIntegrationTest {
   }
 
   @Test
-  public void listIndexWhenNoExistingIndexShouldReturnNoIndex() throws Exception {
+  public void listIndexWhenNoExistingIndexShouldReturnNoIndex() {
     CommandStringBuilder csb = new CommandStringBuilder(LuceneCliStrings.LUCENE_LIST_INDEX);
     gfsh.executeAndAssertThat(csb.toString()).containsOutput("No lucene indexes found");
   }
 
   @Test
-  public void listIndexShouldReturnCorrectStatus() throws Exception {
+  public void listIndexShouldReturnCorrectStatus() {
     createIndexWithoutRegion();
 
     CommandStringBuilder csb = new CommandStringBuilder(LuceneCliStrings.LUCENE_LIST_INDEX);
@@ -165,7 +163,7 @@ public class LuceneIndexCommandsIntegrationTest {
 
     LuceneService luceneService = LuceneServiceProvider.get(server.getCache());
     final LuceneIndex index = luceneService.getIndex(INDEX_NAME, REGION_NAME);
-    assertArrayEquals(new String[] {"field1", "field2", "field3"}, index.getFieldNames());
+    assertThat(index.getFieldNames()).isEqualTo(new String[] {"field1", "field2", "field3"});
   }
 
   @Test
@@ -189,9 +187,9 @@ public class LuceneIndexCommandsIntegrationTest {
     LuceneService luceneService = LuceneServiceProvider.get(server.getCache());
     final LuceneIndex index = luceneService.getIndex(INDEX_NAME, REGION_NAME);
     final Map<String, Analyzer> fieldAnalyzers = index.getFieldAnalyzers();
-    assertEquals(StandardAnalyzer.class, fieldAnalyzers.get("field1").getClass());
-    assertEquals(KeywordAnalyzer.class, fieldAnalyzers.get("field2").getClass());
-    assertEquals(StandardAnalyzer.class, fieldAnalyzers.get("field3").getClass());
+    assertThat(fieldAnalyzers.get("field1").getClass()).isEqualTo(StandardAnalyzer.class);
+    assertThat(fieldAnalyzers.get("field2").getClass()).isEqualTo(KeywordAnalyzer.class);
+    assertThat(fieldAnalyzers.get("field3").getClass()).isEqualTo(StandardAnalyzer.class);
 
   }
 
@@ -252,11 +250,6 @@ public class LuceneIndexCommandsIntegrationTest {
 
   @Test
   public void createIndexShouldTrimAnalyzerNames() {
-    List<String> analyzerNames = new ArrayList<>();
-    analyzerNames.add(StandardAnalyzer.class.getCanonicalName());
-    analyzerNames.add(KeywordAnalyzer.class.getCanonicalName());
-    analyzerNames.add(StandardAnalyzer.class.getCanonicalName());
-
     CommandStringBuilder csb = new CommandStringBuilder(LuceneCliStrings.LUCENE_CREATE_INDEX);
     csb.addOption(LuceneCliStrings.LUCENE__INDEX_NAME, INDEX_NAME);
     csb.addOption(LuceneCliStrings.LUCENE__REGION_PATH, REGION_NAME);
@@ -272,13 +265,13 @@ public class LuceneIndexCommandsIntegrationTest {
     LuceneService luceneService = LuceneServiceProvider.get(server.getCache());
     final LuceneIndex index = luceneService.getIndex(INDEX_NAME, REGION_NAME);
     final Map<String, Analyzer> fieldAnalyzers = index.getFieldAnalyzers();
-    assertEquals(StandardAnalyzer.class, fieldAnalyzers.get("field1").getClass());
-    assertEquals(KeywordAnalyzer.class, fieldAnalyzers.get("field2").getClass());
-    assertEquals(StandardAnalyzer.class, fieldAnalyzers.get("field3").getClass());
+    assertThat(fieldAnalyzers.get("field1").getClass()).isEqualTo(StandardAnalyzer.class);
+    assertThat(fieldAnalyzers.get("field2").getClass()).isEqualTo(KeywordAnalyzer.class);
+    assertThat(fieldAnalyzers.get("field3").getClass()).isEqualTo(StandardAnalyzer.class);
   }
 
   @Test
-  public void createIndexWithoutRegionShouldReturnCorrectResults() throws Exception {
+  public void createIndexWithoutRegionShouldReturnCorrectResults() {
     CommandStringBuilder csb = new CommandStringBuilder(LuceneCliStrings.LUCENE_CREATE_INDEX);
     csb.addOption(LuceneCliStrings.LUCENE__INDEX_NAME, INDEX_NAME);
     csb.addOption(LuceneCliStrings.LUCENE__REGION_PATH, REGION_NAME);
@@ -290,8 +283,8 @@ public class LuceneIndexCommandsIntegrationTest {
         (LuceneServiceImpl) LuceneServiceProvider.get(server.getCache());
     final ArrayList<LuceneIndexCreationProfile> profiles =
         new ArrayList<>(luceneService.getAllDefinedIndexes());
-    assertEquals(1, profiles.size());
-    assertEquals(INDEX_NAME, profiles.get(0).getIndexName());
+    assertThat(profiles.size()).isEqualTo(1);
+    assertThat(profiles.get(0).getIndexName()).isEqualTo(INDEX_NAME);
   }
 
   @Test
@@ -344,33 +337,33 @@ public class LuceneIndexCommandsIntegrationTest {
     final Map<String, Analyzer> keywordFieldAnalyzers = keywordIndex.getFieldAnalyzers();
 
     // Test whitespace analyzers
-    assertEquals(StandardAnalyzer.class.getCanonicalName(),
-        spaceFieldAnalyzers.get("field1").getClass().getCanonicalName());
-    assertEquals(StandardAnalyzer.class.getCanonicalName(),
-        spaceFieldAnalyzers.get("field2").getClass().getCanonicalName());
-    assertEquals(KeywordAnalyzer.class.getCanonicalName(),
-        spaceFieldAnalyzers.get("field3").getClass().getCanonicalName());
+    assertThat(spaceFieldAnalyzers.get("field1").getClass().getCanonicalName())
+        .isEqualTo(StandardAnalyzer.class.getCanonicalName());
+    assertThat(spaceFieldAnalyzers.get("field2").getClass().getCanonicalName())
+        .isEqualTo(StandardAnalyzer.class.getCanonicalName());
+    assertThat(spaceFieldAnalyzers.get("field3").getClass().getCanonicalName())
+        .isEqualTo(KeywordAnalyzer.class.getCanonicalName());
 
     // Test empty analyzers
-    assertEquals(StandardAnalyzer.class.getCanonicalName(),
-        emptyFieldAnalyzers2.get("field1").getClass().getCanonicalName());
-    assertEquals(StandardAnalyzer.class.getCanonicalName(),
-        emptyFieldAnalyzers2.get("field2").getClass().getCanonicalName());
-    assertEquals(KeywordAnalyzer.class.getCanonicalName(),
-        emptyFieldAnalyzers2.get("field3").getClass().getCanonicalName());
+    assertThat(emptyFieldAnalyzers2.get("field1").getClass().getCanonicalName())
+        .isEqualTo(StandardAnalyzer.class.getCanonicalName());
+    assertThat(emptyFieldAnalyzers2.get("field2").getClass().getCanonicalName())
+        .isEqualTo(StandardAnalyzer.class.getCanonicalName());
+    assertThat(emptyFieldAnalyzers2.get("field3").getClass().getCanonicalName())
+        .isEqualTo(KeywordAnalyzer.class.getCanonicalName());
 
     // Test keyword analyzers
-    assertEquals(StandardAnalyzer.class.getCanonicalName(),
-        keywordFieldAnalyzers.get("field1").getClass().getCanonicalName());
-    assertEquals(StandardAnalyzer.class.getCanonicalName(),
-        keywordFieldAnalyzers.get("field2").getClass().getCanonicalName());
-    assertEquals(KeywordAnalyzer.class.getCanonicalName(),
-        keywordFieldAnalyzers.get("field3").getClass().getCanonicalName());
+    assertThat(keywordFieldAnalyzers.get("field1").getClass().getCanonicalName())
+        .isEqualTo(StandardAnalyzer.class.getCanonicalName());
+    assertThat(keywordFieldAnalyzers.get("field2").getClass().getCanonicalName())
+        .isEqualTo(StandardAnalyzer.class.getCanonicalName());
+    assertThat(keywordFieldAnalyzers.get("field3").getClass().getCanonicalName())
+        .isEqualTo(KeywordAnalyzer.class.getCanonicalName());
 
   }
 
   @Test
-  public void describeIndexShouldReturnExistingIndex() throws Exception {
+  public void describeIndexShouldReturnExistingIndex() {
     createIndex();
 
     CommandStringBuilder csb = new CommandStringBuilder(LuceneCliStrings.LUCENE_DESCRIBE_INDEX);
@@ -380,7 +373,7 @@ public class LuceneIndexCommandsIntegrationTest {
   }
 
   @Test
-  public void describeIndexShouldShowSerializer() throws Exception {
+  public void describeIndexShouldShowSerializer() {
     CommandStringBuilder csb = new CommandStringBuilder(LuceneCliStrings.LUCENE_CREATE_INDEX);
     csb.addOption(LuceneCliStrings.LUCENE__INDEX_NAME, INDEX_NAME);
     csb.addOption(LuceneCliStrings.LUCENE__REGION_PATH, REGION_NAME);
@@ -399,7 +392,7 @@ public class LuceneIndexCommandsIntegrationTest {
   }
 
   @Test
-  public void describeIndexShouldNotReturnResultWhenIndexNotFound() throws Exception {
+  public void describeIndexShouldNotReturnResultWhenIndexNotFound() {
     createIndex();
 
     CommandStringBuilder csb = new CommandStringBuilder(LuceneCliStrings.LUCENE_DESCRIBE_INDEX);
@@ -410,7 +403,7 @@ public class LuceneIndexCommandsIntegrationTest {
   }
 
   @Test
-  public void describeIndexWithoutRegionShouldReturnErrorMessage() throws Exception {
+  public void describeIndexWithoutRegionShouldReturnErrorMessage() {
     createIndexWithoutRegion();
     CommandStringBuilder csb = new CommandStringBuilder(LuceneCliStrings.LUCENE_DESCRIBE_INDEX);
     csb.addOption(LuceneCliStrings.LUCENE__INDEX_NAME, "notAnIndex");
@@ -544,7 +537,7 @@ public class LuceneIndexCommandsIntegrationTest {
   }
 
   @Test
-  public void searchOnIndexWithoutRegionShouldReturnError() throws Exception {
+  public void searchOnIndexWithoutRegionShouldReturnError() {
     createIndexWithoutRegion();
     CommandStringBuilder csb = new CommandStringBuilder(LuceneCliStrings.LUCENE_SEARCH_INDEX);
     csb.addOption(LuceneCliStrings.LUCENE__INDEX_NAME, INDEX_NAME);
@@ -557,7 +550,7 @@ public class LuceneIndexCommandsIntegrationTest {
   }
 
   @Test
-  public void searchWithoutIndexShouldReturnError() throws Exception {
+  public void searchWithoutIndexShouldReturnError() {
     createRegion();
 
     CommandStringBuilder csb = new CommandStringBuilder(LuceneCliStrings.LUCENE_SEARCH_INDEX);
@@ -571,9 +564,9 @@ public class LuceneIndexCommandsIntegrationTest {
     CommandResult commandResult = gfsh.executeCommand(commandString);
     String resultAsString = gfsh.getGfshOutput();
     writeToLog("Result String :\n ", resultAsString);
-    assertEquals(Status.ERROR, commandResult.getStatus());
-    assertEquals("Unexpected CommandResult string :" + resultAsString, true,
-        resultAsString.contains("Index " + INDEX_NAME + " not found"));
+    assertThat(commandResult.getStatus()).isEqualTo(Status.ERROR);
+    assertThat(resultAsString.contains("Index " + INDEX_NAME + " not found"))
+        .as("Unexpected CommandResult string :" + resultAsString).isTrue();
   }
 
   @Test
@@ -603,7 +596,7 @@ public class LuceneIndexCommandsIntegrationTest {
 
   @Test
   @Parameters({"true", "false"})
-  public void testDestroySingleIndex(boolean createRegion) throws Exception {
+  public void testDestroySingleIndex(boolean createRegion) {
     if (createRegion) {
       createIndex();
     } else {
@@ -612,14 +605,14 @@ public class LuceneIndexCommandsIntegrationTest {
 
     String expectedStatus = CliStrings.format(
         LuceneCliStrings.LUCENE_DESTROY_INDEX__MSG__SUCCESSFULLY_DESTROYED_INDEX_0_FROM_REGION_1,
-        new Object[] {"index", "/region"});
+        "index", "/region");
     gfsh.executeAndAssertThat("destroy lucene index --name=index --region=region").statusIsSuccess()
         .containsOutput(expectedStatus);
   }
 
   @Test
   @Parameters({"true", "false"})
-  public void testDestroyAllIndexes(boolean createRegion) throws Exception {
+  public void testDestroyAllIndexes(boolean createRegion) {
     if (createRegion) {
       createIndex();
     } else {
@@ -635,29 +628,27 @@ public class LuceneIndexCommandsIntegrationTest {
         .containsOutput(expectedOutput);
 
     // Verify destroy all indexes again reports no indexes exist
-    expectedOutput = String.format("No Lucene indexes were found in region %s",
-        new Object[] {"/region"});
+    expectedOutput = String.format("No Lucene indexes were found in region %s", "/region");
 
     gfsh.executeAndAssertThat("destroy lucene index --region=region").statusIsSuccess()
         .containsOutput(expectedOutput);
   }
 
   @Test
-  public void testDestroyNonExistentSingleIndex() throws Exception {
+  public void testDestroyNonExistentSingleIndex() {
     createRegion();
-    String expectedStatus = String.format("Lucene index %s was not found in region %s",
-        new Object[] {INDEX_NAME, '/' + REGION_NAME});
+    String expectedStatus =
+        String.format("Lucene index %s was not found in region %s", INDEX_NAME, '/' + REGION_NAME);
 
     gfsh.executeAndAssertThat("destroy lucene index --name=index --region=region").statusIsSuccess()
         .containsOutput(expectedStatus);
   }
 
   @Test
-  public void testDestroyNonExistentIndexes() throws Exception {
+  public void testDestroyNonExistentIndexes() {
     createRegion();
 
-    String expectedOutput = String.format("No Lucene indexes were found in region %s",
-        new Object[] {"/region"});
+    String expectedOutput = String.format("No Lucene indexes were found in region %s", "/region");
     gfsh.executeAndAssertThat("destroy lucene index --region=region").statusIsSuccess()
         .containsOutput(expectedOutput);
   }
@@ -668,7 +659,7 @@ public class LuceneIndexCommandsIntegrationTest {
 
   private void createIndex() {
     LuceneService luceneService = LuceneServiceProvider.get(server.getCache());
-    Map<String, Analyzer> fieldAnalyzers = new HashMap();
+    Map<String, Analyzer> fieldAnalyzers = new HashMap<>();
     fieldAnalyzers.put("field1", new StandardAnalyzer());
     fieldAnalyzers.put("field2", new KeywordAnalyzer());
     fieldAnalyzers.put("field3", null);
@@ -678,7 +669,7 @@ public class LuceneIndexCommandsIntegrationTest {
 
   private void createIndexWithoutRegion() {
     LuceneService luceneService = LuceneServiceProvider.get(server.getCache());
-    Map<String, Analyzer> fieldAnalyzers = new HashMap();
+    Map<String, Analyzer> fieldAnalyzers = new HashMap<>();
     fieldAnalyzers.put("field1", new StandardAnalyzer());
     fieldAnalyzers.put("field2", new KeywordAnalyzer());
     fieldAnalyzers.put("field3", null);
@@ -693,7 +684,7 @@ public class LuceneIndexCommandsIntegrationTest {
   private void putEntries(Map<String, TestObject> entries, int countOfDocuments)
       throws InterruptedException {
     LuceneService luceneService = LuceneServiceProvider.get(server.getCache());
-    Region region = server.getCache().getRegion(REGION_NAME);
+    Region<String, TestObject> region = server.getCache().getRegion(REGION_NAME);
     region.putAll(entries);
     luceneService.waitUntilFlushed(INDEX_NAME, REGION_NAME, 60000, TimeUnit.MILLISECONDS);
     LuceneIndexImpl index = (LuceneIndexImpl) luceneService.getIndex(INDEX_NAME, REGION_NAME);
@@ -706,7 +697,7 @@ public class LuceneIndexCommandsIntegrationTest {
     LuceneService luceneService = LuceneServiceProvider.get(server.getCache());
     final LuceneQuery<String, TestObject> query = luceneService.createLuceneQueryFactory()
         .create(INDEX_NAME, REGION_NAME, queryString, defaultField);
-    assertEquals(Collections.singletonList("A"), query.findKeys());
+    assertThat(query.findKeys()).isEqualTo(Collections.singletonList("A"));
   }
 
   private String getRegionNotFoundErrorMessage(String regionPath) {

--- a/geode-lucene/src/integrationTest/java/org/apache/geode/cache/lucene/test/LuceneFunctionSecurityTest.java
+++ b/geode-lucene/src/integrationTest/java/org/apache/geode/cache/lucene/test/LuceneFunctionSecurityTest.java
@@ -75,15 +75,12 @@ public class LuceneFunctionSecurityTest {
 
   @Test
   @ConnectionConfiguration(user = "user", password = "user")
-  public void functionRequireExpectedPermission() throws Exception {
-    functionStringMap.entrySet().stream().forEach(entry -> {
-      Function function = entry.getKey();
-      String permission = entry.getValue();
-      gfsh.executeAndAssertThat("execute function --region=testRegion --id=" + function.getId())
-          .tableHasRowCount(RESULT_HEADER, 1)
-          .tableHasRowWithValues(RESULT_HEADER, "Exception: user not authorized for " + permission)
-          .statusIsError();
-    });
+  public void functionRequireExpectedPermission() {
+    functionStringMap.forEach((function, permission) -> gfsh
+        .executeAndAssertThat("execute function --region=testRegion --id=" + function.getId())
+        .tableHasRowCount(RESULT_HEADER, 1)
+        .tableHasRowWithValues(RESULT_HEADER, "Exception: user not authorized for " + permission)
+        .statusIsError());
   }
 
   // use DumpDirectoryFile function to verify that all the permissions returned by the

--- a/geode-web-api/src/integrationTest/java/org/apache/geode/rest/internal/web/controllers/RestAccessControllerTest.java
+++ b/geode-web-api/src/integrationTest/java/org/apache/geode/rest/internal/web/controllers/RestAccessControllerTest.java
@@ -106,6 +106,7 @@ public class RestAccessControllerTest {
   private WebApplicationContext webApplicationContext;
 
   @BeforeClass
+  @SuppressWarnings("unchecked")
   public static void setupCClass() throws Exception {
     loadResource(ORDER1_JSON);
     loadResource(ORDER1_NO_TYPE_JSON);
@@ -481,6 +482,7 @@ public class RestAccessControllerTest {
 
   @Test
   @WithMockUser
+  @SuppressWarnings("unchecked")
   public void getCustomers() throws Exception {
     putAll();
     mockMvc.perform(get("/v1/customers?limit=ALL")
@@ -650,6 +652,7 @@ public class RestAccessControllerTest {
 
   @Test
   @WithMockUser
+  @SuppressWarnings("unchecked")
   public void executeQueryWithParams() throws Exception {
     String QUERY_ARGS =
         "[{\"@type\": \"int\", \"@value\": 2}, {\"@type\": \"double\", \"@value\": 150.00}]";
@@ -666,6 +669,7 @@ public class RestAccessControllerTest {
 
   @Test
   @WithMockUser
+  @SuppressWarnings("unchecked")
   public void executeAdhocQuery() throws Exception {
     putAll();
     mockMvc.perform(get("/v1/queries/adhoc?q=SELECT * FROM /customers LIMIT 100")
@@ -887,6 +891,7 @@ public class RestAccessControllerTest {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void init(Properties props) {
       // nothing
     }

--- a/geode-web/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/CommandOverHttpTest.java
+++ b/geode-web/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/CommandOverHttpTest.java
@@ -34,7 +34,7 @@ import org.apache.geode.test.junit.categories.GfshTest;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({GfshTest.class})
+@Category(GfshTest.class)
 public class CommandOverHttpTest {
 
   @ClassRule
@@ -55,21 +55,21 @@ public class CommandOverHttpTest {
   }
 
   @Test
-  public void testListClient() throws Exception {
+  public void testListClient() {
     CommandResult result = gfshRule.executeCommand("list clients");
     assertThat(result.getStatus()).isEqualTo(Result.Status.ERROR);
     assertThat(result.toString()).contains("No clients were retrieved for cache-servers");
   }
 
   @Test
-  public void testDescribeClient() throws Exception {
+  public void testDescribeClient() {
     CommandResult result = gfshRule.executeCommand("describe client --clientID=xyz");
     assertThat(result.getStatus()).isEqualTo(Result.Status.ERROR);
     assertThat(result.getErrorMessage()).contains("Specified Client ID xyz not present");
   }
 
   @Test
-  public void exportLogs() throws Exception {
+  public void exportLogs() {
     gfshRule.executeAndAssertThat("export logs").statusIsSuccess()
         .containsOutput("Logs exported to:");
   }
@@ -84,7 +84,7 @@ public class CommandOverHttpTest {
   }
 
   @Test
-  public void exportConfig() throws Exception {
+  public void exportConfig() {
     String dir = temporaryFolder.getRoot().getAbsolutePath();
     gfshRule.executeAndAssertThat("export config --dir=" + dir).statusIsSuccess()
         .containsOutput("File saved to " + Paths.get(dir, "server-cache.xml").toString())

--- a/geode-web/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/ConnectCommandIntegrationTest.java
+++ b/geode-web/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/ConnectCommandIntegrationTest.java
@@ -24,7 +24,7 @@ import org.apache.geode.test.junit.categories.GfshTest;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
 import org.apache.geode.test.junit.rules.LocatorStarterRule;
 
-@Category({GfshTest.class})
+@Category(GfshTest.class)
 public class ConnectCommandIntegrationTest {
 
   @ClassRule

--- a/geode-web/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/IndexCommandOverHttpTest.java
+++ b/geode-web/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/IndexCommandOverHttpTest.java
@@ -21,7 +21,7 @@ import org.apache.geode.test.junit.categories.GfshTest;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
 import org.apache.geode.test.junit.rules.Server;
 
-@Category({GfshTest.class})
+@Category(GfshTest.class)
 public class IndexCommandOverHttpTest extends IndexCommandsIntegrationTestBase {
   @Override
   public void connect(Server server) throws Exception {

--- a/geode-web/src/integrationTest/java/org/apache/geode/management/internal/web/shell/HttpOperationInvokerMBeanOperationTest.java
+++ b/geode-web/src/integrationTest/java/org/apache/geode/management/internal/web/shell/HttpOperationInvokerMBeanOperationTest.java
@@ -17,7 +17,6 @@ package org.apache.geode.management.internal.web.shell;
 
 import static org.apache.geode.distributed.ConfigurationProperties.DISTRIBUTED_SYSTEM_ID;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 
 import java.util.Set;
 
@@ -53,7 +52,7 @@ public class HttpOperationInvokerMBeanOperationTest {
   }
 
   @Test
-  public void getAttribute() throws Exception {
+  public void getAttribute() {
     Integer distributedSystemId =
         (Integer) invoker.getAttribute(ManagementConstants.OBJECTNAME__DISTRIBUTEDSYSTEM_MXBEAN,
             "DistributedSystemId");
@@ -61,7 +60,7 @@ public class HttpOperationInvokerMBeanOperationTest {
   }
 
   @Test
-  public void invoke() throws Exception {
+  public void invoke() {
     String[] gatewayReceivers =
         (String[]) invoker.invoke(ManagementConstants.OBJECTNAME__DISTRIBUTEDSYSTEM_MXBEAN,
             "listGatewayReceivers", new Object[0], new String[0]);
@@ -75,16 +74,16 @@ public class HttpOperationInvokerMBeanOperationTest {
     QueryExp query = Query.eq(Query.attr("Name"), Query.value("mock"));
 
     Set<ObjectName> names = invoker.queryNames(objectName, query);
-    assertTrue(names.isEmpty());
+    assertThat(names.isEmpty()).isTrue();
   }
 
   @Test
-  public void getClusterId() throws Exception {
+  public void getClusterId() {
     assertThat(invoker.getClusterId()).isEqualTo(100);
   }
 
   @Test
-  public void getDistributedSystemMbean() throws Exception {
+  public void getDistributedSystemMbean() {
     DistributedSystemMXBean bean = invoker.getDistributedSystemMXBean();
     assertThat(bean).isInstanceOf(DistributedSystemMXBean.class);
   }

--- a/geode-web/src/integrationTest/java/org/apache/geode/management/internal/web/shell/HttpOperationInvokerSecurityTest.java
+++ b/geode-web/src/integrationTest/java/org/apache/geode/management/internal/web/shell/HttpOperationInvokerSecurityTest.java
@@ -17,7 +17,6 @@ package org.apache.geode.management.internal.web.shell;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -76,7 +75,7 @@ public class HttpOperationInvokerSecurityTest {
     QueryExp query = Query.eq(Query.attr("Name"), Query.value("mock"));
 
     Set<ObjectName> names = invoker.queryNames(objectName, query);
-    assertTrue(names.isEmpty());
+    assertThat(names.isEmpty()).isTrue();
     gfsh.disconnect();
   }
 


### PR DESCRIPTION
GEODE-5739: Use Launchers in StarterRules

Rules ServerStarterRule and LocatorStarterRule now use LocatorLauncher
and ServerLauncher classes to start the members instead of the internal
API.

- Changed ServerStarterRule to use ServerLauncher.
- Changed LocatorStarterRule to use LocatorLauncher.
- Revisited tests using the changed rules, fixed some warnings,
eliminated duplicated code and replaced the usage of `junit.Assert`
by `assertj`.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
