### PR TITLE
GEODE-5950 ensure images pick up new Java11 versions

### DIFF
--- a/ci/images/google-geode-builder/scripts/setup.sh
+++ b/ci/images/google-geode-builder/scripts/setup.sh
@@ -57,8 +57,9 @@ apt-get install -y --no-install-recommends \
 rm -rf /etc/alternatives
 mv /etc/keep-alternatives /etc/alternatives
 
-tar xfvz <(curl https://download.java.net/java/GA/jdk11/28/GPL/openjdk-11+28_linux-x64_bin.tar.gz) -C /usr/lib/jvm
-mv /usr/lib/jvm/jdk-11 /usr/lib/jvm/java-11-openjdk-amd64
+JDK_URL=$(curl -Ls http://jdk.java.net/11 | awk '/linux-x64/{sub(/.*href=./,"");sub(/".*/,"");if(found!=1)print;found=1}')
+tar xzf <(curl -s $JDK_URL) -C /usr/lib/jvm
+mv /usr/lib/jvm/jdk-11* /usr/lib/jvm/java-11-openjdk-amd64
 
 pushd /tmp
   curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz

--- a/ci/pipelines/images/jinja.template.yml
+++ b/ci/pipelines/images/jinja.template.yml
@@ -20,6 +20,15 @@
 ---
 
 resources:
+- name: once-a-week
+  type: time
+  source:
+    days: [Monday]
+    start: 6:00 AM
+    stop: 7:00 AM
+    interval: 1h
+    location: US/Pacific
+
 - name: build-concourse-dockerfile
   type: git
   source:
@@ -159,6 +168,8 @@ jobs:
   serial: true
   plan:
   - aggregate:
+    - get: once-a-week
+      trigger: true
     - get: test-container-docker-image
       passed: [build-test-container-docker-image]
       trigger: true
@@ -187,6 +198,8 @@ jobs:
   serial: true
   plan:
   - aggregate:
+    - get: once-a-week
+      trigger: true
     - get: google-windows-geode-builder
       trigger: true
     - get: alpine-tools-docker-image


### PR DESCRIPTION
The Java 11.0.1 release exposed an oversight in the new pipeline: some triggers were not in place to ensure images were rebuilt with the new version.

With this fix, the linux image now grabs the latest released version of OpenJDK11 (instead of a hardcoded version), and both linux and windows images are triggered once a week (for lack of a better way to know when there is a new chocolatey update for windows or a change to download link for linux).

- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [n/a] Does `gradlew build` run cleanly?

- [n/a] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?