### PR TITLE
GEODE-6053: Parameterized Queries fixed

### DIFF
--- a/geode-assembly/src/integrationTest/resources/assembly_content.txt
+++ b/geode-assembly/src/integrationTest/resources/assembly_content.txt
@@ -531,6 +531,12 @@ javadoc/org/apache/geode/cache/query/data/PortfolioData.html
 javadoc/org/apache/geode/cache/query/data/PortfolioNoDS.html
 javadoc/org/apache/geode/cache/query/data/PortfolioPdx.Day.html
 javadoc/org/apache/geode/cache/query/data/PortfolioPdx.html
+javadoc/org/apache/geode/cache/query/data/Limit.html
+javadoc/org/apache/geode/cache/query/data/PortfolioMetric.html
+javadoc/org/apache/geode/cache/query/data/PortfolioWithMetrics.html
+javadoc/org/apache/geode/cache/query/data/QuerySupportService.QueryContext.html
+javadoc/org/apache/geode/cache/query/data/QuerySupportService.html
+javadoc/org/apache/geode/cache/query/data/TempLimit.html
 javadoc/org/apache/geode/cache/query/data/Position.html
 javadoc/org/apache/geode/cache/query/data/PositionNoDS.html
 javadoc/org/apache/geode/cache/query/data/PositionPdx.html

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/functional/IndexUsageInNestedQueryWithParamsJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/functional/IndexUsageInNestedQueryWithParamsJUnitTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache.query.functional;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.query.CacheUtils;
+import org.apache.geode.cache.query.Query;
+import org.apache.geode.cache.query.QueryService;
+import org.apache.geode.cache.query.SelectResults;
+import org.apache.geode.cache.query.data.Limit;
+import org.apache.geode.cache.query.data.PortfolioMetric;
+import org.apache.geode.cache.query.data.PortfolioWithMetrics;
+import org.apache.geode.cache.query.data.QuerySupportService;
+import org.apache.geode.cache.query.data.TempLimit;
+import org.apache.geode.test.junit.categories.OQLIndexTest;
+
+@Category({OQLIndexTest.class})
+public class IndexUsageInNestedQueryWithParamsJUnitTest {
+  @Before
+  public void setUp() throws java.lang.Exception {
+    CacheUtils.startCache();
+    Region portfolioRegion = CacheUtils.createRegion("portfolio", PortfolioWithMetrics.class);
+    Region tempLimitRegion = CacheUtils.createRegion("TempLimit", TempLimit.class);
+    QueryService queryService = CacheUtils.getQueryService();
+    queryService.defineIndex("portfolioIdIndex", "p.id", "/portfolio p");
+    queryService.defineIndex("temporaryOriginalLimitIdIdx", "tl.originalId", "/TempLimit tl");
+    queryService.createDefinedIndexes();
+    PortfolioWithMetrics p = new PortfolioWithMetrics(1L);
+    p.setMetrics(Arrays
+        .asList(new PortfolioMetric(Arrays.asList(new Limit(11L), new Limit(12L))),
+            new PortfolioMetric(Arrays.asList(new Limit(21L), new Limit(22L)))));
+    portfolioRegion.put(p.getId(), p);
+    tempLimitRegion.put(91L, new TempLimit(91L, 12L, new Limit(91L)));
+    tempLimitRegion.put(92L, new TempLimit(92L, 21L, new Limit(92L)));
+  }
+
+  @After
+  public void tearDown() throws java.lang.Exception {
+    CacheUtils.closeCache();
+  }
+
+  @Test
+  public void testingJPMCNestedQueryFailure()
+      throws Exception {
+
+    QueryService queryService = CacheUtils.getQueryService();
+    Query query = queryService.newQuery(
+        "<TRACE>select l.id from /portfolio p, p.metrics m, ($1).getLimitsAndTempLimits(m) l WHERE p.id IN SET(1L,2L)");
+    QuerySupportService querySupportService = new QuerySupportService(CacheUtils.getCache());
+    Object[] params = new Object[] {querySupportService.createQueryContext()};
+    SelectResults result = (SelectResults) query.execute(params);
+    assertEquals("The query returned a wrong result set = " + result.asList(), true,
+        result.containsAll(new ArrayList<>(Arrays.asList(21L, 22L, 92L, 12L, 11L, 91L))));
+  }
+
+}

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/CompiledID.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/CompiledID.java
@@ -61,7 +61,10 @@ public class CompiledID extends AbstractCompiledValue {
     return _id;
   }
 
