### PR TITLE
GEODE-5985 Possible integer overflow before assigning result to a long variable

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/PortfolioPdxVersion.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/PortfolioPdxVersion.java
@@ -52,18 +52,18 @@ public class PortfolioPdxVersion {
     status = i % 2 == 0 ? "active" : "inactive";
     type = "type" + (i % 3);
     position1 = new PositionPdxVersion(secIds[PositionPdxVersion.cnt % secIds.length],
-        PositionPdxVersion.cnt * 1000);
+        PositionPdxVersion.cnt * 1000L);
     if (i % 2 != 0) {
       position2 = new PositionPdxVersion(secIds[PositionPdxVersion.cnt % secIds.length],
-          PositionPdxVersion.cnt * 1000);
+          PositionPdxVersion.cnt * 1000L);
     } else {
       position2 = null;
     }
 
     positions.put(secIds[PositionPdxVersion.cnt % secIds.length], new PositionPdxVersion(
-        secIds[PositionPdxVersion.cnt % secIds.length], PositionPdxVersion.cnt * 1000));
+        secIds[PositionPdxVersion.cnt % secIds.length], PositionPdxVersion.cnt * 1000L));
     positions.put(secIds[PositionPdxVersion.cnt % secIds.length], new PositionPdxVersion(
-        secIds[PositionPdxVersion.cnt % secIds.length], PositionPdxVersion.cnt * 1000));
+        secIds[PositionPdxVersion.cnt % secIds.length], PositionPdxVersion.cnt * 1000L));
 
     collectionHolderMap.put("0", new CollectionHolder());
     collectionHolderMap.put("1", new CollectionHolder());
