### PR TITLE
GEODE-5595: DeltaPropagationDUnit.testBug40165ClientReconnects - NoSubscriptionServersAvailableException

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/DeltaPropagationDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/DeltaPropagationDUnitTest.java
@@ -24,6 +24,7 @@ import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
+import java.security.SecureRandom;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -621,11 +622,11 @@ public class DeltaPropagationDUnitTest extends JUnit4DistributedTestCase {
     /*
      * 1. Create a cache server with slow dispatcher
      * 2. Start a durable client with a custom cache listener which shuts itself down
-     *    as soon as it receives a marker message.
+     * as soon as it receives a marker message.
      * 3. Do some puts on the server region
      * 4. Let the dispatcher start dispatching
      * 5. Verify that durable client is disconnected as soon as it processes the marker.
-     *    Server will retain its queue which has some events (containing deltas) in it.
+     * Server will retain its queue which has some events (containing deltas) in it.
      * 6. Restart the durable client without the self-destructing listener.
      * 7. Wait till the durable client processes all its events.
      * 8. Verify that no deltas are received by it.
@@ -649,7 +650,9 @@ public class DeltaPropagationDUnitTest extends JUnit4DistributedTestCase {
       Properties properties = new Properties();
       properties.setProperty(MCAST_PORT, "0");
       properties.setProperty(LOCATORS, "");
-      properties.setProperty(DURABLE_CLIENT_ID, durableClientId);
+      SecureRandom sr = new SecureRandom();
+
+      properties.setProperty(DURABLE_CLIENT_ID, durableClientId + sr.nextInt());
       properties.setProperty(DURABLE_CLIENT_TIMEOUT, String.valueOf(60));
 
       createDurableCacheClient(((PoolFactoryImpl) pf).getPoolAttributes(), properties,
@@ -657,9 +660,9 @@ public class DeltaPropagationDUnitTest extends JUnit4DistributedTestCase {
 
       // Step 3
       vm0.invoke(this::doPuts);
-//
-//      // Step 3a
-//      vm0.invoke(this::doPutLast);
+      //
+      // // Step 3a
+      // vm0.invoke(this::doPutLast);
 
       // Step 4
       vm0.invoke(ConflationDUnitTestHelper::unsetIsSlowStart);
@@ -911,14 +914,14 @@ public class DeltaPropagationDUnitTest extends JUnit4DistributedTestCase {
 
   private void doPutLast() {
     try {
-//      final int AbsurdlyLongTime = 10000;
-//      Thread.sleep(AbsurdlyLongTime);
+      // final int AbsurdlyLongTime = 10000;
+      // Thread.sleep(AbsurdlyLongTime);
       Region<String, DeltaTestImpl> r = cache.getRegion("/" + regionName);
       assertThat(r).isNotNull();
-//      assertThat(cache).isInstanceOf(GemFireCacheImpl.class);
-//      GemFireCacheImpl cacheAsProxy = (GemFireCacheImpl) cache;
-//      System.out.println("The Cow says: ");
-//      System.out.println(cacheAsProxy.iss ? "NOTHING!" : "Moo.");
+      // assertThat(cache).isInstanceOf(GemFireCacheImpl.class);
+      // GemFireCacheImpl cacheAsProxy = (GemFireCacheImpl) cache;
+      // System.out.println("The Cow says: ");
+      // System.out.println(cacheAsProxy.iss ? "NOTHING!" : "Moo.");
       DeltaTestImpl val = new DeltaTestImpl();
       val.setStr("");
       r.put(LAST_KEY, val);

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/DeltaPropagationDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/DeltaPropagationDUnitTest.java
@@ -890,7 +890,7 @@ public class DeltaPropagationDUnitTest extends JUnit4DistributedTestCase {
       Region<String, DeltaTestImpl> r = cache.getRegion("/" + regionName);
       assertThat(r).isNotNull();
       DeltaTestImpl val;
-      for (int i = 0; i < 1000; i++) {
+      for (int i = 0; i < 10000; i++) {
         val = new DeltaTestImpl();
         val.setStr("" + i);
         r.put(DELTA_KEY, val);

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/DeltaPropagationDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/DeltaPropagationDUnitTest.java
@@ -671,11 +671,14 @@ public class DeltaPropagationDUnitTest extends JUnit4DistributedTestCase {
       createDurableCacheClient(((PoolFactoryImpl) pf).getPoolAttributes(), properties,
           false);
 
-//      await().until(markerReceived::get);
 
       // Step 7
-      waitForLastKey();
-
+      try {
+        waitForLastKey();
+      } catch (org.awaitility.core.ConditionTimeoutException conditionTimeoutException) {
+        logger.info("******** MLH ******");
+        throw conditionTimeoutException;
+      }
       // Step 8
       long fromDeltasOnClient = DeltaTestImpl.getFromDeltaInvocations();
       assertThat(fromDeltasOnClient < 1)

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/DeltaPropagationDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/DeltaPropagationDUnitTest.java
@@ -619,13 +619,16 @@ public class DeltaPropagationDUnitTest extends JUnit4DistributedTestCase {
     PORT1 = vm0.invoke(() -> createServerCache(HARegionQueue.HA_EVICTION_POLICY_MEMORY));
 
     /*
-     * 1. Create a cache server with slow dispatcher 2. Start a durable client with a custom cache
-     * listener which shuts itself down as soon as it receives a marker message. 3. Do some puts on
-     * the server region 4. Let the dispatcher start dispatching 5. Verify that durable client is
-     * disconnected as soon as it processes the marker. Server will retain its queue which has some
-     * events (containing deltas) in it. 6. Restart the durable client without the self-destructing
-     * listener. 7. Wait till the durable client processes all its events. 8. Verify that no deltas
-     * are received by it.
+     * 1. Create a cache server with slow dispatcher
+     * 2. Start a durable client with a custom cache listener which shuts itself down
+     *    as soon as it receives a marker message.
+     * 3. Do some puts on the server region
+     * 4. Let the dispatcher start dispatching
+     * 5. Verify that durable client is disconnected as soon as it processes the marker.
+     *    Server will retain its queue which has some events (containing deltas) in it.
+     * 6. Restart the durable client without the self-destructing listener.
+     * 7. Wait till the durable client processes all its events.
+     * 8. Verify that no deltas are received by it.
      */
 
     // Step 0

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/DeltaPropagationDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/DeltaPropagationDUnitTest.java
@@ -1282,22 +1282,8 @@ public class DeltaPropagationDUnitTest extends JUnit4DistributedTestCase {
 
     PoolFactoryImpl poolFactory = (PoolFactoryImpl) PoolManager.createFactory();
     poolFactory.init(poolAttr);
-    PoolImpl pool = null;
+    PoolImpl pool = (PoolImpl) poolFactory.create("DeltaPropagationDUnitTest");
 
-    GeodeAwaitility.await()
-        .until(() -> !cache.isReconnecting() && !cache.isClosed());
-
-
-    while (pool == null) {
-      try {
-        pool = (PoolImpl) poolFactory.create("DeltaPropagationDUnitTest");
-        if (pool == null) {
-          Thread.sleep(100);
-        }
-      } catch (org.apache.geode.cache.NoSubscriptionServersAvailableException e) {
-        Thread.sleep(100);
-      }
-    }
 
     AttributesFactory<String, DeltaTestImpl> factory = new AttributesFactory<>();
     factory.setScope(Scope.LOCAL);

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/P2PDeltaPropagationDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/P2PDeltaPropagationDUnitTest.java
@@ -521,8 +521,8 @@ public class P2PDeltaPropagationDUnitTest extends JUnit4DistributedTestCase {
         deltas == 2);
     assertTrue(
         "Expected 2 deltas to be processed at receiver but were "
-            + DeltaTestImpl.getFromDeltaInvokations() + " (implementation counter)",
-        DeltaTestImpl.getFromDeltaInvokations() == 2);
+            + DeltaTestImpl.getFromDeltaInvocations() + " (implementation counter)",
+        DeltaTestImpl.getFromDeltaInvocations() == 2);
     assertTrue("Expected " + updates + " updates but found " + numOfUpdates,
         numOfUpdates == updates);
     DeltaTestImpl val = (DeltaTestImpl) region.getEntry("KEY").getValue();
@@ -540,7 +540,7 @@ public class P2PDeltaPropagationDUnitTest extends JUnit4DistributedTestCase {
         + " (statistics)", deltas > 0);
     assertFalse(
         "Expected no deltas to be processed at receiver but processed were "
-            + DeltaTestImpl.getFromDeltaInvokations() + " (implementation counter)",
+            + DeltaTestImpl.getFromDeltaInvocations() + " (implementation counter)",
         DeltaTestImpl.fromDeltaFeatureUsed());
     assertTrue("Expected " + updates + " updates but found " + numOfUpdates,
         numOfUpdates == updates);
@@ -552,7 +552,7 @@ public class P2PDeltaPropagationDUnitTest extends JUnit4DistributedTestCase {
   }
 
   public static void resetFlags() {
-    DeltaTestImpl.resetDeltaInvokationCounters();
+    DeltaTestImpl.resetDeltaInvocationCounters();
     numOfUpdates = 0;
     hasDeltaBytes = 0;
     check = false;

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/QueueManagerImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/QueueManagerImpl.java
@@ -566,6 +566,8 @@ public class QueueManagerImpl implements QueueManager {
         lock.notifyAll();
       }
       cqsDisconnected();
+      throw new NoSubscriptionServersAvailableException(
+          "Could not initialize a primary queue on startup. No queue servers available.");
     } else {
       cqsConnected();
     }

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/QueueManagerImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/QueueManagerImpl.java
@@ -946,6 +946,7 @@ public class QueueManagerImpl implements QueueManager {
       ClientUpdater failedUpdater) {
     QueueConnectionImpl queueConnection = null;
     FailureTracker failureTracker = denyList.getFailureTracker(connection.getServer());
+    logger.info(" ****** denyList = " + denyList.toString());
     try {
       ClientUpdater updater = factory.createServerToClientConnection(connection.getEndpoint(), this,
           isPrimary, failedUpdater);

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/QueueManagerImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/QueueManagerImpl.java
@@ -946,7 +946,7 @@ public class QueueManagerImpl implements QueueManager {
       ClientUpdater failedUpdater) {
     QueueConnectionImpl queueConnection = null;
     FailureTracker failureTracker = denyList.getFailureTracker(connection.getServer());
-    logger.info(" ****** denyList = " + denyList.toString());
+    logger.info(" ****** denyList = " + denyList.getBadServers());
     try {
       ClientUpdater updater = factory.createServerToClientConnection(connection.getEndpoint(), this,
           isPrimary, failedUpdater);

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalDistributedSystem.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalDistributedSystem.java
@@ -1084,7 +1084,7 @@ public class InternalDistributedSystem extends DistributedSystem
       t.join(MAX_DISCONNECT_WAIT);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-      logger.warn("Interrupted while processing disconnect listener",
+      logger.warn("Interrupted while processing disconnect listener thread id = " + t,
           e);
     }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PoolFactoryImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PoolFactoryImpl.java
@@ -358,6 +358,7 @@ public class PoolFactoryImpl implements PoolFactory {
             PoolImpl
                 .create(this.pm, name, this.attributes, this.locatorAddresses, distributedSystem,
                     cache, threadMonitoring);
+        logger.info(" **** Did we retry?");
       } catch (NoSubscriptionServersAvailableException nsa) {
         retries++;
         try {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PoolFactoryImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PoolFactoryImpl.java
@@ -360,6 +360,7 @@ public class PoolFactoryImpl implements PoolFactory {
                     cache, threadMonitoring);
         logger.info(" **** Did we retry?");
       } catch (NoSubscriptionServersAvailableException nsa) {
+        logger.warn("About to retry");
         retries++;
         try {
           Thread.sleep(100);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientUpdater.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientUpdater.java
@@ -505,6 +505,7 @@ public class CacheClientUpdater extends LoggingThread implements ClientUpdater, 
    * stop method.
    */
   private void stopUpdater() {
+    logger.warn("{}: Stopping {}", this.location, this);
     boolean isSelfDestroying = Thread.currentThread() == this;
     stopProcessing();
 
@@ -515,7 +516,6 @@ public class CacheClientUpdater extends LoggingThread implements ClientUpdater, 
       if (logger.isDebugEnabled()) {
         logger.debug("{}: Stopping {}", this.location, this);
       }
-
       if (!isSelfDestroying) {
         interrupt();
         try {
@@ -1815,7 +1815,10 @@ public class CacheClientUpdater extends LoggingThread implements ClientUpdater, 
 
   @Override
   public void onDisconnect(InternalDistributedSystem sys) {
+    logger.warn("{}: onDisconnect about to stopUpdater {}", this.location, this);
     stopUpdater();
+    logger.warn("{}: onDisconnect done stopUpdater {}", this.location, this);
+
   }
 
   private void verifySocketBufferSize(int requestedBufferSize, int actualBufferSize, String type) {

--- a/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/PRDeltaPropagationDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/PRDeltaPropagationDUnitTest.java
@@ -115,7 +115,7 @@ public class PRDeltaPropagationDUnitTest extends DistributedTestCase {
     client1 = getHost(0).getVM(2);
     dataStore3 = getHost(0).getVM(3);
 
-    DeltaTestImpl.resetDeltaInvokationCounters();
+    DeltaTestImpl.resetDeltaInvocationCounters();
     dataStore1.invoke(() -> resetAll());
     dataStore2.invoke(() -> resetAll());
     dataStore3.invoke(() -> resetAll());
@@ -125,7 +125,7 @@ public class PRDeltaPropagationDUnitTest extends DistributedTestCase {
   public void tearDown() throws Exception {
     disconnectAllFromDS();
     Invoke.invokeInEveryVM(() -> {
-      DeltaTestImpl.resetDeltaInvokationCounters();
+      DeltaTestImpl.resetDeltaInvocationCounters();
       isFailed = false;
       isBadToDelta = false;
       isBadFromDelta = false;
@@ -690,18 +690,18 @@ public class PRDeltaPropagationDUnitTest extends DistributedTestCase {
   private void checkToDeltaCounter(int count) {
     assertTrue(
         "ToDelta counters do not match, expected: " + count + ", actual: "
-            + DeltaTestImpl.getToDeltaInvokations(),
-        DeltaTestImpl.getToDeltaInvokations() == count);
-    DeltaTestImpl.resetDeltaInvokationCounters();
+            + DeltaTestImpl.getToDeltaInvocations(),
+        DeltaTestImpl.getToDeltaInvocations() == count);
+    DeltaTestImpl.resetDeltaInvocationCounters();
   }
 
   // check and reset delta counters
   private void fromDeltaCounter(int count) {
     assertTrue(
         "FromDelta counters do not match, expected: " + count + ", but actual: "
-            + DeltaTestImpl.getFromDeltaInvokations(),
-        DeltaTestImpl.getFromDeltaInvokations() == count);
-    DeltaTestImpl.resetDeltaInvokationCounters();
+            + DeltaTestImpl.getFromDeltaInvocations(),
+        DeltaTestImpl.getFromDeltaInvocations() == count);
+    DeltaTestImpl.resetDeltaInvocationCounters();
   }
 
   private void checkIsFailed() {
@@ -1097,7 +1097,7 @@ public class PRDeltaPropagationDUnitTest extends DistributedTestCase {
   }
 
   private void resetAll() {
-    DeltaTestImpl.resetDeltaInvokationCounters();
+    DeltaTestImpl.resetDeltaInvocationCounters();
     ConflationDUnitTestHelper.unsetIsSlowStart();
   }
 

--- a/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/ClientToServerDeltaDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/ClientToServerDeltaDUnitTest.java
@@ -135,11 +135,11 @@ public class ClientToServerDeltaDUnitTest extends JUnit4DistributedTestCase {
   @Override
   public final void preTearDown() throws Exception {
     // reset all flags
-    DeltaTestImpl.resetDeltaInvokationCounters();
-    server.invoke(() -> DeltaTestImpl.resetDeltaInvokationCounters());
-    server2.invoke(() -> DeltaTestImpl.resetDeltaInvokationCounters());
-    client.invoke(() -> DeltaTestImpl.resetDeltaInvokationCounters());
-    client2.invoke(() -> DeltaTestImpl.resetDeltaInvokationCounters());
+    DeltaTestImpl.resetDeltaInvocationCounters();
+    server.invoke(() -> DeltaTestImpl.resetDeltaInvocationCounters());
+    server2.invoke(() -> DeltaTestImpl.resetDeltaInvocationCounters());
+    client.invoke(() -> DeltaTestImpl.resetDeltaInvocationCounters());
+    client2.invoke(() -> DeltaTestImpl.resetDeltaInvocationCounters());
     // close the clients first
     client.invoke(() -> ClientToServerDeltaDUnitTest.closeCache());
     client2.invoke(() -> ClientToServerDeltaDUnitTest.closeCache());
@@ -901,8 +901,8 @@ public class ClientToServerDeltaDUnitTest extends JUnit4DistributedTestCase {
 
   public static void verifyDeltaReceived() {
     assertTrue(
-        "Expected 1 fromDelta() invokation but was " + DeltaTestImpl.getFromDeltaInvokations(),
-        DeltaTestImpl.getFromDeltaInvokations() == 1);
+        "Expected 1 fromDelta() invokation but was " + DeltaTestImpl.getFromDeltaInvocations(),
+        DeltaTestImpl.getFromDeltaInvocations() == 1);
   }
 
   public static void verifyDeltaSent(Integer deltas) {
@@ -918,15 +918,15 @@ public class ClientToServerDeltaDUnitTest extends JUnit4DistributedTestCase {
   public static void checkFromdeltaCounter() {
     assertTrue(
         "FromDelta counters do not match, expected: " + (NO_PUT_OPERATION - 1) + ", actual: "
-            + DeltaTestImpl.getFromDeltaInvokations(),
-        DeltaTestImpl.getFromDeltaInvokations() >= (NO_PUT_OPERATION - 1));
+            + DeltaTestImpl.getFromDeltaInvocations(),
+        DeltaTestImpl.getFromDeltaInvocations() >= (NO_PUT_OPERATION - 1));
   }
 
   public static void checkTodeltaCounter(Integer count) {
     assertTrue(
         "ToDelta counters do not match, expected: " + count.intValue() + ", actual: "
-            + DeltaTestImpl.getToDeltaInvokations(),
-        DeltaTestImpl.getToDeltaInvokations() >= count.intValue());
+            + DeltaTestImpl.getToDeltaInvocations(),
+        DeltaTestImpl.getToDeltaInvocations() >= count.intValue());
   }
 
   public static void checkDeltaFeatureNotUsed() {
@@ -961,7 +961,7 @@ public class ClientToServerDeltaDUnitTest extends JUnit4DistributedTestCase {
 
   public static void checkForDelta() {
     assertTrue("Delta sent to EMPTY data policy region",
-        DeltaTestImpl.getFromDeltaInvokations() == 0);
+        DeltaTestImpl.getFromDeltaInvocations() == 0);
   }
 
   public static void waitForLastKey() {

--- a/geode-junit/src/main/java/org/apache/geode/DeltaTestImpl.java
+++ b/geode-junit/src/main/java/org/apache/geode/DeltaTestImpl.java
@@ -43,8 +43,8 @@ public class DeltaTestImpl implements DataSerializable, Delta {
    */
   public static final String ERRONEOUS_STRING_FOR_FROM_DELTA = "ERRONEOUS_STRING";
   public static final int ERRONEOUS_INT_FOR_TO_DELTA = -101;
-  private static long fromDeltaInvokations;
-  private static long toDeltaInvokations;
+  private static long fromDeltaInvocations;
+  private static long toDeltaInvocations;
   private static long toDeltaFailure;
   private static long fromDeltaFailure;
   private static long timesConstructed = 0;
@@ -156,18 +156,18 @@ public class DeltaTestImpl implements DataSerializable, Delta {
   /*****************************************************************************
    * Below methods are not part of standard Delta implementation but are used for testing purpose.
    */
-  public static void resetDeltaInvokationCounters() {
+  public static void resetDeltaInvocationCounters() {
     resetToDeltaCounter();
     resetFromDeltaCounter();
     resetFailureCounter();
   }
 
   public static void resetToDeltaCounter() {
-    toDeltaInvokations = 0;
+    toDeltaInvocations = 0;
   }
 
   public static void resetFromDeltaCounter() {
-    fromDeltaInvokations = 0;
+    fromDeltaInvocations = 0;
   }
 
   public static void resetFailureCounter() {
@@ -176,23 +176,23 @@ public class DeltaTestImpl implements DataSerializable, Delta {
   }
 
   public static Boolean deltaFeatureUsed() {
-    return (toDeltaInvokations > 0) || (fromDeltaInvokations > 0);
+    return (toDeltaInvocations > 0) || (fromDeltaInvocations > 0);
   }
 
   public static Boolean toDeltaFeatureUsed() {
-    return (toDeltaInvokations > 0);
+    return (toDeltaInvocations > 0);
   }
 
-  public static Long getFromDeltaInvokations() {
-    return fromDeltaInvokations;
+  public static Long getFromDeltaInvocations() {
+    return fromDeltaInvocations;
   }
 
-  public static Long getToDeltaInvokations() {
-    return toDeltaInvokations;
+  public static Long getToDeltaInvocations() {
+    return toDeltaInvocations;
   }
 
   public static Boolean fromDeltaFeatureUsed() {
-    return (fromDeltaInvokations > 0);
+    return (fromDeltaInvocations > 0);
   }
 
   public static Boolean isFromDeltaFailure() {
@@ -258,7 +258,7 @@ public class DeltaTestImpl implements DataSerializable, Delta {
   @Override
   public void fromDelta(DataInput in) throws IOException {
     try {
-      fromDeltaInvokations++;
+      fromDeltaInvocations++;
       boolean tempHasDelta = false;
       byte tempDeltaBits = this.deltaBits;
       byte[] tempByteArr = this.byteArr;
@@ -318,7 +318,7 @@ public class DeltaTestImpl implements DataSerializable, Delta {
   @Override
   public void toDelta(DataOutput out) throws IOException {
     try {
-      toDeltaInvokations++;
+      toDeltaInvocations++;
       DataSerializer.writeByte(this.deltaBits, out);
 
       if (deltaBits != 0) {


### PR DESCRIPTION
The basic problem with this code was that it was declaring an exception in one part of the code and later "picking up" that error and throwing it. This messed with the time and handling of errors as one might imagine... QueueManagerImpl.java was the source of that problem. Then there were timing issues in the DeltaPropogationDUnitTests themselves. So I alleviated that in part moving to awaitility and to the new GeodeAwaitility. There was also a little more synchronization added in the form of atomic booleans..


Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
