### PR TITLE
GEODE-5915: Fix IllegalMonitorStateException logged for Alerts

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/management/DistributedSystemDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/DistributedSystemDUnitTest.java
@@ -88,8 +88,7 @@ import org.apache.geode.test.dunit.VM;
  * <p>
  * TODO: break up the large tests into smaller tests
  */
-
-@SuppressWarnings({"serial", "unused"})
+@SuppressWarnings("serial,unused")
 public class DistributedSystemDUnitTest implements Serializable {
 
   private static final Logger logger = LogService.getLogger();
@@ -118,8 +117,8 @@ public class DistributedSystemDUnitTest implements Serializable {
   }
 
   @After
-  public void after() throws Exception {
-    resetAlertCounts(this.managerVM);
+  public void after() {
+    resetAlertCounts(managerVM);
 
     notifications = null;
     notificationListenerMap = null;
@@ -131,68 +130,68 @@ public class DistributedSystemDUnitTest implements Serializable {
    * Tests each and every operations that is defined on the MemberMXBean
    */
   @Test
-  public void testDistributedSystemAggregate() throws Exception {
-    this.managementTestRule.createManager(this.managerVM);
-    addNotificationListener(this.managerVM);
+  public void testDistributedSystemAggregate() {
+    managementTestRule.createManager(managerVM);
+    addNotificationListener(managerVM);
 
-    for (VM memberVM : this.memberVMs) {
-      this.managementTestRule.createMember(memberVM);
+    for (VM memberVM : memberVMs) {
+      managementTestRule.createMember(memberVM);
     }
 
-    verifyDistributedSystemMXBean(this.managerVM);
+    verifyDistributedSystemMXBean(managerVM);
   }
 
   /**
    * Tests each and every operations that is defined on the MemberMXBean
    */
   @Test
-  public void testAlertManagedNodeFirst() throws Exception {
-    for (VM memberVM : this.memberVMs) {
-      this.managementTestRule.createMember(memberVM);
+  public void testAlertManagedNodeFirst() {
+    for (VM memberVM : memberVMs) {
+      managementTestRule.createMember(memberVM);
       generateWarningAlert(memberVM);
       generateSevereAlert(memberVM);
     }
 
-    this.managementTestRule.createManager(this.managerVM);
-    addAlertListener(this.managerVM);
-    verifyAlertCount(this.managerVM, 0, 0);
+    managementTestRule.createManager(managerVM);
+    addAlertListener(managerVM);
+    verifyAlertCount(managerVM, 0, 0);
 
     DistributedMember managerDistributedMember =
-        this.managementTestRule.getDistributedMember(this.managerVM);
+        managementTestRule.getDistributedMember(managerVM);
 
     // Before we start we need to ensure that the initial (implicit) SEVERE alert has propagated
     // everywhere.
-    for (VM memberVM : this.memberVMs) {
+    for (VM memberVM : memberVMs) {
       verifyAlertAppender(memberVM, managerDistributedMember, Alert.SEVERE);
     }
 
-    setAlertLevel(this.managerVM, AlertDetails.getAlertLevelAsString(Alert.WARNING));
+    setAlertLevel(managerVM, AlertDetails.getAlertLevelAsString(Alert.WARNING));
 
-    for (VM memberVM : this.memberVMs) {
+    for (VM memberVM : memberVMs) {
       verifyAlertAppender(memberVM, managerDistributedMember, Alert.WARNING);
       generateWarningAlert(memberVM);
       generateSevereAlert(memberVM);
     }
 
-    verifyAlertCount(this.managerVM, 3, 3);
-    resetAlertCounts(this.managerVM);
+    verifyAlertCount(managerVM, 3, 3);
+    resetAlertCounts(managerVM);
 
-    setAlertLevel(this.managerVM, AlertDetails.getAlertLevelAsString(Alert.SEVERE));
+    setAlertLevel(managerVM, AlertDetails.getAlertLevelAsString(Alert.SEVERE));
 
-    for (VM memberVM : this.memberVMs) {
+    for (VM memberVM : memberVMs) {
       verifyAlertAppender(memberVM, managerDistributedMember, Alert.SEVERE);
       generateWarningAlert(memberVM);
       generateSevereAlert(memberVM);
     }
 
-    verifyAlertCount(this.managerVM, 3, 0);
+    verifyAlertCount(managerVM, 3, 0);
   }
 
   /**
    * Tests each and every operations that is defined on the MemberMXBean
    */
   @Test
-  public void testShutdownAll() throws Exception {
+  public void testShutdownAll() {
     VM memberVM1 = getHost(0).getVM(0);
     VM memberVM2 = getHost(0).getVM(1);
     VM memberVM3 = getHost(0).getVM(2);
@@ -200,30 +199,30 @@ public class DistributedSystemDUnitTest implements Serializable {
     VM managerVM = getHost(0).getVM(3);
 
     // managerVM Node is created first
-    this.managementTestRule.createManager(managerVM);
+    managementTestRule.createManager(managerVM);
 
-    this.managementTestRule.createMember(memberVM1);
-    this.managementTestRule.createMember(memberVM2);
-    this.managementTestRule.createMember(memberVM3);
+    managementTestRule.createMember(memberVM1);
+    managementTestRule.createMember(memberVM2);
+    managementTestRule.createMember(memberVM3);
 
     shutDownAll(managerVM);
   }
 
   @Test
-  public void testNavigationAPIS() throws Exception {
-    this.managementTestRule.createManager(this.managerVM);
+  public void testNavigationAPIS() {
+    managementTestRule.createManager(managerVM);
 
-    for (VM memberVM : this.memberVMs) {
-      this.managementTestRule.createMember(memberVM);
+    for (VM memberVM : memberVMs) {
+      managementTestRule.createMember(memberVM);
     }
 
-    verifyFetchMemberObjectName(this.managerVM, this.memberVMs.length + 1);
+    verifyFetchMemberObjectName(managerVM, memberVMs.length + 1);
   }
 
   @Test
-  public void testNotificationHub() throws Exception {
-    this.managementTestRule.createMembers();
-    this.managementTestRule.createManagers();
+  public void testNotificationHub() {
+    managementTestRule.createMembers();
+    managementTestRule.createManagers();
 
     class NotificationHubTestListener implements NotificationListener {
 
@@ -234,8 +233,8 @@ public class DistributedSystemDUnitTest implements Serializable {
       }
     }
 
-    this.managerVM.invoke("addListenerToMemberMXBean", () -> {
-      ManagementService service = this.managementTestRule.getManagementService();
+    managerVM.invoke("addListenerToMemberMXBean", () -> {
+      ManagementService service = managementTestRule.getManagementService();
       DistributedSystemMXBean distributedSystemMXBean = service.getDistributedSystemMXBean();
 
       GeodeAwaitility.await().untilAsserted(
@@ -250,16 +249,16 @@ public class DistributedSystemDUnitTest implements Serializable {
 
     // Check in all VMS
 
-    for (VM memberVM : this.memberVMs) {
+    for (VM memberVM : memberVMs) {
       memberVM.invoke("checkNotificationHubListenerCount", () -> {
-        SystemManagementService service = this.managementTestRule.getSystemManagementService();
+        SystemManagementService service = managementTestRule.getSystemManagementService();
         NotificationHub notificationHub = service.getNotificationHub();
         Map<ObjectName, NotificationHubListener> listenerMap =
             notificationHub.getListenerObjectMap();
         assertThat(listenerMap.keySet()).hasSize(1);
 
         ObjectName memberMBeanName =
-            getMemberMBeanName(this.managementTestRule.getDistributedMember());
+            getMemberMBeanName(managementTestRule.getDistributedMember());
         NotificationHubListener listener = listenerMap.get(memberMBeanName);
 
         /*
@@ -271,7 +270,7 @@ public class DistributedSystemDUnitTest implements Serializable {
         // Raise some notifications
 
         NotificationBroadcasterSupport notifier = (MemberMBean) service.getMemberMXBean();
-        String memberSource = getMemberNameOrId(this.managementTestRule.getDistributedMember());
+        String memberSource = getMemberNameOrId(managementTestRule.getDistributedMember());
 
         // Only a dummy notification , no actual region is created
         Notification notification = new Notification(JMXNotificationType.REGION_CREATED,
@@ -281,7 +280,7 @@ public class DistributedSystemDUnitTest implements Serializable {
       });
     }
 
-    this.managerVM.invoke("checkNotificationsAndRemoveListeners", () -> {
+    managerVM.invoke("checkNotificationsAndRemoveListeners", () -> {
       GeodeAwaitility.await().untilAsserted(() -> assertThat(notifications).hasSize(3));
 
       notifications.clear();
@@ -294,15 +293,15 @@ public class DistributedSystemDUnitTest implements Serializable {
 
     // Check in all VMS again
 
-    for (VM memberVM : this.memberVMs) {
+    for (VM memberVM : memberVMs) {
       memberVM.invoke("checkNotificationHubListenerCountAgain", () -> {
-        SystemManagementService service = this.managementTestRule.getSystemManagementService();
+        SystemManagementService service = managementTestRule.getSystemManagementService();
         NotificationHub hub = service.getNotificationHub();
         Map<ObjectName, NotificationHubListener> listenerObjectMap = hub.getListenerObjectMap();
         assertThat(listenerObjectMap.keySet().size()).isEqualTo(1);
 
         ObjectName memberMBeanName =
-            getMemberMBeanName(this.managementTestRule.getDistributedMember());
+            getMemberMBeanName(managementTestRule.getDistributedMember());
         NotificationHubListener listener = listenerObjectMap.get(memberMBeanName);
 
         /*
@@ -313,8 +312,8 @@ public class DistributedSystemDUnitTest implements Serializable {
       });
     }
 
-    this.managerVM.invoke("removeListenerFromMemberMXBean", () -> {
-      ManagementService service = this.managementTestRule.getManagementService();
+    managerVM.invoke("removeListenerFromMemberMXBean", () -> {
+      ManagementService service = managementTestRule.getManagementService();
       DistributedSystemMXBean distributedSystemMXBean = service.getDistributedSystemMXBean();
 
       GeodeAwaitility.await().untilAsserted(
@@ -333,9 +332,9 @@ public class DistributedSystemDUnitTest implements Serializable {
       }
     });
 
-    for (VM memberVM : this.memberVMs) {
+    for (VM memberVM : memberVMs) {
       memberVM.invoke("verifyNotificationHubListenersWereRemoved", () -> {
-        SystemManagementService service = this.managementTestRule.getSystemManagementService();
+        SystemManagementService service = managementTestRule.getSystemManagementService();
         NotificationHub notificationHub = service.getNotificationHub();
         notificationHub.cleanUpListeners();
         assertThat(notificationHub.getListenerObjectMap()).isEmpty();
@@ -354,21 +353,21 @@ public class DistributedSystemDUnitTest implements Serializable {
    * Tests each and every operations that is defined on the MemberMXBean
    */
   @Test
-  public void testAlert() throws Exception {
-    this.managementTestRule.createManager(this.managerVM);
-    addAlertListener(this.managerVM);
-    resetAlertCounts(this.managerVM);
+  public void testAlert() {
+    managementTestRule.createManager(managerVM);
+    addAlertListener(managerVM);
+    resetAlertCounts(managerVM);
 
     DistributedMember managerDistributedMember =
-        this.managementTestRule.getDistributedMember(this.managerVM);
+        managementTestRule.getDistributedMember(managerVM);
 
-    generateWarningAlert(this.managerVM);
-    generateSevereAlert(this.managerVM);
-    verifyAlertCount(this.managerVM, 1, 0);
-    resetAlertCounts(this.managerVM);
+    generateWarningAlert(managerVM);
+    generateSevereAlert(managerVM);
+    verifyAlertCount(managerVM, 1, 0);
+    resetAlertCounts(managerVM);
 
-    for (VM memberVM : this.memberVMs) {
-      this.managementTestRule.createMember(memberVM);
+    for (VM memberVM : memberVMs) {
+      managementTestRule.createMember(memberVM);
 
       verifyAlertAppender(memberVM, managerDistributedMember, Alert.SEVERE);
 
@@ -376,29 +375,29 @@ public class DistributedSystemDUnitTest implements Serializable {
       generateSevereAlert(memberVM);
     }
 
-    verifyAlertCount(this.managerVM, 3, 0);
-    resetAlertCounts(this.managerVM);
-    setAlertLevel(this.managerVM, AlertDetails.getAlertLevelAsString(Alert.WARNING));
+    verifyAlertCount(managerVM, 3, 0);
+    resetAlertCounts(managerVM);
+    setAlertLevel(managerVM, AlertDetails.getAlertLevelAsString(Alert.WARNING));
 
-    for (VM memberVM : this.memberVMs) {
+    for (VM memberVM : memberVMs) {
       verifyAlertAppender(memberVM, managerDistributedMember, Alert.WARNING);
       generateWarningAlert(memberVM);
       generateSevereAlert(memberVM);
     }
 
-    verifyAlertCount(this.managerVM, 3, 3);
+    verifyAlertCount(managerVM, 3, 3);
 
-    resetAlertCounts(this.managerVM);
+    resetAlertCounts(managerVM);
 
-    setAlertLevel(this.managerVM, AlertDetails.getAlertLevelAsString(Alert.OFF));
+    setAlertLevel(managerVM, AlertDetails.getAlertLevelAsString(Alert.OFF));
 
-    for (VM memberVM : this.memberVMs) {
+    for (VM memberVM : memberVMs) {
       verifyAlertAppender(memberVM, managerDistributedMember, Alert.OFF);
       generateWarningAlert(memberVM);
       generateSevereAlert(memberVM);
     }
 
-    verifyAlertCount(this.managerVM, 0, 0);
+    verifyAlertCount(managerVM, 0, 0);
   }
 
   private void verifyAlertAppender(final VM memberVM, final DistributedMember member,
@@ -423,7 +422,7 @@ public class DistributedSystemDUnitTest implements Serializable {
 
   private void setAlertLevel(final VM managerVM, final String alertLevel) {
     managerVM.invoke("setAlertLevel", () -> {
-      ManagementService service = this.managementTestRule.getManagementService();
+      ManagementService service = managementTestRule.getManagementService();
       DistributedSystemMXBean distributedSystemMXBean = service.getDistributedSystemMXBean();
       distributedSystemMXBean.changeAlertLevel(alertLevel);
     });
@@ -470,13 +469,13 @@ public class DistributedSystemDUnitTest implements Serializable {
    */
   private void verifyDistributedSystemMXBean(final VM managerVM) {
     managerVM.invoke("verifyDistributedSystemMXBean", () -> {
-      ManagementService service = this.managementTestRule.getManagementService();
+      ManagementService service = managementTestRule.getManagementService();
       DistributedSystemMXBean distributedSystemMXBean = service.getDistributedSystemMXBean();
 
       GeodeAwaitility.await()
           .untilAsserted(() -> assertThat(distributedSystemMXBean.getMemberCount()).isEqualTo(5));
 
-      Set<DistributedMember> otherMemberSet = this.managementTestRule.getOtherNormalMembers();
+      Set<DistributedMember> otherMemberSet = managementTestRule.getOtherNormalMembers();
       for (DistributedMember member : otherMemberSet) {
         // TODO: create some assertions (this used to just print JVMMetrics and OSMetrics)
       }
@@ -485,7 +484,7 @@ public class DistributedSystemDUnitTest implements Serializable {
 
   private void addNotificationListener(final VM managerVM) {
     managerVM.invoke("addNotificationListener", () -> {
-      ManagementService service = this.managementTestRule.getManagementService();
+      ManagementService service = managementTestRule.getManagementService();
       DistributedSystemMXBean distributedSystemMXBean = service.getDistributedSystemMXBean();
       assertThat(distributedSystemMXBean).isNotNull();
 
@@ -497,24 +496,24 @@ public class DistributedSystemDUnitTest implements Serializable {
 
   private void shutDownAll(final VM managerVM) {
     managerVM.invoke("shutDownAll", () -> {
-      ManagementService service = this.managementTestRule.getManagementService();
+      ManagementService service = managementTestRule.getManagementService();
       DistributedSystemMXBean distributedSystemMXBean = service.getDistributedSystemMXBean();
       distributedSystemMXBean.shutDownAllMembers();
 
       GeodeAwaitility.await().untilAsserted(
-          () -> assertThat(this.managementTestRule.getOtherNormalMembers()).hasSize(0));
+          () -> assertThat(managementTestRule.getOtherNormalMembers()).hasSize(0));
     });
   }
 
   private void verifyFetchMemberObjectName(final VM managerVM, final int memberCount) {
     managerVM.invoke("verifyFetchMemberObjectName", () -> {
-      ManagementService service = this.managementTestRule.getManagementService();
+      ManagementService service = managementTestRule.getManagementService();
       DistributedSystemMXBean distributedSystemMXBean = service.getDistributedSystemMXBean();
 
       GeodeAwaitility.await().untilAsserted(
           () -> assertThat(distributedSystemMXBean.listMemberObjectNames()).hasSize(memberCount));
 
-      String memberId = this.managementTestRule.getDistributedMember().getId();
+      String memberId = managementTestRule.getDistributedMember().getId();
       ObjectName thisMemberName = getMemberMBeanName(memberId);
       ObjectName memberName = distributedSystemMXBean.fetchMemberObjectName(memberId);
       assertThat(memberName).isEqualTo(thisMemberName);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
@@ -863,7 +863,7 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
         // We only support management on members of a distributed system
         // Should do this: if (!getSystem().isLoner()) {
         // but it causes quickstart.CqClientTest to hang
-        this.resourceEventsListener = new ManagementListener();
+        this.resourceEventsListener = new ManagementListener(this.system);
         this.system.addResourceListener(this.resourceEventsListener);
         if (this.system.isLoner()) {
           this.system.getInternalLogWriter()

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/ManagementListener.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/ManagementListener.java
@@ -14,23 +14,22 @@
  */
 package org.apache.geode.management.internal.beans;
 
+import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-import org.apache.geode.LogWriter;
+import org.apache.geode.annotations.TestingOnly;
 import org.apache.geode.cache.DiskStore;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.asyncqueue.AsyncEventQueue;
 import org.apache.geode.cache.server.CacheServer;
 import org.apache.geode.cache.wan.GatewayReceiver;
 import org.apache.geode.cache.wan.GatewaySender;
-import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.distributed.Locator;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.ResourceEvent;
 import org.apache.geode.distributed.internal.ResourceEventsListener;
 import org.apache.geode.distributed.internal.locks.DLockService;
 import org.apache.geode.internal.cache.CacheService;
-import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.management.internal.AlertDetails;
 
@@ -40,23 +39,28 @@ import org.apache.geode.management.internal.AlertDetails;
  */
 public class ManagementListener implements ResourceEventsListener {
 
+  private final InternalDistributedSystem system;
+
   /**
    * Adapter to co-ordinate between GemFire and Federation framework
    */
-  private ManagementAdapter adapter;
-
-  private LogWriter logger;
-
-  // having a readwrite lock to synchronize between handling cache creation/removal vs handling
-  // other notifications
-  private final ReentrantReadWriteLock readWriteLock = new ReentrantReadWriteLock();
+  private final ManagementAdapter adapter;
 
   /**
-   * Constructor
+   * ReadWriteLock to protect between handling cache creation/removal vs other notifications
    */
-  public ManagementListener() {
-    this.adapter = new ManagementAdapter();
-    this.logger = InternalDistributedSystem.getLogger();
+  private final ReadWriteLock readWriteLock;
+
+  public ManagementListener(InternalDistributedSystem system) {
+    this(system, new ManagementAdapter(), new ReentrantReadWriteLock());
+  }
+
+  @TestingOnly
+  ManagementListener(InternalDistributedSystem system, ManagementAdapter adapter,
+      ReadWriteLock readWriteLock) {
+    this.system = system;
+    this.adapter = adapter;
+    this.readWriteLock = readWriteLock;
   }
 
   /**
@@ -71,27 +75,19 @@ public class ManagementListener implements ResourceEventsListener {
    *
    * @return true or false depending on the status of Cache and System
    */
-  private boolean shouldProceed(ResourceEvent event) {
-    DistributedSystem system = InternalDistributedSystem.getConnectedInstance();
+  boolean shouldProceed(ResourceEvent event) {
+    InternalDistributedSystem.getConnectedInstance();
 
-    // CACHE_REMOVE is a special event . It may happen that a
-    // ForcedDisconnectExcpetion will raise this event
-
-    // No need to check system.isConnected as
-    // InternalDistributedSystem.getConnectedInstance() does that internally.
-
-    if (system == null && !event.equals(ResourceEvent.CACHE_REMOVE)) {
+    // CACHE_REMOVE is a special event. ForcedDisconnectException may raise this event.
+    if (!system.isConnected() && !event.equals(ResourceEvent.CACHE_REMOVE)) {
       return false;
     }
 
-    InternalCache currentCache = GemFireCacheImpl.getInstance();
+    InternalCache currentCache = system.getCache();
     if (currentCache == null) {
       return false;
     }
-    if (currentCache.isClosed()) {
-      return false;
-    }
-    return true;
+    return !currentCache.isClosed();
   }
 
   /**
@@ -102,6 +98,7 @@ public class ManagementListener implements ResourceEventsListener {
    * @param event Management event for which invocation has happened
    * @param resource the GFE resource type
    */
+  @Override
   public void handleEvent(ResourceEvent event, Object resource) {
     if (!shouldProceed(event)) {
       return;
@@ -228,7 +225,7 @@ public class ManagementListener implements ResourceEventsListener {
     } finally {
       if (event == ResourceEvent.CACHE_CREATE || event == ResourceEvent.CACHE_REMOVE) {
         readWriteLock.writeLock().unlock();
-      } else {
+      } else if (event != ResourceEvent.SYSTEM_ALERT) {
         readWriteLock.readLock().unlock();
       }
     }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/beans/ManagementListenerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/beans/ManagementListenerTest.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.geode.management.internal.beans;
+
+import static org.apache.geode.distributed.internal.ResourceEvent.CACHE_CREATE;
+import static org.apache.geode.distributed.internal.ResourceEvent.CACHE_REMOVE;
+import static org.apache.geode.distributed.internal.ResourceEvent.SYSTEM_ALERT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.InOrder;
+
+import org.apache.geode.distributed.internal.InternalDistributedSystem;
+import org.apache.geode.distributed.internal.ResourceEvent;
+import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.test.junit.categories.ManagementTest;
+
+/**
+ * Unit tests for {@link ManagementListener}.
+ */
+@Category(ManagementTest.class)
+public class ManagementListenerTest {
+
+  private InternalDistributedSystem system;
+  private Lock readLock;
+  private Lock writeLock;
+  private ReadWriteLock readWriteLock;
+  private InOrder readLockInOrder;
+  private InOrder writeLockInOrder;
+
+  private ManagementListener managementListener;
+
+  @Before
+  public void setUp() {
+    system = mock(InternalDistributedSystem.class);
+    ManagementAdapter managementAdapter = mock(ManagementAdapter.class);
+    readWriteLock = spy(ReadWriteLock.class);
+    readLock = spy(Lock.class);
+    writeLock = spy(Lock.class);
+
+    when(system.getCache()).thenReturn(mock(InternalCache.class));
+    when(system.isConnected()).thenReturn(true);
+
+    when(readWriteLock.readLock()).thenReturn(readLock);
+    when(readWriteLock.writeLock()).thenReturn(writeLock);
+
+    readLockInOrder = inOrder(readLock, readLock);
+    writeLockInOrder = inOrder(writeLock, writeLock);
+
+    managementListener = new ManagementListener(system, managementAdapter, readWriteLock);
+  }
+
+  @Test
+  public void shouldProceedReturnsTrueIfSystemNotConnectedForCacheRemoveEvent() {
+    when(system.isConnected()).thenReturn(false);
+
+    assertThat(managementListener.shouldProceed(CACHE_REMOVE)).isTrue();
+  }
+
+  @Test
+  public void shouldProceedReturnsFalseIfSystemNotConnectedForOtherEvents() {
+    when(system.isConnected()).thenReturn(false);
+
+    for (ResourceEvent resourceEvent : ResourceEvent.values()) {
+      if (resourceEvent != CACHE_REMOVE) {
+        assertThat(managementListener.shouldProceed(CACHE_REMOVE)).isTrue();
+      }
+    }
+  }
+
+  @Test
+  public void shouldProceedReturnsTrueIfSystemIsConnected() {
+    for (ResourceEvent resourceEvent : ResourceEvent.values()) {
+      assertThat(managementListener.shouldProceed(resourceEvent)).isTrue();
+    }
+  }
+
+  @Test
+  public void shouldProceedReturnsFalseIfNoCache() {
+    when(system.getCache()).thenReturn(null);
+
+    for (ResourceEvent resourceEvent : ResourceEvent.values()) {
+      assertThat(managementListener.shouldProceed(resourceEvent)).isFalse();
+    }
+  }
+
+  @Test
+  public void handleEventUsesWriteLockForCacheCreateEvent() {
+    managementListener.handleEvent(CACHE_CREATE, null);
+
+    writeLockInOrder.verify(writeLock).lock();
+    writeLockInOrder.verify(writeLock).unlock();
+  }
+
+  @Test
+  public void handleEventUsesWriteLockForCacheRemoveEvent() {
+    managementListener.handleEvent(CACHE_REMOVE, null);
+
+    writeLockInOrder.verify(writeLock).lock();
+    writeLockInOrder.verify(writeLock).unlock();
+  }
+
+  @Test
+  public void handleEventDoesNotUseLocksForSystemAlertEvent() {
+    managementListener.handleEvent(SYSTEM_ALERT, null);
+
+    verifyZeroInteractions(readWriteLock);
+    verifyZeroInteractions(readLock);
+    verifyZeroInteractions(writeLock);
+  }
+
+  @Test
+  public void handleEventUsesReadLockForOtherEvents() {
+    for (ResourceEvent resourceEvent : ResourceEvent.values()) {
+      if (resourceEvent != CACHE_CREATE && resourceEvent != CACHE_REMOVE
+          && resourceEvent != SYSTEM_ALERT) {
+        managementListener.handleEvent(resourceEvent, null);
+
+        readLockInOrder.verify(readLock).lock();
+        readLockInOrder.verify(readLock).unlock();
+      }
+    }
+  }
+}


### PR DESCRIPTION
```
commit 9fdb6597cd5df3899fb791d1c81dbfe9e27dfaf5 (HEAD -> GEODE-5915-Alert-warning, kirklund-fork/GEODE-5915-Alert-warning)
Author: Kirk Lund <klund@apache.org>
Date:   Tue Oct 23 14:47:58 2018 -0700

    GEODE-5915: Fix IllegalMonitorStateException logged for Alerts
    
    * Prevent IllegalMonitorStateException in ManagementListener.
    * Pass in InternalDistributedSystem to prevent singleton fetches.
    * Create unit tests for ManagementListener.
```
```
commit 651d2058ef33630f2e83a16a6a4f4bf4a56eb782
Author: Kirk Lund <klund@apache.org>
Date:   Tue Oct 23 14:46:38 2018 -0700

    GEODE-5915: Cleanup DistributedSystemDUnitTest
    
    * Remove unnecessary this qualifiers.
    * Minor whitespace changes.
```