### PR TITLE
GEODE-5674: Stop using random values for test ports

### DIFF
--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/standalone/ChildVM.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/standalone/ChildVM.java
@@ -18,6 +18,7 @@ import java.rmi.Naming;
 
 import org.apache.logging.log4j.Logger;
 
+import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.internal.ExitCode;
 import org.apache.geode.internal.OSProcess;
 import org.apache.geode.internal.Version;
@@ -58,6 +59,7 @@ public class ChildVM {
       Naming.rebind(name, dunitVM);
       JUnit4DistributedTestCase.initializeBlackboard();
       holder.signalVMReady();
+      AvailablePortHelper.initializeUniquePortRange(vmNum + 2); // hacky, locator is -2
       // This loop is here so this VM will die even if the master is mean killed.
       while (!stopMainLoop) {
         holder.ping();


### PR DESCRIPTION
It seems our test framework will fairly frequently have test failing due to
multiple users trying to bind the same port number.  This happens when the
different users happen to randomly generate the same port.  To keep this from
happening, this change will simply hand out the available ports consecutively
as the test runs.  For dunit tests, each child vm will be given a portion of
the overall range for their use.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
