### PR TITLE
GEODE-5873: Fix VMProvider.invokeInEveryMember

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/CreateJndiBindingCommandDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/CreateJndiBindingCommandDUnitTest.java
@@ -73,10 +73,10 @@ public class CreateJndiBindingCommandDUnitTest {
 
     // verify cluster config is updated
     locator.invoke(() -> {
-      InternalLocator locator = ClusterStartupRule.getLocator();
-      assertThat(locator).isNotNull();
+      InternalLocator internalLocator = ClusterStartupRule.getLocator();
+      assertThat(internalLocator).isNotNull();
       InternalConfigurationPersistenceService ccService =
-          locator.getConfigurationPersistenceService();
+          internalLocator.getConfigurationPersistenceService();
       Configuration configuration = ccService.getConfiguration("cluster");
       String xmlContent = configuration.getCacheXmlContent();
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/CreateJndiBindingCommandDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/CreateJndiBindingCommandDUnitTest.java
@@ -20,11 +20,13 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
 import org.apache.geode.distributed.internal.InternalConfigurationPersistenceService;
+import org.apache.geode.distributed.internal.InternalLocator;
 import org.apache.geode.internal.jndi.JNDIInvoker;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.management.internal.configuration.domain.Configuration;
@@ -33,9 +35,11 @@ import org.apache.geode.test.dunit.IgnoredException;
 import org.apache.geode.test.dunit.SerializableRunnableIF;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
+import org.apache.geode.test.junit.categories.GfshTest;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
 import org.apache.geode.test.junit.rules.VMProvider;
 
+@Category(GfshTest.class)
 public class CreateJndiBindingCommandDUnitTest {
 
   private static MemberVM locator, server1, server2;
@@ -57,10 +61,10 @@ public class CreateJndiBindingCommandDUnitTest {
   }
 
   @Test
-  public void testCreateJndiBinding() throws Exception {
+  public void testCreateJndiBinding() {
     // assert that is no datasource
     VMProvider.invokeInEveryMember(
-        () -> assertThat(JNDIInvoker.getNoOfAvailableDataSources()).isEqualTo(0));
+        () -> assertThat(JNDIInvoker.getNoOfAvailableDataSources()).isEqualTo(0), server1, server2);
 
     // create the binding
     gfsh.executeAndAssertThat(
@@ -69,8 +73,10 @@ public class CreateJndiBindingCommandDUnitTest {
 
     // verify cluster config is updated
     locator.invoke(() -> {
+      InternalLocator locator = ClusterStartupRule.getLocator();
+      assertThat(locator).isNotNull();
       InternalConfigurationPersistenceService ccService =
-          ClusterStartupRule.getLocator().getConfigurationPersistenceService();
+          locator.getConfigurationPersistenceService();
       Configuration configuration = ccService.getConfiguration("cluster");
       String xmlContent = configuration.getCacheXmlContent();
 
@@ -94,7 +100,7 @@ public class CreateJndiBindingCommandDUnitTest {
 
     // verify datasource exists
     VMProvider.invokeInEveryMember(
-        () -> assertThat(JNDIInvoker.getNoOfAvailableDataSources()).isEqualTo(1));
+        () -> assertThat(JNDIInvoker.getNoOfAvailableDataSources()).isEqualTo(1), server1, server2);
 
     // bounce server1
     server1.stop(false);

--- a/geode-dunit/src/main/java/org/apache/geode/test/junit/rules/VMProvider.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/junit/rules/VMProvider.java
@@ -30,8 +30,10 @@ import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 public abstract class VMProvider {
 
   public static void invokeInEveryMember(SerializableRunnableIF runnableIF, VMProvider... members) {
-    if (ArrayUtils.isEmpty(members))
+    if (ArrayUtils.isEmpty(members)) {
       throw new IllegalArgumentException("Array of members must not be null nor empty.");
+    }
+
     Arrays.stream(members).forEach(member -> member.invoke(runnableIF));
   }
 

--- a/geode-dunit/src/main/java/org/apache/geode/test/junit/rules/VMProvider.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/junit/rules/VMProvider.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.util.Arrays;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.ArrayUtils;
 
 import org.apache.geode.test.dunit.AsyncInvocation;
 import org.apache.geode.test.dunit.SerializableCallableIF;
@@ -27,7 +28,10 @@ import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 
 public abstract class VMProvider {
+
   public static void invokeInEveryMember(SerializableRunnableIF runnableIF, VMProvider... members) {
+    if (ArrayUtils.isEmpty(members))
+      throw new IllegalArgumentException("Array of members must not be null nor empty.");
     Arrays.stream(members).forEach(member -> member.invoke(runnableIF));
   }
 


### PR DESCRIPTION
GEODE-5873: Fix VMProvider.invokeInEveryMember

Method `invokeInEveryMember` from `VMProvider` ends up being a no-op
when the array of members is empty or null.

- Fixed tests `CreateJndiBindingCommandDUnitTest` and
`DestroyJndiBindingCommandDUnitTest`, they weren't fully validating
the result.
- Method `invokeInEveryMember` now validates its parameters, throwing
an exception when the arguments are invalid.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
