### PR TITLE
GEODE-5925 Server shutdown delays election of new primary bucket owners

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/tier/sockets/AcceptorImplJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/tier/sockets/AcceptorImplJUnitTest.java
@@ -15,9 +15,10 @@
 package org.apache.geode.internal.cache.tier.sockets;
 
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
 import java.net.BindException;
@@ -26,9 +27,9 @@ import java.util.Properties;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
 
 import org.apache.geode.cache.CacheException;
 import org.apache.geode.cache.CacheFactory;
@@ -36,7 +37,6 @@ import org.apache.geode.cache.server.CacheServer;
 import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
-import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.test.junit.categories.ClientServerTest;
 
@@ -45,6 +45,8 @@ public class AcceptorImplJUnitTest {
 
   DistributedSystem system;
   InternalCache cache;
+  AcceptorImpl a1 = null, a2 = null;
+  ServerConnectionFactory serverConnectionFactory = new ServerConnectionFactory();
 
   @Before
   public void setUp() throws Exception {
@@ -56,85 +58,87 @@ public class AcceptorImplJUnitTest {
 
   @After
   public void tearDown() throws Exception {
+    if (a1 != null) {
+      a1.close();
+    }
+    if (a2 != null) {
+      a2.close();
+    }
     this.cache.close();
     this.system.disconnect();
   }
 
-  /*
-   * Test method for 'org.apache.geode.internal.cache.tier.sockets.AcceptorImpl(int, int, boolean,
-   * int, Cache)'
-   */
-  @Ignore
+  @Test(expected = BindException.class)
+  public void constructorThrowsBindException() throws CacheException, IOException {
+    a1 = new AcceptorImpl(0, null, false, CacheServer.DEFAULT_SOCKET_BUFFER_SIZE,
+        CacheServer.DEFAULT_MAXIMUM_TIME_BETWEEN_PINGS, this.cache,
+        AcceptorImpl.MINIMUM_MAX_CONNECTIONS, CacheServer.DEFAULT_MAX_THREADS,
+        CacheServer.DEFAULT_MAXIMUM_MESSAGE_COUNT, CacheServer.DEFAULT_MESSAGE_TIME_TO_LIVE,
+        null, null, false, Collections.EMPTY_LIST, CacheServer.DEFAULT_TCP_NO_DELAY,
+        serverConnectionFactory, 1000);
+    a2 = new AcceptorImpl(a1.getPort(), null, false, CacheServer.DEFAULT_SOCKET_BUFFER_SIZE,
+        CacheServer.DEFAULT_MAXIMUM_TIME_BETWEEN_PINGS, this.cache,
+        AcceptorImpl.MINIMUM_MAX_CONNECTIONS, CacheServer.DEFAULT_MAX_THREADS,
+        CacheServer.DEFAULT_MAXIMUM_MESSAGE_COUNT, CacheServer.DEFAULT_MESSAGE_TIME_TO_LIVE,
+        null, null, false, Collections.EMPTY_LIST, CacheServer.DEFAULT_TCP_NO_DELAY,
+        serverConnectionFactory, 1000);
+  }
+
   @Test
-  public void testConstructor() throws CacheException, IOException {
-    AcceptorImpl a1 = null, a2 = null, a3 = null;
-    try {
-      final int[] freeTCPPorts = AvailablePortHelper.getRandomAvailableTCPPorts(2);
-      int port1 = freeTCPPorts[0];
-      int port2 = freeTCPPorts[1];
-
-
-      ServerConnectionFactory serverConnectionFactory = new ServerConnectionFactory();
-      try {
-        new AcceptorImpl(port1, null, false, CacheServer.DEFAULT_SOCKET_BUFFER_SIZE,
-            CacheServer.DEFAULT_MAXIMUM_TIME_BETWEEN_PINGS, this.cache,
-            AcceptorImpl.MINIMUM_MAX_CONNECTIONS - 1, CacheServer.DEFAULT_MAX_THREADS,
-            CacheServer.DEFAULT_MAXIMUM_MESSAGE_COUNT, CacheServer.DEFAULT_MESSAGE_TIME_TO_LIVE,
-            null, null, false, Collections.EMPTY_LIST, CacheServer.DEFAULT_TCP_NO_DELAY,
-            serverConnectionFactory);
-        fail("Expected an IllegalArgumentExcption due to max conns < min pool size");
-      } catch (IllegalArgumentException expected) {
-      }
-
-      try {
-        new AcceptorImpl(port2, null, false, CacheServer.DEFAULT_SOCKET_BUFFER_SIZE,
-            CacheServer.DEFAULT_MAXIMUM_TIME_BETWEEN_PINGS, this.cache, 0,
-            CacheServer.DEFAULT_MAX_THREADS, CacheServer.DEFAULT_MAXIMUM_MESSAGE_COUNT,
-            CacheServer.DEFAULT_MESSAGE_TIME_TO_LIVE, null, null, false, Collections.EMPTY_LIST,
-            CacheServer.DEFAULT_TCP_NO_DELAY, serverConnectionFactory);
-        fail("Expected an IllegalArgumentExcption due to max conns of zero");
-      } catch (IllegalArgumentException expected) {
-      }
-
-      try {
-        a1 = new AcceptorImpl(port1, null, false, CacheServer.DEFAULT_SOCKET_BUFFER_SIZE,
-            CacheServer.DEFAULT_MAXIMUM_TIME_BETWEEN_PINGS, this.cache,
-            AcceptorImpl.MINIMUM_MAX_CONNECTIONS, CacheServer.DEFAULT_MAX_THREADS,
-            CacheServer.DEFAULT_MAXIMUM_MESSAGE_COUNT, CacheServer.DEFAULT_MESSAGE_TIME_TO_LIVE,
-            null, null, false, Collections.EMPTY_LIST, CacheServer.DEFAULT_TCP_NO_DELAY,
-            serverConnectionFactory);
-        a2 = new AcceptorImpl(port1, null, false, CacheServer.DEFAULT_SOCKET_BUFFER_SIZE,
-            CacheServer.DEFAULT_MAXIMUM_TIME_BETWEEN_PINGS, this.cache,
-            AcceptorImpl.MINIMUM_MAX_CONNECTIONS, CacheServer.DEFAULT_MAX_THREADS,
-            CacheServer.DEFAULT_MAXIMUM_MESSAGE_COUNT, CacheServer.DEFAULT_MESSAGE_TIME_TO_LIVE,
-            null, null, false, Collections.EMPTY_LIST, CacheServer.DEFAULT_TCP_NO_DELAY,
-            serverConnectionFactory);
-        fail("Expecetd a BindException while attaching to the same port");
-      } catch (BindException expected) {
-      }
-
-      a3 = new AcceptorImpl(port2, null, false, CacheServer.DEFAULT_SOCKET_BUFFER_SIZE,
-          CacheServer.DEFAULT_MAXIMUM_TIME_BETWEEN_PINGS, this.cache,
-          AcceptorImpl.MINIMUM_MAX_CONNECTIONS, CacheServer.DEFAULT_MAX_THREADS,
-          CacheServer.DEFAULT_MAXIMUM_MESSAGE_COUNT, CacheServer.DEFAULT_MESSAGE_TIME_TO_LIVE, null,
-          null, false, Collections.EMPTY_LIST, CacheServer.DEFAULT_TCP_NO_DELAY,
-          serverConnectionFactory);
-      assertEquals(port2, a3.getPort());
-      InternalDistributedSystem isystem =
-          (InternalDistributedSystem) this.cache.getDistributedSystem();
-      DistributionConfig config = isystem.getConfig();
-      String bindAddress = config.getBindAddress();
-      if (bindAddress == null || bindAddress.length() <= 0) {
-        assertTrue(a3.getServerInetAddr().isAnyLocalAddress());
-      }
-    } finally {
-      if (a1 != null)
-        a1.close();
-      if (a2 != null)
-        a2.close();
-      if (a3 != null)
-        a3.close();
+  public void acceptorBindsToLocalAddress() throws CacheException, IOException {
+    a1 = new AcceptorImpl(0, null, false, CacheServer.DEFAULT_SOCKET_BUFFER_SIZE,
+        CacheServer.DEFAULT_MAXIMUM_TIME_BETWEEN_PINGS, this.cache,
+        AcceptorImpl.MINIMUM_MAX_CONNECTIONS, CacheServer.DEFAULT_MAX_THREADS,
+        CacheServer.DEFAULT_MAXIMUM_MESSAGE_COUNT, CacheServer.DEFAULT_MESSAGE_TIME_TO_LIVE, null,
+        null, false, Collections.EMPTY_LIST, CacheServer.DEFAULT_TCP_NO_DELAY,
+        serverConnectionFactory, 1000);
+    InternalDistributedSystem isystem =
+        (InternalDistributedSystem) this.cache.getDistributedSystem();
+    DistributionConfig config = isystem.getConfig();
+    String bindAddress = config.getBindAddress();
+    if (bindAddress == null || bindAddress.length() <= 0) {
+      assertTrue(a1.getServerInetAddr().isAnyLocalAddress());
     }
+  }
+
+  /**
+   * If a CacheServer is stopped but the cache is still open we need to inform other members
+   * of the cluster that the server component no longer exists. Partitioned Region bucket
+   * advisors need to know about this event.
+   */
+  @Test
+  public void acceptorCloseInformsOtherServersIfCacheIsNotClosed() throws Exception {
+    a1 = new AcceptorImpl(0, null, false, CacheServer.DEFAULT_SOCKET_BUFFER_SIZE,
+        CacheServer.DEFAULT_MAXIMUM_TIME_BETWEEN_PINGS, this.cache,
+        AcceptorImpl.MINIMUM_MAX_CONNECTIONS, CacheServer.DEFAULT_MAX_THREADS,
+        CacheServer.DEFAULT_MAXIMUM_MESSAGE_COUNT, CacheServer.DEFAULT_MESSAGE_TIME_TO_LIVE, null,
+        null, false, Collections.EMPTY_LIST, CacheServer.DEFAULT_TCP_NO_DELAY,
+        serverConnectionFactory, 1000);
+    InternalDistributedSystem isystem =
+        (InternalDistributedSystem) this.cache.getDistributedSystem();
+    AcceptorImpl spy = Mockito.spy(a1);
+    spy.close();
+    verify(spy, atLeastOnce()).notifyCacheMembersOfClose();
+  }
+
+  /**
+   * If a CacheServer is stopped as part of cache.close() we don't need to inform other
+   * members of the cluster since all regions will be destroyed.
+   */
+  @Test
+  public void acceptorCloseDoesNotInformOtherServersIfCacheIsClosed() throws Exception {
+    a1 = new AcceptorImpl(0, null, false, CacheServer.DEFAULT_SOCKET_BUFFER_SIZE,
+        CacheServer.DEFAULT_MAXIMUM_TIME_BETWEEN_PINGS, this.cache,
+        AcceptorImpl.MINIMUM_MAX_CONNECTIONS, CacheServer.DEFAULT_MAX_THREADS,
+        CacheServer.DEFAULT_MAXIMUM_MESSAGE_COUNT, CacheServer.DEFAULT_MESSAGE_TIME_TO_LIVE, null,
+        null, false, Collections.EMPTY_LIST, CacheServer.DEFAULT_TCP_NO_DELAY,
+        serverConnectionFactory, 1000);
+    InternalDistributedSystem isystem =
+        (InternalDistributedSystem) this.cache.getDistributedSystem();
+    AcceptorImpl spy = Mockito.spy(a1);
+    cache.close();
+    spy.close();
+    verify(spy, never()).notifyCacheMembersOfClose();
   }
 
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/CacheServerImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/CacheServerImpl.java
@@ -351,7 +351,7 @@ public class CacheServerImpl extends AbstractCacheServer implements Distribution
         getSocketBufferSize(), getMaximumTimeBetweenPings(), this.cache, getMaxConnections(),
         getMaxThreads(), getMaximumMessageCount(), getMessageTimeToLive(), this.loadMonitor,
         overflowAttributesList, this.isGatewayReceiver, this.gatewayTransportFilters,
-        this.tcpNoDelay, serverConnectionFactory);
+        this.tcpNoDelay, serverConnectionFactory, 120000);
 
     this.acceptor.start();
     this.advisor.handshake();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/AllBucketProfilesUpdateMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/AllBucketProfilesUpdateMessage.java
@@ -113,21 +113,18 @@ public class AllBucketProfilesUpdateMessage extends DistributionMessage
    * @param dm the distribution manager used to send the message
    * @param prId the unique partitioned region identifier
    * @param profiles bucked id to profile map
-   * @param requireAck whether or not to expect a reply
    * @return an instance of reply processor if requireAck is true on which the caller can wait until
    *         the event has finished.
    */
   public static ReplyProcessor21 send(Set recipients, DistributionManager dm, int prId,
-      Map<Integer, BucketAdvisor.BucketProfile> profiles, boolean requireAck) {
+      Map<Integer, BucketAdvisor.BucketProfile> profiles) {
     if (recipients.isEmpty()) {
       return null;
     }
     ReplyProcessor21 rp = null;
     int procId = 0;
-    if (requireAck) {
-      rp = new ReplyProcessor21(dm, recipients);
-      procId = rp.getProcessorId();
-    }
+    rp = new ReplyProcessor21(dm, recipients);
+    procId = rp.getProcessorId();
     AllBucketProfilesUpdateMessage m =
         new AllBucketProfilesUpdateMessage(recipients, prId, procId, profiles);
     dm.putOutgoing(m);


### PR DESCRIPTION
This PR addresses the problem of AcceptorImpl sending out expensive
profile update messages when it's being stopped during Cache.close().
There is no reason to send these messages if the affected regions are
going to be destroyed since that also sends profile updates
to other members of the cluster.

Most of the changes to the unit test class are to remove old "ignored" tests that didn't make any sense and to add a new test concerning the sending of profile updates.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
