### PR TITLE
GEODE-6063 remove PublishArtifacts from Geode release pipelines

### DIFF
--- a/ci/pipelines/geode-build/jinja.template.yml
+++ b/ci/pipelines/geode-build/jinja.template.yml
@@ -92,8 +92,10 @@ groups:
   jobs:
   - {{ build_test.name }}
   {{- all_gating_jobs() | indent(2) }}
-  {%- if repository.sanitized_fork == repository.upstream_fork %}
+  {%- if repository.sanitized_fork == "apache" and repository.branch == "develop" %}
   - UpdatePassingRef
+  {%- endif %}
+  {%- if repository.upstream_fork != "apache" or repository.branch == "develop" %}
   - PublishArtifacts
   {%- endif %}
 - name: complete
@@ -104,8 +106,10 @@ groups:
   - {{test.name}}Test{{java_test_version.name}}
     {%- endfor -%}
   {%- endfor -%}
-  {%- if repository.sanitized_fork == repository.upstream_fork %}
+  {%- if repository.sanitized_fork == "apache" and repository.branch == "develop" %}
   - UpdatePassingRef
+  {%- endif %}
+  {%- if repository.upstream_fork != "apache" or repository.branch == "develop" %}
   - PublishArtifacts
   {%- endif %}
 - name: linux
@@ -313,7 +317,7 @@ jobs:
               - name: instance-data
             timeout: 1h
 
-{% if repository.sanitized_fork == repository.upstream_fork %}
+{% if repository.sanitized_fork == "apache" and repository.branch == "develop" %}
 - name: UpdatePassingRef
   public: true
   serial: true
@@ -336,6 +340,8 @@ jobs:
       - name: geode-ci
       outputs:
       - name: results
+{% endif %}
+{% if repository.upstream_fork != "apache" or repository.branch == "develop" %}
 - name: PublishArtifacts
   public: true
   plan:


### PR DESCRIPTION
This PR will resolve the red job on the release/1.8.0 pipeline.  Releases should only be signed and published manually, so unlike develop branch which publishes a snapshot automatically after every successful build, release pipelines do not need publish step at all.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [n/a] Does `gradlew build` run cleanly?

- [n/a] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.