### PR TITLE
GEODE-5910: Disabling acceptance tests in StressNewTest

### DIFF
--- a/ci/scripts/repeat-new-tests.sh
+++ b/ci/scripts/repeat-new-tests.sh
@@ -76,8 +76,10 @@ function append_to_test_targets() {
 append_to_test_targets "repeatUnitTest" "$UNIT_TEST_CHANGES"
 append_to_test_targets "repeatIntegrationTest" "$INTEGRATION_TEST_CHANGES"
 append_to_test_targets "repeatDistributedTest" "$DISTRIBUTED_TEST_CHANGES"
-append_to_test_targets "repeatAcceptanceTest" "$ACCEPTANCE_TEST_CHANGES"
 append_to_test_targets "repeatUpgradeTest" "$UPGRADE_TEST_CHANGES"
+
+# Acceptance tests cannot currently run in parallel, so do not stress these tests
+#append_to_test_targets "repeatAcceptanceTest" "$ACCEPTANCE_TEST_CHANGES"
 
 export GRADLE_TASK="compileTestJava compileIntegrationTestJava compileDistributedTestJava $TEST_TARGETS"
 export GRADLE_TASK_OPTIONS="--no-parallel -Prepeat=50 -PfailOnNoMatchingTests=false"

--- a/gradle/docker.gradle
+++ b/gradle/docker.gradle
@@ -149,8 +149,7 @@ subprojects {
     upgradeTest.configure(dockerConfig)
     repeatUpgradeTest.configure(dockerConfig)
 
-    // ACCEPTANCE TEST NEEDS DOCKER-COMPOSE TO WORK WITHIN DOCKER FIRST
-    // acceptanceTest.configure(dockerConfig)
-    // repeatAcceptanceTest.configure(dockerConfig)
+    acceptanceTest.configure(dockerConfig)
+    repeatAcceptanceTest.configure(dockerConfig)
   }
 }


### PR DESCRIPTION
Not all acceptance tests can be run in parallel in docker containers, so
disabling them in StressNewTest.

Also, enabling docker for acceptance tests if the user has configured
docker. We were getting hard to diagnose failures when running
repeatAcceptanceTest with docker configured, because the build silently
ignored the docker settings. Now the build will not ignore those
settings, so acceptance tests than *can* run in
docker will, and tests that cannot will consistently fail with a docker
related error.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
