### PR TITLE
GEODE-6019: Move gradle constants in constants files.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,26 +51,15 @@ allprojects {
   version = versionNumber + releaseQualifier + releaseType
   ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
-  // We want to see all test results.  This is equivalent to setting --continue
-  // on the command line.
-  gradle.startParameter.continueOnFailure = true
-
   repositories {
     mavenCentral()
     maven { url "http://repo.spring.io/release" }
   }
 
-  group = "org.apache.geode"
-
   buildRoot = buildRoot.trim()
   if (!buildRoot.isEmpty()) {
     buildDir = buildRoot + project.path.replace(":", "/") + "/build"
   }
-}
-
-// allow external projects to override include location
-if (name == 'geode') {
-  ext.scriptDir = 'gradle'
 }
 
 // utilities.gradle MUST be read before publish.gradle for reasons
@@ -150,4 +139,7 @@ task writeBuildInfo {
 task generate() {
   group = 'Build'
   description = "Top-level target for all source generation. Helps IDE integration"
+  // This task is a no-op, with other tasks (such as geode-protobuf-messages:generateProto)
+  // injecting themselves as a task dependency into this task.  E.g., via
+  // `afterEvaluate.rootProject.generate.dependsOn(generateProto)`
 }

--- a/geode-assembly/build.gradle
+++ b/geode-assembly/build.gradle
@@ -538,7 +538,7 @@ task dumpInstalledJars(dependsOn: installDist) {
           println ""
           println file.name
           println("==========================")
-          printJars(warContents);
+          printJars(warContents)
       }
     }
   }

--- a/geode-core/build.gradle
+++ b/geode-core/build.gradle
@@ -180,17 +180,17 @@ dependencies {
   }
   compile('it.unimi.dsi:fastutil:' + project.'fastutil.version')
   compile('javax.mail:javax.mail-api:' + project.'javax.mail-api.version') {
-    ext.optional = true;
+    ext.optional = true
   }
   compile('javax.resource:javax.resource-api:' + project.'javax.resource-api.version')
   compile('mx4j:mx4j:' + project.'mx4j.version') {
-    ext.optional = true;
+    ext.optional = true
   }
   compile('mx4j:mx4j-remote:' + project.'mx4j-remote.version') {
-    ext.optional = true;
+    ext.optional = true
   }
   compile('mx4j:mx4j-tools:' + project.'mx4j-tools.version') {
-    ext.optional = true;
+    ext.optional = true
   }
   compile('net.java.dev.jna:jna:' + project.'jna.version')
 

