### PR TITLE
GEODE-3835: Use TemporayFolder instead of /tmp

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/beans/DistributedSystemBridgeIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/beans/DistributedSystemBridgeIntegrationTest.java
@@ -52,7 +52,7 @@ import org.apache.geode.management.GatewaySenderMXBean;
 import org.apache.geode.management.internal.FederationComponent;
 import org.apache.geode.test.fake.Fakes;
 
-public class DistributedSystemBridgeJUnitTest {
+public class DistributedSystemBridgeIntegrationTest {
   @Rule
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
 


### PR DESCRIPTION
GEODE-3835: Use TemporayFolder instead of /tmp

- Fixed minor warnings.
- Replaced the usage of `junit.Assert` by `assertj`.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
