### PR TITLE
GEODE-5960: Add test to verify CommandMarker file for the JDBC connector

### DIFF
--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/ConnectionsCommandManagerJUnitTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/ConnectionsCommandManagerJUnitTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.connectors.jdbc.internal.cli;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.ServiceLoader;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.shell.core.CommandMarker;
+
+import org.apache.geode.internal.ClassPathLoader;
+import org.apache.geode.management.cli.GfshCommand;
+import org.apache.geode.management.internal.cli.CommandManager;
+import org.apache.geode.management.internal.cli.commands.InternalGfshCommand;
+import org.apache.geode.management.internal.cli.util.ClasspathScanLoadHelper;
+
+/**
+ * CommandManagerTest - Includes tests to check the CommandManager functions
+ */
+public class ConnectionsCommandManagerJUnitTest {
+
+  private CommandManager commandManager;
+
+  @Before
+  public void before() {
+    commandManager = new CommandManager();
+  }
+
+  /**
+   * tests loadCommands()
+   */
+  @Test
+  public void testCommandManagerLoadCommands() {
+    Set<String> packagesToScan = new HashSet<>();
+    packagesToScan.add(GfshCommand.class.getPackage().getName());
+    packagesToScan.add(InternalGfshCommand.class.getPackage().getName());
+
+    ClasspathScanLoadHelper scanner = new ClasspathScanLoadHelper(packagesToScan);
+    ServiceLoader<CommandMarker> loader =
+        ServiceLoader.load(CommandMarker.class, ClassPathLoader.getLatest().asClassLoader());
+    loader.reload();
+    Iterator<CommandMarker> iterator = loader.iterator();
+
+    Set<Class<?>> foundClasses;
+
+    // geode's commands
+    foundClasses = scanner.scanPackagesForClassesImplementing(CommandMarker.class,
+        GfshCommand.class.getPackage().getName(),
+        InternalGfshCommand.class.getPackage().getName());
+
+    while (iterator.hasNext()) {
+      foundClasses.add(iterator.next().getClass());
+    }
+
+    Set<Class<?>> expectedClasses = new HashSet<>();
+
+    for (CommandMarker commandMarker : commandManager.getCommandMarkers()) {
+      expectedClasses.add(commandMarker.getClass());
+    }
+
+    assertThat(expectedClasses).isEqualTo(foundClasses);
+  }
+}


### PR DESCRIPTION
Added a new test to the JDBC connector project to verify that the list
of commands loaded via the scanner and the command marker match the list
of commands found via these two sources. This is to avoid
errors/warnings due to commands which appear in Command Marker files but
don't have available source code.

Co-authored-by: Ben Ross <bross@pivotal.io>
Co-authored-by: Darrel Schneider <dschneider@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
