### PR TITLE
GEODE-6003 don't fail if we can't kill a process because it's already exited

### DIFF
--- a/ci/images/google-windows-geode-builder/windows-packer.json
+++ b/ci/images/google-windows-geode-builder/windows-packer.json
@@ -84,7 +84,7 @@
         "popd",
 
         "write-output '>>>>>>>>>> Killing all java processes <<<<<<<<<<'",
-        "kill -name java -force",
+        "kill -name java -force -ErrorAction ignore",
         "Start-Sleep 10",
 
         "write-output '>>>>>>>>>> List remaining java processes for debug purposes <<<<<<<<<<'",


### PR DESCRIPTION
added -ErrorAction ignore to ensure we continue the script if the
process does not need to be killed because it has already exited.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [n/a] Does `gradlew build` run cleanly?

- [n/a] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
