### PR TITLE
GEODE-6013: Use expected initial image requester's rvv information

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/PersistentRegionRecoveryDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/PersistentRegionRecoveryDUnitTest.java
@@ -29,6 +29,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.apache.geode.cache.DiskStore;
 import org.apache.geode.cache.DiskStoreFactory;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionFactory;
@@ -407,6 +408,91 @@ public class PersistentRegionRecoveryDUnitTest extends JUnit4DistributedTestCase
       assertThat(region.get("KEY-1")).isEqualTo("VALUE-1");
       assertThat(region.get("KEY-2")).isEqualTo("VALUE-2");
     });
+  }
+
+  @Test
+  public void testRecoveryFromBackupAndRequestingDeltaGiiDoesFullGiiIfTombstoneGCVersionDiffers()
+      throws Exception {
+    getBlackboard().initBlackboard();
+    vm1.invoke(() -> cacheRule.createCache());
+
+    vm0.invoke(() -> createAsyncDiskRegion(true));
+    vm0.invoke(() -> {
+      Region<String, String> region = cacheRule.getCache().getRegion(regionName);
+      region.put("KEY-1", "VALUE-1");
+      region.put("KEY-2", "VALUE-2");
+      flushAsyncDiskRegion();
+    });
+
+    vm1.invoke(() -> createAsyncDiskRegion(true));
+    vm1.invoke(() -> {
+      Region<String, String> region = cacheRule.getCache().getRegion(regionName);
+      region.put("KEY-1", "VALUE-1");
+      region.put("KEY-2", "VALUE-2");
+      region.put("KEY-1", "VALUE-3");
+      region.put("KEY-2", "VALUE-4");
+      flushAsyncDiskRegion();
+    });
+
+    vm0.invoke(() -> {
+      Region<String, String> region = cacheRule.getCache().getRegion(regionName);
+      region.destroy("KEY-1");
+    });
+
+    vm0.bounceForcibly();
+
+    vm1.invoke(() -> flushAsyncDiskRegion());
+
+    vm1.invoke(() -> {
+      DistributionMessageObserver.setInstance(
+          new DistributionMessageObserver() {
+            @Override
+            public void beforeProcessMessage(ClusterDistributionManager dm,
+                DistributionMessage message) {
+              if (message instanceof InitialImageOperation.RequestImageMessage) {
+                InitialImageOperation.RequestImageMessage rim =
+                    (InitialImageOperation.RequestImageMessage) message;
+                if (rim.regionPath.contains(regionName)) {
+                  getBlackboard().signalGate("GotRegionIIRequest");
+                  await().until(() -> getBlackboard().isGateSignaled("TombstoneGCDone"));
+                }
+              }
+            }
+          });
+    });
+
+    AsyncInvocation vm0createRegion = vm0.invokeAsync(() -> createAsyncDiskRegion(true));
+
+    vm1.invoke(() -> {
+      await().until(() -> getBlackboard().isGateSignaled("GotRegionIIRequest"));
+      cacheRule.getCache().getTombstoneService().forceBatchExpirationForTests(1);
+      flushAsyncDiskRegion();
+      getBlackboard().signalGate("TombstoneGCDone");
+    });
+
+    vm0createRegion.await();
+
+    vm1.invoke(() -> {
+      Region<String, String> region = cacheRule.getCache().getRegion(regionName);
+      assertThat(region.get("KEY-1")).isEqualTo(null);
+      assertThat(region.get("KEY-2")).isEqualTo("VALUE-4");
+    });
+
+    vm0.invoke(() -> {
+      Region<String, String> region = cacheRule.getCache().getRegion(regionName);
+      assertThat(region.get("KEY-1")).isEqualTo(null);
+      assertThat(region.get("KEY-2")).isEqualTo("VALUE-4");
+
+      CachePerfStats stats = ((LocalRegion) region).getRegionPerfStats();
+      assertThat(stats.getDeltaGetInitialImagesCompleted()).isEqualTo(0);
+      assertThat(stats.getGetInitialImagesCompleted()).isEqualTo(1);
+    });
+  }
+
+  private void flushAsyncDiskRegion() {
+    for (DiskStore store : cacheRule.getCache().listDiskStoresIncludingRegionOwned()) {
+      ((DiskStoreImpl) store).forceFlush();
+    }
   }
 
   private void createSyncDiskRegion() throws IOException {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InitialImageOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InitialImageOperation.java
@@ -1596,7 +1596,6 @@ public class InitialImageOperation {
         }
         return true;
       }