-
+  @Override
+  public boolean hasIdentifierAtLeafNode() {
+    return true;
+  }
 
   public int getType() {
     return Identifier;

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/CompiledIndexOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/CompiledIndexOperation.java
@@ -162,6 +162,15 @@ public class CompiledIndexOperation extends AbstractCompiledValue implements Map
     return receiver;
   }
 
+  @Override
+  public boolean hasIdentifierAtLeafNode() {
+    if (this.receiver.getType() == Identifier) {
+      return true;
+    } else {
+      return this.receiver.hasIdentifierAtLeafNode();
+    }
+  }
+
   public CompiledValue getExpression() {
     return indexExpr;
   }

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/CompiledOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/CompiledOperation.java
@@ -91,6 +91,15 @@ public class CompiledOperation extends AbstractCompiledValue {
   }
 
   @Override
+  public boolean hasIdentifierAtLeafNode() {
+    if (this.receiver.getType() == Identifier) {
+      return true;
+    } else {
+      return this.receiver.hasIdentifierAtLeafNode();
+    }
+  }
+
+  @Override
   public CompiledValue getReceiver() {
     return this.getReceiver(null);
   }

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/CompiledPath.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/CompiledPath.java
@@ -164,6 +164,15 @@ public class CompiledPath extends AbstractCompiledValue {
   }
 
   @Override
+  public boolean hasIdentifierAtLeafNode() {
+    if (this._receiver.getType() == Identifier) {
+      return true;
+    } else {
+      return this._receiver.hasIdentifierAtLeafNode();
+    }
+  }
+
+  @Override
   public void generateCanonicalizedExpression(StringBuilder clauseBuffer, ExecutionContext context)
       throws AmbiguousNameException, TypeMismatchException, NameResolutionException {
     // Asif: Canonicalize the tail ID. If the tail ID contains

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/CompiledValue.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/CompiledValue.java
@@ -141,4 +141,8 @@ public interface CompiledValue {
   }
 
   CompiledValue getReceiver();
+
+  default boolean hasIdentifierAtLeafNode() {
+    return false;
+  }
 }

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/QueryUtils.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/QueryUtils.java
@@ -722,13 +722,17 @@ public class QueryUtils {
       } else if (currentLevel.getCmpIteratorDefn().getCollectionExpr()
           .getType() == OQLLexerTokenTypes.LITERAL_select) {
         useDerivedResults = false;
-      } else {
-        key = getCompiledIdFromPath(currentLevel.getCmpIteratorDefn().getCollectionExpr()).getId()
-            + ':' + currentLevel.getDefinition();
       }
       SelectResults c;
