### PR TITLE
GEODE-5945: Remove ref to JDBC connection commands

### DIFF
--- a/geode-connectors/src/main/resources/META-INF/services/org.springframework.shell.core.CommandMarker
+++ b/geode-connectors/src/main/resources/META-INF/services/org.springframework.shell.core.CommandMarker
@@ -15,11 +15,6 @@
 # limitations under the License.
 #
 # JDBC Connector Extension commands
-org.apache.geode.connectors.jdbc.internal.cli.CreateConnectionCommand
-org.apache.geode.connectors.jdbc.internal.cli.DestroyConnectionCommand
-org.apache.geode.connectors.jdbc.internal.cli.ListConnectionCommand
-org.apache.geode.connectors.jdbc.internal.cli.DescribeConnectionCommand
-org.apache.geode.connectors.jdbc.internal.cli.AlterConnectionCommand
 org.apache.geode.connectors.jdbc.internal.cli.CreateMappingCommand
 org.apache.geode.connectors.jdbc.internal.cli.AlterMappingCommand
 org.apache.geode.connectors.jdbc.internal.cli.DestroyMappingCommand


### PR DESCRIPTION
Remove the references to the JDBC connection commands

[GEODE-5945]

Co-authored-by: Ben Ross <bross@pivotal.io>
Co-authored-by: Jianxia Chen <jchen@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