-      // TODO GGG: verify GII after UpgradeDiskStore
       return false;
     }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/versions/RegionVersionVector.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/versions/RegionVersionVector.java
@@ -977,7 +977,8 @@ public abstract class RegionVersionVector<T extends VersionSource<?>>
     return false;
   }
 
-  private boolean isGCVersionDominatedByHolder(Long gcVersion, RegionVersionHolder<T> otherHolder) {
+  private boolean isGCVersionDominatedByOtherHolder(Long gcVersion,
+      RegionVersionHolder<T> otherHolder) {
     if (gcVersion == null || gcVersion.longValue() == 0) {
       return true;
     } else {
@@ -987,24 +988,24 @@ public abstract class RegionVersionVector<T extends VersionSource<?>>
   }
 
   /**
-   * Test to see if this vector's rvvgc has updates that has not seen.
+   * See if this vector's rvvgc has updates that has not seen.
    */
-  public synchronized boolean isRVVGCDominatedBy(RegionVersionVector<T> other) {
-    if (other.singleMember) {
+  public synchronized boolean isRVVGCDominatedBy(RegionVersionVector<T> requesterRVV) {
+    if (requesterRVV.singleMember) {
       // do the diff for only a single member. This is typically a member that
       // recently crashed.
       Map.Entry<T, RegionVersionHolder<T>> entry =
-          other.memberToVersion.entrySet().iterator().next();
+          requesterRVV.memberToVersion.entrySet().iterator().next();
 
       Long gcVersion = this.memberToGCVersion.get(entry.getKey());
-      return isGCVersionDominatedByHolder(gcVersion, entry.getValue());
+      return isGCVersionDominatedByOtherHolder(gcVersion, entry.getValue());
     }
 
     boolean isDominatedByRemote = true;
     long localgcversion = this.localGCVersion.get();
     if (localgcversion > 0) {
-      RegionVersionHolder<T> otherHolder = other.memberToVersion.get(this.myId);
-      isDominatedByRemote = isGCVersionDominatedByHolder(localgcversion, otherHolder);
+      RegionVersionHolder<T> otherHolder = requesterRVV.memberToVersion.get(this.myId);
+      isDominatedByRemote = isGCVersionDominatedByOtherHolder(localgcversion, otherHolder);
       if (isDominatedByRemote == false) {
         return false;
       }
@@ -1014,12 +1015,12 @@ public abstract class RegionVersionVector<T extends VersionSource<?>>
       T mbr = entry.getKey();
       Long gcVersion = entry.getValue();
       RegionVersionHolder<T> otherHolder = null;
-      if (mbr.equals(other.getOwnerId())) {
-        otherHolder = localExceptions;
+      if (mbr.equals(requesterRVV.getOwnerId())) {
+        otherHolder = requesterRVV.localExceptions;
       } else {
-        otherHolder = other.memberToVersion.get(mbr);
+        otherHolder = requesterRVV.memberToVersion.get(mbr);
       }
-      isDominatedByRemote = isGCVersionDominatedByHolder(gcVersion, otherHolder);
+      isDominatedByRemote = isGCVersionDominatedByOtherHolder(gcVersion, otherHolder);
       if (isDominatedByRemote == false) {
         return false;
       }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/versions/RegionVersionVectorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/versions/RegionVersionVectorTest.java
@@ -661,6 +661,167 @@ public class RegionVersionVectorTest {
     assertThat(rvv.getVersionForMember(ownerId)).isEqualTo(newVersion);
   }
 
+  @Test
+  public void isRvvGcDominatedByRequesterRvvReturnsTrueIfRequesterRvvForLostMemberDominates()
+      throws Exception {
+    InternalDistributedMember lostMember = mock(InternalDistributedMember.class);
+    ConcurrentHashMap<InternalDistributedMember, Long> memberToGcVersion =
+        new ConcurrentHashMap<>();
+    memberToGcVersion.put(lostMember, new Long(1) /* lostMemberGcVersion */);
+    RegionVersionVector providerRvv = new VMRegionVersionVector(lostMember, null,
+        0, memberToGcVersion, 0, true, null);
+
+    ConcurrentHashMap<InternalDistributedMember, RegionVersionHolder<InternalDistributedMember>> memberToRegionVersionHolder =
+        new ConcurrentHashMap<>();
+    RegionVersionHolder regionVersionHolder = new RegionVersionHolder(lostMember);
+    regionVersionHolder.setVersion(2);
+    memberToRegionVersionHolder.put(lostMember, regionVersionHolder);
+    RegionVersionVector requesterRvv =
+        new VMRegionVersionVector(lostMember, memberToRegionVersionHolder,
+            0, null, 0, true, null);
+
+    assertThat(providerRvv.isRVVGCDominatedBy(requesterRvv)).isTrue();
+  }
+
+  @Test
+  public void isRvvGcDominatedByRequesterRvvReturnsFalseIfRequesterRvvForLostMemberDominates()
+      throws Exception {
+    InternalDistributedMember lostMember = mock(InternalDistributedMember.class);
+    ConcurrentHashMap<InternalDistributedMember, Long> memberToGcVersion =
+        new ConcurrentHashMap<>();
+    memberToGcVersion.put(lostMember, new Long(1) /* lostMemberGcVersion */);
+    RegionVersionVector providerRvv = new VMRegionVersionVector(lostMember, null,
+        0, memberToGcVersion, 0, true, null);
+
+    ConcurrentHashMap<InternalDistributedMember, RegionVersionHolder<InternalDistributedMember>> memberToRegionVersionHolder =
+        new ConcurrentHashMap<>();
+    RegionVersionHolder regionVersionHolder = new RegionVersionHolder(lostMember);
+    regionVersionHolder.setVersion(0);
+    memberToRegionVersionHolder.put(lostMember, regionVersionHolder);
+    RegionVersionVector requesterRvv =
+        new VMRegionVersionVector(lostMember, memberToRegionVersionHolder,
+            0, null, 0, true, null);
+
+    assertThat(providerRvv.isRVVGCDominatedBy(requesterRvv)).isFalse();
+  }
+
+  @Test
+  public void isRvvGcDominatedByRequesterRvvReturnsFalseIfProviderRvvIsNotPresent()
+      throws Exception {
+    final String local = getIPLiteral();
+    InternalDistributedMember provider = new InternalDistributedMember(local, 101);
+    InternalDistributedMember requester = new InternalDistributedMember(local, 102);
+
+    RegionVersionVector providerRvv = new VMRegionVersionVector(provider, null,
+        1, null, 1, false, null);
+
+    ConcurrentHashMap<InternalDistributedMember, RegionVersionHolder<InternalDistributedMember>> memberToRegionVersionHolder =
+        new ConcurrentHashMap<>();
+    RegionVersionHolder regionVersionHolder = new RegionVersionHolder(provider);
+    regionVersionHolder.setVersion(0);
+    // memberToRegionVersionHolder.put(provider, regionVersionHolder);
+    RegionVersionVector requesterRvv =
+        new VMRegionVersionVector(requester, memberToRegionVersionHolder,
+            0, null, 0, false, null);
+
+    assertThat(providerRvv.isRVVGCDominatedBy(requesterRvv)).isFalse();
+  }
+
+  @Test
+  public void isRvvGcDominatedByRequesterRvvReturnsFalseIfRequesterRvvDominatesProvider()
+      throws Exception {
+    final String local = getIPLiteral();
+    InternalDistributedMember provider = new InternalDistributedMember(local, 101);
+    InternalDistributedMember requester = new InternalDistributedMember(local, 102);
+
+    RegionVersionVector providerRvv = new VMRegionVersionVector(provider, null,
+        1, null, 1, false, null);
+
+    ConcurrentHashMap<InternalDistributedMember, RegionVersionHolder<InternalDistributedMember>> memberToRegionVersionHolder =
+        new ConcurrentHashMap<>();
+    RegionVersionHolder regionVersionHolder = new RegionVersionHolder(provider);
+    regionVersionHolder.setVersion(0);
+    memberToRegionVersionHolder.put(provider, regionVersionHolder);
+    RegionVersionVector requesterRvv =
+        new VMRegionVersionVector(requester, memberToRegionVersionHolder,
+            0, null, 0, false, null);
+
+    assertThat(providerRvv.isRVVGCDominatedBy(requesterRvv)).isFalse();
+  }
+
+  @Test
+  public void isRvvGcDominatedByRequesterRvvReturnsTrueIfRequesterRvvDominatesWithNoGcVersion()
+      throws Exception {
+    final String local = getIPLiteral();
+    InternalDistributedMember provider = new InternalDistributedMember(local, 101);
+    InternalDistributedMember requester = new InternalDistributedMember(local, 102);
+
+    ConcurrentHashMap<InternalDistributedMember, Long> memberToGcVersion =
+        new ConcurrentHashMap<>();
+    RegionVersionVector providerRvv = new VMRegionVersionVector(provider, null,
+        1, memberToGcVersion, 1, false, null);
+
+    ConcurrentHashMap<InternalDistributedMember, RegionVersionHolder<InternalDistributedMember>> memberToRegionVersionHolder =
+        new ConcurrentHashMap<>();
+    RegionVersionHolder regionVersionHolder = new RegionVersionHolder(provider);
+    regionVersionHolder.setVersion(2);
+    memberToRegionVersionHolder.put(provider, regionVersionHolder);
+    RegionVersionVector requesterRvv =
+        new VMRegionVersionVector(requester, memberToRegionVersionHolder,
+            0, null, 0, false, null);
+
+    assertThat(providerRvv.isRVVGCDominatedBy(requesterRvv)).isTrue();
+  }
+
+  @Test
+  public void isRvvGcDominatedByRequesterRvvReturnsTrueIfRequesterRvvDominates() throws Exception {
+    final String local = getIPLiteral();
+    InternalDistributedMember provider = new InternalDistributedMember(local, 101);
+    InternalDistributedMember requester = new InternalDistributedMember(local, 102);
+    ConcurrentHashMap<InternalDistributedMember, Long> memberToGcVersion =
+        new ConcurrentHashMap<>();
+    memberToGcVersion.put(requester, new Long(1));
+    RegionVersionVector providerRvv = new VMRegionVersionVector(provider, null,
+        1, memberToGcVersion, 1, false, null);
+
+    ConcurrentHashMap<InternalDistributedMember, RegionVersionHolder<InternalDistributedMember>> memberToRegionVersionHolder =
+        new ConcurrentHashMap<>();
+    RegionVersionHolder regionVersionHolder = new RegionVersionHolder(provider);
+    regionVersionHolder.setVersion(2);
+    memberToRegionVersionHolder.put(provider, regionVersionHolder);
+    RegionVersionVector requesterRvv =
+        new VMRegionVersionVector(requester, memberToRegionVersionHolder,
+            2, null, 0, false, regionVersionHolder);
+
+    assertThat(providerRvv.isRVVGCDominatedBy(requesterRvv)).isTrue();
+  }
+
+  @Test
+  public void isRvvGcDominatedByRequesterRvvReturnsFalseIfRequesterRvvDominates() throws Exception {
+    final String local = getIPLiteral();
+    InternalDistributedMember provider = new InternalDistributedMember(local, 101);
+    InternalDistributedMember requester = new InternalDistributedMember(local, 102);
+    ConcurrentHashMap<InternalDistributedMember, Long> memberToGcVersion =
+        new ConcurrentHashMap<>();
+    memberToGcVersion.put(requester, new Long(3));
+    RegionVersionHolder pRegionVersionHolder = new RegionVersionHolder(provider);
+    pRegionVersionHolder.setVersion(4);
+
+    RegionVersionVector providerRvv = new VMRegionVersionVector(provider, null,
+        1, memberToGcVersion, 1, false, pRegionVersionHolder);
+
+    ConcurrentHashMap<InternalDistributedMember, RegionVersionHolder<InternalDistributedMember>> memberToRegionVersionHolder =
+        new ConcurrentHashMap<>();
+    RegionVersionHolder regionVersionHolder = new RegionVersionHolder(provider);
+    regionVersionHolder.setVersion(2);
+    memberToRegionVersionHolder.put(provider, regionVersionHolder);
+    RegionVersionVector requesterRvv =
+        new VMRegionVersionVector(requester, memberToRegionVersionHolder,
+            2, null, 0, false, regionVersionHolder);
+
+    assertThat(providerRvv.isRVVGCDominatedBy(requesterRvv)).isFalse();
+  }
+
   private RegionVersionVector createRegionVersionVector(InternalDistributedMember ownerId,
       LocalRegion owner) {
     @SuppressWarnings({"unchecked", "rawtypes"})


### PR DESCRIPTION
Re-submitting after fixing NPE from previous checkin.

Made changes to use the expected initial image requester's rvv
information instead of the image provider's local rvv while
determining full or delta GII.

There was logical error where it was using provider's local
exception(rvv) instead of using requester's local exception(rvv).
This could result in performing Delta GII instead of Full GII.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [Yes ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [Yes ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [Yes] Is your initial contribution a single, squashed commit?

- [Yes] Does `gradlew build` run cleanly?

- [Yes ] Have you written or updated unit tests to verify your changes?

- [NA] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

