### PR TITLE
[Discuss] POMs with <distributionManagement> vs existing versioning.

### DIFF
--- a/geode-connectors/build.gradle
+++ b/geode-connectors/build.gradle
@@ -50,13 +50,13 @@ dependencies {
   }
 
   compile('com.zaxxer:HikariCP:3.2.0')
-  compile('commons-lang:commons-lang:' + project.'commons-lang.version')
-  compile('javax.xml.bind:jaxb-api:' + project.'jaxb.version')
-  compile('org.apache.logging.log4j:log4j-api:' + project.'log4j.version')
-  compile('org.apache.logging.log4j:log4j-jcl:' + project.'log4j.version') {
+  compile('commons-lang:commons-lang')
+  compile('javax.xml.bind:jaxb-api')
+  compile('org.apache.logging.log4j:log4j-api')
+  compile('org.apache.logging.log4j:log4j-jcl') {
     ext.optional = true
   }
-  compile('org.springframework.shell:spring-shell:' + project.'spring-shell.version') {
+  compile('org.springframework.shell:spring-shell') {
     exclude module: 'aopalliance'
     exclude module: 'asm'
     exclude module: 'cglib'
@@ -66,23 +66,23 @@ dependencies {
     ext.optional = true
   }
 
-  testCompile('pl.pragmatists:JUnitParams:' + project.'JUnitParams.version')
+  testCompile('pl.pragmatists:JUnitParams')
 
-  integrationTestCompile('junit:junit:' + project.'junit.version')
-  integrationTestCompile('junit:junit:4.12')
-  integrationTestCompile('org.assertj:assertj-core:' + project.'assertj-core.version')
+  integrationTestCompile('junit:junit')
+  integrationTestCompile('org.assertj:assertj-core')
 
-  distributedTestCompile('junit:junit:' + project.'junit.version')
-  distributedTestCompile('org.assertj:assertj-core:' + project.'assertj-core.version')
+  distributedTestCompile('junit:junit')
+  distributedTestCompile('org.assertj:assertj-core')
   distributedTestCompile('org.mockito:mockito-core:2.19.1')
 
-  acceptanceTestCompile('com.github.stefanbirkner:system-rules:' + project.'system-rules.version') {
+  acceptanceTestCompile('com.github.stefanbirkner:system-rules') {
     exclude module: 'junit-dep'
   }
-  acceptanceTestCompile('junit:junit:' + project.'junit.version')
-  acceptanceTestCompile('org.assertj:assertj-core:' + project.'assertj-core.version')
-  acceptanceTestCompile('org.awaitility:awaitility:' + project.'awaitility.version')
-  acceptanceTestCompile('org.mockito:mockito-core:' + project.'mockito-core.version')
+  
+  acceptanceTestCompile('junit:junit')
+  acceptanceTestCompile('org.assertj:assertj-core')
+  acceptanceTestCompile('org.awaitility:awaitility')
+  acceptanceTestCompile('org.mockito:mockito-core')
   acceptanceTestCompile(group: 'com.palantir.docker.compose', name: 'docker-compose-rule-core', version: '0.31.1')
 
   acceptanceTestCompile(group: 'com.palantir.docker.compose', name: 'docker-compose-rule-junit4', version: '0.31.1')
@@ -90,6 +90,38 @@ dependencies {
   acceptanceTestRuntime(group: 'mysql', name: 'mysql-connector-java', version: '5.1.46')
   acceptanceTestRuntime(group: 'org.apache.derby', name: 'derby', version: project.'derby.version')
   acceptanceTestRuntime(group: 'org.postgresql', name: 'postgresql', version: '42.2.2')
+}
+dependencies {
+  constraints {
+    compile('com.zaxxer:HikariCP:3.2.0')
+    compile('commons-lang:commons-lang:' + project.'commons-lang.version')
+    compile('javax.xml.bind:jaxb-api:' + project.'jaxb.version')
+    compile('org.apache.logging.log4j:log4j-api:' + project.'log4j.version')
+    compile('org.apache.logging.log4j:log4j-jcl:' + project.'log4j.version')
+    compile('org.springframework.shell:spring-shell:' + project.'spring-shell.version') 
+
+    testCompile('pl.pragmatists:JUnitParams:' + project.'JUnitParams.version')
+
+    integrationTestCompile('junit:junit:' + project.'junit.version')
+    integrationTestCompile('org.assertj:assertj-core:' + project.'assertj-core.version')
+
+    distributedTestCompile('junit:junit:' + project.'junit.version')
+    distributedTestCompile('org.assertj:assertj-core:' + project.'assertj-core.version')
+    distributedTestCompile('org.mockito:mockito-core:2.19.1')
+
+    acceptanceTestCompile('com.github.stefanbirkner:system-rules:' + project.'system-rules.version')
+    acceptanceTestCompile('junit:junit:' + project.'junit.version')
+    acceptanceTestCompile('org.assertj:assertj-core:' + project.'assertj-core.version')
+    acceptanceTestCompile('org.awaitility:awaitility:' + project.'awaitility.version')
+    acceptanceTestCompile('org.mockito:mockito-core:' + project.'mockito-core.version')
+    acceptanceTestCompile(group: 'com.palantir.docker.compose', name: 'docker-compose-rule-core', version: '0.31.1')
+
+    acceptanceTestCompile(group: 'com.palantir.docker.compose', name: 'docker-compose-rule-junit4', version: '0.31.1')
+
+    acceptanceTestRuntime(group: 'mysql', name: 'mysql-connector-java', version: '5.1.46')
+    acceptanceTestRuntime(group: 'org.apache.derby', name: 'derby', version: project.'derby.version')
+    acceptanceTestRuntime(group: 'org.postgresql', name: 'postgresql', version: '42.2.2')
+  }
 }
 
 integrationTest.forkEvery 0

--- a/geode-connectors/src/test/resources/expected-pom.xml
+++ b/geode-connectors/src/test/resources/expected-pom.xml
@@ -34,6 +34,46 @@
     <developerConnection>scm:git:https://github.com:apache/geode.git</developerConnection>
     <url>https://github.com/apache/geode</url>
   </scm>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.zaxxer</groupId>
+        <artifactId>HikariCP</artifactId>
+        <version>3.2.0</version>
+        <scope>compile</scope>
+      </dependency>
+      <dependency>
+        <groupId>commons-lang</groupId>
+        <artifactId>commons-lang</artifactId>
+        <version>2.6</version>
+        <scope>compile</scope>
+      </dependency>
+      <dependency>
+        <groupId>javax.xml.bind</groupId>
+        <artifactId>jaxb-api</artifactId>
+        <version>2.2.11</version>
+        <scope>compile</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-api</artifactId>
+        <version>2.11.0</version>
+        <scope>compile</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-jcl</artifactId>
+        <version>2.11.0</version>
+        <scope>compile</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.shell</groupId>
+        <artifactId>spring-shell</artifactId>
+        <version>1.2.0.RELEASE</version>
+        <scope>compile</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>org.apache.geode</groupId>
@@ -56,32 +96,27 @@
     <dependency>
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
-      <version>2.6</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>javax.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>
-      <version>2.2.11</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>2.11.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-jcl</artifactId>
-      <version>2.11.0</version>
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.springframework.shell</groupId>
       <artifactId>spring-shell</artifactId>
-      <version>1.2.0.RELEASE</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
Hello all!

I'm not very familiar with how POMs are published to Maven and consumed downstream.  Please refer to my recent thread on the `dev@geode.apache.org` for a longer-winded message, but tl;dr: what's the meaningful difference between these two POMs?  Or is the actual, published POM not quite what we report with `./gradle checkPom` et al?