### PR TITLE
[DO NOT MERGE] GEODE-4731: AbstractLauncher.Command refactor

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/distributed/ServerLauncherDUnitTestHelper.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/distributed/ServerLauncherDUnitTestHelper.java
@@ -24,7 +24,7 @@ public class ServerLauncherDUnitTestHelper {
     System.setProperty("gemfire.server-port", "0");
 
     final ServerLauncher serverLauncher =
-        new ServerLauncher.Builder().setCommand(ServerLauncher.Command.START)
+        new ServerLauncher.Builder().setCommand(AbstractLauncher.Command.START)
             .setMemberName("server1").set("locators", "localhost[" + locatorPort + "]")
             .set("log-level", "config").set("log-file", "").setDebug(true).build();
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/LocatorCommand.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/LocatorCommand.java
@@ -17,7 +17,7 @@ package org.apache.geode.distributed;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.geode.distributed.LocatorLauncher.Command;
+import org.apache.geode.distributed.AbstractLauncher.Command;
 
 public class LocatorCommand {
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/LocatorLauncherIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/LocatorLauncherIntegrationTest.java
@@ -37,8 +37,8 @@ import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestName;
 
-import org.apache.geode.distributed.LocatorLauncher.Builder;
 import org.apache.geode.distributed.AbstractLauncher.Command;
+import org.apache.geode.distributed.LocatorLauncher.Builder;
 
 /**
  * Integration tests for using {@link LocatorLauncher} as an in-process API within an existing JVM.

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/LocatorLauncherIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/LocatorLauncherIntegrationTest.java
@@ -38,7 +38,7 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestName;
 
 import org.apache.geode.distributed.LocatorLauncher.Builder;
-import org.apache.geode.distributed.LocatorLauncher.Command;
+import org.apache.geode.distributed.AbstractLauncher.Command;
 
 /**
  * Integration tests for using {@link LocatorLauncher} as an in-process API within an existing JVM.

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/LocatorLauncherRemoteIntegrationTestCase.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/LocatorLauncherRemoteIntegrationTestCase.java
@@ -30,9 +30,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.After;
 import org.junit.Before;
 
+import org.apache.geode.distributed.AbstractLauncher.Command;
 import org.apache.geode.distributed.AbstractLauncher.Status;
 import org.apache.geode.distributed.LocatorLauncher.Builder;
-import org.apache.geode.distributed.LocatorLauncher.Command;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.internal.process.ProcessStreamReader;
 import org.apache.geode.internal.process.ProcessStreamReader.InputListener;

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/LocatorLauncherRemoteWithCustomLoggingIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/LocatorLauncherRemoteWithCustomLoggingIntegrationTest.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 import org.junit.contrib.java.lang.system.SystemOutRule;
 import org.junit.experimental.categories.Category;
 
-import org.apache.geode.distributed.LocatorLauncher.Command;
+import org.apache.geode.distributed.AbstractLauncher.Command;
 import org.apache.geode.internal.process.ProcessStreamReader.InputListener;
 import org.apache.geode.test.junit.categories.GfshTest;
 import org.apache.geode.test.junit.categories.LoggingTest;

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/ServerCommand.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/ServerCommand.java
@@ -17,7 +17,7 @@ package org.apache.geode.distributed;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.geode.distributed.ServerLauncher.Command;
+import org.apache.geode.distributed.AbstractLauncher.Command;
 
 public class ServerCommand {
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/ServerLauncherBuilderIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/ServerLauncherBuilderIntegrationTest.java
@@ -38,7 +38,7 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestName;
 
 import org.apache.geode.distributed.ServerLauncher.Builder;
-import org.apache.geode.distributed.ServerLauncher.Command;
+import org.apache.geode.distributed.AbstractLauncher.Command;
 import org.apache.geode.internal.AvailablePortHelper;
 
 /**

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/ServerLauncherBuilderIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/ServerLauncherBuilderIntegrationTest.java
@@ -37,8 +37,8 @@ import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestName;
 
-import org.apache.geode.distributed.ServerLauncher.Builder;
 import org.apache.geode.distributed.AbstractLauncher.Command;
+import org.apache.geode.distributed.ServerLauncher.Builder;
 import org.apache.geode.internal.AvailablePortHelper;
 
 /**

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/ServerLauncherIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/ServerLauncherIntegrationTest.java
@@ -37,7 +37,7 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestName;
 
 import org.apache.geode.distributed.ServerLauncher.Builder;
-import org.apache.geode.distributed.ServerLauncher.Command;
+import org.apache.geode.distributed.AbstractLauncher.Command;
 import org.apache.geode.internal.AvailablePortHelper;
 
 /**

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/ServerLauncherIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/ServerLauncherIntegrationTest.java
@@ -36,8 +36,8 @@ import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestName;
 
-import org.apache.geode.distributed.ServerLauncher.Builder;
 import org.apache.geode.distributed.AbstractLauncher.Command;
+import org.apache.geode.distributed.ServerLauncher.Builder;
 import org.apache.geode.internal.AvailablePortHelper;
 
 /**

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/ServerLauncherRemoteWithCustomLoggingIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/ServerLauncherRemoteWithCustomLoggingIntegrationTest.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 import org.junit.contrib.java.lang.system.SystemOutRule;
 import org.junit.experimental.categories.Category;
 
-import org.apache.geode.distributed.ServerLauncher.Command;
+import org.apache.geode.distributed.AbstractLauncher.Command;
 import org.apache.geode.internal.process.ProcessStreamReader.InputListener;
 import org.apache.geode.test.junit.categories.GfshTest;
 import org.apache.geode.test.junit.categories.LoggingTest;

--- a/geode-core/src/main/java/org/apache/geode/distributed/LauncherCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/LauncherCommand.java
@@ -1,103 +1,98 @@
-//package org.apache.geode.distributed;
+// package org.apache.geode.distributed;
 //
-//import static org.apache.commons.lang.StringUtils.lowerCase;
 //
-//import org.apache.geode.management.internal.cli.Launcher;
 //
-//import java.util.Collections;
-//import java.util.List;
-//import joptsimple.internal.Strings;
 //
-//public interface LauncherCommand {
-//  String name = Strings.EMPTY;
-//  List<String> options = Collections.emptyList();
+// public interface LauncherCommand {
+// String name = Strings.EMPTY;
+// List<String> options = Collections.emptyList();
 //
-//  /**
-//   * Determines whether the specified name refers to a valid launcher command, as defined
-//   * by the enumerated type implementing this interface.
-//   *
-//   * @param name a String value indicating the potential name of a launcher command.
-//   * @return a boolean indicating whether the specified name for a launcher command is
-//   *         valid.
-//   */
-//  public static boolean isCommand(final String name) {
-//    return (valueOfName(name) != null);
-//  }
+// /**
+// * Determines whether the specified name refers to a valid launcher command, as defined
+// * by the enumerated type implementing this interface.
+// *
+// * @param name a String value indicating the potential name of a launcher command.
+// * @return a boolean indicating whether the specified name for a launcher command is
+// * valid.
+// */
+// public static boolean isCommand(final String name) {
+// return (valueOfName(name) != null);
+// }
 //
-//  /**
-//   * Determines whether the given launcher command has been properly specified. The
-//   * command is deemed unspecified if the reference is null or the Command is UNSPECIFIED.
-//   *
-//   * @param command the launcher command.
-//   * @return a boolean value indicating whether the launcher command is unspecified.
-//   * @see LauncherCommand#UNSPECIFIED
-//   */
-//  static boolean isUnspecified(final LauncherCommand command) {
-//    return (command == null || command.isUnspecified());
-//  }
+// /**
+// * Determines whether the given launcher command has been properly specified. The
+// * command is deemed unspecified if the reference is null or the Command is UNSPECIFIED.
+// *
+// * @param command the launcher command.
+// * @return a boolean value indicating whether the launcher command is unspecified.
+// * @see LauncherCommand#UNSPECIFIED
+// */
+// static boolean isUnspecified(final LauncherCommand command) {
+// return (command == null || command.isUnspecified());
+// }
 //
-//  /**
-//   * Looks up a Locator launcher command by name. The equality comparison on name is
-//   * case-insensitive.
-//   *
-//   * @param name a String value indicating the name of the Locator launcher command.
-//   * @return an enumerated type representing the command name or null if the no such command with
-//   *         the specified name exists.
-//   */
-//  static LauncherCommand valueOfName(final String name) {
-//    for (LauncherCommand command : values()) {
-//      if (command.getName().equalsIgnoreCase(name)) {
-//        return command;
-//      }
-//    }
+// /**
+// * Looks up a Locator launcher command by name. The equality comparison on name is
+// * case-insensitive.
+// *
+// * @param name a String value indicating the name of the Locator launcher command.
+// * @return an enumerated type representing the command name or null if the no such command with
+// * the specified name exists.
+// */
+// static LauncherCommand valueOfName(final String name) {
+// for (LauncherCommand command : values()) {
+// if (command.getName().equalsIgnoreCase(name)) {
+// return command;
+// }
+// }
 //
-//    return null;
-//  }
-//  /**
-//   * Gets the name of the Locator launcher command.
-//   *
-//   * @return a String value indicating the name of the Locator launcher command.
-//   */
-//  default String getName() {
-//    return this.name;
-//  }
+// return null;
+// }
+// /**
+// * Gets the name of the Locator launcher command.
+// *
+// * @return a String value indicating the name of the Locator launcher command.
+// */
+// default String getName() {
+// return this.name;
+// }
 //
-//  /**
-//   * Gets a set of valid options that can be used with the Locator launcher command when used from
-//   * the command-line.
-//   *
-//   * @return a Set of Strings indicating the names of the options available to the Locator
-//   *         launcher command.
-//   */
-//  default List<String> getOptions() {
-//    return this.options;
-//  }
+// /**
+// * Gets a set of valid options that can be used with the Locator launcher command when used from
+// * the command-line.
+// *
+// * @return a Set of Strings indicating the names of the options available to the Locator
+// * launcher command.
+// */
+// default List<String> getOptions() {
+// return this.options;
+// }
 //
-//  /**
-//   * Determines whether this Locator launcher command has the specified command-line option.
-//   *
-//   * @param option a String indicating the name of the command-line option to this command.
-//   * @return a boolean value indicating whether this command has the specified named command-line
-//   *         option.
-//   */
-//  default boolean hasOption(final String option) {
-//    return getOptions().contains(lowerCase(option));
-//  }
+// /**
+// * Determines whether this Locator launcher command has the specified command-line option.
+// *
+// * @param option a String indicating the name of the command-line option to this command.
+// * @return a boolean value indicating whether this command has the specified named command-line
+// * option.
+// */
+// default boolean hasOption(final String option) {
+// return getOptions().contains(lowerCase(option));
+// }
 //
-//  /**
-//   * Convenience method for determining whether this is the UNSPECIFIED Locator launcher command.
-//   *
-//   * @return a boolean indicating if this command is UNSPECIFIED.
-//   */
-//  boolean isUnspecified();
+// /**
+// * Convenience method for determining whether this is the UNSPECIFIED Locator launcher command.
+// *
+// * @return a boolean indicating if this command is UNSPECIFIED.
+// */
+// boolean isUnspecified();
 //
-//  /**
-//   * Gets the String representation of this Locator launcher command.
-//   *
-//   * @return a String value representing this Locator launcher command.
-//   */
-//  @Override
-//  default String toString() {
-//    return getName();
-//  }
-//}
+// /**
+// * Gets the String representation of this Locator launcher command.
+// *
+// * @return a String value representing this Locator launcher command.
+// */
+// @Override
+// default String toString() {
+// return getName();
+// }
+// }

--- a/geode-core/src/main/java/org/apache/geode/distributed/LauncherCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/LauncherCommand.java
@@ -1,0 +1,103 @@
+//package org.apache.geode.distributed;
+//
+//import static org.apache.commons.lang.StringUtils.lowerCase;
+//
+//import org.apache.geode.management.internal.cli.Launcher;
+//
+//import java.util.Collections;
+//import java.util.List;
+//import joptsimple.internal.Strings;
+//
+//public interface LauncherCommand {
+//  String name = Strings.EMPTY;
+//  List<String> options = Collections.emptyList();
+//
+//  /**
+//   * Determines whether the specified name refers to a valid launcher command, as defined
+//   * by the enumerated type implementing this interface.
+//   *
+//   * @param name a String value indicating the potential name of a launcher command.
+//   * @return a boolean indicating whether the specified name for a launcher command is
+//   *         valid.
+//   */
+//  public static boolean isCommand(final String name) {
+//    return (valueOfName(name) != null);
+//  }
+//
+//  /**
+//   * Determines whether the given launcher command has been properly specified. The
+//   * command is deemed unspecified if the reference is null or the Command is UNSPECIFIED.
+//   *
+//   * @param command the launcher command.
+//   * @return a boolean value indicating whether the launcher command is unspecified.
+//   * @see LauncherCommand#UNSPECIFIED
+//   */
+//  static boolean isUnspecified(final LauncherCommand command) {
+//    return (command == null || command.isUnspecified());
+//  }
+//
+//  /**
+//   * Looks up a Locator launcher command by name. The equality comparison on name is
+//   * case-insensitive.
+//   *
+//   * @param name a String value indicating the name of the Locator launcher command.
+//   * @return an enumerated type representing the command name or null if the no such command with
+//   *         the specified name exists.
+//   */
+//  static LauncherCommand valueOfName(final String name) {
+//    for (LauncherCommand command : values()) {
+//      if (command.getName().equalsIgnoreCase(name)) {
+//        return command;
+//      }
+//    }
+//
+//    return null;
+//  }
+//  /**
+//   * Gets the name of the Locator launcher command.
+//   *
+//   * @return a String value indicating the name of the Locator launcher command.
+//   */
+//  default String getName() {
+//    return this.name;
+//  }
+//
+//  /**
+//   * Gets a set of valid options that can be used with the Locator launcher command when used from
+//   * the command-line.
+//   *
+//   * @return a Set of Strings indicating the names of the options available to the Locator
+//   *         launcher command.
+//   */
+//  default List<String> getOptions() {
+//    return this.options;
+//  }
+//
+//  /**
+//   * Determines whether this Locator launcher command has the specified command-line option.
+//   *
+//   * @param option a String indicating the name of the command-line option to this command.
+//   * @return a boolean value indicating whether this command has the specified named command-line
+//   *         option.
+//   */
+//  default boolean hasOption(final String option) {
+//    return getOptions().contains(lowerCase(option));
+//  }
+//
+//  /**
+//   * Convenience method for determining whether this is the UNSPECIFIED Locator launcher command.
+//   *
+//   * @return a boolean indicating if this command is UNSPECIFIED.
+//   */
+//  boolean isUnspecified();
+//
+//  /**
+//   * Gets the String representation of this Locator launcher command.
+//   *
+//   * @return a String value representing this Locator launcher command.
+//   */
+//  @Override
+//  default String toString() {
+//    return getName();
+//  }
+//}

--- a/geode-core/src/main/java/org/apache/geode/distributed/LocatorLauncher.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/LocatorLauncher.java
@@ -17,7 +17,6 @@ package org.apache.geode.distributed;
 import static org.apache.commons.lang.StringUtils.defaultIfBlank;
 import static org.apache.commons.lang.StringUtils.isBlank;
 import static org.apache.commons.lang.StringUtils.isNotBlank;
-import static org.apache.commons.lang.StringUtils.lowerCase;
 import static org.apache.geode.distributed.AbstractLauncher.Command.START;
 import static org.apache.geode.distributed.AbstractLauncher.Command.STATUS;
 import static org.apache.geode.distributed.ConfigurationProperties.LOG_FILE;
@@ -33,7 +32,6 @@ import java.lang.management.ManagementFactory;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -1184,7 +1182,8 @@ public class LocatorLauncher extends AbstractLauncher<String> {
    */
   public static class Builder {
 
-    protected static final AbstractLauncher.Command DEFAULT_COMMAND = AbstractLauncher.Command.UNSPECIFIED;
+    protected static final AbstractLauncher.Command DEFAULT_COMMAND =
+        AbstractLauncher.Command.UNSPECIFIED;
 
     private Boolean debug;
     private Boolean deletePidFileOnStop;
@@ -1838,121 +1837,6 @@ public class LocatorLauncher extends AbstractLauncher<String> {
     public LocatorLauncher build() {
       validate();
       return new LocatorLauncher(this);
-    }
-  }
-
-  /**
-   * An enumerated type representing valid commands to the Locator launcher.
-   */
-  public enum Command {
-    START("start", "bind-address", "hostname-for-clients", "port", "force", "debug", "help"),
-    STATUS("status", "bind-address", "port", "member", "pid", "dir", "debug", "help"),
-    STOP("stop", "member", "pid", "dir", "debug", "help"),
-    VERSION("version"),
-    UNSPECIFIED("unspecified");
-
-    private final List<String> options;
-
-    private final String name;
-
-    Command(final String name, final String... options) {
-      assert isNotBlank(name) : "The name of the locator launcher command must be specified!";
-      this.name = name;
-      this.options = (options != null ? Collections.unmodifiableList(Arrays.asList(options))
-          : Collections.emptyList());
-    }
-
-    /**
-     * Determines whether the specified name refers to a valid Locator launcher command, as defined
-     * by this enumerated type.
-     *
-     * @param name a String value indicating the potential name of a Locator launcher command.
-     * @return a boolean indicating whether the specified name for a Locator launcher command is
-     *         valid.
-     */
-    public static boolean isCommand(final String name) {
-      return (valueOfName(name) != null);
-    }
-
-    /**
-     * Determines whether the given Locator launcher command has been properly specified. The
-     * command is deemed unspecified if the reference is null or the Command is UNSPECIFIED.
-     *
-     * @param command the Locator launcher command.
-     * @return a boolean value indicating whether the Locator launcher command is unspecified.
-     * @see Command#UNSPECIFIED
-     */
-    public static boolean isUnspecified(final Command command) {
-      return (command == null || command.isUnspecified());
-    }
-
-    /**
-     * Looks up a Locator launcher command by name. The equality comparison on name is
-     * case-insensitive.
-     *
-     * @param name a String value indicating the name of the Locator launcher command.
-     * @return an enumerated type representing the command name or null if the no such command with
-     *         the specified name exists.
-     */
-    public static Command valueOfName(final String name) {
-      for (Command command : values()) {
-        if (command.getName().equalsIgnoreCase(name)) {
-          return command;
-        }
-      }
-
-      return null;
-    }
-
-    /**
-     * Gets the name of the Locator launcher command.
-     *
-     * @return a String value indicating the name of the Locator launcher command.
-     */
-    public String getName() {
-      return this.name;
-    }
-
-    /**
-     * Gets a set of valid options that can be used with the Locator launcher command when used from
-     * the command-line.
-     *
-     * @return a Set of Strings indicating the names of the options available to the Locator
-     *         launcher command.
-     */
-    public List<String> getOptions() {
-      return this.options;
-    }
-
-    /**
-     * Determines whether this Locator launcher command has the specified command-line option.
-     *
-     * @param option a String indicating the name of the command-line option to this command.
-     * @return a boolean value indicating whether this command has the specified named command-line
-     *         option.
-     */
-    public boolean hasOption(final String option) {
-      return getOptions().contains(lowerCase(option));
-    }
-
-    /**
-     * Convenience method for determining whether this is the UNSPECIFIED Locator launcher command.
-     *
-     * @return a boolean indicating if this command is UNSPECIFIED.
-     * @see #UNSPECIFIED
-     */
-    public boolean isUnspecified() {
-      return UNSPECIFIED == this;
-    }
-
-    /**
-     * Gets the String representation of this Locator launcher command.
-     *
-     * @return a String value representing this Locator launcher command.
-     */
-    @Override
-    public String toString() {
-      return getName();
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/LocatorLauncher.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/LocatorLauncher.java
@@ -18,6 +18,8 @@ import static org.apache.commons.lang.StringUtils.defaultIfBlank;
 import static org.apache.commons.lang.StringUtils.isBlank;
 import static org.apache.commons.lang.StringUtils.isNotBlank;
 import static org.apache.commons.lang.StringUtils.lowerCase;
+import static org.apache.geode.distributed.AbstractLauncher.Command.START;
+import static org.apache.geode.distributed.AbstractLauncher.Command.STATUS;
 import static org.apache.geode.distributed.ConfigurationProperties.LOG_FILE;
 import static org.apache.geode.distributed.ConfigurationProperties.NAME;
 import static org.apache.geode.internal.lang.StringUtils.wrap;
@@ -92,6 +94,11 @@ public class LocatorLauncher extends AbstractLauncher<String> {
 
   private static final Boolean DEFAULT_LOAD_SHARED_CONFIG_FROM_DIR = Boolean.FALSE;
 
+  private static final String[] startOptions =
+      new String[] {"bind-address", "hostname-for-clients", "port", "force", "debug", "help"};
+  private static final String[] statusOptions =
+      new String[] {"bind-address", "port", "member", "pid", "dir", "debug", "help"};
+
   private static final Map<String, String> helpMap = new HashMap<>();
 
   static {
@@ -128,16 +135,16 @@ public class LocatorLauncher extends AbstractLauncher<String> {
         "An option to cause the Locator to redirect standard out and standard error to the GemFire log file.");
   }
 
-  private static final Map<Command, String> usageMap = new TreeMap<>();
+  private static final Map<AbstractLauncher.Command, String> usageMap = new TreeMap<>();
 
   static {
-    usageMap.put(Command.START,
+    usageMap.put(AbstractLauncher.Command.START,
         "start <member-name> [--bind-address=<IP-address>] [--hostname-for-clients=<IP-address>] [--port=<port>] [--dir=<Locator-working-directory>] [--force] [--debug] [--help]");
-    usageMap.put(Command.STATUS,
+    usageMap.put(AbstractLauncher.Command.STATUS,
         "status [--bind-address=<IP-address>] [--port=<port>] [--member=<member-ID/Name>] [--pid=<process-ID>] [--dir=<Locator-working-directory>] [--debug] [--help]");
-    usageMap.put(Command.STOP,
+    usageMap.put(AbstractLauncher.Command.STOP,
         "stop [--member=<member-ID/Name>] [--pid=<process-ID>] [--dir=<Locator-working-directory>] [--debug] [--help]");
-    usageMap.put(Command.VERSION, "version");
+    usageMap.put(AbstractLauncher.Command.VERSION, "version");
   }
 
   private static final String DEFAULT_LOCATOR_LOG_EXT = ".log";
@@ -157,7 +164,7 @@ public class LocatorLauncher extends AbstractLauncher<String> {
   private final boolean help;
   private final boolean redirectOutput;
 
-  private final Command command;
+  private final AbstractLauncher.Command command;
 
   private final boolean bindAddressSpecified;
   private final boolean portSpecified;
@@ -232,6 +239,8 @@ public class LocatorLauncher extends AbstractLauncher<String> {
    * @see org.apache.geode.distributed.LocatorLauncher.Builder
    */
   private LocatorLauncher(final Builder builder) {
+    commandOptions.put(START, startOptions);
+    commandOptions.put(STATUS, statusOptions);
     this.command = builder.getCommand();
     this.help = Boolean.TRUE.equals(builder.getHelp());
     this.bindAddressSpecified = builder.isBindAddressSpecified();
@@ -307,9 +316,9 @@ public class LocatorLauncher extends AbstractLauncher<String> {
    * Get the Locator launcher command used to invoke the Locator.
    *
    * @return the Locator launcher command used to invoke the Locator.
-   * @see org.apache.geode.distributed.LocatorLauncher.Command
+   * @see org.apache.geode.distributed.AbstractLauncher.Command
    */
-  public Command getCommand() {
+  public AbstractLauncher.Command getCommand() {
     return this.command;
   }
 
@@ -330,7 +339,7 @@ public class LocatorLauncher extends AbstractLauncher<String> {
    * command-line.
    *
    * @return a boolean value indicating if this launcher is used for displaying help information.
-   * @see org.apache.geode.distributed.LocatorLauncher.Command
+   * @see org.apache.geode.distributed.AbstractLauncher.Command
    */
   public boolean isHelping() {
     return this.help;
@@ -495,8 +504,8 @@ public class LocatorLauncher extends AbstractLauncher<String> {
    * @param command the Locator launcher command in which to display help information.
    * @see #usage()
    */
-  public void help(final Command command) {
-    if (Command.isUnspecified(command)) {
+  public void help(final AbstractLauncher.Command command) {
+    if (AbstractLauncher.Command.isUnspecified(command)) {
       usage();
     } else {
       info(wrap(helpMap.get(command.getName()), 80, ""));
@@ -516,16 +525,16 @@ public class LocatorLauncher extends AbstractLauncher<String> {
    * Displays usage information on the proper invocation of the LocatorLauncher from the
    * command-line to standard err.
    *
-   * @see #help(org.apache.geode.distributed.LocatorLauncher.Command)
+   * @see #help(org.apache.geode.distributed.AbstractLauncher.Command)
    */
   public void usage() {
     info(wrap(helpMap.get("launcher"), 80, "\t"));
     info("\n\nSTART\n\n");
-    help(Command.START);
+    help(AbstractLauncher.Command.START);
     info("STATUS\n\n");
-    help(Command.STATUS);
+    help(AbstractLauncher.Command.STATUS);
     info("STOP\n\n");
-    help(Command.STOP);
+    help(AbstractLauncher.Command.STOP);
   }
 
   /**
@@ -534,13 +543,13 @@ public class LocatorLauncher extends AbstractLauncher<String> {
    * implemented with a call to start() followed by a call to waitOnLocator().
    *
    * @see java.lang.Runnable
-   * @see LocatorLauncher.Command
+   * @see AbstractLauncher.Command
    * @see LocatorLauncher#start()
    * @see LocatorLauncher#waitOnLocator()
    * @see LocatorLauncher#status()
    * @see LocatorLauncher#stop()
    * @see LocatorLauncher#version()
-   * @see LocatorLauncher#help(org.apache.geode.distributed.LocatorLauncher.Command)
+   * @see LocatorLauncher#help(org.apache.geode.distributed.AbstractLauncher.Command)
    * @see LocatorLauncher#usage()
    */
   @Override
@@ -1175,7 +1184,7 @@ public class LocatorLauncher extends AbstractLauncher<String> {
    */
   public static class Builder {
 
-    protected static final Command DEFAULT_COMMAND = Command.UNSPECIFIED;
+    protected static final AbstractLauncher.Command DEFAULT_COMMAND = AbstractLauncher.Command.UNSPECIFIED;
 
     private Boolean debug;
     private Boolean deletePidFileOnStop;
@@ -1183,7 +1192,7 @@ public class LocatorLauncher extends AbstractLauncher<String> {
     private Boolean help;
     private Boolean redirectOutput;
     private Boolean loadSharedConfigFromDir;
-    private Command command;
+    private AbstractLauncher.Command command;
 
     private InetAddress bindAddress;
 
@@ -1280,7 +1289,7 @@ public class LocatorLauncher extends AbstractLauncher<String> {
           }
 
           if (options.has("version")) {
-            setCommand(Command.VERSION);
+            setCommand(AbstractLauncher.Command.VERSION);
           }
         }
       } catch (OptionException e) {
@@ -1297,7 +1306,7 @@ public class LocatorLauncher extends AbstractLauncher<String> {
      * Iterates the list of arguments in search of the target Locator launcher command.
      *
      * @param args an array of arguments from which to search for the Locator launcher command.
-     * @see org.apache.geode.distributed.LocatorLauncher.Command#valueOfName(String)
+     * @see org.apache.geode.distributed.AbstractLauncher.Command#valueOfName(String)
      * @see #parseArguments(String...)
      */
     protected void parseCommand(final String... args) {
@@ -1306,7 +1315,7 @@ public class LocatorLauncher extends AbstractLauncher<String> {
       // list, but does it really matter? stop after we find one valid command.
       if (args != null) {
         for (String arg : args) {
-          final Command command = Command.valueOfName(arg);
+          final AbstractLauncher.Command command = AbstractLauncher.Command.valueOfName(arg);
           if (command != null) {
             setCommand(command);
             break;
@@ -1322,13 +1331,13 @@ public class LocatorLauncher extends AbstractLauncher<String> {
      *
      * @param args the array of arguments from which to search for the Locator's member name in
      *        GemFire.
-     * @see org.apache.geode.distributed.LocatorLauncher.Command#isCommand(String)
+     * @see org.apache.geode.distributed.AbstractLauncher.Command#isCommand(String)
      * @see #parseArguments(String...)
      */
     protected void parseMemberName(final String... args) {
       if (args != null) {
         for (String arg : args) {
-          if (!(arg.startsWith(OPTION_PREFIX) || Command.isCommand(arg))) {
+          if (!(arg.startsWith(OPTION_PREFIX) || AbstractLauncher.Command.isCommand(arg))) {
             setMemberName(arg);
             break;
           }
@@ -1340,10 +1349,10 @@ public class LocatorLauncher extends AbstractLauncher<String> {
      * Gets the Locator launcher command used during the invocation of the LocatorLauncher.
      *
      * @return the Locator launcher command used to invoke (run) the LocatorLauncher class.
-     * @see #setCommand(org.apache.geode.distributed.LocatorLauncher.Command)
-     * @see LocatorLauncher.Command
+     * @see #setCommand(org.apache.geode.distributed.AbstractLauncher.Command)
+     * @see AbstractLauncher.Command
      */
-    public Command getCommand() {
+    public AbstractLauncher.Command getCommand() {
       return this.command != null ? this.command : DEFAULT_COMMAND;
     }
 
@@ -1354,9 +1363,9 @@ public class LocatorLauncher extends AbstractLauncher<String> {
      *        LocatorLauncher.
      * @return this Builder instance.
      * @see #getCommand()
-     * @see LocatorLauncher.Command
+     * @see AbstractLauncher.Command
      */
-    public Builder setCommand(final Command command) {
+    public Builder setCommand(final AbstractLauncher.Command command) {
       this.command = command;
       return this;
     }
@@ -1775,10 +1784,10 @@ public class LocatorLauncher extends AbstractLauncher<String> {
     /**
      * Validates the arguments passed to the Builder when the 'start' command has been issued.
      *
-     * @see org.apache.geode.distributed.LocatorLauncher.Command#START
+     * @see org.apache.geode.distributed.AbstractLauncher.Command#START
      */
     protected void validateOnStart() {
-      if (Command.START == getCommand()) {
+      if (AbstractLauncher.Command.START == getCommand()) {
         if (isBlank(getMemberName())
             && !isSet(System.getProperties(), DistributionConfig.GEMFIRE_PREFIX + NAME)
             && !isSet(getDistributedSystemProperties(), NAME)
@@ -1801,20 +1810,20 @@ public class LocatorLauncher extends AbstractLauncher<String> {
     /**
      * Validates the arguments passed to the Builder when the 'status' command has been issued.
      *
-     * @see org.apache.geode.distributed.LocatorLauncher.Command#STATUS
+     * @see org.apache.geode.distributed.AbstractLauncher.Command#STATUS
      */
     protected void validateOnStatus() {
-      if (Command.STATUS == getCommand()) {
+      if (AbstractLauncher.Command.STATUS == getCommand()) {
       }
     }
 
     /**
      * Validates the arguments passed to the Builder when the 'stop' command has been issued.
      *
-     * @see org.apache.geode.distributed.LocatorLauncher.Command#STOP
+     * @see org.apache.geode.distributed.AbstractLauncher.Command#STOP
      */
     protected void validateOnStop() {
-      if (Command.STOP == getCommand()) {
+      if (AbstractLauncher.Command.STOP == getCommand()) {
       }
     }
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/ServerLauncher.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/ServerLauncher.java
@@ -144,16 +144,16 @@ public class ServerLauncher extends AbstractLauncher<String> {
         String.valueOf(getDefaultServerPort())));
   }
 
-  private static final Map<Command, String> usageMap = new TreeMap<>();
+  private static final Map<AbstractLauncher.Command, String> usageMap = new TreeMap<>();
 
   static {
-    usageMap.put(Command.START,
+    usageMap.put(AbstractLauncher.Command.START,
         "start <member-name> [--assign-buckets] [--disable-default-server] [--rebalance] [--server-bind-address=<IP-address>] [--server-port=<port>] [--force] [--debug] [--help]");
-    usageMap.put(Command.STATUS,
+    usageMap.put(AbstractLauncher.Command.STATUS,
         "status [--member=<member-ID/Name>] [--pid=<process-ID>] [--dir=<Server-working-directory>] [--debug] [--help]");
-    usageMap.put(Command.STOP,
+    usageMap.put(AbstractLauncher.Command.STOP,
         "stop [--member=<member-ID/Name>] [--pid=<process-ID>] [--dir=<Server-working-directory>] [--debug] [--help]");
-    usageMap.put(Command.VERSION, "version");
+    usageMap.put(AbstractLauncher.Command.VERSION, "version");
   }
 
   private static final String DEFAULT_SERVER_LOG_EXT = ".log";
@@ -183,7 +183,7 @@ public class ServerLauncher extends AbstractLauncher<String> {
 
   private final CacheConfig cacheConfig;
 
-  private final Command command;
+  private final AbstractLauncher.Command command;
 
   private final InetAddress serverBindAddress;
 
@@ -388,7 +388,7 @@ public class ServerLauncher extends AbstractLauncher<String> {
    * @return the Server launcher command used to invoke the Server.
    * @see org.apache.geode.distributed.ServerLauncher.Command
    */
-  public Command getCommand() {
+  public AbstractLauncher.Command getCommand() {
     return this.command;
   }
 
@@ -659,8 +659,8 @@ public class ServerLauncher extends AbstractLauncher<String> {
    * @param command the Server launcher command in which to display help information.
    * @see #usage()
    */
-  public void help(final Command command) {
-    if (Command.isUnspecified(command)) {
+  public void help(final AbstractLauncher.Command command) {
+    if (AbstractLauncher.Command.isUnspecified(command)) {
       usage();
     } else {
       info(wrap(helpMap.get(command.getName()), 80, ""));
@@ -680,16 +680,16 @@ public class ServerLauncher extends AbstractLauncher<String> {
    * Displays usage information on the proper invocation of the ServerLauncher from the command-line
    * to standard err.
    *
-   * @see #help(org.apache.geode.distributed.ServerLauncher.Command)
+   * @see #help(org.apache.geode.distributed.AbstractLauncher.Command)
    */
   public void usage() {
     info(wrap(helpMap.get("launcher"), 80, "\t"));
     info("\n\nSTART\n\n");
-    help(Command.START);
+    help(AbstractLauncher.Command.START);
     info("STATUS\n\n");
-    help(Command.STATUS);
+    help(AbstractLauncher.Command.STATUS);
     info("STOP\n\n");
-    help(Command.STOP);
+    help(AbstractLauncher.Command.STOP);
   }
 
   /**
@@ -1355,7 +1355,7 @@ public class ServerLauncher extends AbstractLauncher<String> {
    */
   public static class Builder {
 
-    protected static final Command DEFAULT_COMMAND = Command.UNSPECIFIED;
+    protected static final AbstractLauncher.Command DEFAULT_COMMAND = AbstractLauncher.Command.UNSPECIFIED;
 
     private boolean serverBindAddressSetByUser;
     private boolean serverPortSetByUser;
@@ -1373,7 +1373,7 @@ public class ServerLauncher extends AbstractLauncher<String> {
 
     private final CacheConfig cacheConfig = new CacheConfig();
 
-    private Command command;
+    private AbstractLauncher.Command command;
 
     private InetAddress serverBindAddress;
 
@@ -1556,7 +1556,7 @@ public class ServerLauncher extends AbstractLauncher<String> {
           }
 
           if (options.has("version")) {
-            setCommand(Command.VERSION);
+            setCommand(AbstractLauncher.Command.VERSION);
           }
         }
 
@@ -1622,7 +1622,7 @@ public class ServerLauncher extends AbstractLauncher<String> {
     protected void parseCommand(final String... args) {
       if (args != null) {
         for (String arg : args) {
-          Command command = Command.valueOfName(arg);
+          AbstractLauncher.Command command = AbstractLauncher.Command.valueOfName(arg);
           if (command != null) {
             setCommand(command);
             break;
@@ -1644,7 +1644,7 @@ public class ServerLauncher extends AbstractLauncher<String> {
     protected void parseMemberName(final String... args) {
       if (args != null) {
         for (String arg : args) {
-          if (!(arg.startsWith(OPTION_PREFIX) || Command.isCommand(arg))) {
+          if (!(arg.startsWith(OPTION_PREFIX) || AbstractLauncher.Command.isCommand(arg))) {
             setMemberName(arg);
             break;
           }
@@ -1665,10 +1665,10 @@ public class ServerLauncher extends AbstractLauncher<String> {
      * Gets the Server launcher command used during the invocation of the ServerLauncher.
      *
      * @return the Server launcher command used to invoke (run) the ServerLauncher class.
-     * @see #setCommand(org.apache.geode.distributed.ServerLauncher.Command)
+     * @see #setCommand(org.apache.geode.distributed.AbstractLauncher.Command)
      * @see org.apache.geode.distributed.ServerLauncher.Command
      */
-    public Command getCommand() {
+    public AbstractLauncher.Command getCommand() {
       return this.command != null ? this.command : DEFAULT_COMMAND;
     }
 
@@ -1679,9 +1679,9 @@ public class ServerLauncher extends AbstractLauncher<String> {
      *        ServerLauncher.
      * @return this Builder instance.
      * @see #getCommand()
-     * @see org.apache.geode.distributed.ServerLauncher.Command
+     * @see org.apache.geode.distributed.AbstractLauncher.Command
      */
-    public Builder setCommand(final Command command) {
+    public Builder setCommand(final AbstractLauncher.Command command) {
       this.command = command;
       return this;
     }
@@ -2393,7 +2393,7 @@ public class ServerLauncher extends AbstractLauncher<String> {
      * @see org.apache.geode.distributed.ServerLauncher.Command#START
      */
     void validateOnStart() {
-      if (Command.START == getCommand()) {
+      if (AbstractLauncher.Command.START == getCommand()) {
         if (isBlank(getMemberName())
             && !isSet(System.getProperties(), DistributionConfig.GEMFIRE_PREFIX + NAME)
             && !isSet(getDistributedSystemProperties(), NAME)
@@ -2419,7 +2419,7 @@ public class ServerLauncher extends AbstractLauncher<String> {
      * @see org.apache.geode.distributed.ServerLauncher.Command#STATUS
      */
     void validateOnStatus() {
-      if (Command.STATUS == getCommand()) {
+      if (AbstractLauncher.Command.STATUS == getCommand()) {
         // do nothing
       }
     }
@@ -2430,7 +2430,7 @@ public class ServerLauncher extends AbstractLauncher<String> {
      * @see org.apache.geode.distributed.ServerLauncher.Command#STOP
      */
     void validateOnStop() {
-      if (Command.STOP == getCommand()) {
+      if (AbstractLauncher.Command.STOP == getCommand()) {
         // do nothing
       }
     }
@@ -2491,7 +2491,7 @@ public class ServerLauncher extends AbstractLauncher<String> {
      * @return a boolean value indicating whether the Server launcher command is unspecified.
      * @see Command#UNSPECIFIED
      */
-    public static boolean isUnspecified(final Command command) {
+    public static boolean isUnspecified(final AbstractLauncher.Command command) {
       return command == null || command.isUnspecified();
     }
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartLocatorCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartLocatorCommand.java
@@ -478,7 +478,7 @@ public class StartLocatorCommand extends InternalGfshCommand {
           .add("-D".concat(OSProcess.DISABLE_REDIRECTION_CONFIGURATION_PROPERTY).concat("=true"));
     }
     commandLine.add(LocatorLauncher.class.getName());
-    commandLine.add(LocatorLauncher.Command.START.getName());
+    commandLine.add(AbstractLauncher.Command.START.getName());
 
     if (StringUtils.isNotBlank(launcher.getMemberName())) {
       commandLine.add(launcher.getMemberName());

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartServerCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartServerCommand.java
@@ -467,7 +467,7 @@ public class StartServerCommand extends InternalGfshCommand {
           .add("-D".concat(OSProcess.DISABLE_REDIRECTION_CONFIGURATION_PROPERTY).concat("=true"));
     }
     commandLine.add(ServerLauncher.class.getName());
-    commandLine.add(ServerLauncher.Command.START.getName());
+    commandLine.add(AbstractLauncher.Command.START.getName());
 
     if (StringUtils.isNotBlank(launcher.getMemberName())) {
       commandLine.add(launcher.getMemberName());

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/lifecycle/StatusLocatorCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/lifecycle/StatusLocatorCommand.java
@@ -70,8 +70,9 @@ public class StatusLocatorCommand extends InternalGfshCommand {
             CliStrings.STATUS_SERVICE__GFSH_NOT_CONNECTED_ERROR_MESSAGE, LOCATOR_TERM_NAME));
       }
     } else {
+      AbstractLauncher.Command cmd = AbstractLauncher.Command.STATUS;
       final LocatorLauncher locatorLauncher =
-          new LocatorLauncher.Builder().setCommand(LocatorLauncher.Command.STATUS)
+          new LocatorLauncher.Builder().setCommand(AbstractLauncher.Command.STATUS)
               .setBindAddress(locatorHost).setDebug(isDebugging()).setPid(pid).setPort(locatorPort)
               .setWorkingDirectory(workingDirectory).build();
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/lifecycle/StatusServerCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/lifecycle/StatusServerCommand.java
@@ -63,7 +63,7 @@ public class StatusServerCommand extends InternalGfshCommand {
       }
     } else {
       final ServerLauncher serverLauncher = new ServerLauncher.Builder()
-          .setCommand(ServerLauncher.Command.STATUS).setDebug(isDebugging())
+          .setCommand(AbstractLauncher.Command.STATUS).setDebug(isDebugging())
           // NOTE since we do not know whether the "CacheServer" was enabled or not on the GemFire
           // server when it was started,
           // set the disableDefaultServer property in the ServerLauncher.Builder to default status

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/lifecycle/StopLocatorCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/lifecycle/StopLocatorCommand.java
@@ -79,7 +79,7 @@ public class StopLocatorCommand extends InternalGfshCommand {
       }
     } else {
       final LocatorLauncher locatorLauncher =
-          new LocatorLauncher.Builder().setCommand(LocatorLauncher.Command.STOP)
+          new LocatorLauncher.Builder().setCommand(AbstractLauncher.Command.STOP)
               .setDebug(isDebugging()).setPid(pid).setWorkingDirectory(workingDirectory).build();
 
       locatorState = locatorLauncher.status();

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/lifecycle/StopServerCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/lifecycle/StopServerCommand.java
@@ -73,7 +73,7 @@ public class StopServerCommand extends InternalGfshCommand {
 
     } else {
       final ServerLauncher serverLauncher =
-          new ServerLauncher.Builder().setCommand(ServerLauncher.Command.STOP)
+          new ServerLauncher.Builder().setCommand(AbstractLauncher.Command.STOP)
               .setDebug(isDebugging()).setPid(pid).setWorkingDirectory(workingDirectory).build();
 
       serverState = serverLauncher.status();

--- a/geode-core/src/test/java/org/apache/geode/distributed/LocatorLauncherBuilderTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/LocatorLauncherBuilderTest.java
@@ -28,8 +28,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 
-import org.apache.geode.distributed.LocatorLauncher.Builder;
 import org.apache.geode.distributed.AbstractLauncher.Command;
+import org.apache.geode.distributed.LocatorLauncher.Builder;
 import org.apache.geode.distributed.internal.DistributionConfig;
 
 /**

--- a/geode-core/src/test/java/org/apache/geode/distributed/LocatorLauncherBuilderTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/LocatorLauncherBuilderTest.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 
 import org.apache.geode.distributed.LocatorLauncher.Builder;
-import org.apache.geode.distributed.LocatorLauncher.Command;
+import org.apache.geode.distributed.AbstractLauncher.Command;
 import org.apache.geode.distributed.internal.DistributionConfig;
 
 /**
@@ -499,7 +499,7 @@ public class LocatorLauncherBuilderTest {
   @Test
   public void buildUsesMemberNameSetInApiProperties() {
     LocatorLauncher launcher =
-        new Builder().setCommand(LocatorLauncher.Command.START).set(NAME, "locatorABC").build();
+        new Builder().setCommand(Command.START).set(NAME, "locatorABC").build();
 
     assertThat(launcher.getMemberName()).isNull();
     assertThat(launcher.getProperties().getProperty(NAME)).isEqualTo("locatorABC");
@@ -509,7 +509,7 @@ public class LocatorLauncherBuilderTest {
   public void buildUsesMemberNameSetInSystemPropertiesOnStart() {
     System.setProperty(DistributionConfig.GEMFIRE_PREFIX + NAME, "locatorXYZ");
 
-    LocatorLauncher launcher = new Builder().setCommand(LocatorLauncher.Command.START).build();
+    LocatorLauncher launcher = new Builder().setCommand(Command.START).build();
 
     assertThat(launcher.getCommand()).isEqualTo(LocatorLauncher.Command.START);
     assertThat(launcher.getMemberName()).isNull();

--- a/geode-core/src/test/java/org/apache/geode/distributed/ServerLauncherBuilderTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/ServerLauncherBuilderTest.java
@@ -29,7 +29,7 @@ import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 
 import org.apache.geode.cache.server.CacheServer;
 import org.apache.geode.distributed.ServerLauncher.Builder;
-import org.apache.geode.distributed.ServerLauncher.Command;
+import org.apache.geode.distributed.AbstractLauncher.Command;
 import org.apache.geode.distributed.internal.DistributionConfig;
 
 /**
@@ -862,7 +862,7 @@ public class ServerLauncherBuilderTest {
   @Test
   public void buildUsesMemberNameSetInApiProperties() {
     ServerLauncher launcher =
-        new Builder().setCommand(ServerLauncher.Command.START).set(NAME, "serverABC").build();
+        new Builder().setCommand(Command.START).set(NAME, "serverABC").build();
 
     assertThat(launcher.getMemberName()).isNull();
     assertThat(launcher.getProperties().getProperty(NAME)).isEqualTo("serverABC");
@@ -872,7 +872,7 @@ public class ServerLauncherBuilderTest {
   public void buildUsesMemberNameSetInSystemProperties() {
     System.setProperty(DistributionConfig.GEMFIRE_PREFIX + NAME, "serverXYZ");
 
-    ServerLauncher launcher = new Builder().setCommand(ServerLauncher.Command.START).build();
+    ServerLauncher launcher = new Builder().setCommand(Command.START).build();
 
     assertThat(launcher.getMemberName()).isNull();
   }

--- a/geode-core/src/test/java/org/apache/geode/distributed/ServerLauncherBuilderTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/ServerLauncherBuilderTest.java
@@ -28,8 +28,8 @@ import org.junit.Test;
 import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 
 import org.apache.geode.cache.server.CacheServer;
-import org.apache.geode.distributed.ServerLauncher.Builder;
 import org.apache.geode.distributed.AbstractLauncher.Command;
+import org.apache.geode.distributed.ServerLauncher.Builder;
 import org.apache.geode.distributed.internal.DistributionConfig;
 
 /**


### PR DESCRIPTION
This change is the first step toward removing duplicate code in the classes that extend AbstractLauncher. The subclasses had their own Command Enum; this change replaces those distinct Enums with a common Enum in AbstractLauncher. An EnumMap has been introduced to handle the different Command options of the Launcher subclasses.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
