### PR TITLE
GEODE-5742: increase timeout for statusCommandWithIncorrectPidShouldF…

### DIFF
--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/management/internal/cli/shell/StatusServerExitCodeAcceptanceTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/management/internal/cli/shell/StatusServerExitCodeAcceptanceTest.java
@@ -95,7 +95,7 @@ public class StatusServerExitCodeAcceptanceTest {
   @Test
   public void statusCommandWithIncorrectPidShouldFail() {
     String commandWithWrongPid = "status server --pid=100";
-    GfshScript.of(commandWithWrongPid).withName("test-frame").awaitAtMost(1, MINUTES)
+    GfshScript.of(commandWithWrongPid).withName("test-frame").awaitAtMost(2, MINUTES)
         .expectExitCode(ExitCode.FATAL.getValue()).execute(gfsh);
   }
 

--- a/geode-junit/src/main/java/org/apache/geode/test/junit/rules/gfsh/GfshExecution.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/junit/rules/gfsh/GfshExecution.java
@@ -120,7 +120,8 @@ public class GfshExecution {
     boolean exited = process.waitFor(script.getTimeout(), script.getTimeoutTimeUnit());
 
     try {
-      assertThat(exited).isTrue();
+      assertThat(exited).describedAs("Process of [" + script.toString() + "] did not exit after "
+          + script.getTimeout() + " " + script.getTimeoutTimeUnit().toString()).isTrue();
       assertThat(process.exitValue()).isEqualTo(script.getExpectedExitValue());
     } catch (AssertionError error) {
       printLogFiles();


### PR DESCRIPTION
…ail test

Co-authored-by: Brian Rowe <browe@pivotal.io>

* this test legitimately takes a long time to exit if attach api is available in jdk
* make the failure message more descriptive

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
