### PR TITLE
GEODE-5963: Change destroy no entry found log statement to debug

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Destroy.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Destroy.java
@@ -153,8 +153,10 @@ public class Destroy extends BaseCommand {
     } catch (EntryNotFoundException e) {
       // Don't send an exception back to the client if this
       // exception happens. Just log it and continue.
-      logger.info("{}: during entry destroy no entry was found for key {}",
-          serverConnection.getName(), key);
+      if (logger.isDebugEnabled()) {
+        logger.debug("{}: during entry destroy no entry was found for key {}",
+            serverConnection.getName(), key);
+      }
     } catch (RegionDestroyedException rde) {
       writeException(clientMessage, rde, false, serverConnection);
       serverConnection.setAsTrue(RESPONDED);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Destroy65.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Destroy65.java
@@ -281,8 +281,10 @@ public class Destroy65 extends BaseCommand {
     } catch (EntryNotFoundException e) {
       // Don't send an exception back to the client if this
       // exception happens. Just log it and continue.
-      logger.info("{}: during entry destroy no entry was found for key {}",
-          new Object[] {serverConnection.getName(), key});
+      if (logger.isDebugEnabled()) {
+        logger.debug("{}: during entry destroy no entry was found for key {}",
+            serverConnection.getName(), key);
+      }
       entryNotFoundForRemove = true;
     } catch (RegionDestroyedException rde) {
       writeException(clientMessage, rde, false, serverConnection);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/Destroy65Test.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/Destroy65Test.java
@@ -14,6 +14,9 @@
  */
 package org.apache.geode.internal.cache.tier.sockets.command;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doThrow;
@@ -29,6 +32,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import org.apache.geode.CancelCriterion;
+import org.apache.geode.cache.EntryNotFoundException;
 import org.apache.geode.cache.operations.DestroyOperationContext;
 import org.apache.geode.internal.Version;
 import org.apache.geode.internal.cache.InternalCache;
@@ -176,4 +180,12 @@ public class Destroy65Test {
     verify(this.errorResponseMessage).send(eq(this.serverConnection));
   }
 
+  @Test
+  public void destroyThrowsAndHandlesEntryNotFoundExceptionOnServer() {
+    doThrow(new EntryNotFoundException("")).when(region).basicBridgeDestroy(any(), any(), any(),
+        anyBoolean(), any());
+
+    assertThatCode(() -> destroy65.cmdExecute(message, serverConnection, securityService, 0))
+        .doesNotThrowAnyException();
+  }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/DestroyTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/DestroyTest.java
@@ -14,6 +14,9 @@
  */
 package org.apache.geode.internal.cache.tier.sockets.command;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doThrow;
@@ -29,6 +32,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import org.apache.geode.CancelCriterion;
+import org.apache.geode.cache.EntryNotFoundException;
 import org.apache.geode.cache.operations.DestroyOperationContext;
 import org.apache.geode.internal.Version;
 import org.apache.geode.internal.cache.InternalCache;
@@ -179,4 +183,12 @@ public class DestroyTest {
     verify(this.errorResponseMessage).send(eq(this.serverConnection));
   }
 
+  @Test
+  public void destroyThrowsAndHandlesEntryNotFoundExceptionOnServer() {
+    doThrow(new EntryNotFoundException("")).when(region).basicBridgeDestroy(any(), any(), any(),
+        anyBoolean(), any());
+
+    assertThatCode(() -> destroy.cmdExecute(message, serverConnection, securityService, 0))
+        .doesNotThrowAnyException();
+  }
 }


### PR DESCRIPTION
Also fixed new Object[] mistake in log statement in Destroy65
that was introduced by changes for GEODE-5686.
