### PR TITLE
GEODE-5908: DiskStoreID.compare should compare mostSig, then leastSig

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/DiskStoreID.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/DiskStoreID.java
@@ -80,7 +80,7 @@ public class DiskStoreID implements VersionSource<DiskStoreID>, Serializable {
       return 1;
     }
     int result = Long.signum(mostSig - tagID.mostSig);
-    if (result != 0) {
+    if (result == 0) {
       result = Long.signum(leastSig - tagID.leastSig);
     }
     return result;

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/persistence/DiskStoreIDJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/persistence/DiskStoreIDJUnitTest.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.persistence;
+
+import static org.apache.geode.internal.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class DiskStoreIDJUnitTest {
+  @Test
+  public void biggerMostSigButSmallerLeastSigShouldBeBiggerThanSmallerMostSigButBiggerLeastSig() {
+    DiskStoreID diskStoreID_1 = new DiskStoreID(0x02L, 0x01L);
+    DiskStoreID diskStoreID_2 = new DiskStoreID(0x01L, 0x02L);
+    assertTrue(diskStoreID_1.compareTo(diskStoreID_2) > 0);
+  }
+
+  @Test
+  public void diskStoreIDWithSameLeastSigShouldCompareBaseOnMostSig() {
+    DiskStoreID diskStoreID_1 = new DiskStoreID(0x02L, 0x01L);
+    DiskStoreID diskStoreID_2 = new DiskStoreID(0x01L, 0x01L);
+    assertTrue(diskStoreID_1.compareTo(diskStoreID_2) != 0);
+  }
+}


### PR DESCRIPTION
Thank you for submitting a contribution to Apache Geode.

@dschneider-pivotal @boglesby @bschuchardt @jhuynh1 

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
