### PR TITLE
GEODE-5971: Refactor AlterAsyncEventQueueCommand to extend SingleGfshCommand

### DIFF
--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/CreateMappingCommand.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/CreateMappingCommand.java
@@ -78,8 +78,7 @@ public class CreateMappingCommand extends SingleGfshCommand {
   }
 
   @Override
-  public boolean updateClusterConfig(String group, CacheConfig cacheConfig, Object element,
-      ResultModel resultModel) {
+  public boolean updateGroupConfig(String group, CacheConfig cacheConfig, Object element) {
     RegionMapping newCacheElement = (RegionMapping) element;
     RegionMapping existingCacheElement = cacheConfig.findCustomRegionElement(
         newCacheElement.getRegionName(), newCacheElement.getId(), RegionMapping.class);

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/CreateMappingCommand.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/CreateMappingCommand.java
@@ -78,7 +78,8 @@ public class CreateMappingCommand extends SingleGfshCommand {
   }
 
   @Override
-  public void updateClusterConfig(String group, CacheConfig cacheConfig, Object element) {
+  public boolean updateClusterConfig(String group, CacheConfig cacheConfig, Object element,
+      ResultModel resultModel) {
     RegionMapping newCacheElement = (RegionMapping) element;
     RegionMapping existingCacheElement = cacheConfig.findCustomRegionElement(
         newCacheElement.getRegionName(), newCacheElement.getId(), RegionMapping.class);
@@ -97,5 +98,6 @@ public class CreateMappingCommand extends SingleGfshCommand {
         .stream()
         .filter(regionConfig -> regionConfig.getName().equals(newCacheElement.getRegionName()))
         .forEach(regionConfig -> regionConfig.getCustomRegionElements().add(newCacheElement));
+    return true;
   }
 }

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyMappingCommand.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyMappingCommand.java
@@ -61,8 +61,7 @@ public class DestroyMappingCommand extends SingleGfshCommand {
   }
 
   @Override
-  public boolean updateClusterConfig(String group, CacheConfig cacheConfig, Object configObject,
-      ResultModel resultModel) {
+  public boolean updateGroupConfig(String group, CacheConfig cacheConfig, Object configObject) {
     String region = (String) configObject;
     RegionMapping existingCacheElement = cacheConfig.findCustomRegionElement("/" + region,
         RegionMapping.ELEMENT_ID, RegionMapping.class);

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyMappingCommand.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyMappingCommand.java
@@ -61,7 +61,8 @@ public class DestroyMappingCommand extends SingleGfshCommand {
   }
 
   @Override
-  public void updateClusterConfig(String group, CacheConfig cacheConfig, Object configObject) {
+  public boolean updateClusterConfig(String group, CacheConfig cacheConfig, Object configObject,
+      ResultModel resultModel) {
     String region = (String) configObject;
     RegionMapping existingCacheElement = cacheConfig.findCustomRegionElement("/" + region,
         RegionMapping.ELEMENT_ID, RegionMapping.class);
@@ -73,6 +74,8 @@ public class DestroyMappingCommand extends SingleGfshCommand {
           .filter(regionConfig -> regionConfig.getName().equals(region))
           .forEach(
               regionConfig -> regionConfig.getCustomRegionElements().remove(existingCacheElement));
+      return true;
     }
+    return false;
   }
 }

--- a/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/AlterAsyncEventQueueCommandDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/AlterAsyncEventQueueCommandDUnitTest.java
@@ -49,8 +49,6 @@ public class AlterAsyncEventQueueCommandDUnitTest {
     gfsh.connectAndVerify(locator);
   }
 
-
-
   @Test
   public void testAlterAsyncEventQueue() throws Exception {
     gfsh.executeAndAssertThat("create async-event-queue --id=queue1 --group=group1 --listener="

--- a/geode-core/src/main/java/org/apache/geode/cache/configuration/CacheConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/configuration/CacheConfig.java
@@ -20,7 +20,6 @@ package org.apache.geode.cache.configuration;
 
 import static org.apache.geode.cache.configuration.CacheElement.findElement;
 
-import java.io.Serializable;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
@@ -1108,7 +1107,7 @@ public class CacheConfig {
   @XmlAccessorType(XmlAccessType.FIELD)
   @XmlType(name = "",
       propOrder = {"gatewayEventFilters", "gatewayEventSubstitutionFilter", "asyncEventListener"})
-  public static class AsyncEventQueue implements Serializable {
+  public static class AsyncEventQueue implements CacheElement {
 
     @XmlElement(name = "gateway-event-filter", namespace = "http://geode.apache.org/schema/cache")
     protected List<DeclarableType> gatewayEventFilters;

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalConfigurationPersistenceService.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalConfigurationPersistenceService.java
@@ -992,4 +992,20 @@ public class InternalConfigurationPersistenceService implements ConfigurationPer
     }
   }
 
+  public void replaceCacheConfig(String group, CacheConfig newConfig) {
+    lockSharedConfiguration();
+    try {
+      if (newConfig == null) {
+        return;
+      }
+      Configuration configuration = getConfiguration(group);
+      if (configuration == null) {
+        configuration = new Configuration(group);
+      }
+      configuration.setCacheXmlContent(jaxbService.marshall(newConfig));
+      getConfigurationRegion().put(group, configuration);
+    } finally {
+      unlockSharedConfiguration();
+    }
+  }
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalConfigurationPersistenceService.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalConfigurationPersistenceService.java
@@ -716,6 +716,10 @@ public class InternalConfigurationPersistenceService implements ConfigurationPer
     return getConfigurationRegion().getAll(keys);
   }
 
+  public Set<String> getGroups() {
+    return getConfigurationRegion().keySet();
+  }
+
   /**
    * Returns the path of Shared configuration directory
    *

--- a/geode-core/src/main/java/org/apache/geode/management/cli/SingleGfshCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/cli/SingleGfshCommand.java
@@ -19,6 +19,7 @@ package org.apache.geode.management.cli;
 
 import org.apache.geode.annotations.Experimental;
 import org.apache.geode.cache.configuration.CacheConfig;
+import org.apache.geode.management.internal.cli.result.model.ResultModel;
 
 /**
  * Command class that extends this class can only have one single command method,
@@ -36,12 +37,11 @@ public abstract class SingleGfshCommand extends GfshCommand {
    * @param group the group name of the cluster config, never null
    * @param config the configuration object, never null
    * @param configObject the return value of CommandResult.getConfigObject. CommandResult is the
-   *        return
-   *        value of your command method.
-   *
-   *        it should throw some RuntimeException if update failed.
+   *        return value of your command method.
+   * @return a boolean indicating whether a change to the cluster configuration was persisted.
    */
-  public void updateClusterConfig(String group, CacheConfig config, Object configObject) {
-    // Default is a no-op
+  public boolean updateClusterConfig(String group, CacheConfig config, Object configObject,
+      ResultModel resultModel) {
+    return false;
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/management/cli/SingleGfshCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/cli/SingleGfshCommand.java
@@ -17,9 +17,10 @@
 
 package org.apache.geode.management.cli;
 
+import java.util.Map;
+
 import org.apache.geode.annotations.Experimental;
 import org.apache.geode.cache.configuration.CacheConfig;
-import org.apache.geode.management.internal.cli.result.model.ResultModel;
 
 /**
  * Command class that extends this class can only have one single command method,
@@ -29,7 +30,7 @@ import org.apache.geode.management.internal.cli.result.model.ResultModel;
 public abstract class SingleGfshCommand extends GfshCommand {
 
   /**
-   * implement this method for updating the cluster configuration of the group
+   * implement this method for updating the configuration of a given group
    *
    * the implementation should update the passed in config object with appropriate changes
    * if for any reason config can't be updated. throw a RuntimeException stating the reason.
@@ -40,8 +41,21 @@ public abstract class SingleGfshCommand extends GfshCommand {
    *        return value of your command method.
    * @return a boolean indicating whether a change to the cluster configuration was persisted.
    */
-  public boolean updateClusterConfig(String group, CacheConfig config, Object configObject,
-      ResultModel resultModel) {
+  public boolean updateGroupConfig(String group, CacheConfig config, Object configObject) {
+    return false;
+  }
+
+  /**
+   * implement this method for updating a configuration of a given group or groups, when the group
+   * is
+   * not specified by the command (and hence is unavailable to be passed in as a parameter)
+   *
+   * @param groupConfigs map of group name -> cache config object representing config for the group.
+   * @param configObject the return value of CommandResult.getConfigObject. CommandResult is the
+   *        return value of your command method.
+   * @return a boolean indicating whether a change to the cluster configuration was persisted.
+   */
+  public boolean updateAllConfigs(Map<String, CacheConfig> groupConfigs, Object configObject) {
     return false;
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/AlterAsyncEventQueueCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/AlterAsyncEventQueueCommand.java
@@ -28,7 +28,7 @@ import java.util.Set;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.shell.core.annotation.CliCommand;
 import org.springframework.shell.core.annotation.CliOption;
 import org.xml.sax.SAXException;

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ConfigurePDXCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ConfigurePDXCommand.java
@@ -109,8 +109,10 @@ public class ConfigurePDXCommand extends SingleGfshCommand {
   }
 
   @Override
-  public void updateClusterConfig(String group, CacheConfig config, Object configObject) {
+  public boolean updateClusterConfig(String group, CacheConfig config, Object configObject,
+      ResultModel resultModel) {
     config.setPdx((PdxType) configObject);
+    return true;
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ConfigurePDXCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ConfigurePDXCommand.java
@@ -109,8 +109,7 @@ public class ConfigurePDXCommand extends SingleGfshCommand {
   }
 
   @Override
-  public boolean updateClusterConfig(String group, CacheConfig config, Object configObject,
-      ResultModel resultModel) {
+  public boolean updateGroupConfig(String group, CacheConfig config, Object configObject) {
     config.setPdx((PdxType) configObject);
     return true;
   }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateAsyncEventQueueCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateAsyncEventQueueCommand.java
@@ -139,7 +139,9 @@ public class CreateAsyncEventQueueCommand extends SingleGfshCommand {
   }
 
   @Override
-  public void updateClusterConfig(String group, CacheConfig config, Object configObject) {
+  public boolean updateClusterConfig(String group, CacheConfig config, Object configObject,
+      ResultModel resultModel) {
     config.getAsyncEventQueues().add((CacheConfig.AsyncEventQueue) configObject);
+    return true;
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateAsyncEventQueueCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateAsyncEventQueueCommand.java
@@ -139,8 +139,7 @@ public class CreateAsyncEventQueueCommand extends SingleGfshCommand {
   }
 
   @Override
-  public boolean updateClusterConfig(String group, CacheConfig config, Object configObject,
-      ResultModel resultModel) {
+  public boolean updateGroupConfig(String group, CacheConfig config, Object configObject) {
     config.getAsyncEventQueues().add((CacheConfig.AsyncEventQueue) configObject);
     return true;
   }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateDataSourceCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateDataSourceCommand.java
@@ -143,8 +143,7 @@ public class CreateDataSourceCommand extends SingleGfshCommand {
   }
 
   @Override
-  public boolean updateClusterConfig(String group, CacheConfig config, Object element,
-      ResultModel resultModel) {
+  public boolean updateGroupConfig(String group, CacheConfig config, Object element) {
     config.getJndiBindings().add((JndiBindingsType.JndiBinding) element);
     return true;
   }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateDataSourceCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateDataSourceCommand.java
@@ -143,8 +143,10 @@ public class CreateDataSourceCommand extends SingleGfshCommand {
   }
 
   @Override
-  public void updateClusterConfig(String group, CacheConfig config, Object element) {
+  public boolean updateClusterConfig(String group, CacheConfig config, Object element,
+      ResultModel resultModel) {
     config.getJndiBindings().add((JndiBindingsType.JndiBinding) element);
+    return true;
   }
 
   public static class PoolProperty {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateDefinedIndexesCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateDefinedIndexesCommand.java
@@ -73,8 +73,7 @@ public class CreateDefinedIndexesCommand extends SingleGfshCommand {
   }
 
   @Override
-  public boolean updateClusterConfig(String group, CacheConfig config, Object configObject,
-      ResultModel resultModel) {
+  public boolean updateGroupConfig(String group, CacheConfig config, Object configObject) {
     Set<RegionConfig.Index> updatedIndexes = (Set<RegionConfig.Index>) configObject;
     if (updatedIndexes == null) {
       return false;

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateDefinedIndexesCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateDefinedIndexesCommand.java
@@ -73,10 +73,11 @@ public class CreateDefinedIndexesCommand extends SingleGfshCommand {
   }
 
   @Override
-  public void updateClusterConfig(String group, CacheConfig config, Object configObject) {
+  public boolean updateClusterConfig(String group, CacheConfig config, Object configObject,
+      ResultModel resultModel) {
     Set<RegionConfig.Index> updatedIndexes = (Set<RegionConfig.Index>) configObject;
     if (updatedIndexes == null) {
-      return;
+      return false;
     }
 
     for (RegionConfig.Index index : updatedIndexes) {
@@ -87,6 +88,7 @@ public class CreateDefinedIndexesCommand extends SingleGfshCommand {
 
       regionConfig.getIndexes().add(index);
     }
+    return true;
   }
 
   RegionConfig getValidRegionConfig(String regionPath, CacheConfig cacheConfig) {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateDiskStoreCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateDiskStoreCommand.java
@@ -153,8 +153,7 @@ public class CreateDiskStoreCommand extends SingleGfshCommand {
   }
 
   @Override
-  public boolean updateClusterConfig(String group, CacheConfig config, Object configObject,
-      ResultModel resultModel) {
+  public boolean updateGroupConfig(String group, CacheConfig config, Object configObject) {
     DiskStoreType diskStoreType = (DiskStoreType) configObject;
     config.getDiskStores().add(diskStoreType);
     return true;

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateDiskStoreCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateDiskStoreCommand.java
@@ -153,8 +153,10 @@ public class CreateDiskStoreCommand extends SingleGfshCommand {
   }
 
   @Override
-  public void updateClusterConfig(String group, CacheConfig config, Object configObject) {
+  public boolean updateClusterConfig(String group, CacheConfig config, Object configObject,
+      ResultModel resultModel) {
     DiskStoreType diskStoreType = (DiskStoreType) configObject;
     config.getDiskStores().add(diskStoreType);
+    return true;
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateGatewayReceiverCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateGatewayReceiverCommand.java
@@ -102,8 +102,10 @@ public class CreateGatewayReceiverCommand extends SingleGfshCommand {
   }
 
   @Override
-  public void updateClusterConfig(String group, CacheConfig config, Object configObject) {
+  public boolean updateClusterConfig(String group, CacheConfig config, Object configObject,
+      ResultModel resultModel) {
     config.setGatewayReceiver((CacheConfig.GatewayReceiver) configObject);
+    return true;
   }
 
   private CacheConfig.GatewayReceiver buildConfiguration(Boolean manualStart, Integer startPort,

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateGatewayReceiverCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateGatewayReceiverCommand.java
@@ -102,8 +102,7 @@ public class CreateGatewayReceiverCommand extends SingleGfshCommand {
   }
 
   @Override
-  public boolean updateClusterConfig(String group, CacheConfig config, Object configObject,
-      ResultModel resultModel) {
+  public boolean updateGroupConfig(String group, CacheConfig config, Object configObject) {
     config.setGatewayReceiver((CacheConfig.GatewayReceiver) configObject);
     return true;
   }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateGatewaySenderCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateGatewaySenderCommand.java
@@ -142,8 +142,10 @@ public class CreateGatewaySenderCommand extends SingleGfshCommand {
   }
 
   @Override
-  public void updateClusterConfig(String group, CacheConfig config, Object configObject) {
+  public boolean updateClusterConfig(String group, CacheConfig config, Object configObject,
+      ResultModel resultModel) {
     config.getGatewaySenders().add((CacheConfig.GatewaySender) configObject);
+    return true;
   }
 
   private boolean verifyAllCurrentVersion(Set<DistributedMember> members) {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateGatewaySenderCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateGatewaySenderCommand.java
@@ -142,8 +142,7 @@ public class CreateGatewaySenderCommand extends SingleGfshCommand {
   }
 
   @Override
-  public boolean updateClusterConfig(String group, CacheConfig config, Object configObject,
-      ResultModel resultModel) {
+  public boolean updateGroupConfig(String group, CacheConfig config, Object configObject) {
     config.getGatewaySenders().add((CacheConfig.GatewaySender) configObject);
     return true;
   }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateIndexCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateIndexCommand.java
@@ -102,7 +102,8 @@ public class CreateIndexCommand extends SingleGfshCommand {
   }
 
   @Override
-  public void updateClusterConfig(String group, CacheConfig config, Object element) {
+  public boolean updateClusterConfig(String group, CacheConfig config, Object element,
+      ResultModel resultModel) {
     RegionConfig.Index index = (RegionConfig.Index) element;
     String regionPath = getValidRegionName(index.getFromClause(), config);
 
@@ -111,5 +112,6 @@ public class CreateIndexCommand extends SingleGfshCommand {
       throw new EntityNotFoundException("Region " + index.getFromClause() + " not found.");
     }
     regionConfig.getIndexes().add(index);
+    return true;
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateIndexCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateIndexCommand.java
@@ -102,8 +102,7 @@ public class CreateIndexCommand extends SingleGfshCommand {
   }
 
   @Override
-  public boolean updateClusterConfig(String group, CacheConfig config, Object element,
-      ResultModel resultModel) {
+  public boolean updateGroupConfig(String group, CacheConfig config, Object element) {
     RegionConfig.Index index = (RegionConfig.Index) element;
     String regionPath = getValidRegionName(index.getFromClause(), config);
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateJndiBindingCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateJndiBindingCommand.java
@@ -180,8 +180,7 @@ public class CreateJndiBindingCommand extends SingleGfshCommand {
   }
 
   @Override
-  public boolean updateClusterConfig(String group, CacheConfig config, Object element,
-      ResultModel resultModel) {
+  public boolean updateGroupConfig(String group, CacheConfig config, Object element) {
     config.getJndiBindings().add((JndiBindingsType.JndiBinding) element);
     return true;
   }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateJndiBindingCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateJndiBindingCommand.java
@@ -180,8 +180,10 @@ public class CreateJndiBindingCommand extends SingleGfshCommand {
   }
 
   @Override
-  public void updateClusterConfig(String group, CacheConfig config, Object element) {
+  public boolean updateClusterConfig(String group, CacheConfig config, Object element,
+      ResultModel resultModel) {
     config.getJndiBindings().add((JndiBindingsType.JndiBinding) element);
+    return true;
   }
 
   public enum DATASOURCE_TYPE {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyDiskStoreCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyDiskStoreCommand.java
@@ -67,8 +67,7 @@ public class DestroyDiskStoreCommand extends SingleGfshCommand {
   }
 
   @Override
-  public boolean updateClusterConfig(String group, CacheConfig config, Object configObject,
-      ResultModel resultModel) {
+  public boolean updateGroupConfig(String group, CacheConfig config, Object configObject) {
     String diskStoreName = (String) configObject;
     CacheElement.removeElement(config.getDiskStores(), diskStoreName);
     return true;

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyDiskStoreCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyDiskStoreCommand.java
@@ -67,8 +67,10 @@ public class DestroyDiskStoreCommand extends SingleGfshCommand {
   }
 
   @Override
-  public void updateClusterConfig(String group, CacheConfig config, Object configObject) {
+  public boolean updateClusterConfig(String group, CacheConfig config, Object configObject,
+      ResultModel resultModel) {
     String diskStoreName = (String) configObject;
     CacheElement.removeElement(config.getDiskStores(), diskStoreName);
+    return true;
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyGatewayReceiverCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyGatewayReceiverCommand.java
@@ -69,8 +69,7 @@ public class DestroyGatewayReceiverCommand extends SingleGfshCommand {
   }
 
   @Override
-  public boolean updateClusterConfig(String group, CacheConfig config, Object element,
-      ResultModel resultModel) {
+  public boolean updateGroupConfig(String group, CacheConfig config, Object element) {
     if (config.getGatewayReceiver() != null) {
       config.setGatewayReceiver(null);
       return true;

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyGatewayReceiverCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyGatewayReceiverCommand.java
@@ -69,9 +69,12 @@ public class DestroyGatewayReceiverCommand extends SingleGfshCommand {
   }
 
   @Override
-  public void updateClusterConfig(String group, CacheConfig config, Object element) {
+  public boolean updateClusterConfig(String group, CacheConfig config, Object element,
+      ResultModel resultModel) {
     if (config.getGatewayReceiver() != null) {
       config.setGatewayReceiver(null);
+      return true;
     }
+    return false;
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyGatewaySenderCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyGatewaySenderCommand.java
@@ -71,8 +71,7 @@ public class DestroyGatewaySenderCommand extends SingleGfshCommand {
   }
 
   @Override
-  public boolean updateClusterConfig(String group, CacheConfig config, Object id,
-      ResultModel resultModel) {
+  public boolean updateGroupConfig(String group, CacheConfig config, Object id) {
     config.getGatewaySenders().removeIf((sender) -> sender.getId().equals(id));
     return true;
   }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyGatewaySenderCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyGatewaySenderCommand.java
@@ -71,7 +71,9 @@ public class DestroyGatewaySenderCommand extends SingleGfshCommand {
   }
 
   @Override
-  public void updateClusterConfig(String group, CacheConfig config, Object id) {
+  public boolean updateClusterConfig(String group, CacheConfig config, Object id,
+      ResultModel resultModel) {
     config.getGatewaySenders().removeIf((sender) -> sender.getId().equals(id));
+    return true;
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyIndexCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyIndexCommand.java
@@ -91,7 +91,8 @@ public class DestroyIndexCommand extends SingleGfshCommand {
   }
 
   @Override
-  public void updateClusterConfig(String group, CacheConfig config, Object element) {
+  public boolean updateClusterConfig(String group, CacheConfig config, Object element,
+      ResultModel resultModel) {
     RegionConfig.Index indexFromCommand = (RegionConfig.Index) element;
     String indexName = indexFromCommand.getName();
 
@@ -117,6 +118,7 @@ public class DestroyIndexCommand extends SingleGfshCommand {
         CacheElement.removeElement(r.getIndexes(), indexName);
       }
     }
+    return true;
   }
 
 }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyIndexCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyIndexCommand.java
@@ -91,8 +91,7 @@ public class DestroyIndexCommand extends SingleGfshCommand {
   }
 
   @Override
-  public boolean updateClusterConfig(String group, CacheConfig config, Object element,
-      ResultModel resultModel) {
+  public boolean updateGroupConfig(String group, CacheConfig config, Object element) {
     RegionConfig.Index indexFromCommand = (RegionConfig.Index) element;
     String indexName = indexFromCommand.getName();
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyJndiBindingCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyJndiBindingCommand.java
@@ -84,8 +84,7 @@ public class DestroyJndiBindingCommand extends SingleGfshCommand {
   }
 
   @Override
-  public boolean updateClusterConfig(String group, CacheConfig config, Object element,
-      ResultModel resultModel) {
+  public boolean updateGroupConfig(String group, CacheConfig config, Object element) {
     CacheElement.removeElement(config.getJndiBindings(), (String) element);
     return true;
   }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyJndiBindingCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyJndiBindingCommand.java
@@ -84,7 +84,9 @@ public class DestroyJndiBindingCommand extends SingleGfshCommand {
   }
 
   @Override
-  public void updateClusterConfig(String group, CacheConfig config, Object element) {
+  public boolean updateClusterConfig(String group, CacheConfig config, Object element,
+      ResultModel resultModel) {
     CacheElement.removeElement(config.getJndiBindings(), (String) element);
+    return true;
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/remote/CommandExecutor.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/remote/CommandExecutor.java
@@ -138,9 +138,14 @@ public class CommandExecutor {
     for (String group : groups) {
       ccService.updateCacheConfig(group, cc -> {
         try {
-          gfshCommand.updateClusterConfig(group, cc, resultModel.getConfigObject());
-          infoResultModel
-              .addLine("Changes to configuration for group '" + group + "' are persisted.");
+          if (gfshCommand.updateClusterConfig(group, cc, resultModel.getConfigObject(),
+              resultModel)) {
+            infoResultModel
+                .addLine("Changes to configuration for group '" + group + "' are persisted.");
+          } else {
+            infoResultModel
+                .addLine("No changes were made to the configuration for group '" + group + "'");
+          }
         } catch (Exception e) {
           String message = "failed to update cluster config for " + group;
           logger.error(message, e);

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/AlterAsyncEventQueueCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/AlterAsyncEventQueueCommandTest.java
@@ -24,7 +24,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
@@ -92,8 +91,6 @@ public class AlterAsyncEventQueueCommandTest {
     gfsh.executeAndAssertThat(command, "alter async-event-queue --id=test --batch-size=100")
         .statusIsError().containsOutput("Can not find an async event queue");
 
-    verify(service).lockSharedConfiguration();
-    verify(service).unlockSharedConfiguration();
   }
 
   @Test
@@ -102,8 +99,6 @@ public class AlterAsyncEventQueueCommandTest {
         "alter async-event-queue --id=test --batch-size=100 --if-exists").statusIsSuccess()
         .containsOutput("Skipping: Can not find an async event queue with id");
 
-    verify(service).lockSharedConfiguration();
-    verify(service).unlockSharedConfiguration();
   }
 
   @Test
@@ -122,8 +117,6 @@ public class AlterAsyncEventQueueCommandTest {
     gfsh.executeAndAssertThat(command, "alter async-event-queue --batch-size=100 --id=queue")
         .statusIsError().containsOutput("Can not find an async event queue");
 
-    verify(service).lockSharedConfiguration();
-    verify(service).unlockSharedConfiguration();
   }
 
   @Test
@@ -147,9 +140,6 @@ public class AlterAsyncEventQueueCommandTest {
     assertThat(element.getAttribute(BATCH_SIZE)).isEqualTo("100");
     assertThat(element.getAttribute(BATCH_TIME_INTERVAL)).isEqualTo("");
     assertThat(element.getAttribute(MAX_QUEUE_MEMORY)).isEqualTo("");
-
-    verify(service).lockSharedConfiguration();
-    verify(service).unlockSharedConfiguration();
   }
 
   @Test
@@ -168,8 +158,6 @@ public class AlterAsyncEventQueueCommandTest {
     assertThat(element.getAttribute(BATCH_TIME_INTERVAL)).isEqualTo("100");
     assertThat(element.getAttribute(MAX_QUEUE_MEMORY)).isEqualTo("");
 
-    verify(service).lockSharedConfiguration();
-    verify(service).unlockSharedConfiguration();
   }
 
   @Test
@@ -187,8 +175,6 @@ public class AlterAsyncEventQueueCommandTest {
     assertThat(element.getAttribute(BATCH_TIME_INTERVAL)).isEqualTo("");
     assertThat(element.getAttribute(MAXIMUM_QUEUE_MEMORY)).isEqualTo("100");
 
-    verify(service).lockSharedConfiguration();
-    verify(service).unlockSharedConfiguration();
   }
 
   @Test
@@ -217,8 +203,6 @@ public class AlterAsyncEventQueueCommandTest {
     assertThat(element.getAttribute(BATCH_TIME_INTERVAL)).isEqualTo("");
     assertThat(element.getAttribute(MAX_QUEUE_MEMORY)).isEqualTo("");
 
-    verify(service).lockSharedConfiguration();
-    verify(service).unlockSharedConfiguration();
   }
 
   private Element findAsyncEventQueueElement(String xml, int index) throws Exception {

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ConfigurePDXCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ConfigurePDXCommandTest.java
@@ -97,7 +97,7 @@ public class ConfigurePDXCommandTest {
         .statusIsError().containsOutput("Error while processing command")
         .containsOutput("Can't create ReflectionBasedAutoSerializer.");
 
-    verify(command, times(0)).updateClusterConfig(any(), any(), any(), any());
+    verify(command, times(0)).updateGroupConfig(any(), any(), any());
   }
 
   @Test
@@ -109,7 +109,7 @@ public class ConfigurePDXCommandTest {
         .statusIsError().containsOutput(
             "The autoserializer cannot support both portable and non-portable classes at the same time.");
 
-    verify(command, times(0)).updateClusterConfig(any(), any(), any(), any());
+    verify(command, times(0)).updateGroupConfig(any(), any(), any());
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ConfigurePDXCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ConfigurePDXCommandTest.java
@@ -97,7 +97,7 @@ public class ConfigurePDXCommandTest {
         .statusIsError().containsOutput("Error while processing command")
         .containsOutput("Can't create ReflectionBasedAutoSerializer.");
 
-    verify(command, times(0)).updateClusterConfig(any(), any(), any());
+    verify(command, times(0)).updateClusterConfig(any(), any(), any(), any());
   }
 
   @Test
@@ -109,7 +109,7 @@ public class ConfigurePDXCommandTest {
         .statusIsError().containsOutput(
             "The autoserializer cannot support both portable and non-portable classes at the same time.");
 
-    verify(command, times(0)).updateClusterConfig(any(), any(), any());
+    verify(command, times(0)).updateClusterConfig(any(), any(), any(), any());
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateDataSourceCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateDataSourceCommandTest.java
@@ -231,7 +231,7 @@ public class CreateDataSourceCommandTest {
         .containsOutput("Changes to configuration for group 'cluster' are persisted.");
 
     verify(clusterConfigService).updateCacheConfig(any(), any());
-    verify(command).updateClusterConfig(eq("cluster"), eq(cacheConfig), any(), any());
+    verify(command).updateGroupConfig(eq("cluster"), eq(cacheConfig), any());
   }
 
   @Test
@@ -305,7 +305,7 @@ public class CreateDataSourceCommandTest {
             "Tried creating jndi binding \"name\" on \"server1\"");
 
     verify(clusterConfigService).updateCacheConfig(any(), any());
-    verify(command).updateClusterConfig(eq("cluster"), eq(cacheConfig), any(), any());
+    verify(command).updateGroupConfig(eq("cluster"), eq(cacheConfig), any());
 
     ArgumentCaptor<CreateJndiBindingFunction> function =
         ArgumentCaptor.forClass(CreateJndiBindingFunction.class);

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateDataSourceCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateDataSourceCommandTest.java
@@ -231,7 +231,7 @@ public class CreateDataSourceCommandTest {
         .containsOutput("Changes to configuration for group 'cluster' are persisted.");
 
     verify(clusterConfigService).updateCacheConfig(any(), any());
-    verify(command).updateClusterConfig(eq("cluster"), eq(cacheConfig), any());
+    verify(command).updateClusterConfig(eq("cluster"), eq(cacheConfig), any(), any());
   }
 
   @Test
@@ -305,7 +305,7 @@ public class CreateDataSourceCommandTest {
             "Tried creating jndi binding \"name\" on \"server1\"");
 
     verify(clusterConfigService).updateCacheConfig(any(), any());
-    verify(command).updateClusterConfig(eq("cluster"), eq(cacheConfig), any());
+    verify(command).updateClusterConfig(eq("cluster"), eq(cacheConfig), any(), any());
 
     ArgumentCaptor<CreateJndiBindingFunction> function =
         ArgumentCaptor.forClass(CreateJndiBindingFunction.class);

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateDefinedIndexesCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateDefinedIndexesCommandTest.java
@@ -114,7 +114,7 @@ public class CreateDefinedIndexesCommandTest {
     result = gfshParser.executeCommandWithInstance(command, "create defined indexes");
 
     assertThat(result.getStatus()).isEqualTo(OK);
-    verify(command, Mockito.times(0)).updateClusterConfig(any(), any(), any());
+    verify(command, Mockito.times(0)).updateClusterConfig(any(), any(), any(), any());
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateDefinedIndexesCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateDefinedIndexesCommandTest.java
@@ -114,7 +114,7 @@ public class CreateDefinedIndexesCommandTest {
     result = gfshParser.executeCommandWithInstance(command, "create defined indexes");
 
     assertThat(result.getStatus()).isEqualTo(OK);
-    verify(command, Mockito.times(0)).updateClusterConfig(any(), any(), any(), any());
+    verify(command, Mockito.times(0)).updateGroupConfig(any(), any(), any());
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateJndiBindingCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateJndiBindingCommandTest.java
@@ -224,7 +224,7 @@ public class CreateJndiBindingCommandTest {
         .containsOutput("Changes to configuration for group 'cluster' are persisted.");
 
     verify(clusterConfigService).updateCacheConfig(any(), any());
-    verify(command).updateClusterConfig(eq("cluster"), eq(cacheConfig), any());
+    verify(command).updateClusterConfig(eq("cluster"), eq(cacheConfig), any(), any());
   }
 
   @Test
@@ -297,7 +297,7 @@ public class CreateJndiBindingCommandTest {
             "Tried creating jndi binding \"name\" on \"server1\"");
 
     verify(clusterConfigService).updateCacheConfig(any(), any());
-    verify(command).updateClusterConfig(eq("cluster"), eq(cacheConfig), any());
+    verify(command).updateClusterConfig(eq("cluster"), eq(cacheConfig), any(), any());
 
     ArgumentCaptor<CreateJndiBindingFunction> function =
         ArgumentCaptor.forClass(CreateJndiBindingFunction.class);

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateJndiBindingCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateJndiBindingCommandTest.java
@@ -224,7 +224,7 @@ public class CreateJndiBindingCommandTest {
         .containsOutput("Changes to configuration for group 'cluster' are persisted.");
 
     verify(clusterConfigService).updateCacheConfig(any(), any());
-    verify(command).updateClusterConfig(eq("cluster"), eq(cacheConfig), any(), any());
+    verify(command).updateGroupConfig(eq("cluster"), eq(cacheConfig), any());
   }
 
   @Test
@@ -297,7 +297,7 @@ public class CreateJndiBindingCommandTest {
             "Tried creating jndi binding \"name\" on \"server1\"");
 
     verify(clusterConfigService).updateCacheConfig(any(), any());
-    verify(command).updateClusterConfig(eq("cluster"), eq(cacheConfig), any(), any());
+    verify(command).updateGroupConfig(eq("cluster"), eq(cacheConfig), any());
 
     ArgumentCaptor<CreateJndiBindingFunction> function =
         ArgumentCaptor.forClass(CreateJndiBindingFunction.class);

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DestroyJndiBindingCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DestroyJndiBindingCommandTest.java
@@ -133,7 +133,7 @@ public class DestroyJndiBindingCommandTest {
         .containsOutput("Changes to configuration for group 'cluster' are persisted.");
 
     verify(ccService).updateCacheConfig(any(), any());
-    verify(command).updateClusterConfig(eq("cluster"), eq(cacheConfig), any(), any());
+    verify(command).updateGroupConfig(eq("cluster"), eq(cacheConfig), any());
   }
 
   @Test
@@ -195,7 +195,7 @@ public class DestroyJndiBindingCommandTest {
         .tableHasColumnOnlyWithValues("Message", "Jndi binding \"name\" destroyed on \"server1\"");
 
     assertThat(cacheConfig.getJndiBindings().isEmpty()).isTrue();
-    verify(command).updateClusterConfig(eq("cluster"), eq(cacheConfig), any(), any());
+    verify(command).updateGroupConfig(eq("cluster"), eq(cacheConfig), any());
 
     ArgumentCaptor<DestroyJndiBindingFunction> function =
         ArgumentCaptor.forClass(DestroyJndiBindingFunction.class);

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DestroyJndiBindingCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DestroyJndiBindingCommandTest.java
@@ -133,7 +133,7 @@ public class DestroyJndiBindingCommandTest {
         .containsOutput("Changes to configuration for group 'cluster' are persisted.");
 
     verify(ccService).updateCacheConfig(any(), any());
-    verify(command).updateClusterConfig(eq("cluster"), eq(cacheConfig), any());
+    verify(command).updateClusterConfig(eq("cluster"), eq(cacheConfig), any(), any());
   }
 
   @Test
@@ -195,7 +195,7 @@ public class DestroyJndiBindingCommandTest {
         .tableHasColumnOnlyWithValues("Message", "Jndi binding \"name\" destroyed on \"server1\"");
 
     assertThat(cacheConfig.getJndiBindings().isEmpty()).isTrue();
-    verify(command).updateClusterConfig(eq("cluster"), eq(cacheConfig), any());
+    verify(command).updateClusterConfig(eq("cluster"), eq(cacheConfig), any(), any());
 
     ArgumentCaptor<DestroyJndiBindingFunction> function =
         ArgumentCaptor.forClass(DestroyJndiBindingFunction.class);


### PR DESCRIPTION
The following changes were required to implement the configuration updates for a command that does not allow specifying a `--group` option.
- Rename `SingleGfshCommand.updateClusterConfig` to `updateGroupConfig`, and change signature to return `boolean` instead of `void`.
- Add method `SingleGfshCommand.updateAllConfigs` to support configuration updates by commands that don't recognize groups.

This PR includes the proposed changes from https://github.com/apache/geode/pull/2825, with the exception of adding a `ResultModel` argument to `updateClusterConfig`, which was found to not be needed.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
