### PR TITLE
GEODE-1603: wait for receiver MBean federation

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/DistributedSystemBridge.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/DistributedSystemBridge.java
@@ -614,7 +614,9 @@ public class DistributedSystemBridge {
     if (bean != null) {
       return bean;
     } else {
-      throw new Exception(String.format("{0} is an invalid member name or Id", member));
+      throw new Exception(
+          String.format("%s is an invalid member name or Id. Current members are %s", member,
+              mapOfMembers.keySet()));
     }
   }
 
@@ -1058,6 +1060,7 @@ public class DistributedSystemBridge {
     ObjectName receiverName = MBeanJMXAdapter.getGatewayReceiverMBeanName(member);
     GatewayReceiverMXBean bean =
         service.getMBeanInstance(receiverName, GatewayReceiverMXBean.class);
+
     if (bean != null) {
       return receiverName;
     } else {

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/WANTestBase.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/WANTestBase.java
@@ -168,7 +168,6 @@ import org.apache.geode.management.RegionMXBean;
 import org.apache.geode.management.internal.SystemManagementService;
 import org.apache.geode.pdx.SimpleClass;
 import org.apache.geode.pdx.SimpleClass1;
-import org.apache.geode.test.awaitility.GeodeAwaitility;
 import org.apache.geode.test.dunit.Assert;
 import org.apache.geode.test.dunit.AsyncInvocation;
 import org.apache.geode.test.dunit.DistributedTestCase;
@@ -2892,7 +2891,7 @@ public class WANTestBase extends DistributedTestCase {
             + sameRegionSizeCounter + " :regionSize " + previousSize;
       }
     };
-    GeodeAwaitility.await().untilAsserted(wc);
+    await().untilAsserted(wc);
   }
 
   public static String getRegionFullPath(String regionName) {
@@ -3940,6 +3939,10 @@ public class WANTestBase extends DistributedTestCase {
             DistributedSystemMXBean bean = service.getDistributedSystemMXBean();
             ObjectName expectedName = service.getGatewayReceiverMBeanName(receiverMember);
             try {
+              await("wait for member to be added to DistributedSystemBridge membership list")
+                  .untilAsserted(
+                      () -> assertThat(bean.fetchGatewayReceiverObjectName(receiverMember.getId()))
+                          .isNotNull());
               ObjectName actualName = bean.fetchGatewayReceiverObjectName(receiverMember.getId());
               assertEquals(expectedName, actualName);
             } catch (Exception e) {


### PR DESCRIPTION
The check of receiver MBeans was failing with an exception of invalid
member name or id intermittently, when the check occured before the
member was added to DistributedSystemBridge's list of members. This adds
an awaitility around the method that calls this check, since the member
will eventually be put to that list.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
