### PR TITLE
Revert "GEODE-5729: when DistributedCacheOperation needs 2 messages, …

### DIFF
--- a/geode-assembly/geode-assembly-test/src/main/java/org/apache/geode/test/junit/rules/HttpResponseAssert.java
+++ b/geode-assembly/geode-assembly-test/src/main/java/org/apache/geode/test/junit/rules/HttpResponseAssert.java
@@ -20,8 +20,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.stream.Collectors;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedCacheOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedCacheOperation.java
@@ -355,11 +355,6 @@ public abstract class DistributedCacheOperation {
             logger.debug("Computed this filter routing: {}", filterRouting);
           }
         }
-        // if there's one secondary bucket holder needs two messages, then send two messages to all
-        // the secondary bcukets
-        if (!twoMessages.isEmpty()) {
-          twoMessages = recipients;
-        }
       }
 
       // some members need PR notification of the change for client/wan
@@ -510,20 +505,7 @@ public abstract class DistributedCacheOperation {
         }
 
         Set failures = null;
-        boolean inhibitAllNotifications = false;
-        if (event instanceof EntryEventImpl) {
-          inhibitAllNotifications = ((EntryEventImpl) event).inhibitAllNotifications();
-        }
         CacheOperationMessage msg = createMessage();
-        if (!twoMessages.isEmpty() && event instanceof EntryEventImpl) {
-          // If it's message for PR and needs 2 messages, let the distribution message not to
-          // trigger callback
-          ((EntryEventImpl) event).setInhibitAllNotifications(true);
-          logger.info(
-              "after setInhibitAllNotifications:recipients for {}: {} with adjunct messages to: {}",
-              event, recipients,
-              adjunctRecipients);
-        }
         initMessage(msg, this.processor);
 
         if (DistributedCacheOperation.internalBeforePutOutgoing != null) {
@@ -540,8 +522,7 @@ public abstract class DistributedCacheOperation {
           if (r.isUsedForPartitionedRegionBucket() && event.getOperation().isEntry()) {
             PartitionMessage pm = ((EntryEventImpl) event).getPartitionMessage();
             if (pm != null && pm.getSender() != null
-                && !pm.getSender()
-                    .equals(r.getDistributionManager().getDistributionManagerId())) {
+                && !pm.getSender().equals(r.getDistributionManager().getDistributionManagerId())) {
               // PR message sent by another member
               ReplyProcessor21.setShortSevereAlertProcessing(true);
             }
@@ -648,10 +629,6 @@ public abstract class DistributedCacheOperation {
               .getCacheDistributionAdvisor().adviseCacheServers();
           adjunctRecipientsWithNoCacheServer.removeAll(adviseCacheServers);
 
-          // set to its original status
-          if (event instanceof EntryEventImpl) {
-            ((EntryEventImpl) event).setInhibitAllNotifications(inhibitAllNotifications);
-          }
           if (isPutAll) {
             ((BucketRegion) region).performPutAllAdjunctMessaging((DistributedPutAllOperation) this,
                 recipients, adjunctRecipients, filterRouting, this.processor);
@@ -1485,6 +1462,9 @@ public abstract class DistributedCacheOperation {
       }
       if (this.versionTag instanceof DiskVersionTag) {
         bits |= PERSISTENT_TAG_MASK;
+      }
+      if (inhibitAllNotifications) {
+        bits |= INHIBIT_NOTIFICATIONS_MASK;
       }
       return bits;
     }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/CacheOperationMessageTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/CacheOperationMessageTest.java
@@ -15,27 +15,15 @@
 package org.apache.geode.internal.cache;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.io.ByteArrayInputStream;
-import java.io.DataInputStream;
-
 import org.junit.Test;
 
-import org.apache.geode.DataSerializer;
-import org.apache.geode.cache.Operation;
 import org.apache.geode.distributed.internal.ClusterDistributionManager;
-import org.apache.geode.distributed.internal.DistributionConfig;
-import org.apache.geode.distributed.internal.InternalDistributedSystem;
-import org.apache.geode.internal.HeapDataOutputStream;
-import org.apache.geode.internal.Version;
 import org.apache.geode.internal.cache.DistributedCacheOperation.CacheOperationMessage;
 
 public class CacheOperationMessageTest {
@@ -56,43 +44,5 @@ public class CacheOperationMessageTest {
     assertThat(mockCacheOperationMessage.supportsDirectAck()).isTrue();
     assertThat(mockCacheOperationMessage._mayAddToMultipleSerialGateways(mockDistributionManager))
         .isTrue();
-  }
-
-  @Test
-  public void inhibitAllNotificationsShouldOnlybBeSetInextBits() throws Exception {
-    // create an UpdateMessage for a bucket region
-    UpdateOperation.UpdateMessage updateMessage = mock(UpdateOperation.UpdateMessage.class);
-    byte[] memId = {1, 2, 3};
-    EventID eventId = new EventID(memId, 11, 12, 13);
-    BucketRegion br = mock(BucketRegion.class);
-    PartitionedRegion pr = mock(PartitionedRegion.class);
-    when(br.getPartitionedRegion()).thenReturn(pr);
-    when(pr.isUsedForPartitionedRegionBucket()).thenReturn(true);
-    InternalDistributedSystem system = mock(InternalDistributedSystem.class);
-    DistributionConfig dc = mock(DistributionConfig.class);
-    when(br.getSystem()).thenReturn(system);
-    when(system.getConfig()).thenReturn(dc);
-    when(dc.getDeltaPropagation()).thenReturn(false);
-    KeyInfo keyInfo = new KeyInfo("key1", null, null);
-    when(br.getKeyInfo(eq("key1"), any(), any())).thenReturn(keyInfo);
-    EntryEventImpl event = EntryEventImpl.create(br, Operation.UPDATE, "key1", "value1",
-        null, false, null, true, eventId);
-    UpdateOperation operation = new UpdateOperation(event, 0);
-    CacheOperationMessage message = operation.createMessage();
-    event.setInhibitAllNotifications(true);
-    operation.initMessage(message, null);
-    assertTrue(message instanceof UpdateOperation.UpdateMessage);
-    assertTrue(message.inhibitAllNotifications);
-    assertFalse(message.hasDelta()); // inhibitAllNotifications should not be interpreted as
-                                     // hasDelta
-    HeapDataOutputStream hdos = new HeapDataOutputStream(Version.CURRENT);
-    DataSerializer.writeObject(message, hdos);
-    byte[] outputArray = hdos.toByteArray();
-    ByteArrayInputStream bais = new ByteArrayInputStream(outputArray);
-    UpdateOperation.UpdateMessage message2 = DataSerializer.readObject(new DataInputStream(bais));
-    assertTrue(message2 instanceof UpdateOperation.UpdateMessage);
-    assertTrue(message2.inhibitAllNotifications);
-    assertFalse(message2.hasDelta()); // inhibitAllNotifications should not be interpreted as
-                                      // hasDelta
   }
 }


### PR DESCRIPTION
…should let (#2458)"

This reverts commit 49eb1c5fd13aefff0995d76ec7864c82d5730dd8.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
