### PR TITLE
GEODE-6062: Use random server port for ConfigureEvictionThroughGfsh

### DIFF
--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/management/internal/cli/commands/ConfigureEvictionThroughGfsh.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/management/internal/cli/commands/ConfigureEvictionThroughGfsh.java
@@ -38,7 +38,7 @@ public class ConfigureEvictionThroughGfsh {
   public void configureEvictionByEntryCount() throws Exception {
 
     GfshExecution execution = GfshScript
-        .of("start locator --name=locator", "start server --name=server",
+        .of("start locator --name=locator", "start server --name=server --server-port=0",
             "create region --name=region1 --eviction-action=local-destroy --eviction-entry-count=1000 --type=REPLICATE",
             "create region --name=region2 --eviction-action=overflow-to-disk --eviction-entry-count=1000 --type=REPLICATE",
             "create region --name=region3 --eviction-action=overflow-to-disk --eviction-entry-count=1000 --type=REPLICATE_PERSISTENT",
@@ -94,7 +94,7 @@ public class ConfigureEvictionThroughGfsh {
   @Test
   public void configureEvictionByMaxMemory() throws Exception {
     GfshExecution execution = GfshScript
-        .of("start locator --name=locator", "start server --name=server",
+        .of("start locator --name=locator", "start server --name=server --server-port=0",
             "create region --name=region1 --eviction-action=local-destroy --eviction-max-memory=1000 --type=REPLICATE",
             "create region --name=region2 --eviction-action=overflow-to-disk --eviction-max-memory=1000 --type=REPLICATE",
             "create region --name=region3 --eviction-action=overflow-to-disk --eviction-max-memory=1000 --type=REPLICATE_PERSISTENT",
@@ -160,7 +160,8 @@ public class ConfigureEvictionThroughGfsh {
   @Test
   public void configureEvictionByObjectSizer() throws Exception {
     GfshExecution execution = GfshScript
-        .of("start locator --name=locator", "start server --name=server", "sleep --time=1",
+        .of("start locator --name=locator", "start server --name=server --server-port=0",
+            "sleep --time=1",
             "deploy --jar=" + createJar().getAbsolutePath(),
             "create region --name=region1 --eviction-action=local-destroy --eviction-max-memory=1000 --eviction-object-sizer=MySizer --type=REPLICATE",
             "create region --name=region2 --eviction-action=overflow-to-disk --eviction-max-memory=1000 --eviction-object-sizer=MySizer --type=REPLICATE",


### PR DESCRIPTION
This should help reduce the frequency of random CI failures for this
test. It's still a bit worrisome that servers were using the same port
in the first place, but that's not really what we're testing here.

Co-authored-by: Galen O'Sullivan <gosullivan@pivotal.io>
Co-authored-by: Jianxia Chen <jchen@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
