### PR TITLE
GEODE-6059: Get ahold of origin/develop in StressNewTests

### DIFF
--- a/ci/scripts/repeat-new-tests.sh
+++ b/ci/scripts/repeat-new-tests.sh
@@ -29,15 +29,20 @@ SCRIPTDIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
 function changes_for_path() {
   cd geode
-  local path="$1" # only expand once in the line below
-  git diff --name-only HEAD $(git merge-base HEAD origin/develop) -- $path
+  local path; path="$1" # only expand once in the line below
+  local merge_base; merge_base=$(git merge-base HEAD origin/develop) || exit $?
+  git diff --name-only HEAD $merge_base -- $path
 }
 
-UNIT_TEST_CHANGES=$(changes_for_path '*/src/test/java')
-INTEGRATION_TEST_CHANGES=$(changes_for_path '*/src/integrationTest/java')
-DISTRIBUTED_TEST_CHANGES=$(changes_for_path '*/src/distributedTest/java')
-ACCEPTANCE_TEST_CHANGES=$(changes_for_path '*/src/acceptanceTest/java')
-UPGRADE_TEST_CHANGES=$(changes_for_path '*/src/upgradeTest/java')
+cd geode
+git fetch https://github.com/apache/geode.git develop:origin/develop
+cd ..
+
+UNIT_TEST_CHANGES=$(changes_for_path '*/src/test/java') || exit $?
+INTEGRATION_TEST_CHANGES=$(changes_for_path '*/src/integrationTest/java') || exit $?
+DISTRIBUTED_TEST_CHANGES=$(changes_for_path '*/src/distributedTest/java') || exit $?
+ACCEPTANCE_TEST_CHANGES=$(changes_for_path '*/src/acceptanceTest/java') || exit $?
+UPGRADE_TEST_CHANGES=$(changes_for_path '*/src/upgradeTest/java') || exit $?
 
 CHANGED_FILES_ARRAY=( $UNIT_TEST_CHANGES $INTEGRATION_TEST_CHANGES $DISTRIBUTED_TEST_CHANGES $ACCEPTANCE_TEST_CHANGES $UPGRADE_TEST_CHANGES )
 NUM_CHANGED_FILES=${#CHANGED_FILES_ARRAY[@]}


### PR DESCRIPTION
This job was failing because concourse was no longer creating an origin
remote in the git repo.

Also, changing the script to fail if there are issues with some of
commands we are executing in $().

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
