### PR TITLE
GEODE-5742: Restrict default membership range to not conflict with default ports

### DIFF
--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/management/internal/cli/commands/StartLocatorAcceptanceTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/management/internal/cli/commands/StartLocatorAcceptanceTest.java
@@ -52,6 +52,6 @@ public class StartLocatorAcceptanceTest {
         .of("start locator --name=locator1 --J=-Dgemfire.security-manager=org.apache.geode.examples.SimpleSecurityManager")
         .execute(gfshRule);
     assertThat(execution.getOutputText())
-        .contains("Security Manager is enabled - unable to auto-connect.");
+        .contains("Unable to auto-connect (Security Manager may be enabled)");
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/admin/DistributedSystemConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/DistributedSystemConfig.java
@@ -115,7 +115,7 @@ public interface DistributedSystemConfig extends Cloneable {
   /**
    * The default membership-port-range.
    * <p>
-   * Actual value is <code>[1024,65535]</code>.
+   * Actual value is <code>[41000,61000]</code>.
    *
    * @since GemFire 6.5
    */

--- a/geode-core/src/main/java/org/apache/geode/distributed/ConfigurationProperties.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/ConfigurationProperties.java
@@ -1333,7 +1333,7 @@ public interface ConfigurationProperties {
    * (TCP). This range is given as two numbers separated by a minus sign. Minimum 3 values in range
    * are required to successfully startup.
    * <p>
-   * <U>Default</U>: 1024-65535
+   * <U>Default</U>: 41000-61000
    */
   String MEMBERSHIP_PORT_RANGE = "membership-port-range";
   /**

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfig.java
@@ -1801,8 +1801,7 @@ public interface DistributionConfig extends Config, LogConfig {
    */
   String RESTRICT_MEMBERSHIP_PORT_RANGE = GEMFIRE_PREFIX + "use-ephemeral-ports";
 
-  int[] DEFAULT_MEMBERSHIP_PORT_RANGE = Boolean.getBoolean(RESTRICT_MEMBERSHIP_PORT_RANGE)
-      ? new int[] {32769, 61000} : new int[] {1024, 65535};
+  int[] DEFAULT_MEMBERSHIP_PORT_RANGE = new int[] {41000, 61000};
 
   @ConfigAttributeGetter(name = MEMBERSHIP_PORT_RANGE)
   int[] getMembershipPortRange();

--- a/geode-core/src/main/java/org/apache/geode/internal/tcp/TCPConduit.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/tcp/TCPConduit.java
@@ -161,7 +161,8 @@ public class TCPConduit implements Runnable {
    */
   private int port;
 
-  private int[] tcpPortRange = new int[] {1024, 65535};
+  private int[] tcpPortRange = new int[] {DistributionConfig.DEFAULT_MEMBERSHIP_PORT_RANGE[0],
+      DistributionConfig.DEFAULT_MEMBERSHIP_PORT_RANGE[1]};
 
   /**
    * The java groups address that this conduit is associated with

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartLocatorCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartLocatorCommand.java
@@ -51,7 +51,6 @@ import org.apache.geode.management.internal.cli.result.InfoResultData;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
 import org.apache.geode.management.internal.cli.shell.Gfsh;
 import org.apache.geode.management.internal.cli.shell.JmxOperationInvoker;
-import org.apache.geode.management.internal.cli.util.CauseFinder;
 import org.apache.geode.management.internal.cli.util.CommandStringBuilder;
 import org.apache.geode.management.internal.cli.util.ConnectionEndpoint;
 import org.apache.geode.management.internal.cli.util.HostUtils;
@@ -392,10 +391,6 @@ public class StartLocatorCommand extends InternalGfshCommand {
 
         connectSuccess = true;
         responseFailureMessage = null;
-      } catch (IllegalStateException unexpected) {
-        if (CauseFinder.indexOfCause(unexpected, ClassCastException.class, false) != -1) {
-          responseFailureMessage = "The Locator might require SSL Configuration.";
-        }
       } catch (SecurityException ignore) {
         getGfsh().logToFile(ignore.getMessage(), ignore);
         jmxManagerAuthEnabled = true;

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/i18n/CliStrings.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/i18n/CliStrings.java
@@ -2406,7 +2406,7 @@ public class CliStrings {
   public static final String START_LOCATOR__CONNECT__HELP =
       "When connect is set to false or when locator is started with a security manager using --J=-Dgemfire.security-manager option, Gfsh does not automatically connect to the locator which is started using this command.";
   public static final String START_LOCATOR__USE__0__TO__CONNECT_WITH_SECURITY =
-      "Security Manager is enabled - unable to auto-connect. Please use \"{0}\" to connect Gfsh to the locator.";
+      "Unable to auto-connect (Security Manager may be enabled). Please use \"{0}\" to connect Gfsh to the locator.";
   public static final String START_LOCATOR__ENABLE__SHARED__CONFIGURATION =
       ENABLE_CLUSTER_CONFIGURATION;
   public static final String START_LOCATOR__ENABLE__SHARED__CONFIGURATION__HELP =

--- a/geode-docs/configuring/running/firewalls_ports.html.md.erb
+++ b/geode-docs/configuring/running/firewalls_ports.html.md.erb
@@ -156,7 +156,7 @@ This table contains properties potentially involved in firewall behavior, with a
 <tr class="even">
 <td><p>Membership Port Range</p></td>
 <td><code class="ph codeph">membership-port-range</code></td>
-<td>1024 to 65535</td>
+<td>41000 to 61000</td>
 </tr>
 <tr class="odd">
 <td><p>Memcached Port</p></td>

--- a/geode-docs/reference/topics/gemfire_properties.html.md.erb
+++ b/geode-docs/reference/topics/gemfire_properties.html.md.erb
@@ -439,7 +439,7 @@ See <a href="../../configuring/cluster_config/using_member_groups.html">Using Me
 <p>The system uniquely identifies the member using the combined host IP address and UDP port number.</p>
 <p>You may want to restrict the range of ports that <%=vars.product_name%> uses so the product can run in an environment where routers only allow traffic on certain ports.</p></td>
 <td>S, L</td>
-<td>1024-65535</td>
+<td>41000-61000</td>
 </tr>
 <tr class="even">
 <td>memcached-port</td>


### PR DESCRIPTION
Currently the default range for membership ports is 1024-65535.  This results
    in occassional failures where a random membership port selection will conflict
    with the default server or locator port when using all default values.

    This change modifies the default range to 41000-61000.  In addition to not
    conflicting with any of the default ports (highest is 40404), this is also a
    proper subset of the default Linux ephemeral port range (32768-61000).


Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
