### PR TITLE
GEODE-5667: Fix manual-start default value

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateGatewayReceiverCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateGatewayReceiverCommand.java
@@ -57,7 +57,8 @@ public class CreateGatewayReceiverCommand extends SingleGfshCommand {
           help = CliStrings.CREATE_GATEWAYRECEIVER__MEMBER__HELP) String[] onMember,
 
       @CliOption(key = CliStrings.CREATE_GATEWAYRECEIVER__MANUALSTART,
-          help = CliStrings.CREATE_GATEWAYRECEIVER__MANUALSTART__HELP) Boolean manualStart,
+          help = CliStrings.CREATE_GATEWAYRECEIVER__MANUALSTART__HELP,
+          specifiedDefaultValue = "true", unspecifiedDefaultValue = "false") Boolean manualStart,
 
       @CliOption(key = CliStrings.CREATE_GATEWAYRECEIVER__STARTPORT,
           help = CliStrings.CREATE_GATEWAYRECEIVER__STARTPORT__HELP) Integer startPort,

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/wancommand/CreateGatewayReceiverCommandDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/wancommand/CreateGatewayReceiverCommandDUnitTest.java
@@ -33,10 +33,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.wan.GatewayReceiver;
@@ -51,7 +54,8 @@ import org.apache.geode.test.junit.rules.GfshCommandRule;
 /**
  * DUnit tests for 'create gateway-receiver' command.
  */