--- a/geode-old-versions/build.gradle
+++ b/geode-old-versions/build.gradle
@@ -39,18 +39,18 @@ task createGeodeClasspathsFile {
   addOldVersion('test170', '1.7.0', true)
 
   doLast {
-    Properties versions = new Properties();
+    Properties versions = new Properties()
     project(':geode-old-versions').sourceSets.each {
       versions.setProperty(it.name,it.runtimeClasspath.getAsPath())
     }
 
-    classpathsFile.getParentFile().mkdirs();
+    classpathsFile.getParentFile().mkdirs()
 
     new FileOutputStream(classpathsFile).withStream { fos ->
       versions.store(fos, '')
     }
 
-    installsFile.getParentFile().mkdirs();
+    installsFile.getParentFile().mkdirs()
 
     new FileOutputStream(installsFile).withStream { fos ->
       project.ext.installs.store(fos, '')

--- a/geode-pulse/build.gradle
+++ b/geode-pulse/build.gradle
@@ -64,8 +64,8 @@ dependencies {
     exclude module: 'spring-expression'
     exclude module: 'spring-jdbc'
   }
-  compile('org.springframework:spring-context:' + project.'springframework.version');
-  compile('org.springframework:spring-web:' + project.'springframework.version');
+  compile('org.springframework:spring-context:' + project.'springframework.version')
+  compile('org.springframework:spring-web:' + project.'springframework.version')
   runtimeOnly('org.springframework:spring-webmvc:' + project.'springframework.version') {
     exclude module: 'aopalliance'
     exclude module: 'aspectjweaver'

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,23 +13,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Set the release type using the following conventions:
-# -SNAPSHOT - development version
-# .M?       - milestone release
-# <blank>   - release
+
+
+# Version information for use by Maven artifacts
+# The full version string consists of 'versionNumber + releaseQualifier + releaseType'
+#
+# The versionNumber follows semantic versioning conventions.
 versionNumber = 1.8.0
-
-# Set the release qualifier using the following conventions:
-# .M?       - milestone release
-# -beta.?   - beta release
-# <blank>   - release
+# The releaseQualifier uses the following conventions:
+#   .M?       - milestone release
+#   -beta.?   - beta release
+#   <blank>   - release
 releaseQualifier =
-
-# Set the release type using the following conventions:
-# -SNAPSHOT - development version
-# <blank>   - release
-# This is only really relevant for Maven artifacts.
+# The releaseType uses the following conventions:
+#   -SNAPSHOT - development version
+#   <blank>   - release
 releaseType = -SNAPSHOT
+
+# Maven also uses the project group as a prefix.
+group = org.apache.geode
+
+# 'apply from:' location for gradle scripts, relative to the project root.  Specified here so that
+# it may be overridden by external projects or custom develop environment configurations
+scriptDir = gradle
 
 # Set the buildId to add build metadata that can be viewed from
 # gfsh or pulse (`gfsh version --full`). Can be set using

--- a/gradle/dependency-resolution.gradle
+++ b/gradle/dependency-resolution.gradle
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 subprojects {
-  //Task to dump all depencies of all projects, in a way
-  //that can be diffed before and after dependency changes
+  // Task to dump all dependencies of all projects, in a way
+  // that can be diffed before and after dependency changes
   task dumpDependencies() {
     doLast {
       description "Dump all of the dependencies as a flat, sorted list"
@@ -65,18 +65,17 @@ subprojects {
       println "========"
       sourceFiles.visit{ file ->
         if(!file.isDirectory()) {
-          boolean matches = false;
+          boolean matches = false
           file.file.eachLine { line ->
           def matcher = line =~ /^import (.*)\..*;/
             if(matcher) {
               def pack = matcher[0][1]
-//              println pack
               matches |= packages.contains(pack)
             }
           }
 
           if(matches) {
-            println file.relativePath;
+            println file.relativePath
           }
         }
       }

--- a/gradle/spotless.gradle
+++ b/gradle/spotless.gradle
@@ -39,7 +39,7 @@ subprojects {
         // Wildcard imports can't be resolved by spotless itself.
         // This will require the developer themselves to adhere to best practices.
         if (it =~ /\nimport .*\*;/) {
-          throw new AssertionError("Do not use wildcard imports.  'spotlessApply' cannot resolve this issue.");
+          throw new AssertionError("Do not use wildcard imports.  'spotlessApply' cannot resolve this issue.")
         }
       }
       custom 'Refuse Awaitility import', {

--- a/gradle/utilities.gradle
+++ b/gradle/utilities.gradle
@@ -31,7 +31,7 @@ allprojects {
       // Intended to strip off 'extensions/' from the modules so that artifacts
       // don't end up in libs/extensions/
       def parts = project.name.split("/")
-      return parts[parts.length - 1];
+      return parts[parts.length - 1]
     }
 
     disableMavenPublishing = {

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,9 +15,10 @@
  * limitations under the License.
  */
 
-import org.gradle.util.GradleVersion
-
 rootProject.name = 'geode'
+
+// We want to see all test results.  This is equivalent to setting --continue on the command line.
+gradle.startParameter.continueOnFailure = true
 
 include 'geode-old-versions'
 include 'geode-common'

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import org.gradle.util.GradleVersion
+
 rootProject.name = 'geode'
 
 // We want to see all test results.  This is equivalent to setting --continue on the command line.


### PR DESCRIPTION
* gradle.startParameter.continueOnFailure moved to settings.gradle
* Project properties group and scriptDir moved to gradle.properties
* Removed unnecessary import and semicolons in *.gradle
* Improved property and task comments

-----

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [Build is Build] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
