### PR TITLE
GEODE-5892: test rules should not modify the user.dir system property

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocatorRecoveryJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocatorRecoveryJUnitTest.java
@@ -31,6 +31,7 @@ import java.io.ObjectOutputStream;
 import java.net.InetAddress;
 import java.util.Properties;
 
+import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -194,24 +195,20 @@ public class GMSLocatorRecoveryJUnitTest {
   }
 
   @Test
-  public void testViewFileFoundWhenUserDirModified() throws Exception {
+  public void testViewFileNotFound() throws Exception {
     NetView view = new NetView();
     populateStateFile(this.tempStateFile, GMSLocator.LOCATOR_FILE_STAMP, Version.CURRENT_ORDINAL,
         view);
+    assertTrue(this.tempStateFile.exists());
 
-    String userDir = System.getProperty("user.dir");
-    try {
-      File dir = new File("testViewFileFoundWhenUserDirModified");
-      dir.mkdir();
-      System.setProperty("user.dir", dir.getAbsolutePath());
-      File viewFileInNewDirectory = new File(tempStateFile.getName());
-      // GEODE-4180 - file in parent dir still seen with relative path
-      assertTrue(viewFileInNewDirectory.exists());
-      File locatorViewFile = locator.setViewFile(viewFileInNewDirectory);
-      assertFalse(locator.recoverFromFile(locatorViewFile));
-    } finally {
-      System.setProperty("user.dir", userDir);
-    }
+    File dir = new File("testViewFileFoundWhenUserDirModified");
+    dir.mkdir();
+    File viewFileInNewDirectory = new File(dir, tempStateFile.getName());
+
+    assertFalse(viewFileInNewDirectory.exists());
+    File locatorViewFile = locator.setViewFile(viewFileInNewDirectory);
+    assertFalse(locator.recoverFromFile(locatorViewFile));
+    FileUtils.deleteQuietly(dir);
   }
 
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/ClassPathLoaderDeployTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/ClassPathLoaderDeployTest.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.List;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import org.apache.geode.cache.execute.Execution;
+import org.apache.geode.cache.execute.FunctionService;
+import org.apache.geode.cache.execute.ResultCollector;
+import org.apache.geode.distributed.DistributedSystem;
+import org.apache.geode.internal.cache.GemFireCacheImpl;
+import org.apache.geode.test.compiler.ClassBuilder;
+import org.apache.geode.test.junit.rules.ServerStarterRule;
+
+/**
+ * Integration tests for {@link ClassPathLoader}.
+ */
+public class ClassPathLoaderDeployTest {
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @Rule
+  public ServerStarterRule server = new ServerStarterRule();
+
+  @Test
+  public void testDeployWithExistingDependentJars() throws Exception {
+    ClassBuilder classBuilder = new ClassBuilder();
+    final File parentJarFile =
+        new File("JarDeployerDUnitAParent.v1.jar");
+    final File usesJarFile = new File("JarDeployerDUnitUses.v1.jar");
+    final File functionJarFile =
+        new File("JarDeployerDUnitFunction.v1.jar");
+
+    // Write out a JAR files.
+    StringBuffer stringBuffer = new StringBuffer();
+    stringBuffer.append("package jddunit.parent;");
+    stringBuffer.append("public class JarDeployerDUnitParent {");
+    stringBuffer.append("public String getValueParent() {");
+    stringBuffer.append("return \"PARENT\";}}");
+
+    byte[] jarBytes = classBuilder.createJarFromClassContent(
+        "jddunit/parent/JarDeployerDUnitParent", stringBuffer.toString());
+    FileOutputStream outStream = new FileOutputStream(parentJarFile);
+    outStream.write(jarBytes);
+    outStream.close();
+
+    stringBuffer = new StringBuffer();
+    stringBuffer.append("package jddunit.uses;");
+    stringBuffer.append("public class JarDeployerDUnitUses {");
+    stringBuffer.append("public String getValueUses() {");
+    stringBuffer.append("return \"USES\";}}");
+
+    jarBytes = classBuilder.createJarFromClassContent("jddunit/uses/JarDeployerDUnitUses",
+        stringBuffer.toString());
+    outStream = new FileOutputStream(usesJarFile);
+    outStream.write(jarBytes);
+    outStream.close();
+
+    stringBuffer = new StringBuffer();
+    stringBuffer.append("package jddunit.function;");
+    stringBuffer.append("import jddunit.parent.JarDeployerDUnitParent;");
+    stringBuffer.append("import jddunit.uses.JarDeployerDUnitUses;");
+    stringBuffer.append("import org.apache.geode.cache.execute.Function;");
+    stringBuffer.append("import org.apache.geode.cache.execute.FunctionContext;");
+    stringBuffer.append(
+        "public class JarDeployerDUnitFunction  extends JarDeployerDUnitParent implements Function {");
+    stringBuffer.append("private JarDeployerDUnitUses uses = new JarDeployerDUnitUses();");
+    stringBuffer.append("public boolean hasResult() {return true;}");
+    stringBuffer.append(
+        "public void execute(FunctionContext context) {context.getResultSender().lastResult(getValueParent() + \":\" + uses.getValueUses());}");
+    stringBuffer.append("public String getId() {return \"JarDeployerDUnitFunction\";}");
+    stringBuffer.append("public boolean optimizeForWrite() {return false;}");
+    stringBuffer.append("public boolean isHA() {return false;}}");
+
+    ClassBuilder functionClassBuilder = new ClassBuilder();
+    functionClassBuilder.addToClassPath(parentJarFile.getAbsolutePath());
+    functionClassBuilder.addToClassPath(usesJarFile.getAbsolutePath());
+    jarBytes = functionClassBuilder.createJarFromClassContent(
+        "jddunit/function/JarDeployerDUnitFunction", stringBuffer.toString());
+    outStream = new FileOutputStream(functionJarFile);
+    outStream.write(jarBytes);
+    outStream.close();
+
+    server.startServer();
+
+    GemFireCacheImpl gemFireCache = GemFireCacheImpl.getInstance();
+    DistributedSystem distributedSystem = gemFireCache.getDistributedSystem();
+    Execution execution = FunctionService.onMember(distributedSystem.getDistributedMember());
+    ResultCollector resultCollector = execution.execute("JarDeployerDUnitFunction");
+    @SuppressWarnings("unchecked")
+    List<String> result = (List<String>) resultCollector.getResult();
+    assertEquals("PARENT:USES", result.get(0));
+  }
+
+  @Test
+  public void deployNewVersionOfFunctionOverOldVersion() throws Exception {
+    File jarVersion1 = createVersionOfJar("Version1", "MyFunction", "MyJar.jar");
+    File jarVersion2 = createVersionOfJar("Version2", "MyFunction", "MyJar.jar");
+
+    server.startServer();
+
+    GemFireCacheImpl gemFireCache = GemFireCacheImpl.getInstance();
+    DistributedSystem distributedSystem = gemFireCache.getDistributedSystem();
+
+    ClassPathLoader.getLatest().getJarDeployer().deploy("MyJar.jar", jarVersion1);
+
+    assertThatClassCanBeLoaded("jddunit.function.MyFunction");
+    Execution execution = FunctionService.onMember(distributedSystem.getDistributedMember());
+
+    List<String> result = (List<String>) execution.execute("MyFunction").getResult();
+    assertThat(result.get(0)).isEqualTo("Version1");
+
+    ClassPathLoader.getLatest().getJarDeployer().deploy("MyJar.jar", jarVersion2);
+    result = (List<String>) execution.execute("MyFunction").getResult();
+    assertThat(result.get(0)).isEqualTo("Version2");
+  }
+
+
+  private File createVersionOfJar(String version, String functionName, String jarName)
+      throws IOException {
+    String classContents =
+        "package jddunit.function;" + "import org.apache.geode.cache.execute.Function;"
+            + "import org.apache.geode.cache.execute.FunctionContext;" + "public class "
+            + functionName + " implements Function {" + "public boolean hasResult() {return true;}"
+            + "public String getId() {return \"" + functionName + "\";}"
+            + "public void execute(FunctionContext context) {context.getResultSender().lastResult(\""
+            + version + "\");}}";
+
+    File jar = new File(this.temporaryFolder.newFolder(version), jarName);
+    ClassBuilder functionClassBuilder = new ClassBuilder();
+    functionClassBuilder.writeJarFromContent("jddunit/function/" + functionName, classContents,
+        jar);
+
+    return jar;
+  }
+
+  private void assertThatClassCanBeLoaded(String className) throws ClassNotFoundException {
+    assertThat(ClassPathLoader.getLatest().forName(className)).isNotNull();
+  }
+}

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/ClassPathLoaderIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/ClassPathLoaderIntegrationTest.java
@@ -33,7 +33,6 @@ import java.io.OutputStream;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.util.Enumeration;
-import java.util.List;
 import java.util.Vector;
 
 import org.apache.bcel.Constants;
@@ -46,23 +45,16 @@ import org.junit.Test;
 import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.junit.rules.TemporaryFolder;
 
-import org.apache.geode.cache.execute.Execution;
 import org.apache.geode.cache.execute.Function;
 import org.apache.geode.cache.execute.FunctionContext;
 import org.apache.geode.cache.execute.FunctionService;
-import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.cache.execute.ResultSender;
-import org.apache.geode.distributed.DistributedSystem;
-import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.cache.execute.FunctionContextImpl;
 import org.apache.geode.test.compiler.ClassBuilder;
 import org.apache.geode.test.junit.rules.RestoreTCCLRule;
-import org.apache.geode.test.junit.rules.ServerStarterRule;
 
 /**
  * Integration tests for {@link ClassPathLoader}.
- *
- * Extracted from ClassPathLoaderTest.
  */
 public class ClassPathLoaderIntegrationTest {
 
@@ -193,125 +185,6 @@ public class ClassPathLoaderIntegrationTest {
     assertThat(newJarClassLoader).isNull();
     assertThat(deployedJar).exists();
 
-  }
-
-  @Test
-  public void testDeployWithExistingDependentJars() throws Exception {
-    ClassBuilder classBuilder = new ClassBuilder();
-    final File parentJarFile =
-        new File(temporaryFolder.getRoot(), "JarDeployerDUnitAParent.v1.jar");
-    final File usesJarFile = new File(temporaryFolder.getRoot(), "JarDeployerDUnitUses.v1.jar");
-    final File functionJarFile =
-        new File(temporaryFolder.getRoot(), "JarDeployerDUnitFunction.v1.jar");
-
-    // Write out a JAR files.
-    StringBuffer stringBuffer = new StringBuffer();
-    stringBuffer.append("package jddunit.parent;");
-    stringBuffer.append("public class JarDeployerDUnitParent {");
-    stringBuffer.append("public String getValueParent() {");
-    stringBuffer.append("return \"PARENT\";}}");
-
-    byte[] jarBytes = classBuilder.createJarFromClassContent(
-        "jddunit/parent/JarDeployerDUnitParent", stringBuffer.toString());
-    FileOutputStream outStream = new FileOutputStream(parentJarFile);
-    outStream.write(jarBytes);
-    outStream.close();
-
-    stringBuffer = new StringBuffer();
-    stringBuffer.append("package jddunit.uses;");
-    stringBuffer.append("public class JarDeployerDUnitUses {");
-    stringBuffer.append("public String getValueUses() {");
-    stringBuffer.append("return \"USES\";}}");
-
-    jarBytes = classBuilder.createJarFromClassContent("jddunit/uses/JarDeployerDUnitUses",
-        stringBuffer.toString());
-    outStream = new FileOutputStream(usesJarFile);
-    outStream.write(jarBytes);
-    outStream.close();
-
-    stringBuffer = new StringBuffer();
-    stringBuffer.append("package jddunit.function;");
-    stringBuffer.append("import jddunit.parent.JarDeployerDUnitParent;");
-    stringBuffer.append("import jddunit.uses.JarDeployerDUnitUses;");
-    stringBuffer.append("import org.apache.geode.cache.execute.Function;");
-    stringBuffer.append("import org.apache.geode.cache.execute.FunctionContext;");
-    stringBuffer.append(
-        "public class JarDeployerDUnitFunction  extends JarDeployerDUnitParent implements Function {");
-    stringBuffer.append("private JarDeployerDUnitUses uses = new JarDeployerDUnitUses();");
-    stringBuffer.append("public boolean hasResult() {return true;}");
-    stringBuffer.append(
-        "public void execute(FunctionContext context) {context.getResultSender().lastResult(getValueParent() + \":\" + uses.getValueUses());}");
-    stringBuffer.append("public String getId() {return \"JarDeployerDUnitFunction\";}");
-    stringBuffer.append("public boolean optimizeForWrite() {return false;}");
-    stringBuffer.append("public boolean isHA() {return false;}}");
-
-    ClassBuilder functionClassBuilder = new ClassBuilder();
-    functionClassBuilder.addToClassPath(parentJarFile.getAbsolutePath());
-    functionClassBuilder.addToClassPath(usesJarFile.getAbsolutePath());
-    jarBytes = functionClassBuilder.createJarFromClassContent(
-        "jddunit/function/JarDeployerDUnitFunction", stringBuffer.toString());
-    outStream = new FileOutputStream(functionJarFile);
-    outStream.write(jarBytes);
-    outStream.close();
-
-    ServerStarterRule serverStarterRule =
-        new ServerStarterRule().withWorkingDir(temporaryFolder.getRoot());
-    serverStarterRule.startServer();
-
-    GemFireCacheImpl gemFireCache = GemFireCacheImpl.getInstance();
-    DistributedSystem distributedSystem = gemFireCache.getDistributedSystem();
-    Execution execution = FunctionService.onMember(distributedSystem.getDistributedMember());
-    ResultCollector resultCollector = execution.execute("JarDeployerDUnitFunction");
-    @SuppressWarnings("unchecked")
-    List<String> result = (List<String>) resultCollector.getResult();
-    assertEquals("PARENT:USES", result.get(0));
-
-    serverStarterRule.after();
-  }
-
-  @Test
-  public void deployNewVersionOfFunctionOverOldVersion() throws Exception {
-    File jarVersion1 = createVersionOfJar("Version1", "MyFunction", "MyJar.jar");
-    File jarVersion2 = createVersionOfJar("Version2", "MyFunction", "MyJar.jar");
-
-    ServerStarterRule serverStarterRule = new ServerStarterRule();
-    serverStarterRule.startServer();
-
-    GemFireCacheImpl gemFireCache = GemFireCacheImpl.getInstance();
-    DistributedSystem distributedSystem = gemFireCache.getDistributedSystem();
-
-    ClassPathLoader.getLatest().getJarDeployer().deploy("MyJar.jar", jarVersion1);
-
-    assertThatClassCanBeLoaded("jddunit.function.MyFunction");
-    Execution execution = FunctionService.onMember(distributedSystem.getDistributedMember());
-
-    List<String> result = (List<String>) execution.execute("MyFunction").getResult();
-    assertThat(result.get(0)).isEqualTo("Version1");
-
-    ClassPathLoader.getLatest().getJarDeployer().deploy("MyJar.jar", jarVersion2);
-    result = (List<String>) execution.execute("MyFunction").getResult();
-    assertThat(result.get(0)).isEqualTo("Version2");
-
-    serverStarterRule.after();
-  }
-
-
-  private File createVersionOfJar(String version, String functionName, String jarName)
-      throws IOException {
-    String classContents =
-        "package jddunit.function;" + "import org.apache.geode.cache.execute.Function;"
-            + "import org.apache.geode.cache.execute.FunctionContext;" + "public class "
-            + functionName + " implements Function {" + "public boolean hasResult() {return true;}"
-            + "public String getId() {return \"" + functionName + "\";}"
-            + "public void execute(FunctionContext context) {context.getResultSender().lastResult(\""
-            + version + "\");}}";
-
-    File jar = new File(this.temporaryFolder.newFolder(version), jarName);
-    ClassBuilder functionClassBuilder = new ClassBuilder();
-    functionClassBuilder.writeJarFromContent("jddunit/function/" + functionName, classContents,
-        jar);
-
-    return jar;
   }
 
   private void assertThatClassCanBeLoaded(String className) throws ClassNotFoundException {

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/beans/ManagementAdapterTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/beans/ManagementAdapterTest.java
@@ -44,7 +44,7 @@ public class ManagementAdapterTest {
 
   @Rule
   public ServerStarterRule serverRule =
-      new ServerStarterRule().withWorkingDir().withLogFile().withAutoStart();
+      new ServerStarterRule().withLogFile().withAutoStart();
 
   @Rule
   public ConcurrencyRule concurrencyRule = new ConcurrencyRule();

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/ConfigurePDXCommandIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/ConfigurePDXCommandIntegrationTest.java
@@ -34,7 +34,7 @@ public class ConfigurePDXCommandIntegrationTest {
 
   @Rule
   public LocatorStarterRule locator =
-      new LocatorStarterRule().withWorkingDir().withAutoStart().withJMXManager();;
+      new LocatorStarterRule().withAutoStart().withJMXManager();;
 
   @Before
   public void before() throws Exception {

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/functions/ExportLogsFunctionIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/functions/ExportLogsFunctionIntegrationTest.java
@@ -40,8 +40,7 @@ public class ExportLogsFunctionIntegrationTest {
   private File serverWorkingDir;
 
   @Rule
-  public ServerStarterRule serverStarterRule =
-      new ServerStarterRule().withWorkingDir().withAutoStart();
+  public ServerStarterRule serverStarterRule = new ServerStarterRule().withAutoStart();
 
   @Before
   public void setup() throws Exception {

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/util/LogExporterIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/util/LogExporterIntegrationTest.java
@@ -55,7 +55,7 @@ public class LogExporterIntegrationTest {
   private Properties properties;
 
   @Rule
-  public ServerStarterRule server = new ServerStarterRule().withWorkingDir();
+  public ServerStarterRule server = new ServerStarterRule();
 
   @Before
   public void before() throws Exception {

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/ProductUseLog.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/ProductUseLog.java
@@ -53,7 +53,7 @@ public class ProductUseLog implements MembershipListener {
 
   public ProductUseLog(File productUseLogFile) {
     // GEODE-4180, use absolute paths
-    this.productUseLogFile = new File(productUseLogFile.getAbsolutePath());
+    this.productUseLogFile = productUseLogFile.getAbsoluteFile();
     this.logLevel = InternalLogWriter.INFO_LEVEL;
     createLogWriter();
   }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocator.java
@@ -36,6 +36,7 @@ import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.DataSerializer;
 import org.apache.geode.InternalGemFireException;
+import org.apache.geode.annotations.TestingOnly;
 import org.apache.geode.cache.GemFireCache;
 import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.distributed.internal.ClusterDistributionManager;
@@ -132,11 +133,9 @@ public class GMSLocator implements Locator, NetLocator {
     return false;
   }
 
-  /**
-   * Test hook - set the persistent view file
-   */
+  @TestingOnly
   public File setViewFile(File file) {
-    this.viewFile = new File(file.getAbsolutePath()); // GEODE-4180, use absolute paths
+    this.viewFile = file.getAbsoluteFile();
     return this.viewFile;
   }
 
@@ -144,8 +143,7 @@ public class GMSLocator implements Locator, NetLocator {
   public void init(TcpServer server) throws InternalGemFireException {
     if (this.viewFile == null) {
       // GEODE-4180, use absolute paths
-      this.viewFile =
-          new File(new File("locator" + server.getPort() + "view.dat").getAbsolutePath());
+      this.viewFile = new File("locator" + server.getPort() + "view.dat").getAbsoluteFile();
     }
     logger.info(
         "GemFire peer location service starting.  Other locators: {}  Locators preferred as coordinators: {}  Network partition detection enabled: {}  View persistence file: {}",

--- a/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/rules/tests/MemberStarterRuleTest.java
+++ b/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/rules/tests/MemberStarterRuleTest.java
@@ -88,29 +88,11 @@ public class MemberStarterRuleTest {
   }
 
   @Test
-  public void workingDirNotCreatedByDefault() throws Exception {
+  public void workingDirIsUserDir() throws Exception {
     String userDir = System.getProperty("user.dir");
     locator = new LocatorStarterRule();
     locator.before();
-    assertThat(System.getProperty("user.dir")).isSameAs(userDir);
-    assertThat(locator.getWorkingDir()).isNull();
-  }
-
-  @Test
-  public void logFileDoesNotCreatesWorkingDir() throws Exception {
-    locator = new LocatorStarterRule().withLogFile();
-    locator.before();
-
-    assertThat(locator.getName()).isNotNull();
-    assertThat(locator.getWorkingDir()).isNull();
-  }
-
-  @Test
-  public void workDirCreatesWorkDir() throws Exception {
-    locator = new LocatorStarterRule().withWorkingDir();
-    locator.before();
-
-    assertThat(locator.getWorkingDir()).isNotNull();
+    assertThat(locator.getWorkingDir().getAbsolutePath()).isEqualTo(userDir);
   }
 
   @Test

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/rules/ClusterStartupRule.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/rules/ClusterStartupRule.java
@@ -381,6 +381,7 @@ public class ClusterStartupRule extends ExternalResource implements Serializable
 
   public static void stopElementInsideVM() {
     if (memberStarter != null) {
+      memberStarter.setCleanWorkingDir(false);
       memberStarter.after();
       memberStarter = null;
     }

--- a/geode-dunit/src/main/java/org/apache/geode/test/junit/rules/MemberStarterRule.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/junit/rules/MemberStarterRule.java
@@ -32,8 +32,8 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
 import java.io.File;
-import java.io.IOException;
 import java.text.MessageFormat;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -47,10 +47,10 @@ import java.util.stream.Collectors;
 
 import javax.management.ObjectName;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.ArrayUtils;
 import org.assertj.core.api.Assertions;
 import org.awaitility.core.ConditionTimeoutException;
-import org.junit.rules.TemporaryFolder;
 
 import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
@@ -73,13 +73,11 @@ import org.apache.geode.test.junit.rules.serializable.SerializableExternalResour
 /**
  * the abstract class that's used by LocatorStarterRule and ServerStarterRule to avoid code
  * duplication.
+ *
+ * The rule will try to clean up the working dir as best as it can. Any first level children
+ * created in the test will be cleaned up after the test.
  */
 public abstract class MemberStarterRule<T> extends SerializableExternalResource implements Member {
-
-  protected String oldUserDir;
-
-  protected transient TemporaryFolder temporaryFolder;
-  protected File workingDir;
   protected int memberPort = 0;
   protected int jmxPort = -1;
   protected int httpPort = -1;
@@ -90,6 +88,9 @@ public abstract class MemberStarterRule<T> extends SerializableExternalResource 
 
   protected boolean autoStart = false;
   private final transient UniquePortSupplier portSupplier;
+
+  private List<File> firstLevelChildrenFile = new ArrayList<>();
+  private boolean cleanWorkingDir = true;
 
   public static void setWaitUntilTimeout(int waitUntilTimeout) {
     WAIT_UNTIL_TIMEOUT = waitUntilTimeout;
@@ -103,7 +104,6 @@ public abstract class MemberStarterRule<T> extends SerializableExternalResource 
 
   public MemberStarterRule(UniquePortSupplier portSupplier) {
     this.portSupplier = portSupplier;
-    oldUserDir = System.getProperty("user.dir");
 
     // initial values
     properties.setProperty(MCAST_PORT, "0");
@@ -122,6 +122,7 @@ public abstract class MemberStarterRule<T> extends SerializableExternalResource 
       // use putIfAbsent if it was configured using withProperty
       properties.putIfAbsent(HTTP_SERVICE_PORT, "0");
     }
+    firstLevelChildrenFile = Arrays.asList(getWorkingDir().listFiles());
   }
 
   @Override
@@ -134,42 +135,18 @@ public abstract class MemberStarterRule<T> extends SerializableExternalResource 
     // future tests
     SocketCreatorFactory.close();
 
-    if (temporaryFolder != null) {
-      temporaryFolder.delete();
-    }
-
-    if (oldUserDir == null) {
-      System.clearProperty("user.dir");
-    } else {
-      System.setProperty("user.dir", oldUserDir);
-    }
+    // delete the first-level children files that are created in the tests
+    if (cleanWorkingDir)
+      Arrays.stream(getWorkingDir().listFiles())
+          // do not delete the pre-existing files
+          .filter(f -> !firstLevelChildrenFile.contains(f))
+          // do not delete the dunit folder that might have been created by dunit launcher
+          .filter(f -> !(f.isDirectory() && f.getName().equals("dunit")))
+          .forEach(FileUtils::deleteQuietly);
   }
 
   public T withPort(int memberPort) {
     this.memberPort = memberPort;
-    return (T) this;
-  }
-
-  public T withWorkingDir(File workingDir) {
-    this.workingDir = workingDir;
-    if (workingDir != null) {
-      System.setProperty("user.dir", workingDir.toString());
-    }
-    return (T) this;
-  }
-
-  /**
-   * create a working dir using temporaryFolder. Use with caution, this sets "user.dir" system
-   * property that not approved by JDK
-   */
-  public T withWorkingDir() {
-    temporaryFolder = new TemporaryFolder();
-    try {
-      temporaryFolder.create();
-    } catch (IOException e) {
-      throw new RuntimeException(e.getMessage(), e);
-    }
-    withWorkingDir(temporaryFolder.getRoot().getAbsoluteFile());
     return (T) this;
   }
 
@@ -260,6 +237,10 @@ public abstract class MemberStarterRule<T> extends SerializableExternalResource 
       httpPort = 0;
     }
     return (T) this;
+  }
+
+  public void setCleanWorkingDir(boolean cleanWorkingDir) {
+    this.cleanWorkingDir = cleanWorkingDir;
   }
 
   /**
@@ -498,7 +479,7 @@ public abstract class MemberStarterRule<T> extends SerializableExternalResource 
 
   @Override
   public File getWorkingDir() {
-    return workingDir;
+    return new File(System.getProperty("user.dir"));
   }
 
   @Override

--- a/geode-dunit/src/main/java/org/apache/geode/test/junit/rules/VMProvider.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/junit/rules/VMProvider.java
@@ -39,10 +39,12 @@ public abstract class VMProvider {
 
   public void stop(boolean cleanWorkingDir) {
     getVM().invoke(() -> {
+      // this did not clean up the files
       ClusterStartupRule.stopElementInsideVM();
       MemberStarterRule.disconnectDSIfAny();
     });
 
+    // clean up all the files under the working dir if asked to do so
     if (cleanWorkingDir) {
       Arrays.stream(getWorkingDir().listFiles()).forEach(FileUtils::deleteQuietly);
     }

--- a/geode-web/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/CommandOverHttpTest.java
+++ b/geode-web/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/CommandOverHttpTest.java
@@ -39,7 +39,7 @@ public class CommandOverHttpTest {
 
   @ClassRule
   public static ServerStarterRule server =
-      new ServerStarterRule().withWorkingDir().withLogFile().withJMXManager()
+      new ServerStarterRule().withLogFile().withJMXManager()
           .withHttpService()
           .withAutoStart();
 


### PR DESCRIPTION
* file's absolute path does not change anymore in jdk11 even after user.dir system property is changed.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