-@Category({WanTest.class})
+@Category(WanTest.class)
+@RunWith(JUnitParamsRunner.class)
 public class CreateGatewayReceiverCommandDUnitTest {
 
   private static final String SERVER_1 = "server-1";
@@ -104,12 +108,11 @@ public class CreateGatewayReceiverCommandDUnitTest {
     server1 = clusterStartupRule.startServerVM(1, locator1Port);
     server2 = clusterStartupRule.startServerVM(2, locator1Port);
     String createOnS1 = CREATE_GATEWAYRECEIVER + " --member=" + server1.getName();
-    String createOnBoth = CREATE_GATEWAYRECEIVER;
     gfsh.executeAndAssertThat(createOnS1).statusIsSuccess()
         .tableHasColumnWithExactValuesInAnyOrder("Member", SERVER_1)
         .tableHasColumnWithValuesContaining("Message",
             "GatewayReceiver created on member \"" + SERVER_1 + "\"");
-    gfsh.executeAndAssertThat(createOnBoth).statusIsSuccess()
+    gfsh.executeAndAssertThat(CREATE_GATEWAYRECEIVER).statusIsSuccess()
         .tableHasColumnWithExactValuesInAnyOrder("Member", SERVER_1, SERVER_2)
         .tableHasColumnWithExactValuesInAnyOrder("Status", "ERROR", "OK")
         .tableHasColumnWithValuesContaining("Message",
@@ -190,8 +193,7 @@ public class CreateGatewayReceiverCommandDUnitTest {
     server3 = clusterStartupRule.startServerVM(3, locator1Port);
 
     // Default attributes.
-    String command = CliStrings.CREATE_GATEWAYRECEIVER;
-    gfsh.executeAndAssertThat(command).statusIsSuccess()
+    gfsh.executeAndAssertThat(CliStrings.CREATE_GATEWAYRECEIVER).statusIsSuccess()
         .tableHasColumnWithExactValuesInAnyOrder("Member", SERVER_1, SERVER_2, SERVER_3)
         .tableHasColumnWithValuesContaining("Message",
             "GatewayReceiver created on member \"" + SERVER_1 + "\"",
@@ -277,18 +279,22 @@ public class CreateGatewayReceiverCommandDUnitTest {
     }, server1, server2, server3);
   }
 
+
   /**
-   * GatewayReceiver with all default attributes and bind-address in gemfire-properties
+   * GatewayReceiver with all default attributes and bind-address / server-bind-address in
+   * gemfire-properties
    */
   @Test
-  public void testCreateGatewayReceiverWithDefaultAndBindProperty() throws Exception {
+  @Parameters({BIND_ADDRESS, SERVER_BIND_ADDRESS})
+  public void testCreateGatewayReceiverWithDefaultsAndAddressProperties(String addressPropertyKey)
+      throws Exception {
     String receiverGroup = "receiverGroup";
     Integer locator1Port = locatorSite1.getPort();
     String expectedBindAddress = getBindAddress();
 
     Properties props = new Properties();
     props.setProperty(GROUPS, receiverGroup);
-    props.setProperty(BIND_ADDRESS, expectedBindAddress);
+    props.setProperty(addressPropertyKey, expectedBindAddress);
 
     server1 = clusterStartupRule.startServerVM(1, props, locator1Port);
     server2 = clusterStartupRule.startServerVM(2, props, locator1Port);
@@ -304,43 +310,6 @@ public class CreateGatewayReceiverCommandDUnitTest {
 
     invokeInEveryMember(() -> {
       // verify bind-address used when provided as a gemfire property
-      verifyGatewayReceiverProfile(expectedBindAddress);
-      verifyGatewayReceiverServerLocations(locator1Port, expectedBindAddress);
-      verifyReceiverCreationWithAttributes(!GatewayReceiver.DEFAULT_MANUAL_START,
-          GatewayReceiver.DEFAULT_START_PORT, GatewayReceiver.DEFAULT_END_PORT,
-          GatewayReceiver.DEFAULT_BIND_ADDRESS, GatewayReceiver.DEFAULT_MAXIMUM_TIME_BETWEEN_PINGS,
-          GatewayReceiver.DEFAULT_SOCKET_BUFFER_SIZE, null,
-          GatewayReceiver.DEFAULT_HOSTNAME_FOR_SENDERS);
-    }, server1, server2, server3);
-  }
-
-  /**
-   * GatewayReceiver with all default attributes and server-bind-address in the gemfire properties
-   */
-  @Test
-  public void testCreateGatewayReceiverWithDefaultsAndServerBindAddressProperty() throws Exception {
-    String receiverGroup = "receiverGroup";
-    Integer locator1Port = locatorSite1.getPort();
-    String expectedBindAddress = getBindAddress();
-
-    Properties props = new Properties();
-    props.setProperty(GROUPS, receiverGroup);
-    props.setProperty(SERVER_BIND_ADDRESS, expectedBindAddress);
-
-    server1 = clusterStartupRule.startServerVM(1, props, locator1Port);
-    server2 = clusterStartupRule.startServerVM(2, props, locator1Port);
-    server3 = clusterStartupRule.startServerVM(3, props, locator1Port);
-
-    String command = CliStrings.CREATE_GATEWAYRECEIVER + " --" + GROUP + "=" + receiverGroup;
-    gfsh.executeAndAssertThat(command).statusIsSuccess()
-        .tableHasColumnWithExactValuesInAnyOrder("Member", SERVER_1, SERVER_2, SERVER_3)
-        .tableHasColumnWithValuesContaining("Message",
-            "GatewayReceiver created on member \"" + SERVER_1 + "\"",
-            "GatewayReceiver created on member \"" + SERVER_2 + "\"",
-            "GatewayReceiver created on member \"" + SERVER_3 + "\"");
-
-    invokeInEveryMember(() -> {
-      // verify server-bind-address used if provided as a gemfire property
       verifyGatewayReceiverProfile(expectedBindAddress);
       verifyGatewayReceiverServerLocations(locator1Port, expectedBindAddress);
       verifyReceiverCreationWithAttributes(!GatewayReceiver.DEFAULT_MANUAL_START,
@@ -573,6 +542,7 @@ public class CreateGatewayReceiverCommandDUnitTest {
 
     invokeInEveryMember(() -> {
       Cache cache = ClusterStartupRule.getCache();
+      assertThat(cache).isNotNull();
       assertThat(cache.getGatewayReceivers()).isEmpty();
     }, server2, server3);
   }
@@ -609,6 +579,7 @@ public class CreateGatewayReceiverCommandDUnitTest {
 
     invokeInEveryMember(() -> {
       Cache cache = ClusterStartupRule.getCache();
+      assertThat(cache).isNotNull();
       assertThat(cache.getGatewayReceivers()).isEmpty();
     }, server3);
   }
@@ -619,7 +590,7 @@ public class CreateGatewayReceiverCommandDUnitTest {
   @Test
   public void testCreateGatewayReceiverOnGroup() {
     String groups = "receiverGroup1";
-    Integer locator1Port = locatorSite1.getPort();
+    int locator1Port = locatorSite1.getPort();
     server1 = startServerWithGroups(1, groups, locator1Port);
     server2 = startServerWithGroups(2, groups, locator1Port);
     server3 = startServerWithGroups(3, groups, locator1Port);
@@ -652,7 +623,7 @@ public class CreateGatewayReceiverCommandDUnitTest {
   public void testCreateGatewayReceiverOnGroupScenario2() {
     String group1 = "receiverGroup1";
     String group2 = "receiverGroup2";
-    Integer locator1Port = locatorSite1.getPort();
+    int locator1Port = locatorSite1.getPort();
     server1 = startServerWithGroups(1, group1, locator1Port);
     server2 = startServerWithGroups(2, group1, locator1Port);
     server3 = startServerWithGroups(3, group2, locator1Port);
@@ -676,6 +647,7 @@ public class CreateGatewayReceiverCommandDUnitTest {
 
     invokeInEveryMember(() -> {
       Cache cache = ClusterStartupRule.getCache();
+      assertThat(cache).isNotNull();
       assertThat(cache.getGatewayReceivers()).isEmpty();
     }, server3);
   }
@@ -685,7 +657,7 @@ public class CreateGatewayReceiverCommandDUnitTest {
    */
   @Test
   public void testCreateGatewayReceiverOnMultipleGroups() {
-    Integer locator1Port = locatorSite1.getPort();
+    int locator1Port = locatorSite1.getPort();
     server1 = startServerWithGroups(1, "receiverGroup1", locator1Port);
     server2 = startServerWithGroups(2, "receiverGroup1", locator1Port);
     server3 = startServerWithGroups(3, "receiverGroup2", locator1Port);


### PR DESCRIPTION
GEODE-5667: Fix manual-start default value

- Fixed minor warnings in test classes.
- The `create gateway-receiver` command now sets the `manual-start`
property as `true` when the parameter is specified without a value.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
