### PR TITLE
GEODE-5676: Disconnect system before closing SocketCreatorFactory

### DIFF
--- a/geode-dunit/src/main/java/org/apache/geode/test/junit/rules/MemberStarterRule.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/junit/rules/MemberStarterRule.java
@@ -129,10 +129,10 @@ public abstract class MemberStarterRule<T> extends SerializableExternalResource 
     // invoke stop() first and then ds.disconnect
     stopMember();
 
+    disconnectDSIfAny();
     // this will clean up the SocketCreators created in this VM so that it won't contaminate
     // future tests
     SocketCreatorFactory.close();
-    disconnectDSIfAny();
 
     if (temporaryFolder != null) {
       temporaryFolder.delete();


### PR DESCRIPTION
The MemberStarterRule was closing SocketCreatorFactory before calling
DistributedSystem.disconnect. In the case of
ClusterConfigLocatorRestartDUnitTest there was a reconnect thread
running in the background that ended up throwing a NullPointerException
if the SocketCreatorFactory was closed. This led to an infinite loop in
the reconnect thread.

We should not be messing with the internal state of Geode until we call
disconnect to stop all of Geode's background threads.

Co-Authored-By: Dale Emery <demery@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
