### PR TITLE
GEODE-5797: Move assertion to async invoke

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/ColocationHelper.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/ColocationHelper.java
@@ -77,6 +77,7 @@ public class ColocationHelper {
     PartitionRegionConfig prConf =
         (PartitionRegionConfig) prRoot.get(getRegionIdentifier(colocatedWith));
     if (prConf == null) {
+      partitionedRegion.getCache().getCancelCriterion().checkCancelInProgress(null);
       throw new IllegalStateException(
           String.format(
               "Region specified in 'colocated-with' (%s) for region %s does not exist. It should be created before setting 'colocated-with' attribute for this region.",
@@ -89,6 +90,7 @@ public class ColocationHelper {
       if (colocatedPR != null) {
         colocatedPR.waitOnBucketMetadataInitialization();
       } else {
+        partitionedRegion.getCache().getCancelCriterion().checkCancelInProgress(null);
         throw new IllegalStateException(
             String.format(
                 "Region specified in 'colocated-with' (%s) for region %s does not exist. It should be created before setting 'colocated-with' attribute for this region.",

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/concurrent/ConcurrentParallelGatewaySenderDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/concurrent/ConcurrentParallelGatewaySenderDUnitTest.java
@@ -642,8 +642,8 @@ public class ConcurrentParallelGatewaySenderDUnitTest extends WANTestBase {
         vm6.invokeAsync(() -> WANTestBase.doPuts(getTestMethodName() + "_PR", 10000));
 
     vm2.invoke(() -> await().untilAsserted(() -> assertEquals(
-                "Failure in waiting for additional 20 events to be received by the receiver ", true,
-                getRegionSize(getTestMethodName() + "_PR") > 20 + prevRegionSize)));
+        "Failure in waiting for additional 20 events to be received by the receiver ", true,
+        getRegionSize(getTestMethodName() + "_PR") > 20 + prevRegionSize)));
 
     AsyncInvocation killsSenderFromVM5 = vm5.invokeAsync(() -> WANTestBase.killSender());
 

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/concurrent/ConcurrentParallelGatewaySenderDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/concurrent/ConcurrentParallelGatewaySenderDUnitTest.java
@@ -613,7 +613,7 @@ public class ConcurrentParallelGatewaySenderDUnitTest extends WANTestBase {
         isOffHeap()));
 
     // wait until regions have all been created
-    waitForRegionToBeReadyOnServers(regionName, 6, vm2, vm3, vm4, vm5, vm6, vm7);
+    waitForRegionToBeReadyOnServers(regionName, vm2, vm3, vm4, vm5, vm6, vm7);
 
     vm4.invoke(() -> WANTestBase.createConcurrentSender("ln", 2, true, 100, 10, false, false, null,
         true, 6, OrderPolicy.KEY));
@@ -663,24 +663,24 @@ public class ConcurrentParallelGatewaySenderDUnitTest extends WANTestBase {
     vm7.invoke(() -> WANTestBase.validateParallelSenderQueueAllBucketsDrained("ln"));
   }
 
-  private void waitForRegionToBeReadyOnServers(String regionName, int expectedNumRegions,
-      VM... vms) {
-    int numRegionsReady = 0;
+  private void waitForRegionToBeReadyOnServers(String regionName, VM... vms) {
+    int numVmsReady = 0;
+    int expectedVmsWithRegion = vms.length;
 
     for (VM vm : vms) {
       try {
         vm.invoke(() -> await().untilAsserted(() -> {
           assertThat(cache.getRegion(Region.SEPARATOR + regionName)).isNotNull();
         }));
-        numRegionsReady += 1;
+        numVmsReady += 1;
       } catch (Exception e) {
         // eat the exception and keep checking
       }
     }
-    if (numRegionsReady != expectedNumRegions) {
+    if (numVmsReady != expectedVmsWithRegion) {
       throw new IllegalStateException(
           "Test regions were not created within a reasonable amount of time. "
-              + (expectedNumRegions - numRegionsReady)
+              + (expectedVmsWithRegion - numVmsReady)
               + " region(s) were not created in time.");
     }
   }

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/concurrent/ConcurrentParallelGatewaySenderDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/concurrent/ConcurrentParallelGatewaySenderDUnitTest.java
@@ -647,10 +647,10 @@ public class ConcurrentParallelGatewaySenderDUnitTest extends WANTestBase {
 
     AsyncInvocation killsSenderFromVM5 = vm5.invokeAsync(() -> WANTestBase.killSender());
 
-    putsToVM7.join();
-    killsSenderFromVM4.join();
-    putsToVM6.join();
-    killsSenderFromVM5.join();
+    putsToVM7.get();
+    killsSenderFromVM4.get();
+    putsToVM6.get();
+    killsSenderFromVM5.get();
 
     vm6.invoke(() -> WANTestBase.validateRegionSize(getTestMethodName() + "_PR", 10000));
     vm7.invoke(() -> WANTestBase.validateRegionSize(getTestMethodName() + "_PR", 10000));


### PR DESCRIPTION
Move assertion on region size to an async invoke, join the thread doing
puts, then join the thread doing the assertions. There was a bug in this
test where the thread doing puts would not progress far enough by the
time the awaitility timed out for region size being 20 entries greater
than the previous region size. Setting off the awaitility as an async
invocation and joining the put thread allows more puts to reliably occur
before the awaitility times out.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
