### PR TITLE
GEODE-5967: change pdx-class-name to pdx-name

### DIFF
--- a/geode-connectors/src/acceptanceTest/java/org/apache/geode/connectors/jdbc/JdbcDistributedTest.java
+++ b/geode-connectors/src/acceptanceTest/java/org/apache/geode/connectors/jdbc/JdbcDistributedTest.java
@@ -647,7 +647,7 @@ public abstract class JdbcDistributedTest implements Serializable {
       boolean valueContainsPrimaryKey) {
     final String commandStr = "create jdbc-mapping --region=" + regionName + " --connection="
         + connectionName + (valueContainsPrimaryKey ? " --value-contains-primary-key" : "")
-        + (pdxClassName != null ? " --pdx-class-name=" + pdxClassName : "");
+        + (pdxClassName != null ? " --pdx-name=" + pdxClassName : "");
     gfsh.executeAndAssertThat(commandStr).statusIsSuccess();
   }
 

--- a/geode-connectors/src/distributedTest/java/org/apache/geode/connectors/jdbc/internal/cli/AlterMappingCommandDUnitTest.java
+++ b/geode-connectors/src/distributedTest/java/org/apache/geode/connectors/jdbc/internal/cli/AlterMappingCommandDUnitTest.java
@@ -24,7 +24,7 @@ import static org.apache.geode.connectors.jdbc.internal.cli.AlterMappingCommand.
 import static org.apache.geode.connectors.jdbc.internal.cli.CreateMappingCommand.CREATE_MAPPING;
 import static org.apache.geode.connectors.jdbc.internal.cli.CreateMappingCommand.CREATE_MAPPING__CONNECTION_NAME;
 import static org.apache.geode.connectors.jdbc.internal.cli.CreateMappingCommand.CREATE_MAPPING__FIELD_MAPPING;
-import static org.apache.geode.connectors.jdbc.internal.cli.CreateMappingCommand.CREATE_MAPPING__PDX_CLASS_NAME;
+import static org.apache.geode.connectors.jdbc.internal.cli.CreateMappingCommand.CREATE_MAPPING__PDX_NAME;
 import static org.apache.geode.connectors.jdbc.internal.cli.CreateMappingCommand.CREATE_MAPPING__REGION_NAME;
 import static org.apache.geode.connectors.jdbc.internal.cli.CreateMappingCommand.CREATE_MAPPING__TABLE_NAME;
 import static org.apache.geode.connectors.jdbc.internal.cli.CreateMappingCommand.CREATE_MAPPING__VALUE_CONTAINS_PRIMARY_KEY;
@@ -76,7 +76,7 @@ public class AlterMappingCommandDUnitTest {
     csb.addOption(CREATE_MAPPING__REGION_NAME, REGION_NAME);
     csb.addOption(CREATE_MAPPING__CONNECTION_NAME, "connection");
     csb.addOption(CREATE_MAPPING__TABLE_NAME, "myTable");
-    csb.addOption(CREATE_MAPPING__PDX_CLASS_NAME, "myPdxClass");
+    csb.addOption(CREATE_MAPPING__PDX_NAME, "myPdxClass");
     csb.addOption(CREATE_MAPPING__VALUE_CONTAINS_PRIMARY_KEY, "true");
     csb.addOption(CREATE_MAPPING__FIELD_MAPPING, "field1:column1,field2:column2");
 
@@ -107,7 +107,7 @@ public class AlterMappingCommandDUnitTest {
           cache.getService(JdbcConnectorService.class).getMappingForRegion(REGION_NAME);
       assertThat(mapping.getConnectionConfigName()).isEqualTo("newConnection");
       assertThat(mapping.getTableName()).isEqualTo("newTable");
-      assertThat(mapping.getPdxClassName()).isEqualTo("newPdxClass");
+      assertThat(mapping.getPdxName()).isEqualTo("newPdxClass");
       assertThat(mapping.isPrimaryKeyInValue()).isEqualTo(false);
       List<RegionMapping.FieldMapping> fieldMappings = mapping.getFieldMapping();
       assertThat(fieldMappings).hasSize(2);
@@ -140,7 +140,7 @@ public class AlterMappingCommandDUnitTest {
           cache.getService(JdbcConnectorService.class).getMappingForRegion(REGION_NAME);
       assertThat(mapping.getConnectionConfigName()).isEqualTo("connection");
       assertThat(mapping.getTableName()).isNull();
-      assertThat(mapping.getPdxClassName()).isNull();
+      assertThat(mapping.getPdxName()).isNull();
       assertThat(mapping.getFieldMapping()).isEmpty();
     });
   }

--- a/geode-connectors/src/distributedTest/java/org/apache/geode/connectors/jdbc/internal/cli/CreateMappingCommandDUnitTest.java
+++ b/geode-connectors/src/distributedTest/java/org/apache/geode/connectors/jdbc/internal/cli/CreateMappingCommandDUnitTest.java
@@ -17,7 +17,7 @@ package org.apache.geode.connectors.jdbc.internal.cli;
 import static org.apache.geode.connectors.jdbc.internal.cli.CreateMappingCommand.CREATE_MAPPING;
 import static org.apache.geode.connectors.jdbc.internal.cli.CreateMappingCommand.CREATE_MAPPING__CONNECTION_NAME;
 import static org.apache.geode.connectors.jdbc.internal.cli.CreateMappingCommand.CREATE_MAPPING__FIELD_MAPPING;
-import static org.apache.geode.connectors.jdbc.internal.cli.CreateMappingCommand.CREATE_MAPPING__PDX_CLASS_NAME;
+import static org.apache.geode.connectors.jdbc.internal.cli.CreateMappingCommand.CREATE_MAPPING__PDX_NAME;
 import static org.apache.geode.connectors.jdbc.internal.cli.CreateMappingCommand.CREATE_MAPPING__REGION_NAME;
 import static org.apache.geode.connectors.jdbc.internal.cli.CreateMappingCommand.CREATE_MAPPING__TABLE_NAME;
 import static org.apache.geode.connectors.jdbc.internal.cli.CreateMappingCommand.CREATE_MAPPING__VALUE_CONTAINS_PRIMARY_KEY;
