### PR TITLE
GEODE-5074 REST dev client should not access or modify internal regions

### DIFF
--- a/geode-assembly/src/integrationTest/java/org/apache/geode/rest/internal/web/RestServersIntegrationTest.java
+++ b/geode-assembly/src/integrationTest/java/org/apache/geode/rest/internal/web/RestServersIntegrationTest.java
@@ -62,6 +62,13 @@ public class RestServersIntegrationTest {
   }
 
   @Test
+  public void testGetOnInternalRegion() {
+    assertResponse(
+        restClient.doGet("/__PR", null, null))
+            .hasStatusCode(HttpStatus.SC_NOT_FOUND);
+  }
+
+  @Test
   public void testServerStartedOnDefaultPort() throws Exception {
     JsonNode jsonArray = assertResponse(restClient.doGet("/servers", null, null))
         .hasStatusCode(HttpStatus.SC_OK).getJsonObject();

--- a/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/controllers/AbstractBaseController.java
+++ b/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/controllers/AbstractBaseController.java
@@ -62,6 +62,7 @@ import org.apache.geode.distributed.LeaseExpiredException;
 import org.apache.geode.distributed.internal.ClusterDistributionManager;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.InternalCacheForClientAccess;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.pdx.JSONFormatter;
 import org.apache.geode.pdx.JSONFormatterException;
@@ -110,6 +111,12 @@ public abstract class AbstractBaseController implements InitializingBean {
   }
 
   protected InternalCache getCache() {
+    InternalCache cache = cacheProvider.getCacheForClientAccess();
+    Assert.state(cache != null, "The Gemfire Cache reference was not properly initialized");
+    return cache;
+  }
+
+  protected InternalCache getCacheForServerAccess() {
     InternalCache cache = cacheProvider.getInternalCache();
     Assert.state(cache != null, "The Gemfire Cache reference was not properly initialized");
     return cache;
@@ -402,7 +409,7 @@ public abstract class AbstractBaseController implements InitializingBean {
   }
 
   Region<String, String> getQueryStore(final String namePath) {
-    return ValidationUtils.returnValueThrowOnNull(getCache().<String, String>getRegion(namePath),
+    return ValidationUtils.returnValueThrowOnNull(getCacheForServerAccess().<String, String>getRegion(namePath),
         new GemfireRestException(String.format("Query store does not exist!", namePath)));
   }
 

--- a/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/controllers/CommonCrudController.java
+++ b/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/controllers/CommonCrudController.java
@@ -15,6 +15,7 @@
 package org.apache.geode.rest.internal.web.controllers;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -38,6 +39,7 @@ import org.apache.geode.cache.execute.Execution;
 import org.apache.geode.cache.execute.FunctionException;
 import org.apache.geode.cache.execute.FunctionService;
 import org.apache.geode.cache.execute.ResultCollector;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.execute.util.FindRestEnabledServersFunction;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.rest.internal.web.controllers.support.RestServersResultCollector;
@@ -73,7 +75,12 @@ public abstract class CommonCrudController extends AbstractBaseController {
     logger.debug("Listing all resources (Regions) in Geode...");
     final HttpHeaders headers = new HttpHeaders();
     headers.setLocation(toUri());
-    final Set<Region<?, ?>> regions = getCache().rootRegions();
+    final Set<Region<?, ?>> regions = new HashSet<>();
+    for (InternalRegion region : getCache().getApplicationRegions()) {
+      if (region instanceof Region) {
+        regions.add(region);
+      }
+    } ;
     String listRegionsAsJson = JSONUtils.formulateJsonForListRegions(regions, "regions");
     return new ResponseEntity<>(listRegionsAsJson, headers, HttpStatus.OK);
   }

--- a/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/controllers/QueryAccessController.java
+++ b/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/controllers/QueryAccessController.java
@@ -244,7 +244,7 @@ public class QueryAccessController extends AbstractBaseController {
       Query compiledQuery = compiledQueries.get(queryId);
       if (compiledQuery == null) {
         // This is first time the query is seen by this server.
-        final String oql = getValue(PARAMETERIZED_QUERIES_REGION, queryId, false);
+        final String oql = getQueryStore(PARAMETERIZED_QUERIES_REGION).get(queryId);
 
         ValidationUtils.returnValueThrowOnNull(oql, new ResourceNotFoundException(
             String.format("No Query with ID (%1$s) was found!", queryId)));

--- a/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/controllers/support/CacheProvider.java
+++ b/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/controllers/support/CacheProvider.java
@@ -14,9 +14,12 @@
  */
 package org.apache.geode.rest.internal.web.controllers.support;
 
+import org.apache.geode.cache.Cache;
 import org.apache.geode.internal.cache.InternalCache;
 
 public interface CacheProvider {
 
   InternalCache getInternalCache();
+
+  InternalCache getCacheForClientAccess();
 }

--- a/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/controllers/support/CacheProviderImpl.java
+++ b/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/controllers/support/CacheProviderImpl.java
@@ -16,8 +16,10 @@ package org.apache.geode.rest.internal.web.controllers.support;
 
 import org.springframework.stereotype.Component;
 
+import org.apache.geode.cache.Cache;
 import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.InternalCacheForClientAccess;
 
 @Component("cacheProvider")
 public class CacheProviderImpl implements CacheProvider {
@@ -25,5 +27,14 @@ public class CacheProviderImpl implements CacheProvider {
   @Override
   public InternalCache getInternalCache() {
     return GemFireCacheImpl.getExisting();
+  }
+
+  @Override
+  public InternalCache getCacheForClientAccess() {
+    InternalCache result = getInternalCache();
+    if (result == null) {
+      return null;
+    }
+    return new InternalCacheForClientAccess(result);
   }
 }


### PR DESCRIPTION
The Developer REST API was accessing a raw cache for all operations.
I've switched it to use a filtered InternalCacheForClientAccess cache
instead for most operations.  It needed to have the unfiltered cache in
order to find the __ParameterizedQueries__ region for accessing saved
queries.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
