### PR TITLE
GEODE-5228:  Deleting existing status file if one exists

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/process/ControlFileWatchdog.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/process/ControlFileWatchdog.java
@@ -59,6 +59,7 @@ class ControlFileWatchdog implements Runnable {
   @Override
   public void run() {
     try { // always set alive before stopping
+      deleteExistingStatusResponseFile();
       while (isAlive()) {
         doWork();
       }
@@ -66,6 +67,12 @@ class ControlFileWatchdog implements Runnable {
       synchronized (this) {
         alive = false;
       }
+    }
+  }
+
+  private void deleteExistingStatusResponseFile() throws IllegalStateException {
+    if (!file.delete() && file.exists()) {
+      throw new IllegalStateException("Unable delete file: " + file);
     }
   }
 


### PR DESCRIPTION
  *  There is a race condition where checking status will read the existing
     status file and not the current status response file.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