@@ -77,7 +77,7 @@ public class PortfolioPdxVersion {
     this.position1.portfolioId = j;
     this.position3 = new Object[3];
     for (int k = 0; k < position3.length; k++) {
-      PositionPdxVersion p = new PositionPdxVersion(secIds[k], (k + 1) * 1000);
+      PositionPdxVersion p = new PositionPdxVersion(secIds[k], (k + 1) * 1000L);
       p.portfolioId = (k + 1);
       this.position3[k] = p;
     }

--- a/geode-core/src/main/java/org/apache/geode/SystemFailure.java
+++ b/geode-core/src/main/java/org/apache/geode/SystemFailure.java
@@ -380,7 +380,7 @@ public final class SystemFailure {
           }
           logFine(WATCHDOG_NAME, "Waiting for disaster");
           try {
-            failureSync.wait(WATCHDOG_WAIT * 1000);
+            failureSync.wait(WATCHDOG_WAIT * 1000L);
           } catch (InterruptedException e) {
             // Ignore
           }

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/DistributedSystemHealthMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/DistributedSystemHealthMonitor.java
@@ -122,7 +122,7 @@ class DistributedSystemHealthMonitor implements Runnable, GemFireVM {
     while (!this.stopRequested) {
       SystemFailure.checkFailure();
       try {
-        Thread.sleep(interval * 1000);
+        Thread.sleep(interval * 1000L);
         List status = new ArrayList();
         eval.evaluate(status);
 

--- a/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/MBeanUtil.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/MBeanUtil.java
@@ -303,7 +303,7 @@ public class MBeanUtil {
    * @param refreshInterval the seconds between refreshes
    */
   static void registerRefreshNotification(NotificationListener client, Object userData,
-      RefreshNotificationType type, int refreshInterval) {
+      RefreshNotificationType type, long refreshInterval) {
     if (client == null) {
       throw new IllegalArgumentException(
           "NotificationListener is required");
@@ -371,8 +371,8 @@ public class MBeanUtil {
         timerNotificationId = refreshTimer.addNotification(type.getType(), // type
             type.getMessage(), // message = "refresh"
             userData, // userData
-            new Date(System.currentTimeMillis() + refreshInterval * 1000), // first occurrence
-            refreshInterval * 1000); // period to repeat
+            new Date(System.currentTimeMillis() + refreshInterval * 1000L), // first occurrence
+            refreshInterval * 1000L); // period to repeat
 
         // put an entry into the map for the listener...
         notifications.put(type, timerNotificationId);

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/IndexElemArray.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/IndexElemArray.java
@@ -21,7 +21,7 @@ import java.util.NoSuchElementException;
 
 /**
  * A wrapper around an object array for storing values in index data structure with minimal set of
- * operations supported and the maximum size of 128 elements
+ * operations supported and the maximum size of 255 elements
  *
  * @since GemFire 7.0
  */
@@ -54,10 +54,13 @@ public class IndexElemArray implements Iterable, Collection {
    * @param minCapacity the desired minimum capacity
    */
   private void ensureCapacity(int minCapacity) {
+    if (minCapacity > 255) {
+      throw new IllegalStateException("attempt to increase the size beyond 255 elements");
+    }
     int oldCapacity = elementData.length;
     if (minCapacity > oldCapacity) {
       int newCapacity = oldCapacity + 5;
-      if (newCapacity < minCapacity) {
+      if (newCapacity < minCapacity || 255 < newCapacity) {
         newCapacity = minCapacity;
       }
       // minCapacity is usually close to size, so this is a win:
@@ -74,7 +77,7 @@ public class IndexElemArray implements Iterable, Collection {
    * @return the number of elements in this list
    */
   public int size() {
-    return size;
+    return size & 0xff;
   }
 
   /**
@@ -106,12 +109,13 @@ public class IndexElemArray implements Iterable, Collection {
    */
   public int indexOf(Object o) {
     synchronized (lock) {
+      int currentSize = size();
       if (o == null) {
-        for (int i = 0; i < size; i++)
+        for (int i = 0; i < currentSize; i++)
           if (elementData[i] == null)
             return i;
       } else {
-        for (int i = 0; i < size; i++)
+        for (int i = 0; i < currentSize; i++)
           if (o.equals(elementData[i]))
             return i;
       }
@@ -128,7 +132,7 @@ public class IndexElemArray implements Iterable, Collection {
    */
   public Object get(int index) {
     synchronized (lock) {
-      RangeCheck(index);
+      rangeCheck(index);
       return elementData[index];
     }
   }
@@ -143,7 +147,7 @@ public class IndexElemArray implements Iterable, Collection {
    */
   public Object set(int index, Object element) {
     synchronized (lock) {
-      RangeCheck(index);
+      rangeCheck(index);
 
       Object oldValue = (Object) elementData[index];
       elementData[index] = element;
@@ -160,11 +164,17 @@ public class IndexElemArray implements Iterable, Collection {
    */
   public boolean add(Object e) {
     synchronized (lock) {
-      ensureCapacity(size + 1);
-      elementData[size] = e;
-      ++size;
+      int currentSize = size(); // byte to int
+      ensureCapacity(currentSize + 1);
+      elementData[currentSize] = e;
+      currentSize++;
+      setSize(currentSize);
     }
     return true;
+  }
+
+  private void setSize(int size) {
+    this.size = (byte) (size & 0xff);
   }
 
   /**
@@ -180,14 +190,15 @@ public class IndexElemArray implements Iterable, Collection {
    */
   public boolean remove(Object o) {
     synchronized (lock) {
+      int currentSize = size(); // byte to int
       if (o == null) {
-        for (int index = 0; index < size; index++)
+        for (int index = 0; index < currentSize; index++)
           if (elementData[index] == null) {
             fastRemove(index);
             return true;
           }
       } else {
-        for (int index = 0; index < size; index++)
+        for (int index = 0; index < currentSize; index++)
           if (o.equals(elementData[index])) {
             fastRemove(index);
             return true;
@@ -216,11 +227,8 @@ public class IndexElemArray implements Iterable, Collection {
    * Removes all of the elements from this list. The list will be empty after this call returns.
    */
   public void clear() {
-    // Let gc do its work
     synchronized (lock) {
-      for (int i = 0; i < size; i++) {
-        elementData[i] = null;
-      }
+      Arrays.fill(this.elementData, null);
       size = 0;
     }
   }
@@ -230,9 +238,10 @@ public class IndexElemArray implements Iterable, Collection {
    * method does *not* check if the index is negative: It is always used immediately prior to an
    * array access, which throws an ArrayIndexOutOfBoundsException if index is negative.
    */
-  private void RangeCheck(int index) {
-    if (index >= size) {
-      throw new IndexOutOfBoundsException("Index: " + index + ", Size: " + size);
+  private void rangeCheck(int index) {
+    int currentSize = size(); // byte to int
+    if (index >= currentSize) {
+      throw new IndexOutOfBoundsException("Index: " + index + ", Size: " + currentSize);
     }
   }
 
@@ -241,16 +250,19 @@ public class IndexElemArray implements Iterable, Collection {
     Object[] a = c.toArray();
     int numNew = a.length;
     synchronized (lock) {
-      ensureCapacity(size + numNew);
-      System.arraycopy(a, 0, elementData, size, numNew);
-      size += (byte) (numNew & 0xFF);
+      int currentSize = size(); // byte to int
+      ensureCapacity(currentSize + numNew);
+      System.arraycopy(a, 0, elementData, currentSize, numNew);
+      setSize(currentSize + numNew);
     }
     return numNew != 0;
   }
 
   @Override
   public Object[] toArray() {
-    return Arrays.copyOf(elementData, size);
+    synchronized (lock) {
+      return Arrays.copyOf(elementData, size);
+    }
   }
 
   @Override
@@ -267,7 +279,7 @@ public class IndexElemArray implements Iterable, Collection {
     IndexArrayListIterator() {
       synchronized (lock) {
         elements = elementData;
-        len = size;
+        len = size();
       }
     }
 

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/IndexElemArray.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/IndexElemArray.java
@@ -243,7 +243,7 @@ public class IndexElemArray implements Iterable, Collection {
     synchronized (lock) {
       ensureCapacity(size + numNew);
       System.arraycopy(a, 0, elementData, size, numNew);
-      size += numNew;
+      size += (byte) (numNew & 0xFF);
     }
     return numNew != 0;
   }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalDistributedSystem.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalDistributedSystem.java
@@ -851,7 +851,7 @@ public class InternalDistributedSystem extends DistributedSystem
     if (attemptingToReconnect && !this.isConnected) {
       if (this.quorumChecker != null) {
         logger.info("performing a quorum check to see if location services can be started early");
-        if (!quorumChecker.checkForQuorum(3 * this.config.getMemberTimeout())) {
+        if (!quorumChecker.checkForQuorum(3L * this.config.getMemberTimeout())) {
           logger.info("quorum check failed - not allowing location services to start early");
           return;
         }
@@ -2798,7 +2798,7 @@ public class InternalDistributedSystem extends DistributedSystem
         if (reconnectDS != null && reconnectDS.isConnected()) {
           // make sure the new DS and cache are stable before exiting this loop
           try {
-            Thread.sleep(config.getMemberTimeout() * 3);
+            Thread.sleep(config.getMemberTimeout() * 3L);
           } catch (InterruptedException e) {
             logger.info("Reconnect thread has been interrupted - exiting");
             Thread.currentThread().interrupt();

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
@@ -961,7 +961,7 @@ public class InternalLocator extends Locator implements ConnectListener {
           }
         }
         if (checker != null && !tcpServerStarted) {
-          boolean start = checker.checkForQuorum(3 * this.myDs.getConfig().getMemberTimeout());
+          boolean start = checker.checkForQuorum(3L * this.myDs.getConfig().getMemberTimeout());
           if (start) {
             // start up peer location. server location is started after the DS finishes
             // reconnecting
@@ -1188,7 +1188,7 @@ public class InternalLocator extends Locator implements ConnectListener {
                 // always retry some number of times
                 locatorWaitTime = 30;
               }
-              giveup = System.currentTimeMillis() + locatorWaitTime * 1000;
+              giveup = System.currentTimeMillis() + locatorWaitTime * 1000L;
               try {
                 Thread.sleep(1000);
               } catch (InterruptedException ignored) {

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/ServiceConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/ServiceConfig.java
@@ -118,7 +118,7 @@ public class ServiceConfig {
 
     // we need to have enough time to figure out that the coordinator has crashed &
     // find a new one
-    long minimumJoinTimeout = dconfig.getMemberTimeout() * 2 + MEMBER_REQUEST_COLLECTION_INTERVAL;
+    long minimumJoinTimeout = dconfig.getMemberTimeout() * 2L + MEMBER_REQUEST_COLLECTION_INTERVAL;
     if (defaultJoinTimeout < minimumJoinTimeout) {
       defaultJoinTimeout = minimumJoinTimeout;
     }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/GMSQuorumChecker.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/GMSQuorumChecker.java
@@ -53,7 +53,7 @@ public class GMSQuorumChecker implements QuorumChecker {
   private boolean quorumAchieved = false;
   private final JChannel channel;
   private JGAddress myAddress;
-  private final int partitionThreshold;
+  private final long partitionThreshold;
   private Set<DistributedMember> oldDistributedMemberIdentifiers;
 
   public GMSQuorumChecker(NetView jgView, int partitionThreshold, JChannel channel,

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/mgr/GMSMembershipManager.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/mgr/GMSMembershipManager.java
@@ -1994,7 +1994,7 @@ public class GMSMembershipManager implements MembershipManager, Manager {
       // Make sure that the entry isn't stale...
       long shunTime = shunnedMembers.get(m).longValue();
       long now = System.currentTimeMillis();
-      if (shunTime + SHUNNED_SUNSET * 1000 > now) {
+      if (shunTime + SHUNNED_SUNSET * 1000L > now) {
         return true;
       }
 
@@ -2088,7 +2088,7 @@ public class GMSMembershipManager implements MembershipManager, Manager {
    * @param m the member to add
    */
   private void addShunnedMember(InternalDistributedMember m) {
-    long deathTime = System.currentTimeMillis() - SHUNNED_SUNSET * 1000;
+    long deathTime = System.currentTimeMillis() - SHUNNED_SUNSET * 1000L;
 
     surpriseMembers.remove(m); // for safety
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/BucketAdvisor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/BucketAdvisor.java
@@ -814,10 +814,10 @@ public class BucketAdvisor extends CacheDistributionAdvisor {
     DistributionManager dm = this.regionAdvisor.getDistributionManager();
     DistributionConfig config = dm.getConfig();
     // failure detection period
-    long timeout = config.getMemberTimeout() * 3;
+    long timeout = config.getMemberTimeout() * 3L;
     // plus time for a new member to become primary
     timeout += Long.getLong(DistributionConfig.GEMFIRE_PREFIX + "BucketAdvisor.getPrimaryTimeout",
-        15 * 1000);
+        15000L);
     InternalDistributedMember newPrimary = waitForPrimaryMember(timeout);
     return newPrimary;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DiskWriteAttributesImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DiskWriteAttributesImpl.java
@@ -361,7 +361,7 @@ public class DiskWriteAttributesImpl implements DiskWriteAttributes {
    */
   @Override
   public int hashCode() {
-    int result = 0;
+    long result = 0;
 
     if (this.isSynchronous()) {
       if (this.isRollOplogs()) {
@@ -373,7 +373,7 @@ public class DiskWriteAttributesImpl implements DiskWriteAttributes {
       result += this.getBytesThreshold();
     }
     result += this.getMaxOplogSize();
-    return result;
+    return (int) (result & 0xFFFFFFFF);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
@@ -2961,7 +2961,7 @@ public class DistributedRegion extends LocalRegion implements InternalDistribute
     if (getCache().getLockLease() == -1) {
       return -1;
     }
-    return getCache().getLockLease() * 1000;
+    return (getCache().getLockLease()) * 1000L;
   }
 
   /**
@@ -3050,13 +3050,13 @@ public class DistributedRegion extends LocalRegion implements InternalDistribute
         end = start + timeoutMS;
       }
 
-      long ackSAThreshold = getSystem().getConfig().getAckSevereAlertThreshold() * 1000;
+      long ackSAThreshold = getSystem().getConfig().getAckSevereAlertThreshold() * 1000L;
 
       long waitInterval;
       long ackWaitThreshold;
 
       if (ackSAThreshold > 0) {
-        ackWaitThreshold = getSystem().getConfig().getAckWaitThreshold() * 1000;
+        ackWaitThreshold = getSystem().getConfig().getAckWaitThreshold() * 1000L;
         waitInterval = ackWaitThreshold;
       } else {
         waitInterval = timeoutMS;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/Oplog.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/Oplog.java
@@ -6648,7 +6648,7 @@ public class Oplog implements CompactableOplog, Flushable {
         long delta = calcDelta(oplogKeyId, this.opCode);
         this.deltaIdBytesLength = bytesNeeded(delta);
         this.size += this.deltaIdBytesLength;
-        this.opCode += this.deltaIdBytesLength - 1;
+        this.opCode += (this.deltaIdBytesLength & 0xFF) - 1;
         for (int i = this.deltaIdBytesLength - 1; i >= 0; i--) {
           this.deltaIdBytes[i] = (byte) (delta & 0xFF);
           delta >>= 8;
@@ -6745,7 +6745,7 @@ public class Oplog implements CompactableOplog, Flushable {
         long delta = calcDelta(keyId, this.opCode);
         this.deltaIdBytesLength = bytesNeeded(delta);
         this.size += this.deltaIdBytesLength;
-        this.opCode += this.deltaIdBytesLength - 1;
+        this.opCode += (byte) (this.deltaIdBytesLength & 0xFF) - 1;
         for (int i = this.deltaIdBytesLength - 1; i >= 0; i--) {
           this.deltaIdBytes[i] = (byte) (delta & 0xFF);
           delta >>= 8;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
@@ -6633,7 +6633,7 @@ public class PartitionedRegion extends LocalRegion
         DistributionManager dm = cache.getInternalDistributedSystem().getDistributionManager();
 
         long ackWaitThreshold = 0;
-        long ackSAThreshold = dm.getConfig().getAckSevereAlertThreshold() * 1000;
+        long ackSAThreshold = dm.getConfig().getAckSevereAlertThreshold() * 1000L;
         boolean suspected = false;
         boolean severeAlertIssued = false;
         DistributedMember lockHolder = null;
@@ -6644,11 +6644,11 @@ public class PartitionedRegion extends LocalRegion
         if (!enableAlerts) {
           // Make sure we only attempt the lock long enough not to
           // get a 15 second warning from the reply processor.
-          ackWaitThreshold = dm.getConfig().getAckWaitThreshold() * 1000;
+          ackWaitThreshold = dm.getConfig().getAckWaitThreshold() * 1000L;
           waitInterval = ackWaitThreshold - 1;
           startTime = System.currentTimeMillis();
         } else if (ackSAThreshold > 0) {
-          ackWaitThreshold = dm.getConfig().getAckWaitThreshold() * 1000;
+          ackWaitThreshold = dm.getConfig().getAckWaitThreshold() * 1000L;
           waitInterval = ackWaitThreshold;
           startTime = System.currentTimeMillis();
         } else {
@@ -6719,7 +6719,7 @@ public class PartitionedRegion extends LocalRegion
       }
 
       long ackSAThreshold =
-          cache.getInternalDistributedSystem().getConfig().getAckSevereAlertThreshold() * 1000;
+          cache.getInternalDistributedSystem().getConfig().getAckSevereAlertThreshold() * 1000L;
       boolean suspected = false;
       boolean severeAlertIssued = false;
       DistributedMember lockHolder = null;
@@ -6729,7 +6729,7 @@ public class PartitionedRegion extends LocalRegion
 
       if (ackSAThreshold > 0) {
         ackWaitThreshold =
-            cache.getInternalDistributedSystem().getConfig().getAckWaitThreshold() * 1000;
+            cache.getInternalDistributedSystem().getConfig().getAckWaitThreshold() * 1000L;
         waitInterval = ackWaitThreshold;
         start = System.currentTimeMillis();
       } else {
@@ -7190,7 +7190,7 @@ public class PartitionedRegion extends LocalRegion
           }
         } else {
           try {
-            Thread.sleep(AbstractGatewaySender.MAXIMUM_SHUTDOWN_WAIT_TIME * 1000);
+            Thread.sleep(AbstractGatewaySender.MAXIMUM_SHUTDOWN_WAIT_TIME * 1000L);
           } catch (InterruptedException ignore) {/* ignore */
             // interrupted
           }
@@ -7937,9 +7937,9 @@ public class PartitionedRegion extends LocalRegion
    * synchronization or concurrent safety
    */
   public static class RetryTimeKeeper {
-    private int totalTimeInRetry;
+    private long totalTimeInRetry;
 
-    private final int maxTimeInRetry;
+    private final long maxTimeInRetry;
 
     public RetryTimeKeeper(int maxTime) {
       this.maxTimeInRetry = maxTime;
@@ -7988,7 +7988,7 @@ public class PartitionedRegion extends LocalRegion
       return this.totalTimeInRetry > this.maxTimeInRetry;
     }
 
-    public int getRetryTime() {
+    public long getRetryTime() {
       return this.totalTimeInRetry;
     }
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXManagerImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXManagerImpl.java
@@ -1799,7 +1799,7 @@ public class TXManagerImpl implements CacheTransactionManager, MembershipListene
     if (this.cache.isClosed()) {
       return;
     }
-    long timeout = getTransactionTimeToLive() * 1000;
+    long timeout = getTransactionTimeToLive() * 1000L;
     if (timeout <= 0) {
       removeTransactionsSentFromDepartedProxy(proxyServer);
     } else {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/AbstractRegionEntry.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/AbstractRegionEntry.java
@@ -1887,9 +1887,9 @@ public abstract class AbstractRegionEntry implements HashRegionEntry<Object, Obj
               .append(stampVersion);
         }
         if (difference < 0) {
-          tagVersion += 0x1000000L;
+          tagVersion += 0x1000000;
         } else {
-          stampVersion += 0x1000000L;
+          stampVersion += 0x1000000;
         }
       }
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/rebalance/model/Member.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/rebalance/model/Member.java
@@ -213,7 +213,7 @@ public class Member implements Comparable<Member> {
   }
 
   void changeTotalBytes(float change) {
-    totalBytes += change;
+    totalBytes += (long) Math.round(change);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/AbstractGatewaySenderEventProcessor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/AbstractGatewaySenderEventProcessor.java
@@ -1155,7 +1155,7 @@ public abstract class AbstractGatewaySenderEventProcessor extends LoggingThread
         }
       } else {
         try {
-          Thread.sleep(AbstractGatewaySender.MAXIMUM_SHUTDOWN_WAIT_TIME * 1000);
+          Thread.sleep(AbstractGatewaySender.MAXIMUM_SHUTDOWN_WAIT_TIME * 1000L);
         } catch (InterruptedException e) {/* ignore */
           // interrupted
         }

--- a/geode-core/src/main/java/org/apache/geode/internal/jta/GlobalTransaction.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/jta/GlobalTransaction.java
@@ -661,7 +661,7 @@ public class GlobalTransaction {
         }
       }
     }
-    long newExp = System.currentTimeMillis() + (seconds * 1000);
+    long newExp = System.currentTimeMillis() + (seconds * 1000L);
     if (!resetXATimeOut)
       newExp = -1;
     return newExp;

--- a/geode-core/src/main/java/org/apache/geode/internal/tcp/Connection.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/tcp/Connection.java
@@ -2587,8 +2587,8 @@ public class Connection implements Runnable {
   /** ensure that a task is running to monitor transmission and reading of acks */
   public synchronized void scheduleAckTimeouts() {
     if (ackTimeoutTask == null) {
-      final long msAW = this.owner.getDM().getConfig().getAckWaitThreshold() * 1000;
-      final long msSA = this.owner.getDM().getConfig().getAckSevereAlertThreshold() * 1000;
+      final long msAW = this.owner.getDM().getConfig().getAckWaitThreshold() * 1000L;
+      final long msSA = this.owner.getDM().getConfig().getAckSevereAlertThreshold() * 1000L;
       ackTimeoutTask = new SystemTimer.SystemTimerTask() {
         @Override
         public void run2() {

--- a/geode-core/src/main/java/org/apache/geode/internal/tcp/MsgOutputStream.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/tcp/MsgOutputStream.java
@@ -48,7 +48,7 @@ public class MsgOutputStream extends OutputStream implements ObjToByteArraySeria
   /** write the low-order 8 bits of the given int */
   @Override
   public void write(int b) {
-    buffer.put((byte) b);
+    buffer.put((byte) (b & 0xff));
   }
 
   /** override OutputStream's write() */
@@ -133,7 +133,7 @@ public class MsgOutputStream extends OutputStream implements ObjToByteArraySeria
    * @exception IOException if an I/O error occurs.
    */
   public void writeShort(int v) throws IOException {
-    buffer.putShort((short) v);
+    buffer.putShort((short) (v & 0xffff));
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/internal/tcp/MsgStreamer.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/tcp/MsgStreamer.java
@@ -254,7 +254,7 @@ public class MsgStreamer extends OutputStream
       this.overflowBuf.write(b);
       return;
     }
-    this.buffer.put((byte) b);
+    this.buffer.put((byte) (b & 0xff));
   }
 
   private void ensureCapacity(int amount) {
@@ -502,7 +502,7 @@ public class MsgStreamer extends OutputStream
       this.overflowBuf.writeShort(v);
       return;
     }
-    this.buffer.putShort((short) v);
+    this.buffer.putShort((short) (v & 0xffff));
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/internal/util/PasswordUtil.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/util/PasswordUtil.java
@@ -61,7 +61,7 @@ public class PasswordUtil {
     for (int i = 0; i < b.length; i++) {
       int index = i * 2;
       int v = Integer.parseInt(s.substring(index, index + 2), 16);
-      b[i] = (byte) v;
+      b[i] = (byte) (v & 0xff);
     }
     return b;
   }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateDiskStoreCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateDiskStoreCommand.java
@@ -83,7 +83,7 @@ public class CreateDiskStoreCommand extends SingleGfshCommand {
     diskStoreAttributes.allowForceCompaction = allowForceCompaction;
     diskStoreAttributes.autoCompact = autoCompact;
     diskStoreAttributes.compactionThreshold = compactionThreshold;
-    diskStoreAttributes.maxOplogSizeInBytes = maxOplogSize * (1024 * 1024);
+    diskStoreAttributes.maxOplogSizeInBytes = maxOplogSize * (1024L * 1024L);
     diskStoreAttributes.queueSize = queueSize;
     diskStoreAttributes.timeInterval = timeInterval;
     diskStoreAttributes.writeBufferSize = writeBufferSize;

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ShutdownCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ShutdownCommand.java
@@ -67,7 +67,7 @@ public class ShutdownCommand extends InternalGfshCommand {
       }
 
       // convert to milliseconds
-      long timeout = userSpecifiedTimeout * 1000;
+      long timeout = userSpecifiedTimeout * 1000L;
       InternalCache cache = (InternalCache) getCache();
       int numDataNodes = getAllNormalMembers().size();
       Set<DistributedMember> locators = getAllMembers();

--- a/geode-core/src/test/java/org/apache/geode/cache/query/internal/index/IndexElemArrayJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/internal/index/IndexElemArrayJUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query.internal.index;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
@@ -22,7 +23,9 @@ import static org.junit.Assert.fail;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -56,6 +59,63 @@ public class IndexElemArrayJUnitTest {
     iterate();
     clearAndAdd();
   }
+
+  @Test
+  public void overflowFromAddThrowsException() {
+    // no exception should be thrown by this loop
+    for (int i = 1; i < 256; i++) {
+      list.add(i);
+    }
+    try {
+      list.add(256);
+      fail("list should have thrown an exception when full");
+    } catch (IllegalStateException e) {
+      // expected
+    }
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void overflowFromAddAllThrowsException() {
+    Object[] array = new Object[256];
+    Arrays.fill(array, new Object());
+    List<Object> data = Arrays.asList(array);
+    list.addAll(data);
+  }
+
+  @Test
+  public void sizeAfterOverflowFromAddIsCorrect() {
+    for (int i = 1; i < 256; i++) {
+      list.add(i);
+    }
+    try {
+      list.add(256);
+    } catch (IllegalStateException e) {
+      assertThat(list.size()).isEqualTo(255);
+    }
+  }
+
+  @Test
+  public void sizeAfterOverflowFromAddAllIsCorrect() {
+    for (int i = 1; i < 256; i++) {
+      list.add(i);
+    }
+    try {
+      list.addAll(Collections.singleton(new Object()));
+    } catch (IllegalStateException e) {
+      assertThat(list.size()).isEqualTo(255);
+    }
+  }
+
+  @Test
+  public void listCanBeIteratedOverFullRange() {
+    for (int i = 1; i < 256; i++) {
+      list.add(i);
+    }
+    for (int i = 1; i < 256; i++) {
+      assertThat(list.get(i - 1)).isEqualTo(i);
+    }
+  }
+
 
   /**
    * This tests concurrent modification of IndexElemArray and to make sure elementData and size are

--- a/geode-junit/src/main/java/org/apache/geode/cache/query/data/Numbers.java
+++ b/geode-junit/src/main/java/org/apache/geode/cache/query/data/Numbers.java
@@ -40,7 +40,7 @@ public class Numbers implements Serializable {
     avg1 = (id + id1 + id2) / 3;
     max1 = id;
     range = (id - id1);
-    l = id * 100000000;
+    l = id * 100000000L;
   }
 
 }

--- a/geode-junit/src/main/java/org/apache/geode/cache/query/data/Portfolio.java
+++ b/geode-junit/src/main/java/org/apache/geode/cache/query/data/Portfolio.java
@@ -134,16 +134,16 @@ public class Portfolio implements Serializable, DataSerializable {
     pkid = "" + i;
     status = i % 2 == 0 ? "active" : "inactive";
     type = "type" + (i % 3);
-    position1 = new Position(secIds[Position.cnt % secIds.length], Position.cnt * 1000);
+    position1 = new Position(secIds[Position.cnt % secIds.length], Position.cnt * 1000L);
     if (i % 2 != 0) {
-      position2 = new Position(secIds[Position.cnt % secIds.length], Position.cnt * 1000);
+      position2 = new Position(secIds[Position.cnt % secIds.length], Position.cnt * 1000L);
     } else {
       position2 = null;
     }
     positions.put(secIds[Position.cnt % secIds.length],
-        new Position(secIds[Position.cnt % secIds.length], Position.cnt * 1000));
+        new Position(secIds[Position.cnt % secIds.length], Position.cnt * 1000L));
     positions.put(secIds[Position.cnt % secIds.length],
-        new Position(secIds[Position.cnt % secIds.length], Position.cnt * 1000));
+        new Position(secIds[Position.cnt % secIds.length], Position.cnt * 1000L));
     collectionHolderMap.put("0", new CollectionHolder());
     collectionHolderMap.put("1", new CollectionHolder());
     collectionHolderMap.put("2", new CollectionHolder());
@@ -158,7 +158,7 @@ public class Portfolio implements Serializable, DataSerializable {
     this.position1.portfolioId = j;
     this.position3 = new Position[3];
     for (int k = 0; k < position3.length; k++) {
-      Position p = new Position(secIds[k], (k + 1) * 1000);
+      Position p = new Position(secIds[k], (k + 1) * 1000L);
       p.portfolioId = (k + 1);
       this.position3[k] = p;
     }

--- a/geode-junit/src/main/java/org/apache/geode/cache/query/data/PortfolioNoDS.java
+++ b/geode-junit/src/main/java/org/apache/geode/cache/query/data/PortfolioNoDS.java
@@ -125,17 +125,18 @@ public class PortfolioNoDS implements Serializable {
     pkid = "" + i;
     status = i % 2 == 0 ? "active" : "inactive";
     type = "type" + (i % 3);
-    position1 = new PositionNoDS(secIds[PositionNoDS.cnt % secIds.length], PositionNoDS.cnt * 1000);
+    position1 =
+        new PositionNoDS(secIds[PositionNoDS.cnt % secIds.length], PositionNoDS.cnt * 1000L);
     if (i % 2 != 0) {
       position2 =
-          new PositionNoDS(secIds[PositionNoDS.cnt % secIds.length], PositionNoDS.cnt * 1000);
+          new PositionNoDS(secIds[PositionNoDS.cnt % secIds.length], PositionNoDS.cnt * 1000L);
     } else {
       position2 = null;
     }
     positions.put(secIds[PositionNoDS.cnt % secIds.length],
-        new PositionNoDS(secIds[PositionNoDS.cnt % secIds.length], PositionNoDS.cnt * 1000));
+        new PositionNoDS(secIds[PositionNoDS.cnt % secIds.length], PositionNoDS.cnt * 1000L));
     positions.put(secIds[PositionNoDS.cnt % secIds.length],
-        new PositionNoDS(secIds[PositionNoDS.cnt % secIds.length], PositionNoDS.cnt * 1000));
+        new PositionNoDS(secIds[PositionNoDS.cnt % secIds.length], PositionNoDS.cnt * 1000L));
     collectionHolderMap.put("0", new CollectionHolder());
     collectionHolderMap.put("1", new CollectionHolder());
     collectionHolderMap.put("2", new CollectionHolder());
@@ -150,7 +151,7 @@ public class PortfolioNoDS implements Serializable {
     this.position1.portfolioId = j;
     this.position3 = new PositionNoDS[3];
     for (int k = 0; k < position3.length; k++) {
-      PositionNoDS p = new PositionNoDS(secIds[k], (k + 1) * 1000);
+      PositionNoDS p = new PositionNoDS(secIds[k], (k + 1) * 1000L);
       p.portfolioId = (k + 1);
       this.position3[k] = p;
     }

--- a/geode-junit/src/main/java/org/apache/geode/cache/query/data/PortfolioPdx.java
+++ b/geode-junit/src/main/java/org/apache/geode/cache/query/data/PortfolioPdx.java
@@ -153,17 +153,17 @@ public class PortfolioPdx implements Serializable, PdxSerializable {
     pkid = "" + i;
     status = i % 2 == 0 ? "active" : "inactive";
     type = "type" + (i % 3);
-    position1 = new PositionPdx(secIds[PositionPdx.cnt % secIds.length], PositionPdx.cnt * 1000);
+    position1 = new PositionPdx(secIds[PositionPdx.cnt % secIds.length], PositionPdx.cnt * 1000L);
     if (i % 2 != 0) {
-      position2 = new PositionPdx(secIds[PositionPdx.cnt % secIds.length], PositionPdx.cnt * 1000);
+      position2 = new PositionPdx(secIds[PositionPdx.cnt % secIds.length], PositionPdx.cnt * 1000L);
     } else {
       position2 = null;
     }
 
     positions.put(secIds[PositionPdx.cnt % secIds.length],
-        new PositionPdx(secIds[PositionPdx.cnt % secIds.length], PositionPdx.cnt * 1000));
+        new PositionPdx(secIds[PositionPdx.cnt % secIds.length], PositionPdx.cnt * 1000L));
     positions.put(secIds[PositionPdx.cnt % secIds.length],
-        new PositionPdx(secIds[PositionPdx.cnt % secIds.length], PositionPdx.cnt * 1000));
+        new PositionPdx(secIds[PositionPdx.cnt % secIds.length], PositionPdx.cnt * 1000L));
 
     collectionHolderMap.put("0", new CollectionHolder());
     collectionHolderMap.put("1", new CollectionHolder());
@@ -180,7 +180,7 @@ public class PortfolioPdx implements Serializable, PdxSerializable {
     this.position1.portfolioId = j;
     this.position3 = new Object[3];
     for (int k = 0; k < position3.length; k++) {
-      PositionPdx p = new PositionPdx(secIds[k], (k + 1) * 1000);
+      PositionPdx p = new PositionPdx(secIds[k], (k + 1) * 1000L);
       p.portfolioId = (k + 1);
       this.position3[k] = p;
     }

--- a/geode-junit/src/main/java/org/apache/geode/cache/query/data/Quote.java
+++ b/geode-junit/src/main/java/org/apache/geode/cache/query/data/Quote.java
@@ -61,7 +61,7 @@ public class Quote implements Serializable {
     String[] arr4 = {"priceType1", "priceType2", "priceType3", "priceType4", "priceType5",
         "priceType6", "priceType7"};
     priceType = arr4[i % 7];
-    price = (i / 10) * 8;
+    price = (i / 10.0) * 8.0;
     lowerQty = i + 100;
     upperQty = i + 1000;
     if ((i % 12) == 0) {

--- a/geode-junit/src/main/java/org/apache/geode/cache/query/data/Restricted.java
+++ b/geode-junit/src/main/java/org/apache/geode/cache/query/data/Restricted.java
@@ -39,7 +39,7 @@ public class Restricted implements Serializable {
         "auto transport", "mortgage"};
     quoteType = arr1[i % 7];
     uniqueQuoteType = "quoteType" + Integer.toString(i);
-    price = (i / 10) * 8;
+    price = (i / 10.0) * 8.0;
     minQty = i + 100;
     maxQty = i + 1000;
     if ((i % 12) == 0) {

--- a/geode-pulse/src/main/java/org/apache/geode/tools/pulse/internal/data/Cluster.java
+++ b/geode-pulse/src/main/java/org/apache/geode/tools/pulse/internal/data/Cluster.java
@@ -789,12 +789,11 @@ public class Cluster extends Thread {
           existingClient.setUptime(updatedClient.getUptime());
 
           // set cpu usage
-          long lastCPUTime = 0;
-          lastCPUTime = existingClient.getProcessCpuTime();
-          long currCPUTime = 0;
-          currCPUTime = updatedClient.getProcessCpuTime();
+          long lastCPUTime = existingClient.getProcessCpuTime();
+          long currCPUTime = updatedClient.getProcessCpuTime();
 
-          double newCPUTime = (double) (currCPUTime - lastCPUTime) / (elapsedTime * 1000000000);
+          double newCPUTime =
+              (double) (((currCPUTime - lastCPUTime) / elapsedTime) / 1_000_000_000L);
 
           double newCPUUsage = 0;
           int availableCpus = updatedClient.getCpus();


### PR DESCRIPTION
We had a number of calculations that were taking place with ints instead
of longs.  I've modified them to, in most places, just add an L to the
constant multiplier.  In other places I had to change a variable type
from int to long.

There were a few places that were also assigning a long to an int
variable or an int to a byte variable.  In these I added bit AND
operators to reduce the chances of overflow.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
