### PR TITLE
GEODE-5952: Provide full cache XML entity for root region when a subregion is created with gfsh

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/Region.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/Region.java
@@ -169,7 +169,8 @@ public interface Region<K, V> extends ConcurrentMap<K, V> {
   String getFullPath();
 
   /**
-   * Gets the parent region of this region. If this region is a root region, returns null.
+   * Gets the parent region of this region. If this region is a root region (i.e. has no parents),
+   * returns null.
    * <p>
    * Does not throw a <code>CacheClosedException</code> or a <code>RegionDestroyedException</code>.
    *
@@ -177,6 +178,26 @@ public interface Region<K, V> extends ConcurrentMap<K, V> {
    * @see Region#createSubregion(String, RegionAttributes) createSubregion
    */
   <PK, PV> Region<PK, PV> getParentRegion();
+
+  /**
+   * Gets the root ancestor region for this region. If the region itself is a root region
+   * (i.e. has no parents), returns null.
+   * <p>
+   * Does not throw a <code>CacheClosedException</code> or a <code>RegionDestroyedException</code>.
+   *
+   * @return the root ancestor region which contains this region; null,
+   *         if this region is the root region
+   * @see Region#createSubregion(String, RegionAttributes) createSubregion
+   */
+  default <PK, PV> Region<PK, PV> getRootRegion() {
+    Region<PK, PV> currentRegion = getParentRegion();
+
+    while (currentRegion != null && currentRegion.getParentRegion() != null) {
+      currentRegion = currentRegion.getParentRegion();
+    }
+
+    return currentRegion;
+  }
 
   /**
    * Returns the <code>RegionAttributes</code> for this region. This object is backed by this

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateRegionCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateRegionCommand.java
@@ -41,7 +41,6 @@ import org.apache.geode.cache.RegionAttributes;
 import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.distributed.DistributedMember;
-import org.apache.geode.distributed.internal.InternalConfigurationPersistenceService;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.management.DistributedRegionMXBean;
 import org.apache.geode.management.DistributedSystemMXBean;
@@ -442,7 +441,7 @@ public class CreateRegionCommand extends InternalGfshCommand {
     if (xmlEntity != null) {
       verifyDistributedRegionMbean(cache, regionPath);
       persistClusterConfiguration(result,
-          () -> ((InternalConfigurationPersistenceService) getConfigurationPersistenceService())
+          () -> (getConfigurationPersistenceService())
               .addXmlEntity(xmlEntity, groups));
     }
     return result;

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/RegionCreateFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/RegionCreateFunction.java
@@ -94,6 +94,12 @@ public class RegionCreateFunction implements InternalFunction {
     try {
       Region<?, ?> createdRegion = createRegion(cache, regionCreateArgs);
       XmlEntity xmlEntity = new XmlEntity(CacheXml.REGION, "name", createdRegion.getName());
+
+      Region<?, ?> rootRegion = createdRegion.getRootRegion();
+      if (rootRegion != null) {
+        xmlEntity = new XmlEntity(CacheXml.REGION, "name", rootRegion.getName());
+      }
+
       resultSender.lastResult(new CliFunctionResult(memberNameOrId, xmlEntity,
           CliStrings.format(CliStrings.CREATE_REGION__MSG__REGION_0_CREATED_ON_1,
               createdRegion.getFullPath(), memberNameOrId)));


### PR DESCRIPTION
- Add getRootRegion default method to Region interface.

Signed-off-by: Jens Deppe <jdeppe@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
