### PR TITLE
GEODE-5864: Put GLOBAL_GRADLE_ARGS in the right place.

### DIFF
--- a/ci/pipelines/geode-build/jinja.template.yml
+++ b/ci/pipelines/geode-build/jinja.template.yml
@@ -352,7 +352,6 @@ jobs:
             {{ common_instance_params(publish_artifacts) | indent(12) }}
             GEODE_BRANCH: {{repository.branch}}
             GEODE_FORK: {{repository.fork}}
-            GRADLE_GLOBAL_ARGS: ((gradle-global-args))
           run:
             path: geode-ci/ci/scripts/create_instance.sh
           inputs:
@@ -379,6 +378,7 @@ jobs:
         SERVICE_ACCOUNT: ((!concourse-gcp-account))
         JAVA_BUILD_VERSION: {{ java_build_version.version }}
         MAVEN_SNAPSHOT_BUCKET: ((maven-snapshot-bucket))
+        GRADLE_GLOBAL_ARGS: ((gradle-global-args))
       run:
         path: geode-ci/ci/scripts/execute_publish.sh
       inputs:

--- a/ci/scripts/execute_publish.sh
+++ b/ci/scripts/execute_publish.sh
@@ -67,6 +67,7 @@ SET_JAVA_HOME="export JAVA_HOME=/usr/lib/jvm/java-${JAVA_BUILD_VERSION}-openjdk-
 
 GRADLE_COMMAND="./gradlew \
     ${DEFAULT_GRADLE_TASK_OPTIONS} \
+    ${GRADLE_GLOBAL_ARGS} \
     -PbuildId=${BUILD_ID} -PmavenSnapshotBucket=${MAVEN_SNAPSHOT_BUCKET} publish"
 
 echo "${GRADLE_COMMAND}"


### PR DESCRIPTION
Authored-by: Sean Goller <sgoller@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
