### PR TITLE
GEODE-5902: Fixing repeatTest task dependencies

### DIFF
--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -168,31 +168,31 @@ subprojects {
   }
 
   task repeatDistributedTest(type: RepeatTest) {
-    dependsOn {distributedTest.getTaskDependencies()}
+    dependsOn {distributedTest.taskDependencies}
     classpath = project.sourceSets.distributedTest.runtimeClasspath
     testClassesDirs = project.sourceSets.distributedTest.output.classesDirs
   }
 
   task repeatIntegrationTest(type: RepeatTest) {
-    dependsOn {integrationTest.getTaskDependencies()}
+    dependsOn {integrationTest.taskDependencies}
     classpath = project.sourceSets.integrationTest.runtimeClasspath
     testClassesDirs = project.sourceSets.integrationTest.output.classesDirs
   }
 
   task repeatAcceptanceTest(type: RepeatTest) {
-    dependsOn {acceptanceTest.getTaskDependencies()}
+    dependsOn {acceptanceTest.taskDependencies}
     classpath = project.sourceSets.acceptanceTest.runtimeClasspath
     testClassesDirs = project.sourceSets.acceptanceTest.output.classesDirs
   }
 
   task repeatUpgradeTest(type: RepeatTest) {
-    dependsOn {upgradeTest.getTaskDependencies()}
+    dependsOn {upgradeTest.taskDependencies}
     classpath = project.sourceSets.upgradeTest.runtimeClasspath
     testClassesDirs = project.sourceSets.upgradeTest.output.classesDirs
   }
 
   task repeatUnitTest(type: RepeatTest) {
-    dependsOn {test.getTaskDependencies()}
+    dependsOn {test.taskDependencies}
     // default classpath works for this one.
   }
 

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -168,26 +168,31 @@ subprojects {
   }
 
   task repeatDistributedTest(type: RepeatTest) {
+    dependsOn {distributedTest.getTaskDependencies()}
     classpath = project.sourceSets.distributedTest.runtimeClasspath
     testClassesDirs = project.sourceSets.distributedTest.output.classesDirs
   }
 
   task repeatIntegrationTest(type: RepeatTest) {
+    dependsOn {integrationTest.getTaskDependencies()}
     classpath = project.sourceSets.integrationTest.runtimeClasspath
     testClassesDirs = project.sourceSets.integrationTest.output.classesDirs
   }
 
   task repeatAcceptanceTest(type: RepeatTest) {
+    dependsOn {acceptanceTest.getTaskDependencies()}
     classpath = project.sourceSets.acceptanceTest.runtimeClasspath
     testClassesDirs = project.sourceSets.acceptanceTest.output.classesDirs
   }
 
   task repeatUpgradeTest(type: RepeatTest) {
+    dependsOn {upgradeTest.getTaskDependencies()}
     classpath = project.sourceSets.upgradeTest.runtimeClasspath
     testClassesDirs = project.sourceSets.upgradeTest.output.classesDirs
   }
 
   task repeatUnitTest(type: RepeatTest) {
+    dependsOn {test.getTaskDependencies()}
     // default classpath works for this one.
   }
 


### PR DESCRIPTION
Changing the repeatXXXTest tasks to copy the dependencies from their
source task.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
