### PR TITLE
GEODE-5827: Use standard pattern converters in suspect appender

### DIFF
--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/standalone/DUnitLauncher.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/standalone/DUnitLauncher.java
@@ -292,7 +292,7 @@ public class DUnitLauncher {
             .getContext();
 
     final PatternLayout layout = PatternLayout.createLayout(
-        "[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} <%thread> tid=%hexTid] %message%n%throwable%n",
+        "[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} <%thread> tid=%tid] %message%n%throwable%n",
         null, null, null, Charset.defaultCharset(), true, false, "", "");
 
     final FileAppender fileAppender = FileAppender.createAppender(suspectFilename, "true", "false",


### PR DESCRIPTION
The suspect appender is added programmatically without a log4j2.xml
so there's no way to specify additional plugin packages.

Change hexTid back to tid to prevent error messages about not
finding the HexThreadIdPatternConverter.
