### PR TITLE
GEODE-5888: Check partitioned region is ready in bucket region

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/Operation.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/Operation.java
@@ -31,7 +31,7 @@ import org.apache.geode.internal.cache.OpType;
  *
  * @since GemFire 5.0
  */
-public final class Operation implements java.io.Serializable {
+public class Operation implements java.io.Serializable {
   private static final long serialVersionUID = -7521751729852504238L;
 
   private static byte nextOrdinal = 0;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/BucketRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/BucketRegion.java
@@ -403,7 +403,7 @@ public class BucketRegion extends DistributedRegion implements Bucket {
    *
    * @return first key found in CM null means not found
    */
-  private LockObject searchAndLock(Object keys[]) {
+  LockObject searchAndLock(Object keys[]) {
     final boolean isDebugEnabled = logger.isDebugEnabled();
 
     LockObject foundLock = null;
@@ -476,12 +476,12 @@ public class BucketRegion extends DistributedRegion implements Bucket {
     final String title = "BucketRegion.waitUntilLocked:";
     while (true) {
       LockObject foundLock = searchAndLock(keys);
-
+      partitionedRegion.checkReadiness();
       if (foundLock != null) {
         synchronized (foundLock) {
           try {
             while (!foundLock.isRemoved()) {
-              this.partitionedRegion.checkReadiness();
+              partitionedRegion.checkReadiness();
               foundLock.wait(1000);
               // primary could be changed by prRebalancing while waiting here
               checkForPrimary();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/BucketRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/BucketRegion.java
@@ -470,13 +470,13 @@ public class BucketRegion extends DistributedRegion implements Bucket {
    * This method will block current thread for long time. It only exits when current thread
    * successfully save its keys into CM.
    */
-  public void waitUntilLocked(Object keys[]) {
+  public boolean waitUntilLocked(Object keys[]) {
     final boolean isDebugEnabled = logger.isDebugEnabled();
 
     final String title = "BucketRegion.waitUntilLocked:";
     while (true) {
       LockObject foundLock = searchAndLock(keys);
-      partitionedRegion.checkReadiness();
+
       if (foundLock != null) {
         synchronized (foundLock) {
           try {
@@ -499,7 +499,7 @@ public class BucketRegion extends DistributedRegion implements Bucket {
         }
       } else {
         // now the keys have been locked by this thread
-        break;
+        return true;
       } // to lock and process
     } // while
   }
@@ -516,7 +516,7 @@ public class BucketRegion extends DistributedRegion implements Bucket {
   public boolean virtualPut(EntryEventImpl event, boolean ifNew, boolean ifOld,
       Object expectedOldValue, boolean requireOldValue, long lastModified,
       boolean overwriteDestroyed) throws TimeoutException, CacheWriterException {
-    beginLocalWrite(event);
+    boolean locked = lockKeysAndPrimary(event);
 
     try {
       if (this.partitionedRegion.isParallelWanEnabled()) {
@@ -548,7 +548,9 @@ public class BucketRegion extends DistributedRegion implements Bucket {
       }
       return true;
     } finally {
-      endLocalWrite(event);
+      if (locked) {
+        releaseLockForKeysAndPrimary(event);
+      }
     }
   }
 
@@ -734,10 +736,10 @@ public class BucketRegion extends DistributedRegion implements Bucket {
 
   /**
    * Checks to make sure that this node is primary, and locks the bucket to make sure the bucket
-   * stays the primary bucket while the write is in progress. Any call to this method must be
-   * followed with a call to endLocalWrite().
+   * stays the primary bucket while the write is in progress. This method must be followed with
+   * a call to releaseLockForKeysAndPrimary() if keys and primary are locked.
    */
-  private boolean beginLocalWrite(EntryEventImpl event) {
+  boolean lockKeysAndPrimary(EntryEventImpl event) {
     if (!needWriteLock(event)) {
       return false;
     }
@@ -746,19 +748,27 @@ public class BucketRegion extends DistributedRegion implements Bucket {
       throw cache.getCacheClosedException("Cache is shutting down");
     }
 
-    Object keys[] = new Object[1];
-    keys[0] = event.getKey();
+    Object[] keys = getKeysToBeLocked(event);
     waitUntilLocked(keys); // it might wait for long time
 
     boolean lockedForPrimary = false;
     try {
-      doLockForPrimary(false);
-      return lockedForPrimary = true;
+      lockedForPrimary = doLockForPrimary(false);
+      // tryLock is false means doLockForPrimary won't return false.
+      // either the method returns true or fails with an exception
+      assert lockedForPrimary : "expected doLockForPrimary returns true";
+      return lockedForPrimary;
     } finally {
       if (!lockedForPrimary) {
         removeAndNotifyKeys(keys);
       }
     }
+  }
+
+  Object[] getKeysToBeLocked(EntryEventImpl event) {
+    Object keys[] = new Object[1];
+    keys[0] = event.getKey();
+    return keys;
   }
 
   /**
@@ -794,8 +804,8 @@ public class BucketRegion extends DistributedRegion implements Bucket {
   }
 
   private boolean lockPrimaryStateReadLock(boolean tryLock) {
-    Lock activeWriteLock = this.getBucketAdvisor().getActiveWriteLock();
-    Lock parentLock = this.getBucketAdvisor().getParentActiveWriteLock();
+    Lock primaryMoveReadLock = getBucketAdvisor().getPrimaryMoveReadLock();
+    Lock parentLock = getBucketAdvisor().getParentPrimaryMoveReadLock();
     for (;;) {
       boolean interrupted = Thread.interrupted();
       try {
@@ -813,22 +823,22 @@ public class BucketRegion extends DistributedRegion implements Bucket {
             parentLock.lockInterruptibly();
           }
           if (tryLock) {
-            boolean locked = activeWriteLock.tryLock();
+            boolean locked = primaryMoveReadLock.tryLock();
             if (!locked) {
               parentLock.unlock();
               return false;
             }
           } else {
-            activeWriteLock.lockInterruptibly();
+            primaryMoveReadLock.lockInterruptibly();
           }
         } else {
           if (tryLock) {
-            boolean locked = activeWriteLock.tryLock();
+            boolean locked = primaryMoveReadLock.tryLock();
             if (!locked) {
               return false;
             }
           } else {
-            activeWriteLock.lockInterruptibly();
+            primaryMoveReadLock.lockInterruptibly();
           }
         }
         break; // success
@@ -847,9 +857,9 @@ public class BucketRegion extends DistributedRegion implements Bucket {
   }
 
   public void doUnlockForPrimary() {
-    Lock activeWriteLock = this.getBucketAdvisor().getActiveWriteLock();
-    activeWriteLock.unlock();
-    Lock parentLock = this.getBucketAdvisor().getParentActiveWriteLock();
+    Lock primaryMoveReadLock = getBucketAdvisor().getPrimaryMoveReadLock();
+    primaryMoveReadLock.unlock();
+    Lock parentLock = getBucketAdvisor().getParentPrimaryMoveReadLock();
     if (parentLock != null) {
       parentLock.unlock();
     }
@@ -857,17 +867,12 @@ public class BucketRegion extends DistributedRegion implements Bucket {
 
   /**
    * Release the lock on the bucket that makes the bucket stay the primary during a write.
+   * And release/remove the lockObject on the key(s)
    */
-  private void endLocalWrite(EntryEventImpl event) {
-    if (!needWriteLock(event)) {
-      return;
-    }
-
-
+  void releaseLockForKeysAndPrimary(EntryEventImpl event) {
     doUnlockForPrimary();
 
-    Object keys[] = new Object[1];
-    keys[0] = event.getKey();
+    Object[] keys = getKeysToBeLocked(event);
     removeAndNotifyKeys(keys);
   }
 
@@ -906,7 +911,7 @@ public class BucketRegion extends DistributedRegion implements Bucket {
     Assert.assertTrue(!isTX());
     Assert.assertTrue(event.getOperation().isDistributed());
 
-    beginLocalWrite(event);
+    boolean locked = lockKeysAndPrimary(event);
     try {
       // which performs the local op.
       // The ARM then calls basicInvalidatePart2 with the entry synchronized.
@@ -939,7 +944,9 @@ public class BucketRegion extends DistributedRegion implements Bucket {
         return;
       }
     } finally {
-      endLocalWrite(event);
+      if (locked) {
+        releaseLockForKeysAndPrimary(event);
+      }
     }
   }
 
@@ -1169,7 +1176,7 @@ public class BucketRegion extends DistributedRegion implements Bucket {
     Assert.assertTrue(!isTX());
     Assert.assertTrue(event.getOperation().isDistributed());
 
-    beginLocalWrite(event);
+    boolean locked = lockKeysAndPrimary(event);
     try {
       // increment the tailKey for the destroy event
       if (this.partitionedRegion.isParallelWanEnabled()) {
@@ -1206,7 +1213,9 @@ public class BucketRegion extends DistributedRegion implements Bucket {
         return;
       }
     } finally {
-      endLocalWrite(event);
+      if (locked) {
+        releaseLockForKeysAndPrimary(event);
+      }
     }
   }
 
@@ -1315,7 +1324,7 @@ public class BucketRegion extends DistributedRegion implements Bucket {
   @Override
   protected RegionEntry basicPutEntry(final EntryEventImpl event, final long lastModified)
       throws TimeoutException, CacheWriterException {
-    beginLocalWrite(event);
+    boolean locked = lockKeysAndPrimary(event);
     try {
       if (getPartitionedRegion().isParallelWanEnabled()) {
         handleWANEvent(event);
@@ -1324,7 +1333,9 @@ public class BucketRegion extends DistributedRegion implements Bucket {
       forceSerialized(event);
       return super.basicPutEntry(event, lastModified);
     } finally {
-      endLocalWrite(event);
+      if (locked) {
+        releaseLockForKeysAndPrimary(event);
+      }
     }
   }
 
@@ -1340,7 +1351,7 @@ public class BucketRegion extends DistributedRegion implements Bucket {
     arm.lockForCacheModification(internalRegion, event);
     final boolean locked = internalRegion.lockWhenRegionIsInitializing();
     try {
-      beginLocalWrite(event);
+      boolean keysAndPrimaryLocked = lockKeysAndPrimary(event);
       try {
         if (!hasSeenEvent(event)) {
           this.entries.updateEntryVersion(event);
@@ -1359,7 +1370,9 @@ public class BucketRegion extends DistributedRegion implements Bucket {
         }
         return;
       } finally {
-        endLocalWrite(event);
+        if (keysAndPrimaryLocked) {
+          releaseLockForKeysAndPrimary(event);
+        }
       }
     } finally {
       if (locked) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
@@ -5767,7 +5767,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
         DistTXState.internalBeforeNonTXBasicPut.run();
       }
 
-      return this.entries.basicPut(event, lastModified, ifNew, false, null, false, false);
+      return getRegionMap().basicPut(event, lastModified, ifNew, false, null, false, false);
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegionDataStore.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegionDataStore.java
@@ -1556,13 +1556,13 @@ public class PartitionedRegionDataStore implements HasCachePerfStats {
       BucketAdvisor bucketAdvisor = bucketRegion.getBucketAdvisor();
       InternalDistributedMember myId =
           this.partitionedRegion.getDistributionManager().getDistributionManagerId();
-      Lock writeLock = bucketAdvisor.getActiveWriteLock();
+      Lock primaryMoveReadLock = bucketAdvisor.getPrimaryMoveReadLock();
 
       // Fix for 43613 - don't remove the bucket
       // if we are primary. We hold the lock here
       // to prevent this member from becoming primary until this
       // member is no longer hosting the bucket.
-      writeLock.lock();
+      primaryMoveReadLock.lock();
       try {
         // forceRemovePrimary==true will enable remove the bucket even when:
         // 1) it's primary
@@ -1602,7 +1602,7 @@ public class PartitionedRegionDataStore implements HasCachePerfStats {
         }
         bucketAdvisor.getProxyBucketRegion().removeBucket();
       } finally {
-        writeLock.unlock();
+        primaryMoveReadLock.unlock();
       }
 
       if (logger.isDebugEnabled()) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/PutAllPRMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/PutAllPRMessage.java
@@ -408,14 +408,9 @@ public class PutAllPRMessage extends PartitionMessageWithDirectReply {
         dpao = new DistributedPutAllOperation(baseEvent, putAllPRDataSize, false);
       }
 
-      // Fix the updateMsg misorder issue
-      // Lock the keys when doing postPutAll
-      Object keys[] = new Object[putAllPRDataSize];
-      for (int i = 0; i < putAllPRDataSize; ++i) {
-        keys[i] = putAllPRData[i].getKey();
-      }
-
+      Object[] keys = getKeysToBeLocked();
       if (!notificationOnly) {
+        boolean locked = false;
         try {
           if (putAllPRData.length > 0) {
             if (this.posDup && bucketRegion.getConcurrencyChecksEnabled()) {
@@ -440,7 +435,7 @@ public class PutAllPRMessage extends PartitionMessageWithDirectReply {
                 new ThreadIdentifier(eventID.getMembershipID(), eventID.getThreadID());
             bucketRegion.recordBulkOpStart(membershipID, eventID);
           }
-          bucketRegion.waitUntilLocked(keys);
+          locked = bucketRegion.waitUntilLocked(keys);
           boolean lockedForPrimary = false;
           final HashMap succeeded = new HashMap();
           PutAllPartialResult partialKeys = new PutAllPartialResult(putAllPRDataSize);
@@ -521,7 +516,9 @@ public class PutAllPRMessage extends PartitionMessageWithDirectReply {
         } catch (RegionDestroyedException e) {
           ds.checkRegionDestroyedOnBucket(bucketRegion, true, e);
         } finally {
-          bucketRegion.removeAndNotifyKeys(keys);
+          if (locked) {
+            bucketRegion.removeAndNotifyKeys(keys);
+          }
         }
       } else {
         for (int i = 0; i < putAllPRDataSize; i++) {
@@ -547,6 +544,16 @@ public class PutAllPRMessage extends PartitionMessageWithDirectReply {
     }
 
     return true;
+  }
+
+  Object[] getKeysToBeLocked() {
+    // Fix the updateMsg misorder issue
+    // Lock the keys when doing postPutAll
+    Object keys[] = new Object[putAllPRDataSize];
+    for (int i = 0; i < putAllPRDataSize; ++i) {
+      keys[i] = putAllPRData[i].getKey();
+    }
+    return keys;
   }
 
   void doPostPutAll(PartitionedRegion r, DistributedPutAllOperation dpao,

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/RemoveAllPRMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/RemoveAllPRMessage.java
@@ -382,7 +382,7 @@ public class RemoveAllPRMessage extends PartitionMessageWithDirectReply {
         // bucketRegion is not null only when !notificationOnly
         bucketRegion = ds.getInitializedBucketForId(null, bucketId);
 
-        this.versions = new VersionedObjectList(this.removeAllPRDataSize, true,
+        versions = new VersionedObjectList(this.removeAllPRDataSize, true,
             bucketRegion.getAttributes().getConcurrencyChecksEnabled());
 
         // create a base event and a DPAO for RemoveAllMessage distributed btw redundant buckets
@@ -401,15 +401,10 @@ public class RemoveAllPRMessage extends PartitionMessageWithDirectReply {
         }
         op = new DistributedRemoveAllOperation(baseEvent, removeAllPRDataSize, false);
       }
-
-      // Fix the updateMsg misorder issue
-      // Lock the keys when doing postRemoveAll
-      Object keys[] = new Object[removeAllPRDataSize];
-      for (int i = 0; i < removeAllPRDataSize; ++i) {
-        keys[i] = removeAllPRData[i].getKey();
-      }
+      Object[] keys = getKeysToBeLocked();
 
       if (!notificationOnly) {
+        boolean locked = false;
         try {
           if (removeAllPRData.length > 0) {
             if (this.posDup && bucketRegion.getConcurrencyChecksEnabled()) {
@@ -434,7 +429,7 @@ public class RemoveAllPRMessage extends PartitionMessageWithDirectReply {
                 new ThreadIdentifier(eventID.getMembershipID(), eventID.getThreadID());
             bucketRegion.recordBulkOpStart(membershipID, eventID);
           }
-          bucketRegion.waitUntilLocked(keys);
+          locked = bucketRegion.waitUntilLocked(keys);
           boolean lockedForPrimary = false;
           final ArrayList<Object> succeeded = new ArrayList<Object>();
           PutAllPartialResult partialKeys = new PutAllPartialResult(removeAllPRDataSize);
@@ -530,7 +525,9 @@ public class RemoveAllPRMessage extends PartitionMessageWithDirectReply {
         } catch (RegionDestroyedException e) {
           ds.checkRegionDestroyedOnBucket(bucketRegion, true, e);
         } finally {
-          bucketRegion.removeAndNotifyKeys(keys);
+          if (locked) {
+            bucketRegion.removeAndNotifyKeys(keys);
+          }
         }
       } else {
         for (int i = 0; i < removeAllPRDataSize; i++) {
@@ -555,6 +552,16 @@ public class RemoveAllPRMessage extends PartitionMessageWithDirectReply {
     }
 
     return true;
+  }
+
+  Object[] getKeysToBeLocked() {
+    // Fix the updateMsg misorder issue
+    // Lock the keys when doing postRemoveAll
+    Object keys[] = new Object[removeAllPRDataSize];
+    for (int i = 0; i < removeAllPRDataSize; ++i) {
+      keys[i] = removeAllPRData[i].getKey();
+    }
+    return keys;
   }
 
   void doPostRemoveAll(PartitionedRegion r, DistributedRemoveAllOperation op,

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/BucketRegionJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/BucketRegionJUnitTest.java
@@ -41,8 +41,8 @@ public class BucketRegionJUnitTest extends DistributedRegionJUnitTest {
     PartitionedRegion pr = mock(PartitionedRegion.class);
     BucketAdvisor ba = mock(BucketAdvisor.class);
     ReadWriteLock primaryMoveLock = new ReentrantReadWriteLock();
-    Lock activeWriteLock = primaryMoveLock.readLock();
-    when(ba.getActiveWriteLock()).thenReturn(activeWriteLock);
+    Lock primaryMoveReadLock = primaryMoveLock.readLock();
+    when(ba.getPrimaryMoveReadLock()).thenReturn(primaryMoveReadLock);
     when(ba.getProxyBucketRegion()).thenReturn(mock(ProxyBucketRegion.class));
     when(ba.isPrimary()).thenReturn(true);
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/BucketRegionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/BucketRegionTest.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache;
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.geode.cache.DataPolicy;
+import org.apache.geode.cache.EvictionAlgorithm;
+import org.apache.geode.cache.ExpirationAttributes;
+import org.apache.geode.cache.LossAction;
+import org.apache.geode.cache.MembershipAttributes;
+import org.apache.geode.cache.RegionAttributes;
+import org.apache.geode.cache.RegionDestroyedException;
+import org.apache.geode.cache.Scope;
+import org.apache.geode.internal.cache.partitioned.LockObject;
+import org.apache.geode.test.fake.Fakes;
+
+public class BucketRegionTest {
+  private RegionAttributes regionAttributes;
+  private PartitionedRegion partitionedRegion;
+  private InternalCache cache;
+  private InternalRegionArguments internalRegionArgs;
+  private DataPolicy dataPolicy;
+
+  private final String regionName = "name";
+
+  @Before
+  @SuppressWarnings("deprecation")
+  public void setup() {
+    regionAttributes = mock(RegionAttributes.class);
+    partitionedRegion = mock(PartitionedRegion.class);
+    cache = Fakes.cache();
+    internalRegionArgs = mock(InternalRegionArguments.class);
+    dataPolicy = mock(DataPolicy.class);
+    EvictionAttributesImpl evictionAttributes = mock(EvictionAttributesImpl.class);
+    ExpirationAttributes expirationAttributes = mock(ExpirationAttributes.class);
+    MembershipAttributes membershipAttributes = mock(MembershipAttributes.class);
+    Scope scope = mock(Scope.class);
+    BucketAdvisor bucketAdvisor = mock(BucketAdvisor.class);
+
+    when(regionAttributes.getEvictionAttributes()).thenReturn(evictionAttributes);
+    when(regionAttributes.getRegionTimeToLive()).thenReturn(expirationAttributes);
+    when(regionAttributes.getRegionIdleTimeout()).thenReturn(expirationAttributes);
+    when(regionAttributes.getEntryTimeToLive()).thenReturn(expirationAttributes);
+    when(regionAttributes.getEntryIdleTimeout()).thenReturn(expirationAttributes);
+    when(regionAttributes.getDataPolicy()).thenReturn(dataPolicy);
+    when(regionAttributes.getDiskStoreName()).thenReturn("store");
+    when(regionAttributes.getConcurrencyLevel()).thenReturn(16);
+    when(regionAttributes.getLoadFactor()).thenReturn(0.75f);
+    when(regionAttributes.getMembershipAttributes()).thenReturn(membershipAttributes);
+    when(regionAttributes.getScope()).thenReturn(scope);
+    when(partitionedRegion.getFullPath()).thenReturn("parent");
+    when(internalRegionArgs.getPartitionedRegion()).thenReturn(partitionedRegion);
+    when(internalRegionArgs.isUsedForPartitionedRegionBucket()).thenReturn(true);
+    when(internalRegionArgs.getBucketAdvisor()).thenReturn(bucketAdvisor);
+    when(evictionAttributes.getAlgorithm()).thenReturn(EvictionAlgorithm.NONE);
+    when(membershipAttributes.getLossAction()).thenReturn(mock(LossAction.class));
+    when(scope.isDistributedAck()).thenReturn(true);
+    when(dataPolicy.withReplication()).thenReturn(true);
+    when(bucketAdvisor.getProxyBucketRegion()).thenReturn(mock(ProxyBucketRegion.class));
+  }
+
+  @Test(expected = RegionDestroyedException.class)
+  public void waitUntilLockedThrowsIfFoundLockAndPartitionedRegionIsClosing() {
+    BucketRegion bucketRegion =
+        spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
+            cache, internalRegionArgs));
+    Integer[] keys = {1};
+    doReturn(mock(LockObject.class)).when(bucketRegion).searchAndLock(keys);
+    doNothing().doThrow(new RegionDestroyedException("", "")).when(partitionedRegion)
+        .checkReadiness();
+
+    bucketRegion.waitUntilLocked(keys);
+  }
+
+  @Test(expected = RegionDestroyedException.class)
+  public void waitUntilLockedThrowsIfNotFoundLockAndPartitionedRegionIsClosing() {
+    BucketRegion bucketRegion =
+        spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
+            cache, internalRegionArgs));
+    Integer[] keys = {1};
+    doReturn(null).when(bucketRegion).searchAndLock(keys);
+    doThrow(new RegionDestroyedException("", "")).when(partitionedRegion).checkReadiness();
+
+    bucketRegion.waitUntilLocked(keys);
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/RemoveAllPRMessageTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/RemoveAllPRMessageTest.java
@@ -15,21 +15,52 @@
 package org.apache.geode.internal.cache.partitioned;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;
 
+import org.apache.geode.cache.RegionDestroyedException;
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.BucketRegion;
 import org.apache.geode.internal.cache.DistributedRemoveAllOperation;
+import org.apache.geode.internal.cache.EventID;
 import org.apache.geode.internal.cache.InternalDataView;
 import org.apache.geode.internal.cache.PartitionedRegion;
+import org.apache.geode.internal.cache.PartitionedRegionDataStore;
+import org.apache.geode.internal.cache.PrimaryBucketException;
 
 public class RemoveAllPRMessageTest {
+  private PartitionedRegion partitionedRegion;
+  private PartitionedRegionDataStore dataStore;
+  private BucketRegion bucketRegion;
+  private Object[] keys;
+  private DistributedRemoveAllOperation.RemoveAllEntryData entryData;
+
+  private final int bucketId = 1;
+
+  @Before
+  public void setup() throws Exception {
+    partitionedRegion = mock(PartitionedRegion.class, RETURNS_DEEP_STUBS);
+    dataStore = mock(PartitionedRegionDataStore.class);
+    bucketRegion = mock(BucketRegion.class, RETURNS_DEEP_STUBS);
+    keys = new Object[] {1};
+    entryData = mock(DistributedRemoveAllOperation.RemoveAllEntryData.class);
+
+    when(partitionedRegion.getDataStore()).thenReturn(dataStore);
+    when(dataStore.getInitializedBucketForId(null, bucketId)).thenReturn(bucketRegion);
+    when(entryData.getEventID()).thenReturn(mock(EventID.class));
+  }
 
   @Test
   public void shouldBeMockable() throws Exception {
@@ -44,10 +75,8 @@ public class RemoveAllPRMessageTest {
 
   @Test
   public void doPostRemoveAllCallsCheckReadinessBeforeAndAfter() throws Exception {
-    PartitionedRegion partitionedRegion = mock(PartitionedRegion.class);
     DistributedRemoveAllOperation distributedRemoveAllOperation =
         mock(DistributedRemoveAllOperation.class);
-    BucketRegion bucketRegion = mock(BucketRegion.class);
     InternalDataView internalDataView = mock(InternalDataView.class);
     when(bucketRegion.getDataView()).thenReturn(internalDataView);
     RemoveAllPRMessage removeAllPRMessage = new RemoveAllPRMessage();
@@ -59,5 +88,33 @@ public class RemoveAllPRMessageTest {
     inOrder.verify(partitionedRegion).checkReadiness();
     inOrder.verify(internalDataView).postRemoveAll(any(), any(), any());
     inOrder.verify(partitionedRegion).checkReadiness();
+  }
+
+  @Test(expected = PrimaryBucketException.class)
+  public void lockedKeysAreRemoved() throws Exception {
+    RemoveAllPRMessage message = spy(new RemoveAllPRMessage(bucketId, 1, false, false, true, null));
+    message.addEntry(entryData);
+    doReturn(keys).when(message).getKeysToBeLocked();
+    when(bucketRegion.waitUntilLocked(keys)).thenReturn(true);
+    when(bucketRegion.doLockForPrimary(false)).thenThrow(new PrimaryBucketException());
+
+    message.doLocalRemoveAll(partitionedRegion, mock(InternalDistributedMember.class), true);
+
+    verify(bucketRegion).removeAndNotifyKeys(eq(keys));
+  }
+
+  @Test
+  public void removeAndNotifyKeysIsNotInvokedIfKeysNotLocked() throws Exception {
+    RemoveAllPRMessage message = spy(new RemoveAllPRMessage(bucketId, 1, false, false, true, null));
+    message.addEntry(entryData);
+    doReturn(keys).when(message).getKeysToBeLocked();
+    RegionDestroyedException regionDestroyedException = new RegionDestroyedException("", "");
+    when(bucketRegion.waitUntilLocked(keys)).thenThrow(regionDestroyedException);
+
+    message.doLocalRemoveAll(partitionedRegion, mock(InternalDistributedMember.class), true);
+
+    verify(bucketRegion, never()).removeAndNotifyKeys(eq(keys));
+    verify(dataStore).checkRegionDestroyedOnBucket(eq(bucketRegion), eq(true),
+        eq(regionDestroyedException));
   }
 }


### PR DESCRIPTION
 * A bulk opertion could remove lockObject due to RegionDestroyedException.
 * Do not allow a new operation to proceed without checking region readiness.

