### PR TITLE
GEODE-5893: Keep docker configuration in RepeatTest

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/RepeatTest.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/RepeatTest.groovy
@@ -48,14 +48,10 @@ class RepeatTest extends Test {
   protected TestExecuter<JvmTestExecutionSpec> createTestExecuter() {
     def oldExecutor = super.createTestExecuter()
 
-    def workerProcessFactory = getProcessBuilderFactory()
-
     //Use the previously set worker process factory. If the test is
     //being run using the parallel docker plugin, this will be a docker
     //process factory
-    if(oldExecutor instanceof DefaultTestExecuter) {
-      workerProcessFactory = oldExecutor.workerFactory
-    }
+    def workerProcessFactory = oldExecutor.workerFactory
 
     return new OverriddenTestExecutor(workerProcessFactory, getActorFactory(),
         getModuleRegistry(),


### PR DESCRIPTION
The RepeatTest task was not retaining the workerProcessFactory installed
by the docker plugin, because the new version of the docker plugin used
a different implementation of TestExcecutor.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
