### PR TITLE
Feature/geode 6016

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/partitioned/fixed/FixedPartitioningWithTransactionDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/partitioned/fixed/FixedPartitioningWithTransactionDistributedTest.java
@@ -252,8 +252,7 @@ public class FixedPartitioningWithTransactionDistributedTest implements
     Throwable caughtException = catchThrowable(() -> doFunctionTransactionAndSuspend(region,
         txManager, new MyTransactionFunction(), Type.ON_MEMBER));
 
-    assertThat(caughtException).isInstanceOf(FunctionException.class);
-    assertThat(caughtException.getCause()).isInstanceOf(UnsupportedOperationException.class);
+    assertThat(caughtException).isInstanceOf(UnsupportedOperationException.class);
     txManager.rollback();
   }
 

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/ServerRegionProxy.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/ServerRegionProxy.java
@@ -670,8 +670,9 @@ public class ServerRegionProxy extends ServerProxy implements ServerRegionDataAc
         serverRegionExecutor, resultCollector, Byte.valueOf(hasResult));
 
     int retryAttempts = pool.getRetryAttempts();
+    boolean inTransaction = TXManagerImpl.getCurrentTXState() != null;
 
-    if (this.pool.getPRSingleHopEnabled()) {
+    if (this.pool.getPRSingleHopEnabled() && !inTransaction) {
       ClientMetadataService cms = region.getCache().getClientMetadataService();
       if (cms.isMetadataStable()) {
         if (serverRegionExecutor.getFilter().isEmpty()) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/MemberFunctionExecutor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/MemberFunctionExecutor.java
@@ -171,8 +171,8 @@ public class MemberFunctionExecutor extends AbstractExecution {
       } else {
         assert dest.size() == 1;
         if (cache.isClient()) {
-          // client function execution on members is not supported with transaction
-          throw new UnsupportedOperationException();
+          throw new UnsupportedOperationException(
+              "Client function execution on members is not supported with transaction");
         }
         DistributedMember funcTarget = (DistributedMember) dest.iterator().next();
         DistributedMember target = cache.getTxManager().getTXState().getTarget();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/MemberFunctionExecutor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/MemberFunctionExecutor.java
@@ -104,11 +104,7 @@ public class MemberFunctionExecutor extends AbstractExecution {
           String.format("No member found for executing function : %s.",
               function.getId()));
     }
-    try {
-      validateExecution(function, dest);
-    } catch (Exception exception) {
-      throw new FunctionException(exception);
-    }
+    validateExecution(function, dest);
     setExecutionNodes(dest);
 
     final InternalDistributedMember localVM =

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/MemberFunctionExecutor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/MemberFunctionExecutor.java
@@ -104,7 +104,11 @@ public class MemberFunctionExecutor extends AbstractExecution {
           String.format("No member found for executing function : %s.",
               function.getId()));
     }
-    validateExecution(function, dest);
+    try {
+      validateExecution(function, dest);
+    } catch (Exception exception) {
+      throw new FunctionException(exception);
+    }
     setExecutionNodes(dest);
 
     final InternalDistributedMember localVM =
@@ -166,6 +170,10 @@ public class MemberFunctionExecutor extends AbstractExecution {
             "Function inside a transaction cannot execute on more than one node");
       } else {
         assert dest.size() == 1;
+        if (cache.isClient()) {
+          // client function execution on members is not supported with transaction
+          throw new UnsupportedOperationException();
+        }
         DistributedMember funcTarget = (DistributedMember) dest.iterator().next();
         DistributedMember target = cache.getTxManager().getTXState().getTarget();
         if (target == null) {


### PR DESCRIPTION
 * Do not use a function execution thread to send message to server even if
   singleHop is enabled when function is in transaction.
 * Throw UnsupportedOperationException if client executes onMembers function
   using transaction - to behave similar to onServers function when using
   transaction.