@@ -78,7 +78,7 @@ public class CreateMappingCommandDUnitTest {
     csb.addOption(CREATE_MAPPING__REGION_NAME, REGION_NAME);
     csb.addOption(CREATE_MAPPING__CONNECTION_NAME, "connection");
     csb.addOption(CREATE_MAPPING__TABLE_NAME, "myTable");
-    csb.addOption(CREATE_MAPPING__PDX_CLASS_NAME, "myPdxClass");
+    csb.addOption(CREATE_MAPPING__PDX_NAME, "myPdxClass");
     csb.addOption(CREATE_MAPPING__VALUE_CONTAINS_PRIMARY_KEY, "true");
     csb.addOption(CREATE_MAPPING__FIELD_MAPPING, "field1:column1,field2:column2");
 
@@ -96,7 +96,7 @@ public class CreateMappingCommandDUnitTest {
           cache.getService(JdbcConnectorService.class).getMappingForRegion(REGION_NAME);
       assertThat(mapping.getConnectionConfigName()).isEqualTo("connection");
       assertThat(mapping.getTableName()).isEqualTo("myTable");
-      assertThat(mapping.getPdxClassName()).isEqualTo("myPdxClass");
+      assertThat(mapping.getPdxName()).isEqualTo("myPdxClass");
       assertThat(mapping.isPrimaryKeyInValue()).isEqualTo(true);
       List<RegionMapping.FieldMapping> fieldMappings = mapping.getFieldMapping();
       assertThat(fieldMappings).hasSize(2);
@@ -113,7 +113,7 @@ public class CreateMappingCommandDUnitTest {
     csb.addOption(CREATE_MAPPING__REGION_NAME, REGION_NAME);
     csb.addOption(CREATE_MAPPING__CONNECTION_NAME, "connection");
     csb.addOption(CREATE_MAPPING__TABLE_NAME, "myTable");
-    csb.addOption(CREATE_MAPPING__PDX_CLASS_NAME, "myPdxClass");
+    csb.addOption(CREATE_MAPPING__PDX_NAME, "myPdxClass");
     csb.addOption(CREATE_MAPPING__FIELD_MAPPING, "field1:column1,field2:column2");
 
     gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
@@ -136,7 +136,7 @@ public class CreateMappingCommandDUnitTest {
           cache.getService(JdbcConnectorService.class).getMappingForRegion(REGION_NAME);
       assertThat(mapping.getConnectionConfigName()).isEqualTo("connection");
       assertThat(mapping.getTableName()).isEqualTo("myTable");
-      assertThat(mapping.getPdxClassName()).isEqualTo("myPdxClass");
+      assertThat(mapping.getPdxName()).isEqualTo("myPdxClass");
       assertThat(mapping.isPrimaryKeyInValue()).isEqualTo(false);
       List<RegionMapping.FieldMapping> fieldMappings = mapping.getFieldMapping();
       assertThat(fieldMappings).hasSize(2);
@@ -153,7 +153,7 @@ public class CreateMappingCommandDUnitTest {
     csb.addOption(CREATE_MAPPING__REGION_NAME, REGION_NAME);
     csb.addOption(CREATE_MAPPING__CONNECTION_NAME, "connection");
     csb.addOption(CREATE_MAPPING__TABLE_NAME, "myTable");
-    csb.addOption(CREATE_MAPPING__PDX_CLASS_NAME, "myPdxClass");
+    csb.addOption(CREATE_MAPPING__PDX_NAME, "myPdxClass");
     csb.addOption(CREATE_MAPPING__VALUE_CONTAINS_PRIMARY_KEY, "false");
 
     gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();

--- a/geode-connectors/src/distributedTest/java/org/apache/geode/connectors/jdbc/internal/cli/DescribeMappingCommandDUnitTest.java
+++ b/geode-connectors/src/distributedTest/java/org/apache/geode/connectors/jdbc/internal/cli/DescribeMappingCommandDUnitTest.java
@@ -17,7 +17,7 @@ package org.apache.geode.connectors.jdbc.internal.cli;
 import static org.apache.geode.connectors.jdbc.internal.cli.CreateMappingCommand.CREATE_MAPPING;
 import static org.apache.geode.connectors.jdbc.internal.cli.CreateMappingCommand.CREATE_MAPPING__CONNECTION_NAME;
 import static org.apache.geode.connectors.jdbc.internal.cli.CreateMappingCommand.CREATE_MAPPING__FIELD_MAPPING;
-import static org.apache.geode.connectors.jdbc.internal.cli.CreateMappingCommand.CREATE_MAPPING__PDX_CLASS_NAME;
+import static org.apache.geode.connectors.jdbc.internal.cli.CreateMappingCommand.CREATE_MAPPING__PDX_NAME;
 import static org.apache.geode.connectors.jdbc.internal.cli.CreateMappingCommand.CREATE_MAPPING__REGION_NAME;
 import static org.apache.geode.connectors.jdbc.internal.cli.CreateMappingCommand.CREATE_MAPPING__TABLE_NAME;
 import static org.apache.geode.connectors.jdbc.internal.cli.CreateMappingCommand.CREATE_MAPPING__VALUE_CONTAINS_PRIMARY_KEY;
@@ -74,7 +74,7 @@ public class DescribeMappingCommandDUnitTest implements Serializable {
     csb.addOption(CREATE_MAPPING__REGION_NAME, REGION_NAME);
     csb.addOption(CREATE_MAPPING__CONNECTION_NAME, "connection");
     csb.addOption(CREATE_MAPPING__TABLE_NAME, "testTable");
-    csb.addOption(CREATE_MAPPING__PDX_CLASS_NAME, "myPdxClass");
+    csb.addOption(CREATE_MAPPING__PDX_NAME, "myPdxClass");
     csb.addOption(CREATE_MAPPING__VALUE_CONTAINS_PRIMARY_KEY, "true");
     csb.addOption(CREATE_MAPPING__FIELD_MAPPING, "field1:column1,field2:column2");
 
@@ -89,7 +89,7 @@ public class DescribeMappingCommandDUnitTest implements Serializable {
     commandResultAssert.containsKeyValuePair(CREATE_MAPPING__REGION_NAME, REGION_NAME);
     commandResultAssert.containsKeyValuePair(CREATE_MAPPING__CONNECTION_NAME, "connection");
     commandResultAssert.containsKeyValuePair(CREATE_MAPPING__TABLE_NAME, "testTable");
-    commandResultAssert.containsKeyValuePair(CREATE_MAPPING__PDX_CLASS_NAME, "myPdxClass");
+    commandResultAssert.containsKeyValuePair(CREATE_MAPPING__PDX_NAME, "myPdxClass");
     commandResultAssert.containsKeyValuePair(CREATE_MAPPING__VALUE_CONTAINS_PRIMARY_KEY, "true");
     commandResultAssert.containsOutput("field1");
     commandResultAssert.containsOutput("field2");
@@ -134,7 +134,7 @@ public class DescribeMappingCommandDUnitTest implements Serializable {
     commandResultAssert.containsKeyValuePair(CREATE_MAPPING__REGION_NAME, REGION_NAME);
     commandResultAssert.containsKeyValuePair(CREATE_MAPPING__CONNECTION_NAME, "connection");
     commandResultAssert.containsKeyValuePair(CREATE_MAPPING__TABLE_NAME, "testTable");
-    commandResultAssert.containsKeyValuePair(CREATE_MAPPING__PDX_CLASS_NAME, "myPdxClass");
+    commandResultAssert.containsKeyValuePair(CREATE_MAPPING__PDX_NAME, "myPdxClass");
     commandResultAssert.containsKeyValuePair(CREATE_MAPPING__VALUE_CONTAINS_PRIMARY_KEY, "true");
   }
 

--- a/geode-connectors/src/distributedTest/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyMappingCommandDunitTest.java
+++ b/geode-connectors/src/distributedTest/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyMappingCommandDunitTest.java
@@ -17,7 +17,7 @@ package org.apache.geode.connectors.jdbc.internal.cli;
 import static org.apache.geode.connectors.jdbc.internal.cli.CreateMappingCommand.CREATE_MAPPING;
 import static org.apache.geode.connectors.jdbc.internal.cli.CreateMappingCommand.CREATE_MAPPING__CONNECTION_NAME;
 import static org.apache.geode.connectors.jdbc.internal.cli.CreateMappingCommand.CREATE_MAPPING__FIELD_MAPPING;
-import static org.apache.geode.connectors.jdbc.internal.cli.CreateMappingCommand.CREATE_MAPPING__PDX_CLASS_NAME;
+import static org.apache.geode.connectors.jdbc.internal.cli.CreateMappingCommand.CREATE_MAPPING__PDX_NAME;
 import static org.apache.geode.connectors.jdbc.internal.cli.CreateMappingCommand.CREATE_MAPPING__REGION_NAME;
 import static org.apache.geode.connectors.jdbc.internal.cli.CreateMappingCommand.CREATE_MAPPING__TABLE_NAME;
 import static org.apache.geode.connectors.jdbc.internal.cli.CreateMappingCommand.CREATE_MAPPING__VALUE_CONTAINS_PRIMARY_KEY;
@@ -75,7 +75,7 @@ public class DestroyMappingCommandDunitTest implements Serializable {
     csb.addOption(CREATE_MAPPING__REGION_NAME, REGION_NAME);
     csb.addOption(CREATE_MAPPING__CONNECTION_NAME, "connection");
     csb.addOption(CREATE_MAPPING__TABLE_NAME, "myTable");
-    csb.addOption(CREATE_MAPPING__PDX_CLASS_NAME, "myPdxClass");
+    csb.addOption(CREATE_MAPPING__PDX_NAME, "myPdxClass");
     csb.addOption(CREATE_MAPPING__VALUE_CONTAINS_PRIMARY_KEY, "true");
     csb.addOption(CREATE_MAPPING__FIELD_MAPPING, "field1:column1,field2:column2");
 

--- a/geode-connectors/src/distributedTest/java/org/apache/geode/connectors/jdbc/internal/cli/JdbcClusterConfigDistributedTest.java
+++ b/geode-connectors/src/distributedTest/java/org/apache/geode/connectors/jdbc/internal/cli/JdbcClusterConfigDistributedTest.java
@@ -55,7 +55,7 @@ public class JdbcClusterConfigDistributedTest {
     gfsh.executeAndAssertThat("create region --name=regionName --type=PARTITION").statusIsSuccess();
 
     gfsh.executeAndAssertThat(
-        "create jdbc-mapping --region=regionName --connection=connection --table=testTable --pdx-class-name=myPdxClass --value-contains-primary-key --field-mapping=field1:column1,field2:column2")
+        "create jdbc-mapping --region=regionName --connection=connection --table=testTable --pdx-name=myPdxClass --value-contains-primary-key --field-mapping=field1:column1,field2:column2")
         .statusIsSuccess();
 
     server.invoke(() -> {
@@ -79,7 +79,7 @@ public class JdbcClusterConfigDistributedTest {
     assertThat(regionMapping.getRegionName()).isEqualTo("regionName");
     assertThat(regionMapping.getConnectionConfigName()).isEqualTo("connection");
     assertThat(regionMapping.getTableName()).isEqualTo("testTable");
-    assertThat(regionMapping.getPdxClassName()).isEqualTo("myPdxClass");
+    assertThat(regionMapping.getPdxName()).isEqualTo("myPdxClass");
     assertThat(regionMapping.isPrimaryKeyInValue()).isEqualTo(true);
     assertThat(regionMapping.getColumnNameForField("field1", mock(TableMetaDataView.class)))
         .isEqualTo("column1");

--- a/geode-connectors/src/distributedTest/java/org/apache/geode/connectors/jdbc/internal/cli/ListMappingCommandDUnitTest.java
+++ b/geode-connectors/src/distributedTest/java/org/apache/geode/connectors/jdbc/internal/cli/ListMappingCommandDUnitTest.java
@@ -62,7 +62,7 @@ public class ListMappingCommandDUnitTest implements Serializable {
         .statusIsSuccess();
 
     String mapping = "create jdbc-mapping --region=testRegion --connection=connection "
-        + "--table=myTable --pdx-class-name=myPdxClass --value-contains-primary-key=true "
+        + "--table=myTable --pdx-name=myPdxClass --value-contains-primary-key=true "
         + "--field-mapping=field1:column1,field2:column2";
     gfsh.executeAndAssertThat(mapping).statusIsSuccess();
 

--- a/geode-connectors/src/integrationTest/java/org/apache/geode/connectors/jdbc/internal/cli/AlterMappingCommandIntegrationTest.java
+++ b/geode-connectors/src/integrationTest/java/org/apache/geode/connectors/jdbc/internal/cli/AlterMappingCommandIntegrationTest.java
@@ -79,7 +79,7 @@ public class AlterMappingCommandIntegrationTest {
     assertThat(regionMapping).isNotNull();
     assertThat(regionMapping.getConnectionConfigName()).isEqualTo("newConnection");
     assertThat(regionMapping.getTableName()).isEqualTo("newTable");
-    assertThat(regionMapping.getPdxClassName()).isEqualTo("newPdxClass");
+    assertThat(regionMapping.getPdxName()).isEqualTo("newPdxClass");
     assertThat(regionMapping.isPrimaryKeyInValue()).isFalse();
   }
 

--- a/geode-connectors/src/integrationTest/java/org/apache/geode/connectors/jdbc/internal/cli/CreateMappingCommandIntegrationTest.java
+++ b/geode-connectors/src/integrationTest/java/org/apache/geode/connectors/jdbc/internal/cli/CreateMappingCommandIntegrationTest.java
@@ -84,7 +84,7 @@ public class CreateMappingCommandIntegrationTest {
     assertThat(regionMapping.getRegionName()).isEqualTo(regionName);
     assertThat(regionMapping.getConnectionConfigName()).isEqualTo(connectionName);
     assertThat(regionMapping.getTableName()).isEqualTo(tableName);
-    assertThat(regionMapping.getPdxClassName()).isEqualTo(pdxClass);
+    assertThat(regionMapping.getPdxName()).isEqualTo(pdxClass);
     assertThat(regionMapping.isPrimaryKeyInValue()).isEqualTo(keyInValue);
     assertThat(regionMapping.getColumnNameForField("field1", mock(TableMetaDataView.class)))
         .isEqualTo("column1");
@@ -128,7 +128,7 @@ public class CreateMappingCommandIntegrationTest {
     assertThat(regionMapping.getRegionName()).isEqualTo(regionName);
     assertThat(regionMapping.getConnectionConfigName()).isEqualTo(connectionName);
     assertThat(regionMapping.getTableName()).isNull();
-    assertThat(regionMapping.getPdxClassName()).isNull();
+    assertThat(regionMapping.getPdxName()).isNull();
     assertThat(regionMapping.isPrimaryKeyInValue()).isFalse();
     assertThat(regionMapping.getFieldMapping()).isEmpty();
   }

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/SqlToPdxInstanceCreator.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/SqlToPdxInstanceCreator.java
@@ -70,7 +70,7 @@ class SqlToPdxInstanceCreator {
   }
 
   private PdxInstanceFactory createPdxInstanceFactory() {
-    String valueClassName = regionMapping.getPdxClassName();
+    String valueClassName = regionMapping.getPdxName();
     if (valueClassName != null) {
       return cache.createPdxInstanceFactory(valueClassName);
     } else {
@@ -250,7 +250,7 @@ class SqlToPdxInstanceCreator {
   }
 
   private FieldType getFieldType(TypeRegistry typeRegistry, String fieldName) {
-    String pdxClassName = regionMapping.getPdxClassName();
+    String pdxClassName = regionMapping.getPdxName();
     if (pdxClassName == null) {
       return FieldType.OBJECT;
     }

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/AlterMappingCommand.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/AlterMappingCommand.java
@@ -42,7 +42,7 @@ public class AlterMappingCommand extends SingleGfshCommand {
   static final String ALTER_MAPPING__REGION_NAME = "region";
   static final String ALTER_MAPPING__REGION_NAME__HELP =
       "Name of the region the mapping to be altered.";
-  static final String ALTER_MAPPING__PDX_CLASS_NAME = "pdx-class-name";
+  static final String ALTER_MAPPING__PDX_CLASS_NAME = "pdx-name";
   static final String ALTER_MAPPING__PDX_CLASS_NAME__HELP =
       "Name of new pdx class for which values with be written to the database.";
   static final String ALTER_MAPPING__TABLE_NAME = "table";

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/AlterMappingFunction.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/AlterMappingFunction.java
@@ -53,7 +53,7 @@ public class AlterMappingFunction extends CliFunction<RegionMapping> {
         existingMapping.getConnectionConfigName());
     String table = getValue(regionMapping.getTableName(), existingMapping.getTableName());
     String pdxClassName =
-        getValue(regionMapping.getPdxClassName(), existingMapping.getPdxClassName());
+        getValue(regionMapping.getPdxName(), existingMapping.getPdxName());
     Boolean keyInValue = regionMapping.isPrimaryKeyInValue() == null
         ? existingMapping.isPrimaryKeyInValue() : regionMapping.isPrimaryKeyInValue();
 

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/CreateMappingCommand.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/CreateMappingCommand.java
@@ -40,8 +40,8 @@ public class CreateMappingCommand extends SingleGfshCommand {
   static final String CREATE_MAPPING__REGION_NAME = "region";
   static final String CREATE_MAPPING__REGION_NAME__HELP =
       "Name of the region the mapping is being created for.";
-  static final String CREATE_MAPPING__PDX_CLASS_NAME = "pdx-class-name";
-  static final String CREATE_MAPPING__PDX_CLASS_NAME__HELP =
+  static final String CREATE_MAPPING__PDX_NAME = "pdx-name";
+  static final String CREATE_MAPPING__PDX_NAME__HELP =
       "Name of pdx class for which values will be written to the database.";
   static final String CREATE_MAPPING__TABLE_NAME = "table";
   static final String CREATE_MAPPING__TABLE_NAME__HELP =
@@ -66,8 +66,8 @@ public class CreateMappingCommand extends SingleGfshCommand {
           help = CREATE_MAPPING__CONNECTION_NAME__HELP) String connectionName,
       @CliOption(key = CREATE_MAPPING__TABLE_NAME,
           help = CREATE_MAPPING__TABLE_NAME__HELP) String table,
-      @CliOption(key = CREATE_MAPPING__PDX_CLASS_NAME,
-          help = CREATE_MAPPING__PDX_CLASS_NAME__HELP) String pdxClassName,
+      @CliOption(key = CREATE_MAPPING__PDX_NAME,
+          help = CREATE_MAPPING__PDX_NAME__HELP) String pdxName,
       @CliOption(key = CREATE_MAPPING__VALUE_CONTAINS_PRIMARY_KEY,
           help = CREATE_MAPPING__PRIMARY_KEY_IN_VALUE__HELP, unspecifiedDefaultValue = "false",
           specifiedDefaultValue = "true") boolean keyInValue,
@@ -76,7 +76,7 @@ public class CreateMappingCommand extends SingleGfshCommand {
     // input
     Set<DistributedMember> targetMembers = getMembers(null, null);
     RegionMapping mapping = new RegionMapping(regionName,
-        pdxClassName, table, connectionName, keyInValue);
+        pdxName, table, connectionName, keyInValue);
     mapping.setFieldMapping(fieldMappings);
 
     // action

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/DescribeMappingCommand.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/DescribeMappingCommand.java
@@ -15,7 +15,7 @@
 package org.apache.geode.connectors.jdbc.internal.cli;
 
 import static org.apache.geode.connectors.jdbc.internal.cli.CreateMappingCommand.CREATE_MAPPING__CONNECTION_NAME;
-import static org.apache.geode.connectors.jdbc.internal.cli.CreateMappingCommand.CREATE_MAPPING__PDX_CLASS_NAME;
+import static org.apache.geode.connectors.jdbc.internal.cli.CreateMappingCommand.CREATE_MAPPING__PDX_NAME;
 import static org.apache.geode.connectors.jdbc.internal.cli.CreateMappingCommand.CREATE_MAPPING__REGION_NAME;
 import static org.apache.geode.connectors.jdbc.internal.cli.CreateMappingCommand.CREATE_MAPPING__TABLE_NAME;
 import static org.apache.geode.connectors.jdbc.internal.cli.CreateMappingCommand.CREATE_MAPPING__VALUE_CONTAINS_PRIMARY_KEY;
@@ -86,7 +86,7 @@ public class DescribeMappingCommand extends GfshCommand {
     sectionModel.addData(CREATE_MAPPING__REGION_NAME, mapping.getRegionName());
     sectionModel.addData(CREATE_MAPPING__CONNECTION_NAME, mapping.getConnectionConfigName());
     sectionModel.addData(CREATE_MAPPING__TABLE_NAME, mapping.getTableName());
-    sectionModel.addData(CREATE_MAPPING__PDX_CLASS_NAME, mapping.getPdxClassName());
+    sectionModel.addData(CREATE_MAPPING__PDX_NAME, mapping.getPdxName());
     sectionModel.addData(CREATE_MAPPING__VALUE_CONTAINS_PRIMARY_KEY, mapping.isPrimaryKeyInValue());
 
     TabularResultModel tabularResultData = resultModel.addTable(FIELD_TO_COLUMN_TABLE);

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/configuration/RegionMapping.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/configuration/RegionMapping.java
@@ -64,7 +64,7 @@ import org.apache.geode.pdx.internal.TypeRegistry;
  *       &lt;/sequence>
  *       &lt;attribute name="connection-name" type="{http://www.w3.org/2001/XMLSchema}string" />
  *       &lt;attribute name="table" type="{http://www.w3.org/2001/XMLSchema}string" />
- *       &lt;attribute name="pdx-class" type="{http://www.w3.org/2001/XMLSchema}string" />
+ *       &lt;attribute name="pdx-name" type="{http://www.w3.org/2001/XMLSchema}string" />
  *       &lt;attribute name="primary-key-in-value" type="{http://www.w3.org/2001/XMLSchema}string" />
  *     &lt;/restriction>
  *   &lt;/complexContent>
@@ -90,8 +90,8 @@ public class RegionMapping implements CacheElement {
   protected String connectionConfigName;
   @XmlAttribute(name = "table")
   protected String tableName;
-  @XmlAttribute(name = "pdx-class")
-  protected String pdxClassName;
+  @XmlAttribute(name = "pdx-name")
+  protected String pdxName;
   @XmlAttribute(name = "primary-key-in-value")
   protected Boolean primaryKeyInValue;
 
@@ -102,10 +102,10 @@ public class RegionMapping implements CacheElement {
 
   public RegionMapping() {}
 
-  public RegionMapping(String regionName, String pdxClassName, String tableName,
+  public RegionMapping(String regionName, String pdxName, String tableName,
       String connectionConfigName, Boolean primaryKeyInValue) {
     this.regionName = regionName;
-    this.pdxClassName = pdxClassName;
+    this.pdxName = pdxName;
     this.tableName = tableName;
     this.connectionConfigName = connectionConfigName;
     this.primaryKeyInValue = primaryKeyInValue;
@@ -145,8 +145,8 @@ public class RegionMapping implements CacheElement {
     this.tableName = tableName;
   }
 
-  public void setPdxClassName(String pdxClassName) {
-    this.pdxClassName = pdxClassName;
+  public void setPdxName(String pdxName) {
+    this.pdxName = pdxName;
   }
 
   public void setPrimaryKeyInValue(Boolean primaryKeyInValue) {
@@ -172,8 +172,8 @@ public class RegionMapping implements CacheElement {
     return regionName;
   }
 
-  public String getPdxClassName() {
-    return pdxClassName;
+  public String getPdxName() {
+    return pdxName;
   }
 
   public String getTableName() {
@@ -232,7 +232,7 @@ public class RegionMapping implements CacheElement {
       return configured.getFieldName();
     }
 
-    if (getPdxClassName() == null) {
+    if (getPdxName() == null) {
       if (columnName.equals(columnName.toUpperCase())) {
         fieldName = columnName.toLowerCase();
       } else {
@@ -251,10 +251,10 @@ public class RegionMapping implements CacheElement {
   }
 
   private Set<PdxType> getPdxTypesForClassName(TypeRegistry typeRegistry) {
-    Set<PdxType> pdxTypes = typeRegistry.getPdxTypesForClassName(getPdxClassName());
+    Set<PdxType> pdxTypes = typeRegistry.getPdxTypesForClassName(getPdxName());
     if (pdxTypes.isEmpty()) {
       throw new JdbcConnectorException(
-          "The class " + getPdxClassName() + " has not been pdx serialized.");
+          "The class " + getPdxName() + " has not been pdx serialized.");
     }
     return pdxTypes;
   }
@@ -277,7 +277,7 @@ public class RegionMapping implements CacheElement {
       }
     }
     if (matchingFieldNames.isEmpty()) {
-      throw new JdbcConnectorException("The class " + getPdxClassName()
+      throw new JdbcConnectorException("The class " + getPdxName()
           + " does not have a field that matches the column " + columnName);
     } else if (matchingFieldNames.size() > 1) {
       throw new JdbcConnectorException(
@@ -319,8 +319,8 @@ public class RegionMapping implements CacheElement {
     if (regionName != null ? !regionName.equals(that.regionName) : that.regionName != null) {
       return false;
     }
-    if (pdxClassName != null ? !pdxClassName.equals(that.pdxClassName)
-        : that.pdxClassName != null) {
+    if (pdxName != null ? !pdxName.equals(that.pdxName)
+        : that.pdxName != null) {
       return false;
     }
     if (tableName != null ? !tableName.equals(that.tableName) : that.tableName != null) {
@@ -340,7 +340,7 @@ public class RegionMapping implements CacheElement {
   @Override
   public int hashCode() {
     int result = regionName != null ? regionName.hashCode() : 0;
-    result = 31 * result + (pdxClassName != null ? pdxClassName.hashCode() : 0);
+    result = 31 * result + (pdxName != null ? pdxName.hashCode() : 0);
     result = 31 * result + (tableName != null ? tableName.hashCode() : 0);
     result = 31 * result + (connectionConfigName != null ? connectionConfigName.hashCode() : 0);
     result = 31 * result + (primaryKeyInValue ? 1 : 0);
@@ -349,8 +349,8 @@ public class RegionMapping implements CacheElement {
 
   @Override
   public String toString() {
-    return "RegionMapping{" + "regionName='" + regionName + '\'' + ", pdxClassName='"
-        + pdxClassName + '\'' + ", tableName='" + tableName + '\'' + ", connectionConfigName='"
+    return "RegionMapping{" + "regionName='" + regionName + '\'' + ", pdxName='"
+        + pdxName + '\'' + ", tableName='" + tableName + '\'' + ", connectionConfigName='"
         + connectionConfigName + '\'' + ", primaryKeyInValue=" + primaryKeyInValue + '}';
   }
 

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/xml/ElementType.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/xml/ElementType.java
@@ -36,7 +36,7 @@ public enum ElementType {
       mapping.setConnectionConfigName(
           attributes.getValue(JdbcConnectorServiceXmlParser.CONNECTION_NAME));
       mapping.setTableName(attributes.getValue(JdbcConnectorServiceXmlParser.TABLE));
-      mapping.setPdxClassName(attributes.getValue(JdbcConnectorServiceXmlParser.PDX_CLASS));
+      mapping.setPdxName(attributes.getValue(JdbcConnectorServiceXmlParser.PDX_NAME));
       mapping.setPrimaryKeyInValue(
           Boolean.valueOf(attributes.getValue(JdbcConnectorServiceXmlParser.PRIMARY_KEY_IN_VALUE)));
       stack.push(mapping);

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/xml/JdbcConnectorServiceXmlParser.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/xml/JdbcConnectorServiceXmlParser.java
@@ -29,7 +29,7 @@ public class JdbcConnectorServiceXmlParser extends AbstractXmlParser {
   static final String PARAMETERS = "parameters";
   static final String CONNECTION_NAME = "connection-name";
   static final String TABLE = "table";
-  static final String PDX_CLASS = "pdx-class";
+  static final String PDX_NAME = "pdx-name";
   static final String FIELD_NAME = "field-name";
   static final String COLUMN_NAME = "column-name";
   static final String PRIMARY_KEY_IN_VALUE = "primary-key-in-value";

--- a/geode-connectors/src/main/resources/META-INF/schemas/geode.apache.org/schema/jdbc/jdbc-1.0.xsd
+++ b/geode-connectors/src/main/resources/META-INF/schemas/geode.apache.org/schema/jdbc/jdbc-1.0.xsd
@@ -54,7 +54,7 @@ XML schema for JDBC Connector Service in Geode.
                 </xsd:sequence>
                 <xsd:attribute type="xsd:string" name="connection-name" use="optional"/>
                 <xsd:attribute type="xsd:string" name="table" use="optional"/>
-                <xsd:attribute type="xsd:string" name="pdx-class" use="optional"/>
+                <xsd:attribute type="xsd:string" name="pdx-name" use="optional"/>
                 <xsd:attribute type="xsd:string" name="primary-key-in-value" use="optional"/>
             </xsd:complexType>
         </xsd:element>

--- a/geode-connectors/src/main/resources/org/apache/geode/internal/sanctioned-geode-connectors-serializables.txt
+++ b/geode-connectors/src/main/resources/org/apache/geode/internal/sanctioned-geode-connectors-serializables.txt
@@ -6,5 +6,5 @@ org/apache/geode/connectors/jdbc/internal/cli/CreateMappingFunction,false
 org/apache/geode/connectors/jdbc/internal/cli/DescribeMappingFunction,false
 org/apache/geode/connectors/jdbc/internal/cli/DestroyMappingFunction,false
 org/apache/geode/connectors/jdbc/internal/cli/ListMappingFunction,false
-org/apache/geode/connectors/jdbc/internal/configuration/RegionMapping,false,connectionConfigName:java/lang/String,fieldMapping:java/util/List,fieldMappingModified:boolean,pdxClassName:java/lang/String,primaryKeyInValue:java/lang/Boolean,regionName:java/lang/String,tableName:java/lang/String
+org/apache/geode/connectors/jdbc/internal/configuration/RegionMapping,false,connectionConfigName:java/lang/String,fieldMapping:java/util/List,fieldMappingModified:boolean,pdxName:java/lang/String,primaryKeyInValue:java/lang/Boolean,regionName:java/lang/String,tableName:java/lang/String
 org/apache/geode/connectors/jdbc/internal/configuration/RegionMapping$FieldMapping,false,columnName:java/lang/String,fieldName:java/lang/String

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/RegionMappingTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/RegionMappingTest.java
@@ -70,7 +70,7 @@ public class RegionMappingTest {
     assertThat(mapping.getTableName()).isNull();
     assertThat(mapping.getRegionName()).isNull();
     assertThat(mapping.getConnectionConfigName()).isNull();
-    assertThat(mapping.getPdxClassName()).isNull();
+    assertThat(mapping.getPdxName()).isNull();
     assertThat(mapping.getRegionToTableName()).isNull();
     assertThat(mapping.getColumnNameForField("fieldName", mock(TableMetaDataView.class)))
         .isEqualTo("fieldName");
@@ -114,7 +114,7 @@ public class RegionMappingTest {
   public void hasCorrectPdxClassName() {
     mapping = new RegionMapping(null, name, null, null, false);
 
-    assertThat(mapping.getPdxClassName()).isEqualTo(name);
+    assertThat(mapping.getPdxName()).isEqualTo(name);
   }
 
   @Test

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/SqlToPdxInstanceCreatorTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/SqlToPdxInstanceCreatorTest.java
@@ -82,7 +82,7 @@ public class SqlToPdxInstanceCreatorTest {
   @Test
   public void usesPdxFactoryForClassWhenExists() throws Exception {
     String pdxClassName = "classname";
-    when(regionMapping.getPdxClassName()).thenReturn(pdxClassName);
+    when(regionMapping.getPdxName()).thenReturn(pdxClassName);
     when(resultSet.next()).thenReturn(false);
 
     createPdxInstance();
@@ -521,7 +521,7 @@ public class SqlToPdxInstanceCreatorTest {
     TypeRegistry pdxTypeRegistry = mock(TypeRegistry.class);
     when(cache.getPdxRegistry()).thenReturn(pdxTypeRegistry);
     PdxType pdxType = mock(PdxType.class);
-    when(regionMapping.getPdxClassName()).thenReturn(pdxClassName);
+    when(regionMapping.getPdxName()).thenReturn(pdxClassName);
     when(pdxTypeRegistry.getPdxTypeForField(PDX_FIELD_NAME_1, pdxClassName)).thenReturn(pdxType);
     when(pdxType.getPdxField(PDX_FIELD_NAME_1)).thenReturn(null);
     when(regionMapping.getFieldNameForColumn(eq(COLUMN_NAME_1), any()))
@@ -541,7 +541,7 @@ public class SqlToPdxInstanceCreatorTest {
     when(cache.createPdxInstanceFactory(pdxClassName)).thenReturn(factory);
     TypeRegistry pdxTypeRegistry = mock(TypeRegistry.class);
     when(cache.getPdxRegistry()).thenReturn(pdxTypeRegistry);
-    when(regionMapping.getPdxClassName()).thenReturn(pdxClassName);
+    when(regionMapping.getPdxName()).thenReturn(pdxClassName);
     when(pdxTypeRegistry.getPdxTypeForField(PDX_FIELD_NAME_1, pdxClassName)).thenReturn(null);
     when(regionMapping.getFieldNameForColumn(eq(COLUMN_NAME_1), any()))
         .thenReturn(PDX_FIELD_NAME_1);
@@ -715,7 +715,7 @@ public class SqlToPdxInstanceCreatorTest {
     when(cache.getPdxRegistry()).thenReturn(pdxTypeRegistry);
     PdxType pdxType = mock(PdxType.class);
 
-    when(regionMapping.getPdxClassName()).thenReturn(pdxClassName);
+    when(regionMapping.getPdxName()).thenReturn(pdxClassName);
     when(pdxTypeRegistry.getPdxTypeForField(PDX_FIELD_NAME_1, pdxClassName)).thenReturn(pdxType);
     PdxField pdxField = mock(PdxField.class);
     when(pdxType.getPdxField(PDX_FIELD_NAME_1)).thenReturn(pdxField);

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/AlterMappingCommandTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/AlterMappingCommandTest.java
@@ -70,7 +70,7 @@ public class AlterMappingCommandTest {
   @Test
   public void valuesAreParsedAsExpected() {
     GfshParseResult parseResult = gfsh.parse("alter jdbc-mapping --region='region' --connection='' "
-        + "--table='' --pdx-class-name='' " + "--field-mapping=''");
+        + "--table='' --pdx-name='' " + "--field-mapping=''");
 
     String[] mappings = (String[]) parseResult.getParamValue("field-mapping");
     assertThat(mappings).hasSize(1);
@@ -78,16 +78,16 @@ public class AlterMappingCommandTest {
     assertThat(parseResult.getParamValue("region")).isEqualTo("region");
     assertThat(parseResult.getParamValue("connection")).isEqualTo("");
     assertThat(parseResult.getParamValue("table")).isEqualTo("");
-    assertThat(parseResult.getParamValue("pdx-class-name")).isEqualTo("");
+    assertThat(parseResult.getParamValue("pdx-name")).isEqualTo("");
 
     parseResult = gfsh.parse("alter jdbc-mapping --region=testRegion-1 --connection=connection "
-        + "--table=myTable --pdx-class-name=myPdxClass " + "--field-mapping");
+        + "--table=myTable --pdx-name=myPdxClass " + "--field-mapping");
     mappings = (String[]) parseResult.getParamValue("field-mapping");
     assertThat(mappings).hasSize(1);
     assertThat(mappings[0]).isEqualTo("");
 
     parseResult = gfsh.parse("alter jdbc-mapping --region=testRegion-1 --connection=connection "
-        + "--table=myTable --pdx-class-name=myPdxClass ");
+        + "--table=myTable --pdx-name=myPdxClass ");
     mappings = (String[]) parseResult.getParamValue("field-mapping");
     assertThat(mappings).isNull();
   }

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/AlterMappingFunctionTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/AlterMappingFunctionTest.java
@@ -144,7 +144,7 @@ public class AlterMappingFunctionTest {
         function.alterRegionMapping(newConfigValues, mappingToAlter);
 
     assertThat(alteredConfig.getRegionName()).isEqualTo(REGION_NAME);
-    assertThat(alteredConfig.getPdxClassName()).isEqualTo("newClassName");
+    assertThat(alteredConfig.getPdxName()).isEqualTo("newClassName");
     assertThat(alteredConfig.getTableName()).isEqualTo("myTable");
     assertThat(alteredConfig.getConnectionConfigName()).isEqualTo("connection");
     assertThat(alteredConfig.isPrimaryKeyInValue()).isTrue();
@@ -171,7 +171,7 @@ public class AlterMappingFunctionTest {
         function.alterRegionMapping(newConfigValues, mappingToAlter);
 
     assertThat(alteredConfig.getRegionName()).isEqualTo(REGION_NAME);
-    assertThat(alteredConfig.getPdxClassName()).isEqualTo("pdxClass");
+    assertThat(alteredConfig.getPdxName()).isEqualTo("pdxClass");
     assertThat(alteredConfig.getTableName()).isEqualTo("newTable");
     assertThat(alteredConfig.getConnectionConfigName()).isEqualTo("connection");
     assertThat(alteredConfig.isPrimaryKeyInValue()).isTrue();
@@ -187,7 +187,7 @@ public class AlterMappingFunctionTest {
         function.alterRegionMapping(newConfigValues, mappingToAlter);
 
     assertThat(alteredConfig.getRegionName()).isEqualTo(REGION_NAME);
-    assertThat(alteredConfig.getPdxClassName()).isEqualTo("pdxClass");
+    assertThat(alteredConfig.getPdxName()).isEqualTo("pdxClass");
     assertThat(alteredConfig.getTableName()).isEqualTo("myTable");
     assertThat(alteredConfig.getConnectionConfigName()).isEqualTo("connection");
     assertThat(alteredConfig.isPrimaryKeyInValue()).isFalse();
@@ -203,7 +203,7 @@ public class AlterMappingFunctionTest {
         function.alterRegionMapping(newConfigValues, mappingToAlter);
 
     assertThat(alteredConfig.getRegionName()).isEqualTo(REGION_NAME);
-    assertThat(alteredConfig.getPdxClassName()).isEqualTo("pdxClass");
+    assertThat(alteredConfig.getPdxName()).isEqualTo("pdxClass");
     assertThat(alteredConfig.getTableName()).isEqualTo("myTable");
     assertThat(alteredConfig.getConnectionConfigName()).isEqualTo("newConnection");
     assertThat(alteredConfig.isPrimaryKeyInValue()).isTrue();
@@ -221,7 +221,7 @@ public class AlterMappingFunctionTest {
         function.alterRegionMapping(newConfigValues, mappingToAlter);
 
     assertThat(alteredConfig.getRegionName()).isEqualTo(REGION_NAME);
-    assertThat(alteredConfig.getPdxClassName()).isEqualTo("pdxClass");
+    assertThat(alteredConfig.getPdxName()).isEqualTo("pdxClass");
     assertThat(alteredConfig.getTableName()).isEqualTo("myTable");
     assertThat(alteredConfig.getConnectionConfigName()).isEqualTo("connection");
     assertThat(alteredConfig.isPrimaryKeyInValue()).isTrue();
@@ -243,7 +243,7 @@ public class AlterMappingFunctionTest {
         function.alterRegionMapping(newConfigValues, mappingToAlter);
 
     assertThat(alteredConfig.getRegionName()).isEqualTo(REGION_NAME);
-    assertThat(alteredConfig.getPdxClassName()).isEqualTo("pdxClass");
+    assertThat(alteredConfig.getPdxName()).isEqualTo("pdxClass");
     assertThat(alteredConfig.getTableName()).isEqualTo("myTable");
     assertThat(alteredConfig.getConnectionConfigName()).isEqualTo("connection");
     assertThat(alteredConfig.isPrimaryKeyInValue()).isTrue();
@@ -261,7 +261,7 @@ public class AlterMappingFunctionTest {
         function.alterRegionMapping(newConfigValues, mappingToAlter);
 
     assertThat(alteredConfig.getRegionName()).isEqualTo(REGION_NAME);
-    assertThat(alteredConfig.getPdxClassName()).isEqualTo("pdxClass");
+    assertThat(alteredConfig.getPdxName()).isEqualTo("pdxClass");
     assertThat(alteredConfig.getTableName()).isEqualTo("myTable");
     assertThat(alteredConfig.getConnectionConfigName()).isEqualTo("connection");
     assertThat(alteredConfig.isPrimaryKeyInValue()).isTrue();
@@ -279,7 +279,7 @@ public class AlterMappingFunctionTest {
         function.alterRegionMapping(newConfigValues, mappingToAlter);
 
     assertThat(alteredConfig.getRegionName()).isEqualTo(REGION_NAME);
-    assertThat(alteredConfig.getPdxClassName()).isEqualTo("pdxClass");
+    assertThat(alteredConfig.getPdxName()).isEqualTo("pdxClass");
     assertThat(alteredConfig.getTableName()).isEqualTo("myTable");
     assertThat(alteredConfig.getConnectionConfigName()).isEqualTo("connection");
     assertThat(alteredConfig.isPrimaryKeyInValue()).isTrue();

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/DescribeMappingCommandTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/DescribeMappingCommandTest.java
@@ -79,7 +79,7 @@ public class DescribeMappingCommandTest {
 
     gfsh.executeAndAssertThat(command, COMMAND).statusIsSuccess().containsOutput("region", "region")
         .containsOutput("connection", "name1").containsOutput("table", "table1")
-        .containsOutput("pdx-class-name", "class1")
+        .containsOutput("pdx-name", "class1")
         .containsOutput("value-contains-primary-key", "true").containsOutput("field1", "value1")
         .containsOutput("field2", "value2");
   }

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/xml/ElementTypeTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/xml/ElementTypeTest.java
@@ -20,7 +20,7 @@ import static org.apache.geode.connectors.jdbc.internal.xml.ElementType.JDBC_MAP
 import static org.apache.geode.connectors.jdbc.internal.xml.JdbcConnectorServiceXmlParser.COLUMN_NAME;
 import static org.apache.geode.connectors.jdbc.internal.xml.JdbcConnectorServiceXmlParser.CONNECTION_NAME;
 import static org.apache.geode.connectors.jdbc.internal.xml.JdbcConnectorServiceXmlParser.FIELD_NAME;
-import static org.apache.geode.connectors.jdbc.internal.xml.JdbcConnectorServiceXmlParser.PDX_CLASS;
+import static org.apache.geode.connectors.jdbc.internal.xml.JdbcConnectorServiceXmlParser.PDX_NAME;
 import static org.apache.geode.connectors.jdbc.internal.xml.JdbcConnectorServiceXmlParser.PRIMARY_KEY_IN_VALUE;
 import static org.apache.geode.connectors.jdbc.internal.xml.JdbcConnectorServiceXmlParser.TABLE;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -78,7 +78,7 @@ public class ElementTypeTest {
   public void startElementRegionMapping() {
     when(attributes.getValue(CONNECTION_NAME)).thenReturn("connectionName");
     when(attributes.getValue(TABLE)).thenReturn("table");
-    when(attributes.getValue(PDX_CLASS)).thenReturn("pdxClass");
+    when(attributes.getValue(PDX_NAME)).thenReturn("pdxClass");
     when(attributes.getValue(PRIMARY_KEY_IN_VALUE)).thenReturn("true");
     when(regionCreation.getFullPath()).thenReturn("/region");
     stack.push(regionCreation);
@@ -89,7 +89,7 @@ public class ElementTypeTest {
     assertThat(regionMapping.getRegionName()).isEqualTo("region");
     assertThat(regionMapping.getConnectionConfigName()).isEqualTo("connectionName");
     assertThat(regionMapping.getTableName()).isEqualTo("table");
-    assertThat(regionMapping.getPdxClassName()).isEqualTo("pdxClass");
+    assertThat(regionMapping.getPdxName()).isEqualTo("pdxClass");
     assertThat(regionMapping.isPrimaryKeyInValue()).isEqualTo(true);
   }
 


### PR DESCRIPTION
Renamed the xsd "pdx-class" to "pdx-name".
Renamed the gfsh "--pdx-class-name" to "--pdx-name".

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

@BenjaminPerryRoss 
@monkeyherder 

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
