### PR TITLE
GEODE-5976:Prevent conversion of string to bytes

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/redis/internal/executor/sortedset/SortedSetExecutor.java
+++ b/geode-core/src/main/java/org/apache/geode/redis/internal/executor/sortedset/SortedSetExecutor.java
@@ -16,12 +16,16 @@ package org.apache.geode.redis.internal.executor.sortedset;
 
 import org.apache.geode.cache.Region;
 import org.apache.geode.redis.internal.ByteArrayWrapper;
+import org.apache.geode.redis.internal.Coder;
 import org.apache.geode.redis.internal.DoubleWrapper;
 import org.apache.geode.redis.internal.ExecutionHandlerContext;
 import org.apache.geode.redis.internal.RedisDataType;
 import org.apache.geode.redis.internal.executor.AbstractExecutor;
 
 public abstract class SortedSetExecutor extends AbstractExecutor {
+
+  final ByteArrayWrapper minus = new ByteArrayWrapper(Coder.stringToBytes("-"));
+  final ByteArrayWrapper plus = new ByteArrayWrapper(Coder.stringToBytes("+"));
 
   @Override
   protected Region<ByteArrayWrapper, DoubleWrapper> getOrCreateRegion(

--- a/geode-core/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZLexCountExecutor.java
+++ b/geode-core/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZLexCountExecutor.java
@@ -103,21 +103,21 @@ public class ZLexCountExecutor extends SortedSetExecutor {
   private int getCount(ByteArrayWrapper key, Region<ByteArrayWrapper, DoubleWrapper> keyRegion,
       ExecutionHandlerContext context, ByteArrayWrapper start, ByteArrayWrapper stop,
       boolean startInclusive, boolean stopInclusive) throws Exception {
-    if (start.equals("-") && stop.equals("+"))
+    if (start.equals(minus) && stop.equals(plus))
       return keyRegion.size();
-    else if (start.equals("+") || stop.equals("-"))
+    else if (start.equals(plus) || stop.equals(minus))
       return 0;
 
     Query query;
     Object[] params;
-    if (start.equals("-")) {
+    if (start.equals(minus)) {
       if (stopInclusive) {
         query = getQuery(key, SortedSetQuery.ZLEXCOUNTNINFI, context);
       } else {
         query = getQuery(key, SortedSetQuery.ZLEXCOUNTNINF, context);
       }
       params = new Object[] {stop};
-    } else if (stop.equals("+")) {
+    } else if (stop.equals(plus)) {
       if (startInclusive) {
         query = getQuery(key, SortedSetQuery.ZLEXCOUNTPINFI, context);
       } else {

--- a/geode-core/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZRangeByLexExecutor.java
+++ b/geode-core/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZRangeByLexExecutor.java
@@ -144,7 +144,7 @@ public class ZRangeByLexExecutor extends SortedSetExecutor {
       ByteArrayWrapper start, ByteArrayWrapper stop, boolean startInclusive, boolean stopInclusive,
       int offset, int limit) throws FunctionDomainException, TypeMismatchException,
       NameResolutionException, QueryInvocationTargetException {
-    if (start.equals("-") && stop.equals("+")) {
+    if (start.equals(minus) && stop.equals(plus)) {
       List<ByteArrayWrapper> l = new ArrayList<ByteArrayWrapper>(keyRegion.keySet());
       int size = l.size();
       Collections.sort(l);
@@ -152,19 +152,19 @@ public class ZRangeByLexExecutor extends SortedSetExecutor {
         limit += size;
       l = l.subList(Math.min(size, offset), Math.min(offset + limit, size));
       return l;
-    } else if (start.equals("+") || stop.equals("-"))
+    } else if (start.equals(plus) || stop.equals(minus))
       return null;
 
     Query query;
     Object[] params;
-    if (start.equals("-")) {
+    if (start.equals(minus)) {
       if (stopInclusive) {
         query = getQuery(key, SortedSetQuery.ZRANGEBYLEXNINFI, context);
       } else {
         query = getQuery(key, SortedSetQuery.ZRANGEBYLEXNINF, context);
       }
       params = new Object[] {stop, INFINITY_LIMIT};
-    } else if (stop.equals("+")) {
+    } else if (stop.equals(plus)) {
       if (startInclusive) {
         query = getQuery(key, SortedSetQuery.ZRANGEBYLEXPINFI, context);
       } else {

--- a/geode-core/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZRemRangeByLexExecutor.java
+++ b/geode-core/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZRemRangeByLexExecutor.java
@@ -113,21 +113,21 @@ public class ZRemRangeByLexExecutor extends SortedSetExecutor {
       Region<ByteArrayWrapper, DoubleWrapper> keyRegion, ExecutionHandlerContext context,
       ByteArrayWrapper start, ByteArrayWrapper stop, boolean startInclusive, boolean stopInclusive)
       throws Exception {
-    if (start.equals("-") && stop.equals("+"))
+    if (start.equals(minus) && stop.equals(plus))
       return new ArrayList<ByteArrayWrapper>(keyRegion.keySet());
-    else if (start.equals("+") || stop.equals("-"))
+    else if (start.equals(plus) || stop.equals(minus))
       return null;
 
     Query query;
     Object[] params;
-    if (start.equals("-")) {
+    if (start.equals(minus)) {
       if (stopInclusive) {
         query = getQuery(key, SortedSetQuery.ZRANGEBYLEXNINFI, context);
       } else {
         query = getQuery(key, SortedSetQuery.ZRANGEBYLEXNINF, context);
       }
       params = new Object[] {stop, INFINITY_LIMIT};
-    } else if (stop.equals("+")) {
+    } else if (stop.equals(plus)) {
       if (startInclusive) {
         query = getQuery(key, SortedSetQuery.ZRANGEBYLEXPINFI, context);
       } else {


### PR DESCRIPTION
	* prevents the conversion of string to bytes everytime equals is called on the immutable strings

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
