### PR TITLE
GEODE-5338: Document 'ssl-use-default-context' property

### DIFF
--- a/geode-docs/managing/security/implementing_ssl.html.md.erb
+++ b/geode-docs/managing/security/implementing_ssl.html.md.erb
@@ -72,12 +72,15 @@ protocols, and to provide the location and credentials for key and trust stores.
 <dd>List of components for which to enable SSL. Component list can be "" (disable SSL), "all", or a comma-separated list of components.</dd>
 
 <dt>**ssl-endpoint-identification-enabled**</dt>
-<dd> A boolean value that, when set to true, 
-causes clients to validate the server's hostname using
-the server's certificate.
+<dd>A boolean value that, when set to true, causes clients to validate the server's hostname using the server's certificate.
 The default value is false.
-Enabling endpoint identification guards against DNS man-in-the-middle
-attacks when trusting certificates that are not self-signed.</dd>
+Enabling endpoint identification guards against DNS man-in-the-middle attacks when trusting certificates that are not self-signed.</dd>
+
+<dt>**ssl-use-default-context**</dt>
+<dd>A boolean value that, when set to true, allows <%=vars.product_name%> to use the default SSL context as returned by
+SSLContext.getInstance('Default') or set by using SSLContext.setDefault().
+When enabled, also causes ssl-endpoint-identification-enabled to be set to true.
+</dd>
 
 <dt>**ssl-require-authentication**</dt>
 <dd>Requires two-way authentication, applies to all components except web. Boolean - if true (the default), two-way authentication is required.</dd>

--- a/geode-docs/managing/security/implementing_ssl.html.md.erb
+++ b/geode-docs/managing/security/implementing_ssl.html.md.erb
@@ -209,6 +209,7 @@ The following table lists the properties you can use to configure SSL on your <%
 |------------------------------------|------------------------------------------------------------------------------|-------|
 | ssl&#8209;enabled&#8209;components | list of components for which to enable SSL | "all", "", or comma-separated list of components: cluster, gateway, web, jmx, locator, server |
 | ssl&#8209;endpoint&#8209;identification&#8209;enabled | causes clients to validate server hostname using server certificate | boolean - if true, does validation; defaults to false |
+| ssl&#8209;use&#8209;default&#8209;context | allows <%=vars.product_name%> to use the default SSL context | boolean - if true, uses the default SSL context. Also sets ssl-endpoint-identification-enabled to true; defaults to false |
 | ssl-require-authentication         | requires two-way authentication, applies to all components except web | boolean - if true (the default), two-way authentication is required |
 | ssl&#8209;web&#8209;require&#8209;authentication    | requires two-way authentication for web component | boolean - if true, two-way authentication is required. Default is false (one-way authentication only) |
 | ssl-default-alias                  | default certificate name                   | string - if empty, use first certificate in key store |

--- a/geode-docs/reference/topics/gemfire_properties.html.md.erb
+++ b/geode-docs/reference/topics/gemfire_properties.html.md.erb
@@ -617,9 +617,15 @@ Any security-related (properties that begin with <code class="ph codeph">securit
 
 <tr>
 <td>ssl-endpoint-identification-enabled</td>
-<td> A boolean value that, when set to true,
-causes clients to validate the server's hostname using 
-the server's certificate.</td>
+<td>Boolean. When set to true, causes clients to validate the server's hostname using the server's certificate.</td>
+<td>C, S, L</td>
+<td>false</td>
+</tr>
+
+<tr>
+<td>ssl-use-default-context</td>
+<td>Boolean. When set to true, allows <%=vars.product_name%> to use the default SSL context.
+When enabled, also sets ssl-endpoint-identification-enabled to true.</td>
 <td>C, S, L</td>
 <td>false</td>
 </tr>


### PR DESCRIPTION
The property has already been implemented. This is its documentation.