### PR TITLE
GEODE-4872: Fixing logging tests in PersistentColocatedPartitionedRegionDUnitTest

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/partitioned/MockAppender.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/partitioned/MockAppender.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.partitioned;
+
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.mockito.ArgumentCaptor;
+
+public class MockAppender implements AutoCloseable {
+
+  private final Logger logger;
+  private final Appender mockAppender;
+
+  public MockAppender(Class<?> loggerClass) {
+    mockAppender = mock(Appender.class);
+    when(mockAppender.getName()).thenReturn("MockAppender");
+    when(mockAppender.isStarted()).thenReturn(true);
+    when(mockAppender.isStopped()).thenReturn(false);
+    logger = (Logger) LogManager.getLogger(loggerClass);
+    logger.addAppender(mockAppender);
+    logger.setLevel(Level.WARN);
+  }
+
+  public Appender getMock() {
+    return this.mockAppender;
+  }
+
+  public List<LogEvent> getLogs() {
+    ArgumentCaptor<LogEvent> loggingEventCaptor = ArgumentCaptor.forClass(LogEvent.class);
+    verify(mockAppender, atLeast(0)).append(loggingEventCaptor.capture());
+    return loggingEventCaptor.getAllValues();
+  }
+
+  public void close() {
+    logger.removeAppender(mockAppender);
+  }
+
+
+}


### PR DESCRIPTION
This test had a number of tests making assertions about log messages.
Unfortunately, these tests had assertions inside of a try/finally block,
and the finally had a return. Therefore the assertion failures were
simply ignored, and the test was just a test that the callables returned
in 60 seconds.

Fixing this test by removing the bad verify calls and returns in finally
blocks.

Cleaning up the way the tests hooked into the logging system.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
