### PR TITLE
GEODE-5925 locks are not released in shutdown hook

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/locks/DLockService.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/locks/DLockService.java
@@ -1727,14 +1727,6 @@ public class DLockService extends DistributedLockService {
   public void unlock(Object name) throws LockNotHeldException, LeaseExpiredException {
     final boolean isDebugEnabled_DLS = logger.isTraceEnabled(LogMarker.DLS_VERBOSE);
 
-    if (this.ds.isDisconnectListenerThread()) {
-      if (isDebugEnabled_DLS) {
-        logger.trace(LogMarker.DLS_VERBOSE,
-            "{}, name: {} - disconnect listener thread is exiting unlock()", this, name);
-      }
-      return;
-    }
-
     if (isDebugEnabled_DLS) {
       logger.trace(LogMarker.DLS_VERBOSE, "{}, name: {} - entering unlock()", this, name);
     }
@@ -2292,7 +2284,7 @@ public class DLockService extends DistributedLockService {
     }
 
     // if hasActiveLocks, tell grantor we're destroying...
-    if (!isCurrentlyLockGrantor && maybeHasActiveLocks && !this.ds.isDisconnectListenerThread()) {
+    if (!isCurrentlyLockGrantor && maybeHasActiveLocks && !this.ds.isDisconnectThread()) {
       boolean retry;
       int nonGrantorDestroyLoopCount = 0;
       do {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DestroyPartitionedRegionMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DestroyPartitionedRegionMessage.java
@@ -152,7 +152,7 @@ public class DestroyPartitionedRegionMessage extends PartitionMessage {
       if (DistributionAdvisor.isNewerSerialNumber(oldSerial, this.prSerial)) {
         ok = false;
         if (logger.isDebugEnabled()) {
-          logger.debug("Not removing region {}l serial requested = {}; actual is {}", r.getName(),
+          logger.debug("Not removing region {} serial requested = {}; actual is {}", r.getName(),
               this.prSerial, r.getSerialNumber());
         }
       }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/AbstractRegionEntry.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/AbstractRegionEntry.java
@@ -158,7 +158,7 @@ public abstract class AbstractRegionEntry implements HashRegionEntry<Object, Obj
 
     event.setCallbacksInvokedByCurrentThread();
 
-    if (logger.isDebugEnabled()) {
+    if (logger.isDebugEnabled() && !rgn.isInternalRegion()) {
       logger.debug("{} dispatching event {}", this, event);
     }
     // All the following code that sets "thr" is to workaround

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/locks/DLockServiceJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/locks/DLockServiceJUnitTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.distributed.internal.locks;
+
+import static org.apache.geode.internal.cache.tier.sockets.ClientProxyMembershipID.system;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Properties;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.geode.distributed.ConfigurationProperties;
+import org.apache.geode.distributed.DistributedLockService;
+import org.apache.geode.distributed.DistributedSystem;
+import org.apache.geode.distributed.internal.InternalDistributedSystem;
+
+public class DLockServiceJUnitTest {
+
+  DistributedSystem system;
+  DistributedLockService lockService;
+
+  @Before
+  public void setup() {
+    Properties properties = new Properties();
+    properties.put(ConfigurationProperties.LOCATORS, "");
+    properties.put(ConfigurationProperties.MCAST_PORT, "0");
+    system = DistributedSystem.connect(properties);
+    lockService = DistributedLockService.create("Test Lock Service", system);
+  }
+
+  @After
+  public void teardown() {
+    if (system != null) {
+      system.disconnect();
+    }
+  }
+
+  @Test
+  public void locksAreReleasedDuringDisconnect() {
+    assertThat(lockService.lock("MyLock", 0, -1)).isTrue();
+    assertThat(lockService.isHeldByCurrentThread("MyLock")).isTrue();
+    ((InternalDistributedSystem) system).setIsDisconnectThread();
+    lockService.unlock("MyLock");
+    assertThat(lockService.isHeldByCurrentThread("MyLock")).isFalse();
+  }
+}


### PR DESCRIPTION
If the cache is closed because the JVM is exiting we aren't releasing
locks until the DistributedSystem disconnects.  This alters the behavior
of shutdown and, in particular, causes long delays in designating new
primary bucket owners and reestablishing redundancy.

This PR enables unlocking during shutdown.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
