### PR TITLE
GEODE-6020 make non-gating jobs run only after all gating jobs have passed

### DIFF
--- a/ci/pipelines/geode-build/jinja.template.yml
+++ b/ci/pipelines/geode-build/jinja.template.yml
@@ -21,12 +21,15 @@
 
 ---
 
-{% macro plan_resource_gets() %}
+{% macro plan_resource_gets(test) %}
 - get: geode-ci
 - aggregate:
   - get: geode
     passed:
     - Build
+    {%- if test.name.startswith("Windows") %}
+    {{- all_gating_jobs() | indent(4) -}}
+    {%- endif %}
   - get: geode-build-version
     passed:
     - Build
@@ -76,7 +79,7 @@ SERVICE_ACCOUNT: ((concourse-gcp-account))
 GRADLE_GLOBAL_ARGS: ((gradle-global-args))
 {%- endmacro %}
 
-{% macro all_gating_jobs(test) %}
+{% macro all_gating_jobs() %}
 {%- for test in (tests) if not test.name=="StressNew" and not test.name.startswith("Windows") -%}
   {%- for java_test_version in (java_test_versions) %}
 - {{test.name}}Test{{java_test_version.name}}
@@ -412,7 +415,7 @@ jobs:
   public: true
   plan:
   - do:
-    {{- plan_resource_gets() |indent(4) }}
+    {{- plan_resource_gets(test) |indent(4) }}
       - put: concourse-metadata-resource
     - aggregate:
       - do:


### PR DESCRIPTION
This fix defers running Windows tests until the commit has first passed all Linux tests.  This will reduce resource usage when some test does not pass, and also alleviates the 18-jobs-tall stack we had in the Complete view.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [n/a] Does `gradlew build` run cleanly?

- [n/a] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.