-      if (useDerivedResults && derivedResults != null && derivedResults.containsKey(key)) {
-        c = derivedResults.get(key);
+      CompiledValue path = currentLevel.getCmpIteratorDefn().getCollectionExpr();
+      if (useDerivedResults && derivedResults != null && path.hasIdentifierAtLeafNode()) {
+        key = getCompiledIdFromPath(path).getId()
+            + ':' + currentLevel.getDefinition();
+        if (derivedResults.containsKey(key)) {
+          c = derivedResults.get(key);
+        } else {
+          c = currentLevel.evaluateCollection(context);
+        }
       } else {
         c = currentLevel.evaluateCollection(context);
       }

--- a/geode-core/src/test/java/org/apache/geode/cache/query/internal/AbstractCompiledValueTestJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/internal/AbstractCompiledValueTestJUnitTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache.query.internal;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.apache.geode.cache.query.internal.types.CollectionTypeImpl;
+
+@RunWith(JUnitParamsRunner.class)
+public class AbstractCompiledValueTestJUnitTest {
+
+  private CompiledValue[] getCompiledValuesWhichDoNotImplementGetReceiver() {
+    CompiledValue compiledValue1 = new CompiledID("testString");
+    CompiledValue compiledValue2 = new CompiledID("testString");
+    return new CompiledValue[] {
+        new CompiledAddition(compiledValue1, compiledValue2, 13),
+        new CompiledAggregateFunction(compiledValue1, 13),
+        new CompiledAddition(compiledValue1, compiledValue2, 13),
+        new CompiledBindArgument(1),
+        new CompiledComparison(compiledValue1, compiledValue2, 13),
+        new CompiledConstruction(Object.class, new ArrayList()),
+        new CompiledDivision(compiledValue1, compiledValue2, 13),
+        new CompiledFunction(new CompiledValue[] {compiledValue1, compiledValue2}, 13),
+        new CompiledGroupBySelect(true, true, compiledValue1, new ArrayList(), new ArrayList(),
+            new ArrayList<>(), compiledValue2, new ArrayList<>(), new ArrayList<>(),
+            new LinkedHashMap<>()),
+        new CompiledIn(compiledValue1, compiledValue2),
+        new CompiledIteratorDef("test", new CollectionTypeImpl(), compiledValue1),
+        new CompiledJunction(new CompiledValue[] {compiledValue1, compiledValue2}, 89),
+        new CompiledLike(compiledValue1, compiledValue2),
+        new CompiledLiteral(compiledValue1),
+        new CompiledMod(compiledValue1, compiledValue2, 13),
+        new CompiledMultiplication(compiledValue1, compiledValue2, 13),
+        new CompiledNegation(compiledValue1),
+        new CompiledRegion("test"),
+        new CompiledSortCriterion(true, compiledValue1),
+        new CompiledSubtraction(compiledValue1, compiledValue2, 13),
+        new CompiledUnaryMinus(compiledValue1),
+        new CompiledUndefined(compiledValue1, true),
+        new CompositeGroupJunction(13, compiledValue1),
+        new GroupJunction(13, new RuntimeIterator[] {}, true,
+            new CompiledValue[] {compiledValue1, compiledValue2})
+    };
+  }
+
+  private CompiledValue[] getCompiledValuesWhichImplementGetReceiver() {
+    CompiledValue compiledValue1 = new CompiledID("testString");
+    CompiledValue compiledValue2 = new CompiledID("testString");
+    return new CompiledValue[] {
+        new CompiledID("testString"),
+        new CompiledIndexOperation(compiledValue1, compiledValue2),
+        new CompiledOperation(compiledValue1, "test", new ArrayList()),
+        new CompiledPath(compiledValue1, "test")
+    };
+  }
+
+  @Test
+  @Parameters(method = "getCompiledValuesWhichDoNotImplementGetReceiver")
+  public void whenGetReceiverIsNotImplementedThenHasIdentifierAtLeafMustReturnFalse(
+      CompiledValue compiledValue) {
+    assertFalse(compiledValue.hasIdentifierAtLeafNode());
+  }
+
+  @Test
+  @Parameters(method = "getCompiledValuesWhichImplementGetReceiver")
+  public void whenGetReceiverIsImplementedThenHasIdentifierAtLeafMustReturnTrue(
+      CompiledValue compiledValue) {
+    assertTrue(compiledValue.hasIdentifierAtLeafNode());
+  }
+
+  @Test
+  public void whenLeafIsIdentifierAtTheLeafThenHasIdentifierAtLeafMustReturnTrue() {
+    CompiledValue compiledValue1 = new CompiledID("testString");
+    CompiledValue compiledValue2 = new CompiledID("testString");
+    CompiledIndexOperation compiledIndexOperation =
+        new CompiledIndexOperation(compiledValue1, compiledValue2);
+    CompiledPath compiledPath = new CompiledPath(compiledIndexOperation, "test");
+    assertTrue(compiledPath.hasIdentifierAtLeafNode());
+  }
+
+  @Test
+  public void whenLeafIsNotIndentifierThenHasIdentifierAtLeafMustReturnFalse() {
+    CompiledValue compiledValue1 = new CompiledBindArgument(1);
+    CompiledValue compiledValue2 = new CompiledBindArgument(1);
+    CompiledIndexOperation compiledIndexOperation =
+        new CompiledIndexOperation(compiledValue1, compiledValue2);
+    CompiledPath compiledPath = new CompiledPath(compiledIndexOperation, "test");
+    assertFalse(compiledPath.hasIdentifierAtLeafNode());
+  }
+
+}

--- a/geode-junit/src/main/java/org/apache/geode/cache/query/data/Limit.java
+++ b/geode-junit/src/main/java/org/apache/geode/cache/query/data/Limit.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache.query.data;
+
+import java.io.Serializable;
+
+public class Limit implements Serializable {
+  long id;
+
+  public long getId() {
+    return id;
+  }
+
+  public void setId(long id) {
+    this.id = id;
+  }
+
+  public Limit(long id) {
+    this.id = id;
+  }
+
+  @Override
+  public String toString() {
+    return "Limit{" +
+        "id=" + id +
+        '}';
+  }
+}

--- a/geode-junit/src/main/java/org/apache/geode/cache/query/data/PortfolioMetric.java
+++ b/geode-junit/src/main/java/org/apache/geode/cache/query/data/PortfolioMetric.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache.query.data;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PortfolioMetric {
+  List<Limit> limits = new ArrayList<>();
+
+  public List<Limit> getLimits() {
+    return limits;
+  }
+
+  public void setLimits(List<Limit> limits) {
+    this.limits = limits;
+  }
+
+  public PortfolioMetric(List<Limit> limits) {
+    this.limits = limits;
+  }
+
+  @Override
+  public String toString() {
+    return "PortfolioMetric{" +
+        "limits=" + limits +
+        '}';
+  }
+}

--- a/geode-junit/src/main/java/org/apache/geode/cache/query/data/PortfolioWithMetrics.java
+++ b/geode-junit/src/main/java/org/apache/geode/cache/query/data/PortfolioWithMetrics.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache.query.data;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class PortfolioWithMetrics implements Serializable {
+  long id;
+  Collection<PortfolioMetric> metrics = new ArrayList<>();
+
+  public long getId() {
+    return id;
+  }
+
+  public void setId(long id) {
+    this.id = id;
+  }
+
+  public Collection<PortfolioMetric> getMetrics() {
+    return metrics;
+  }
+
+  public void setMetrics(Collection<PortfolioMetric> metrics) {
+    this.metrics = metrics;
+  }
+
+  public PortfolioWithMetrics(long l) {
+    this.id = l;
+  }
+
+  public PortfolioWithMetrics(String p1, String s, String p11) {
+
+  }
+
+  @Override
+  public String toString() {
+    return "Portfolio{" +
+        "id=" + id +
+        ", metrics=" + metrics +
+        '}';
+  }
+}

--- a/geode-junit/src/main/java/org/apache/geode/cache/query/data/QuerySupportService.java
+++ b/geode-junit/src/main/java/org/apache/geode/cache/query/data/QuerySupportService.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache.query.data;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.query.Query;
+import org.apache.geode.cache.query.SelectResults;
+
+public class QuerySupportService {
+
+  private Cache gemfireCache;
+
+  public QuerySupportService(Cache gemfireCache) {
+    this.gemfireCache = gemfireCache;
+  }
+
+  public QueryContext createQueryContext() {
+    return new QueryContext(
+        "<TRACE>select distinct tl from /TempLimit tl where tl.originalId in $1");
+  }
+
+  public class QueryContext {
+    private final ExecutorService executorService = Executors.newSingleThreadExecutor();
+    private final Query query;
+
+    private QueryContext(final String queryString) {
+      try {
+        this.query = executorService
+            .submit(() -> gemfireCache.getQueryService().newQuery(queryString)).get();
+      } catch (InterruptedException e) {
+        throw new RuntimeException("Thread was unexpectedly interrupted", e);
+      } catch (ExecutionException e) {
+        throw new RuntimeException("Could not create query context", e);
+      }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Iterable<Limit> getTempLimits(final Set<Long> originalLimitIds) {
+      final Set<TempLimit> infos;
+      final List<Limit> tempLimits = new ArrayList<>();
+      System.out.println("###################### originalLimitIds: " + originalLimitIds);
+
+      try {
+        infos = executorService.submit(
+            () -> ((SelectResults<TempLimit>) query.execute(new Object[] {originalLimitIds}))
+                .asSet())
+            .get();
+      } catch (InterruptedException e) {
+        throw new RuntimeException("Thread was unexpectedly interrupted", e);
+      } catch (ExecutionException e) {
+        throw new RuntimeException("Could not query for temp limits", e);
+      }
+
+      if (infos != null) {
+        for (final TempLimit info : infos) {
+          if (info != null) {
+            final Limit tempLimit = info.getLimit();
+            if (tempLimit != null) {
+              tempLimits.add(tempLimit);
+            }
+          }
+        }
+      }
+      return tempLimits;
+    }
+
+    public Collection<Limit> getLimitsAndTempLimits(final PortfolioMetric portfolioMetric) {
+      final Map<Long, Limit> limits = getLimits(portfolioMetric);
+      return Lists.newArrayList(Iterables.concat(limits.values(), getTempLimits(limits.keySet())));
+    }
+
+    private Map<Long, Limit> getLimits(final PortfolioMetric portfolioMetric) {
+      final Map<Long, Limit> limits = new HashMap<Long, Limit>();
+      if (portfolioMetric != null) {
+        for (final Limit limit : portfolioMetric.limits) {
+          if (limit != null) {
+            limits.put(limit.id, limit);
+          }
+        }
+      }
+      return limits;
+    }
+  }
+}

--- a/geode-junit/src/main/java/org/apache/geode/cache/query/data/TempLimit.java
+++ b/geode-junit/src/main/java/org/apache/geode/cache/query/data/TempLimit.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache.query.data;
+
+import java.io.Serializable;
+
+public class TempLimit implements Serializable {
+  long id;
+  long originalId; // linked back to Limit->id
+  Limit limit;
+
+  public long getOriginalId() {
+    return originalId;
+  }
+
+  public long getId() {
+    return id;
+  }
+
+  public void setId(long id) {
+    this.id = id;
+  }
+
+  public Limit getLimit() {
+    return limit;
+  }
+
+  public TempLimit setOriginalId(long originalId) {
+    this.originalId = originalId;
+    return this;
+  }
+
+  public TempLimit setLimit(Limit limit) {
+    this.limit = limit;
+    return this;
+  }
+
+  public TempLimit(long id, long originalId, Limit limit) {
+    this.id = id;
+    this.originalId = originalId;
+    this.limit = limit;
+  }
+
+  @Override
+  public String toString() {
+    return "Limit{" +
+        "id=" + id +
+        '}';
+  }
+}


### PR DESCRIPTION
	* Parameterized queries were throwing UnsupportedOperationExceptions.
	* This was because of trying to pre-compute values for join optimization.
	* When the query was parameterized it is not possible to compute these values and hence these exceptions are thrown
	* The fix was to prevent this computation when it is not needed or not possible.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
