### PR TITLE
Revert "GEODE-5930 clean up dangling outputs in concourse (#2713)"

### DIFF
--- a/ci/pipelines/examples/jinja.template.yml
+++ b/ci/pipelines/examples/jinja.template.yml
@@ -83,7 +83,7 @@ jobs:
     - get: 24h
       trigger: true
     - do:
-      - get: concourse-metadata-resource
+      - put: concourse-metadata-resource
       - task: create_instance
         {{ alpine_tools_config()|indent(8) }}
           params:

--- a/ci/pipelines/geode-build/jinja.template.yml
+++ b/ci/pipelines/geode-build/jinja.template.yml
@@ -202,7 +202,7 @@ jobs:
       params:
         pre: build
     - do:
-      - get: concourse-metadata-resource
+      - put: concourse-metadata-resource
       - task: create_instance
         {{ alpine_tools_config()|indent(8) }}
           params:
@@ -321,7 +321,7 @@ jobs:
       params:
         pre: build
     - do:
-      - get: concourse-metadata-resource
+      - put: concourse-metadata-resource
       - task: create_instance
         {{ alpine_tools_config()|indent(8) }}
           params:
@@ -387,7 +387,7 @@ jobs:
   - do:
     {{ plan_resource_gets() |indent(4) }}
       - do:
-        - get: concourse-metadata-resource
+        - put: concourse-metadata-resource
         - task: create_instance
           {{ alpine_tools_config()|indent(10) }}
             params:

--- a/ci/pipelines/pull-request/jinja.template.yml
+++ b/ci/pipelines/pull-request/jinja.template.yml
@@ -157,7 +157,7 @@ jobs:
             path: geode-unmerged-request
             status: pending
       - do:
-        - get: concourse-metadata-resource
+        - put: concourse-metadata-resource
         - task: create_instance
           {{- alpine_tools_config()|indent(10) }}
             params:


### PR DESCRIPTION
This reverts commit 5503d5cd1e48f9810c85c2a0a05e730157d13211 because new pipelines were not able to start initial build.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [n/a] Does `gradlew build` run cleanly?

- [n/a] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
