### PR TITLE
GEODE-5783: have a single source for ThreadFactory

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/ReplyMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/ReplyMessage.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 
 import org.apache.logging.log4j.Logger;
 
+import org.apache.geode.CancelException;
 import org.apache.geode.DataSerializer;
 import org.apache.geode.InvalidDeltaException;
 import org.apache.geode.cache.EntryNotFoundException;
@@ -97,12 +98,13 @@ public class ReplyMessage extends HighPriorityDistributionMessage {
       m.returnValueIsException = true;
     }
     if (exception != null && logger.isDebugEnabled()) {
-      if (exception.getCause() != null
-          && (exception.getCause() instanceof EntryNotFoundException)) {
+      Throwable cause = exception.getCause();
+      if (cause instanceof EntryNotFoundException) {
         logger.debug("Replying with entry-not-found: {}", exception.getCause().getMessage());
-      } else if (exception.getCause() != null
-          && (exception.getCause() instanceof ConcurrentCacheModificationException)) {
+      } else if (cause instanceof ConcurrentCacheModificationException) {
         logger.debug("Replying with concurrent-modification-exception");
+      } else if (cause instanceof CancelException) {
+        // no need to log this - it will show up in normal debug-level logs when the reply is sent
       } else {
         logger.debug("Replying with exception: " + m, exception);
       }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
@@ -7079,7 +7079,7 @@ public class PartitionedRegion extends LocalRegion
       boolean callbackEvents) {
 
     if (logger.isDebugEnabled()) {
-      logger.debug("Destoying parallel queue region for senders: {}",
+      logger.debug("Destroying parallel queue region for senders: {}",
           this.getParallelGatewaySenderIds());
     }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientProxy.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientProxy.java
@@ -2309,7 +2309,9 @@ public class CacheClientProxy implements ClientSession {
             && InternalDistributedSystem.getAnyInstance().getConfig().getDeltaPropagation()
             && !(this._proxy.clientConflation == Handshake.CONFLATION_ON);
         if ((createDurableQueue || canHandleDelta) && logger.isDebugEnabled()) {
-          logger.debug("Creating a durable HA queue");
+          logger.debug("Creating a {} subscription queue for {}",
+              createDurableQueue ? "durable" : "non-durable",
+              proxy.getProxyID());
         }
         this._messageQueue = HARegionQueue.getHARegionQueueInstance(getProxy().getHARegionName(),
             getCache(), harq, HARegionQueue.BLOCKING_HA_QUEUE, createDurableQueue,

--- a/geode-core/src/main/java/org/apache/geode/internal/logging/LoggingExecutors.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/logging/LoggingExecutors.java
@@ -171,7 +171,8 @@ public class LoggingExecutors {
     final BlockingQueue<Runnable> blockingQueue = new SynchronousQueue<>();
     ThreadFactory threadFactory =
         new LoggingThreadFactory(threadName, threadInitializer, commandWrapper);
-    return new ThreadPoolExecutor(corePoolSize, maximumPoolSize, 0, SECONDS, blockingQueue,
+    return new ThreadPoolExecutor(corePoolSize, maximumPoolSize, keepAliveSeconds, SECONDS,
+        blockingQueue,
         threadFactory);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/tcp/Connection.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/tcp/Connection.java
@@ -1277,7 +1277,7 @@ public class Connection implements Runnable {
       }
     }
     if (logger.isDebugEnabled()) {
-      logger.debug("Connection: connected to {} with stub {}", remoteAddr, addr);
+      logger.debug("Connection: connected to {} with IP address {}", remoteAddr, addr);
     }
     try {
       getSocket().setTcpNoDelay(true);


### PR DESCRIPTION
Use the keepalive parameter when initializing the thread factory in LoggingExecutors.

I also made some logging changes while debugging the problems this
missing setting was causing.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
