### PR TITLE
GEODE-5076 jmx client should not access or modify internal regions

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
@@ -922,7 +922,8 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
       this.resourceAdvisor = ResourceAdvisor.createResourceAdvisor(this);
 
       // Initialize the advisor here, but wait to exchange profiles until cache is fully built
-      this.jmxAdvisor = JmxManagerAdvisor.createJmxManagerAdvisor(new JmxManagerAdvisee(this));
+      this.jmxAdvisor = JmxManagerAdvisor
+          .createJmxManagerAdvisor(new JmxManagerAdvisee(getCacheForProcessingClientRequests()));
 
       this.resourceManager = InternalResourceManager.createResourceManager(this);
       this.serialNumber = DistributionAdvisor.createSerialNumber();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
@@ -265,6 +265,7 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
   public static final boolean DEFAULT_COPY_ON_READ = false;
 
   /**
+   * getcachefor
    * The default amount of time to wait for a {@code netSearch} to complete
    */
   public static final int DEFAULT_SEARCH_TIMEOUT =
@@ -5329,7 +5330,7 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
       new InternalCacheForClientAccess(this);
 
   @Override
-  public InternalCache getCacheForProcessingClientRequests() {
+  public InternalCacheForClientAccess getCacheForProcessingClientRequests() {
     return cacheForClients;
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCache.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCache.java
@@ -367,5 +367,5 @@ public interface InternalCache extends Cache, Extensible<Cache>, CacheTime {
    * application visible regions. Any regions created internally
    * by Geode will not be accessible from the returned cache.
    */
-  InternalCache getCacheForProcessingClientRequests();
+  InternalCacheForClientAccess getCacheForProcessingClientRequests();
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCacheForClientAccess.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCacheForClientAccess.java
@@ -138,10 +138,9 @@ public class InternalCacheForClientAccess implements InternalCache {
   }
 
   /**
-   * Server-side code using an InternalCacheForClientAccess may need to
-   * get an Internal Region not normally accesible and may use this method to
-   * do so. The REST API, for instance, needs to get at a Query store
-   * region that is not otherwise accessible through the getRegion methods.
+   * This method can be used to locate an internal region.
+   * It should not be invoked with a region name obtained
+   * from a client.
    */
   public <K, V> Region<K, V> getInternalRegion(String path) {
     Region<K, V> result = delegate.getRegion(path);
@@ -225,6 +224,16 @@ public class InternalCacheForClientAccess implements InternalCache {
             + " is an internal region that a client is never allowed to create");
       }
     }
+    return delegate.createVMRegion(name, p_attrs, internalRegionArgs);
+  }
+
+  /**
+   * This method allows server-side code to create an internal region. It should
+   * not be invoked with a region name obtained from a client.
+   */
+  public <K, V> Region<K, V> createInternalRegion(String name, RegionAttributes<K, V> p_attrs,
+      InternalRegionArguments internalRegionArgs)
+      throws RegionExistsException, TimeoutException, IOException, ClassNotFoundException {
     return delegate.createVMRegion(name, p_attrs, internalRegionArgs);
   }
 
@@ -1201,7 +1210,7 @@ public class InternalCacheForClientAccess implements InternalCache {
   }
 
   @Override
-  public InternalCache getCacheForProcessingClientRequests() {
+  public InternalCacheForClientAccess getCacheForProcessingClientRequests() {
     return this;
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCacheForClientAccess.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCacheForClientAccess.java
@@ -143,8 +143,7 @@ public class InternalCacheForClientAccess implements InternalCache {
    * from a client.
    */
   public <K, V> Region<K, V> getInternalRegion(String path) {
-    Region<K, V> result = delegate.getRegion(path);
-    return result;
+    return delegate.getRegion(path);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheCreation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheCreation.java
@@ -119,6 +119,7 @@ import org.apache.geode.internal.cache.FilterProfile;
 import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.cache.InitialImageOperation;
 import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.InternalCacheForClientAccess;
 import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.InternalRegionArguments;
 import org.apache.geode.internal.cache.LocalRegion;
@@ -2407,7 +2408,7 @@ public class CacheCreation implements InternalCache {
   }
 
   @Override
-  public InternalCache getCacheForProcessingClientRequests() {
+  public InternalCacheForClientAccess getCacheForProcessingClientRequests() {
     throw new UnsupportedOperationException("Should not be invoked");
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/management/ManagementService.java
+++ b/geode-core/src/main/java/org/apache/geode/management/ManagementService.java
@@ -38,7 +38,8 @@ public abstract class ManagementService {
    * @param cache Cache for which to get the management service.
    */
   public static ManagementService getManagementService(Cache cache) {
-    return BaseManagementService.getManagementService((InternalCache) cache);
+    return BaseManagementService
+        .getManagementService(((InternalCache) cache).getCacheForProcessingClientRequests());
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/management/cli/GfshCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/cli/GfshCommand.java
@@ -76,7 +76,10 @@ public abstract class GfshCommand implements CommandMarker {
   }
 
   public Cache getCache() {
-    return cache;
+    if (cache == null) {
+      return null;
+    }
+    return cache.getCacheForProcessingClientRequests();
   }
 
   public <T extends ManagementService> T getManagementService() {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/BaseManagementService.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/BaseManagementService.java
@@ -24,6 +24,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.geode.distributed.DistributedSystemDisconnectedException;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.InternalCacheForClientAccess;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.management.ManagementService;
 
@@ -69,7 +70,7 @@ public abstract class BaseManagementService extends ManagementService {
    *
    * @param cache defines the scope of resources to be managed
    */
-  public static ManagementService getManagementService(InternalCache cache) {
+  public static ManagementService getManagementService(InternalCacheForClientAccess cache) {
     synchronized (instances) {
       BaseManagementService service = instances.get(cache);
       if (service == null) {
@@ -83,7 +84,7 @@ public abstract class BaseManagementService extends ManagementService {
 
   public static ManagementService getExistingManagementService(InternalCache cache) {
     synchronized (instances) {
-      BaseManagementService service = (BaseManagementService) instances.get(cache);
+      BaseManagementService service = instances.get(cache.getCacheForProcessingClientRequests());
       return service;
     }
   }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/FederatingManager.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/FederatingManager.java
@@ -357,8 +357,9 @@ public class FederatingManager extends Manager {
         String monitoringRegionName = ManagementConstants.MONITORING_REGION + "_" + appender;
         String notificationRegionName = ManagementConstants.NOTIFICATION_REGION + "_" + appender;
 
-        if (cache.getRegion(monitoringRegionName) != null
-            && cache.getRegion(notificationRegionName) != null) {
+
+        if (cache.getInternalRegion(monitoringRegionName) != null
+            && cache.getInternalRegion(notificationRegionName) != null) {
           return member;
         }
 
@@ -415,7 +416,7 @@ public class FederatingManager extends Manager {
                 return null;
               }
               proxyMonitoringRegion =
-                  cache.createVMRegion(monitoringRegionName, monitoringRegionAttrs,
+                  cache.createInternalRegion(monitoringRegionName, monitoringRegionAttrs,
                       internalRegionArguments);
               proxyMonitoringRegionCreated = true;
 
@@ -434,7 +435,7 @@ public class FederatingManager extends Manager {
                 return null;
               }
               proxyNotificationRegion =
-                  cache.createVMRegion(notificationRegionName, notifRegionAttrs,
+                  cache.createInternalRegion(notificationRegionName, notifRegionAttrs,
                       internalRegionArguments);
               proxyNotificationRegionCreated = true;
             } catch (TimeoutException | RegionExistsException | IOException

--- a/geode-core/src/main/java/org/apache/geode/management/internal/JmxManagerAdvisee.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/JmxManagerAdvisee.java
@@ -24,7 +24,7 @@ import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.internal.admin.SSLConfig;
-import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.InternalCacheForClientAccess;
 import org.apache.geode.internal.net.SSLConfigurationFactory;
 import org.apache.geode.internal.net.SocketCreator;
 import org.apache.geode.internal.security.SecurableCommunicationChannel;
@@ -37,10 +37,10 @@ import org.apache.geode.management.internal.JmxManagerAdvisor.JmxManagerProfile;
 public class JmxManagerAdvisee implements DistributionAdvisee {
 
   private final int serialNumber;
-  private final InternalCache cache;
+  private final InternalCacheForClientAccess cache;
   private JmxManagerProfile myMostRecentProfile;
 
-  public JmxManagerAdvisee(InternalCache cache) {
+  public JmxManagerAdvisee(InternalCacheForClientAccess cache) {
     this.serialNumber = DistributionAdvisor.createSerialNumber();
     this.cache = cache;
   }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/JmxManagerLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/JmxManagerLocator.java
@@ -202,7 +202,8 @@ public class JmxManagerLocator implements TcpHandler {
     @Override
     public void execute(FunctionContext context) {
       try {
-        InternalCache cache = ManagementAgent.getCache();
+        InternalCache cache =
+            ((InternalCache) context.getCache()).getCacheForProcessingClientRequests();
         if (cache != null) {
           ManagementService ms = ManagementService.getExistingManagementService(cache);
           if (ms != null) {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/JmxManagerLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/JmxManagerLocator.java
@@ -30,6 +30,7 @@ import org.apache.geode.distributed.internal.membership.InternalDistributedMembe
 import org.apache.geode.distributed.internal.tcpserver.TcpHandler;
 import org.apache.geode.distributed.internal.tcpserver.TcpServer;
 import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.InternalCacheForClientAccess;
 import org.apache.geode.internal.cache.execute.InternalFunction;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.management.AlreadyRunningException;
@@ -39,10 +40,10 @@ import org.apache.geode.management.internal.JmxManagerAdvisor.JmxManagerProfile;
 public class JmxManagerLocator implements TcpHandler {
   private static final Logger logger = LogService.getLogger();
 
-  private InternalCache cache;
+  private InternalCacheForClientAccess cache;
 
   public JmxManagerLocator(InternalCache internalCache) {
-    this.cache = internalCache;
+    this.cache = internalCache.getCacheForProcessingClientRequests();
   }
 
   @Override
@@ -69,7 +70,7 @@ public class JmxManagerLocator implements TcpHandler {
   @Override
   public void restarting(DistributedSystem ds, GemFireCache cache,
       InternalConfigurationPersistenceService sharedConfig) {
-    this.cache = (InternalCache) cache;
+    this.cache = ((InternalCache) cache).getCacheForProcessingClientRequests();
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/management/internal/JmxManagerLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/JmxManagerLocator.java
@@ -21,8 +21,6 @@ import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.CancelException;
 import org.apache.geode.SystemFailure;
-import org.apache.geode.cache.Cache;
-import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.GemFireCache;
 import org.apache.geode.cache.execute.FunctionContext;
 import org.apache.geode.cache.execute.FunctionService;
@@ -203,7 +201,7 @@ public class JmxManagerLocator implements TcpHandler {
     @Override
     public void execute(FunctionContext context) {
       try {
-        Cache cache = CacheFactory.getAnyInstance();
+        InternalCache cache = ManagementAgent.getCache();
         if (cache != null) {
           ManagementService ms = ManagementService.getExistingManagementService(cache);
           if (ms != null) {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/LocalManager.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/LocalManager.java
@@ -151,7 +151,7 @@ public class LocalManager extends Manager {
 
         try {
           repo.setLocalMonitoringRegion(
-              cache.createVMRegion(ManagementConstants.MONITORING_REGION + "_" + appender,
+              cache.createInternalRegion(ManagementConstants.MONITORING_REGION + "_" + appender,
                   monitoringRegionAttrs, internalArgs));
           monitoringRegionCreated = true;
 
@@ -167,7 +167,7 @@ public class LocalManager extends Manager {
 
         try {
           repo.setLocalNotificationRegion(
-              cache.createVMRegion(ManagementConstants.NOTIFICATION_REGION + "_" + appender,
+              cache.createInternalRegion(ManagementConstants.NOTIFICATION_REGION + "_" + appender,
                   notifRegionAttrs, internalArgs));
           notifRegionCreated = true;
         } catch (TimeoutException e) {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/ManagementAgent.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/ManagementAgent.java
@@ -55,6 +55,7 @@ import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.internal.GemFireVersion;
 import org.apache.geode.internal.admin.SSLConfig;
 import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.InternalCacheForClientAccess;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.net.SSLConfigurationFactory;
 import org.apache.geode.internal.net.SocketCreator;
@@ -142,6 +143,14 @@ public class ManagementAgent {
         && !cache.isClient());
   }
 
+  public static InternalCacheForClientAccess getCache() {
+    InternalCache cache = (InternalCache) CacheFactory.getAnyInstance();
+    if (cache != null) {
+      return cache.getCacheForProcessingClientRequests();
+    }
+    return null;
+  }
+
   public synchronized void startAgent(InternalCache cache) {
     // Do not start Management REST service if developer REST service is already
     // started.
@@ -191,7 +200,7 @@ public class ManagementAgent {
 
   private void startHttpService(boolean isServer) {
     final SystemManagementService managementService = (SystemManagementService) ManagementService
-        .getManagementService(CacheFactory.getAnyInstance());
+        .getManagementService(getCache());
 
     final ManagerMXBean managerBean = managementService.getManagerMXBean();
 
@@ -305,7 +314,7 @@ public class ManagementAgent {
 
           // set cache property for developer REST service running
           if (isRestWebAppAdded) {
-            InternalCache cache = (InternalCache) CacheFactory.getAnyInstance();
+            InternalCache cache = getCache();
             cache.setRESTServiceRunning(true);
 
             // create region to hold query information (queryId, queryString).

--- a/geode-core/src/main/java/org/apache/geode/management/internal/ManagementFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/ManagementFunction.java
@@ -24,7 +24,6 @@ import javax.management.ObjectName;
 import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.cache.execute.FunctionContext;
-import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.execute.InternalFunction;
 import org.apache.geode.internal.logging.LogService;
@@ -72,7 +71,7 @@ public class ManagementFunction implements InternalFunction {
 
     boolean executedSuccessfully = false;
 
-    InternalCache cache = GemFireCacheImpl.getInstance();
+    InternalCache cache = ((InternalCache) fc.getCache()).getCacheForProcessingClientRequests();
 
     Object[] functionArguments = (Object[]) fc.getArguments();
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/Manager.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/Manager.java
@@ -16,6 +16,7 @@ package org.apache.geode.management.internal;
 
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.InternalCacheForClientAccess;
 
 /**
  * The Manager is a 7.0 JMX Agent which is hosted within a GemFire process. Only one instance is
@@ -26,7 +27,7 @@ import org.apache.geode.internal.cache.InternalCache;
  */
 public abstract class Manager {
 
-  protected InternalCache cache;
+  protected InternalCacheForClientAccess cache;
 
   /**
    * depicts whether this node is a Managing node or not
@@ -51,7 +52,7 @@ public abstract class Manager {
   public Manager(ManagementResourceRepo repo, InternalDistributedSystem system,
       InternalCache cache) {
     this.repo = repo;
-    this.cache = cache;
+    this.cache = cache.getCacheForProcessingClientRequests();
     this.system = system;
   }
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/SystemManagementService.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/SystemManagementService.java
@@ -33,6 +33,7 @@ import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.ResourceEvent;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.InternalCacheForClientAccess;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.management.AlreadyRunningException;
 import org.apache.geode.management.AsyncEventQueueMXBean;
@@ -94,7 +95,7 @@ public class SystemManagementService extends BaseManagementService {
    */
   private MBeanJMXAdapter jmxAdapter;
 
-  private InternalCache cache;
+  private InternalCacheForClientAccess cache;
 
   private FederatingManager federatingManager;
 
@@ -116,11 +117,12 @@ public class SystemManagementService extends BaseManagementService {
 
   private UniversalListenerContainer universalListenerContainer = new UniversalListenerContainer();
 
-  public static BaseManagementService newSystemManagementService(InternalCache cache) {
+  public static BaseManagementService newSystemManagementService(
+      InternalCacheForClientAccess cache) {
     return new SystemManagementService(cache).init();
   }
 
-  protected SystemManagementService(InternalCache cache) {
+  protected SystemManagementService(InternalCacheForClientAccess cache) {
     this.cache = cache;
     this.system = (InternalDistributedSystem) cache.getDistributedSystem();
     // This is a safe check to ensure Management service does not start for a

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/BeanUtilFuncs.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/BeanUtilFuncs.java
@@ -26,11 +26,11 @@ import java.util.Set;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
-import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.management.GemFireProperties;
+import org.apache.geode.management.internal.ManagementAgent;
 import org.apache.geode.management.internal.cli.CliUtil;
 
 /**
@@ -123,7 +123,7 @@ public class BeanUtilFuncs {
     DistributedMember memberFound = null;
 
     if (memberNameOrId != null) {
-      InternalCache cache = (InternalCache) CacheFactory.getAnyInstance();
+      InternalCache cache = ManagementAgent.getCache();
       Set<DistributedMember> memberSet = CliUtil.getAllMembers(cache);
       for (DistributedMember member : memberSet) {
         if (memberNameOrId.equals(member.getId()) || memberNameOrId.equals(member.getName())) {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/CacheServerBridge.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/CacheServerBridge.java
@@ -56,7 +56,6 @@ import org.apache.geode.internal.process.ProcessUtils;
 import org.apache.geode.management.ClientHealthStatus;
 import org.apache.geode.management.ClientQueueDetail;
 import org.apache.geode.management.ServerLoadData;
-import org.apache.geode.management.internal.ManagementAgent;
 import org.apache.geode.management.internal.ManagementConstants;
 import org.apache.geode.management.internal.beans.stats.MBeanStatsMonitor;
 import org.apache.geode.management.internal.beans.stats.StatType;
@@ -405,8 +404,6 @@ public class CacheServerBridge extends ServerBridge {
   }
 
   public Version getClientVersion(ClientConnInfo connInfo) {
-    InternalCache cache = ManagementAgent.getCache();
-
     if (cache.getCacheServers().size() == 0) {
       return null;
     }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/CacheServerBridge.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/CacheServerBridge.java
@@ -24,7 +24,6 @@ import java.util.Map;
 
 import org.apache.logging.log4j.Logger;
 
-import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.query.CqClosedException;
 import org.apache.geode.cache.query.CqException;
@@ -57,6 +56,7 @@ import org.apache.geode.internal.process.ProcessUtils;
 import org.apache.geode.management.ClientHealthStatus;
 import org.apache.geode.management.ClientQueueDetail;
 import org.apache.geode.management.ServerLoadData;
+import org.apache.geode.management.internal.ManagementAgent;
 import org.apache.geode.management.internal.ManagementConstants;
 import org.apache.geode.management.internal.beans.stats.MBeanStatsMonitor;
 import org.apache.geode.management.internal.beans.stats.StatType;
@@ -405,7 +405,7 @@ public class CacheServerBridge extends ServerBridge {
   }
 
   public Version getClientVersion(ClientConnInfo connInfo) {
-    InternalCache cache = (InternalCache) CacheFactory.getAnyInstance();
+    InternalCache cache = ManagementAgent.getCache();
 
     if (cache.getCacheServers().size() == 0) {
       return null;

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/QueryDataFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/QueryDataFunction.java
@@ -30,7 +30,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.SystemFailure;
-import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.DataPolicy;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.execute.Function;
@@ -57,6 +56,7 @@ import org.apache.geode.internal.cache.execute.InternalFunction;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.management.DistributedRegionMXBean;
 import org.apache.geode.management.ManagementService;
+import org.apache.geode.management.internal.ManagementAgent;
 import org.apache.geode.management.internal.ManagementConstants;
 import org.apache.geode.management.internal.SystemManagementService;
 import org.apache.geode.management.internal.cli.CliUtil;
@@ -126,7 +126,7 @@ public class QueryDataFunction implements Function, InternalEntity {
   private QueryDataFunctionResult selectWithType(final FunctionContext context, String queryString,
       final boolean showMember, final String regionName, final int limit,
       final int queryResultSetLimit, final int queryCollectionsDepth) throws Exception {
-    InternalCache cache = getCache();
+    InternalCache cache = ManagementAgent.getCache();
     Function localQueryFunc = new LocalQueryFunction("LocalQueryFunction", regionName, showMember)
         .setOptimizeForWrite(true);
     queryString = applyLimitClause(queryString, limit, queryResultSetLimit);
@@ -346,7 +346,7 @@ public class QueryDataFunction implements Function, InternalEntity {
       }
     }
 
-    InternalCache cache = (InternalCache) CacheFactory.getAnyInstance();
+    InternalCache cache = ManagementAgent.getCache();
     try {
 
       SystemManagementService service =
@@ -432,10 +432,6 @@ public class QueryDataFunction implements Function, InternalEntity {
           String.format("Query is invalid due to error : %s", qe.getMessage()))
               .toString();
     }
-  }
-
-  private InternalCache getCache() {
-    return (InternalCache) CacheFactory.getAnyInstance();
   }
 
   private static class JsonisedErrorMessage {
@@ -525,7 +521,7 @@ public class QueryDataFunction implements Function, InternalEntity {
 
     @Override
     public void execute(final FunctionContext context) {
-      InternalCache cache = getCache();
+      InternalCache cache = ManagementAgent.getCache();
       QueryService queryService = cache.getQueryService();
       String qstr = (String) context.getArguments();
       Region r = cache.getRegion(regionName);
@@ -543,10 +539,6 @@ public class QueryDataFunction implements Function, InternalEntity {
       } catch (Exception e) {
         throw new FunctionException(e);
       }
-    }
-
-    private InternalCache getCache() {
-      return (InternalCache) CacheFactory.getAnyInstance();
     }
 
     @Override

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/QueryDataFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/QueryDataFunction.java
@@ -126,7 +126,8 @@ public class QueryDataFunction implements Function, InternalEntity {
   private QueryDataFunctionResult selectWithType(final FunctionContext context, String queryString,
       final boolean showMember, final String regionName, final int limit,
       final int queryResultSetLimit, final int queryCollectionsDepth) throws Exception {
-    InternalCache cache = ManagementAgent.getCache();
+    InternalCache cache =
+        ((InternalCache) context.getCache()).getCacheForProcessingClientRequests();
     Function localQueryFunc = new LocalQueryFunction("LocalQueryFunction", regionName, showMember)
         .setOptimizeForWrite(true);
     queryString = applyLimitClause(queryString, limit, queryResultSetLimit);
@@ -521,7 +522,8 @@ public class QueryDataFunction implements Function, InternalEntity {
 
     @Override
     public void execute(final FunctionContext context) {
-      InternalCache cache = ManagementAgent.getCache();
+      InternalCache cache =
+          ((InternalCache) context.getCache()).getCacheForProcessingClientRequests();
       QueryService queryService = cache.getQueryService();
       String qstr = (String) context.getArguments();
       Region r = cache.getRegion(regionName);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/DataCommandFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/DataCommandFunction.java
@@ -103,7 +103,8 @@ public class DataCommandFunction implements InternalFunction {
   @Override
   public void execute(FunctionContext functionContext) {
     try {
-      InternalCache cache = (InternalCache) functionContext.getCache();
+      InternalCache cache =
+          ((InternalCache) functionContext.getCache()).getCacheForProcessingClientRequests();
       DataCommandRequest request = (DataCommandRequest) functionContext.getArguments();
       if (logger.isDebugEnabled()) {
         logger.debug("Executing function : \n{}\n on member {}", request,

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/DestroyIndexFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/DestroyIndexFunction.java
@@ -23,6 +23,7 @@ import org.apache.geode.cache.configuration.RegionConfig;
 import org.apache.geode.cache.execute.FunctionContext;
 import org.apache.geode.cache.query.Index;
 import org.apache.geode.cache.query.QueryService;
+import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.management.cli.CliFunction;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 
@@ -36,7 +37,7 @@ public class DestroyIndexFunction extends CliFunction {
 
     CliFunctionResult result;
     try {
-      Cache cache = context.getCache();
+      Cache cache = ((InternalCache) context.getCache()).getCacheForProcessingClientRequests();
       memberId = cache.getDistributedSystem().getDistributedMember().getId();
       QueryService queryService = cache.getQueryService();
       String indexName = indexInfo.getName();

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/ExportDataFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/ExportDataFunction.java
@@ -22,6 +22,7 @@ import org.apache.geode.cache.execute.FunctionContext;
 import org.apache.geode.cache.snapshot.RegionSnapshotService;
 import org.apache.geode.cache.snapshot.SnapshotOptions;
 import org.apache.geode.cache.snapshot.SnapshotOptions.SnapshotFormat;
+import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.execute.InternalFunction;
 import org.apache.geode.internal.cache.snapshot.SnapshotOptionsImpl;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
@@ -46,7 +47,7 @@ public class ExportDataFunction implements InternalFunction {
     final boolean parallel = Boolean.parseBoolean(args[2]);
 
     try {
-      Cache cache = context.getCache();
+      Cache cache = ((InternalCache) context.getCache()).getCacheForProcessingClientRequests();
       Region<?, ?> region = cache.getRegion(regionName);
       String hostName = cache.getDistributedSystem().getDistributedMember().getHost();
       if (region != null) {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/ExportLogsFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/ExportLogsFunction.java
@@ -37,6 +37,7 @@ import org.apache.geode.cache.Scope;
 import org.apache.geode.cache.execute.FunctionContext;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.InternalCacheForClientAccess;
 import org.apache.geode.internal.cache.InternalRegionArguments;
 import org.apache.geode.internal.cache.execute.InternalFunction;
 import org.apache.geode.internal.logging.LogService;
@@ -121,7 +122,8 @@ public class ExportLogsFunction implements InternalFunction {
   public static Region createOrGetExistingExportLogsRegion(boolean isInitiatingMember,
       InternalCache cache) throws IOException, ClassNotFoundException {
 
-    Region exportLogsRegion = cache.getRegion(EXPORT_LOGS_REGION);
+    InternalCacheForClientAccess cacheForClientAccess = cache.getCacheForProcessingClientRequests();
+    Region exportLogsRegion = cacheForClientAccess.getInternalRegion(EXPORT_LOGS_REGION);
     if (exportLogsRegion == null) {
       AttributesFactory<String, Configuration> regionAttrsFactory = new AttributesFactory<>();
       regionAttrsFactory.setDataPolicy(DataPolicy.EMPTY);
@@ -133,14 +135,16 @@ public class ExportLogsFunction implements InternalFunction {
       InternalRegionArguments internalArgs = new InternalRegionArguments();
       internalArgs.setIsUsedForMetaRegion(true);
       exportLogsRegion =
-          cache.createVMRegion(EXPORT_LOGS_REGION, regionAttrsFactory.create(), internalArgs);
+          cacheForClientAccess.createInternalRegion(EXPORT_LOGS_REGION, regionAttrsFactory.create(),
+              internalArgs);
     }
 
     return exportLogsRegion;
   }
 
   public static void destroyExportLogsRegion(InternalCache cache) {
-    Region exportLogsRegion = cache.getRegion(EXPORT_LOGS_REGION);
+    Region exportLogsRegion =
+        cache.getCacheForProcessingClientRequests().getInternalRegion(EXPORT_LOGS_REGION);
     if (exportLogsRegion == null) {
       return;
     }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/GetRegionDescriptionFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/GetRegionDescriptionFunction.java
@@ -18,6 +18,7 @@ package org.apache.geode.management.internal.cli.functions;
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.execute.FunctionContext;
+import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.execute.InternalFunction;
 import org.apache.geode.management.internal.cli.domain.RegionDescriptionPerMember;
 
@@ -30,7 +31,7 @@ public class GetRegionDescriptionFunction implements InternalFunction {
   public void execute(FunctionContext context) {
     String regionPath = (String) context.getArguments();
     try {
-      Cache cache = context.getCache();
+      Cache cache = ((InternalCache) context.getCache()).getCacheForProcessingClientRequests();
       Region<?, ?> region = cache.getRegion(regionPath);
 
       if (region != null) {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/ImportDataFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/ImportDataFunction.java
@@ -22,6 +22,7 @@ import org.apache.geode.cache.execute.FunctionContext;
 import org.apache.geode.cache.snapshot.RegionSnapshotService;
 import org.apache.geode.cache.snapshot.SnapshotOptions;
 import org.apache.geode.cache.snapshot.SnapshotOptions.SnapshotFormat;
+import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.execute.InternalFunction;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 
@@ -46,7 +47,8 @@ public class ImportDataFunction implements InternalFunction {
     final boolean parallel = (boolean) args[3];
 
     try {
-      final Cache cache = context.getCache();
+      final Cache cache =
+          ((InternalCache) context.getCache()).getCacheForProcessingClientRequests();
       final Region<?, ?> region = cache.getRegion(regionName);
       final String hostName = cache.getDistributedSystem().getDistributedMember().getHost();
       if (region != null) {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/RegionAlterFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/RegionAlterFunction.java
@@ -32,6 +32,7 @@ import org.apache.geode.cache.execute.FunctionContext;
 import org.apache.geode.cache.execute.ResultSender;
 import org.apache.geode.internal.ClassPathLoader;
 import org.apache.geode.internal.cache.AbstractRegion;
+import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.internal.cache.execute.InternalFunction;
 import org.apache.geode.internal.cache.partitioned.PRLocallyDestroyedException;
@@ -62,7 +63,7 @@ public class RegionAlterFunction implements InternalFunction {
   public void execute(FunctionContext context) {
     ResultSender<Object> resultSender = context.getResultSender();
 
-    Cache cache = context.getCache();
+    Cache cache = ((InternalCache) context.getCache()).getCacheForProcessingClientRequests();
     String memberNameOrId =
         CliUtil.getMemberNameOrId(cache.getDistributedSystem().getDistributedMember());
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/RegionCreateFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/RegionCreateFunction.java
@@ -42,6 +42,7 @@ import org.apache.geode.cache.execute.ResultSender;
 import org.apache.geode.cache.util.ObjectSizer;
 import org.apache.geode.compression.Compressor;
 import org.apache.geode.internal.ClassPathLoader;
+import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.execute.InternalFunction;
 import org.apache.geode.internal.cache.xmlcache.CacheXml;
 import org.apache.geode.internal.logging.LogService;
@@ -75,7 +76,7 @@ public class RegionCreateFunction implements InternalFunction {
   public void execute(FunctionContext context) {
     ResultSender<Object> resultSender = context.getResultSender();
 
-    Cache cache = context.getCache();
+    Cache cache = ((InternalCache) context.getCache()).getCacheForProcessingClientRequests();
     String memberNameOrId = context.getMemberName();
 
     RegionFunctionArgs regionCreateArgs = (RegionFunctionArgs) context.getArguments();

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/RegionDestroyFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/RegionDestroyFunction.java
@@ -18,6 +18,7 @@ import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionDestroyedException;
 import org.apache.geode.cache.execute.FunctionContext;
+import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.execute.InternalFunction;
 import org.apache.geode.internal.cache.xmlcache.CacheXml;
 import org.apache.geode.internal.logging.LogService;
@@ -55,7 +56,7 @@ public class RegionDestroyFunction implements InternalFunction {
       }
 
       regionPath = (String) arguments;
-      Cache cache = context.getCache();
+      Cache cache = ((InternalCache) context.getCache()).getCacheForProcessingClientRequests();
       Region<?, ?> region = cache.getRegion(regionPath);
       // the region is already destroyed by another member
       if (region == null) {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/UserFunctionExecution.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/UserFunctionExecution.java
@@ -57,7 +57,7 @@ public class UserFunctionExecution implements InternalFunction<Object[]> {
 
   @Override
   public void execute(FunctionContext<Object[]> context) {
-    Cache cache = context.getCache();
+    Cache cache = ((InternalCache) context.getCache()).getCacheForProcessingClientRequests();
     DistributedMember member = cache.getDistributedSystem().getDistributedMember();
 
     String[] functionArgs = null;

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/modes/CommandModes.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/modes/CommandModes.java
@@ -21,16 +21,16 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.logging.log4j.Logger;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import org.apache.geode.LogWriter;
-import org.apache.geode.cache.Cache;
-import org.apache.geode.internal.cache.InternalCache;
-import org.apache.geode.management.internal.ManagementAgent;
+import org.apache.geode.internal.logging.LogService;
 
 public class CommandModes {
+
+  private static final Logger logger = LogService.getLogger();
 
   public static final String DEFAULT_MODE = "default";
 
@@ -87,12 +87,7 @@ public class CommandModes {
   }
 
   private void logException(Exception e) {
-    Cache cache = ManagementAgent.getCache();
-    if (cache != null && cache instanceof InternalCache) {
-      cache = ((InternalCache) cache).getCacheForProcessingClientRequests();
-    }
-    LogWriter logger = cache.getLogger();
-    logger.warning("Error parsing command mode descriptor", e);
+    logger.warn("Error parsing command mode descriptor", e);
   }
 
   private void addCommandMode(String commandName) throws JSONException, IOException {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/modes/CommandModes.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/modes/CommandModes.java
@@ -27,7 +27,8 @@ import org.json.JSONObject;
 
 import org.apache.geode.LogWriter;
 import org.apache.geode.cache.Cache;
-import org.apache.geode.cache.CacheFactory;
+import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.management.internal.ManagementAgent;
 
 public class CommandModes {
 
@@ -86,7 +87,10 @@ public class CommandModes {
   }
 
   private void logException(Exception e) {
-    Cache cache = CacheFactory.getAnyInstance();
+    Cache cache = ManagementAgent.getCache();
+    if (cache != null && cache instanceof InternalCache) {
+      cache = ((InternalCache) cache).getCacheForProcessingClientRequests();
+    }
     LogWriter logger = cache.getLogger();
     logger.warning("Error parsing command mode descriptor", e);
   }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/configuration/domain/XmlEntity.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/configuration/domain/XmlEntity.java
@@ -90,7 +90,8 @@ public class XmlEntity implements VersionedDataSerializable {
   }
 
   private static CacheProvider createDefaultCacheProvider() {
-    return () -> (InternalCache) CacheFactory.getAnyInstance();
+    return () -> ((InternalCache) CacheFactory.getAnyInstance())
+        .getCacheForProcessingClientRequests();
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/management/internal/configuration/functions/GetRegionNamesFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/configuration/functions/GetRegionNamesFunction.java
@@ -19,7 +19,6 @@ import static java.util.stream.Collectors.toSet;
 import java.util.Set;
 
 import org.apache.geode.cache.execute.FunctionContext;
-import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.execute.InternalFunction;
@@ -27,7 +26,7 @@ import org.apache.geode.internal.cache.execute.InternalFunction;
 public class GetRegionNamesFunction implements InternalFunction {
   @Override
   public void execute(FunctionContext context) {
-    InternalCache cache = GemFireCacheImpl.getInstance();
+    InternalCache cache = (InternalCache) context.getCache();
 
     Set<String> regions =
         cache.getApplicationRegions().stream().map(InternalRegion::getName).collect(toSet());

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ExportLogsCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ExportLogsCommandTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -40,6 +41,7 @@ import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.InternalCacheForClientAccess;
 import org.apache.geode.management.ManagementException;
 import org.apache.geode.management.cli.Result;
 import org.apache.geode.management.internal.cli.functions.SizeExportLogsFunction;
@@ -157,6 +159,8 @@ public class ExportLogsCommandTest {
   @Test
   public void testTotalEstimateSizeExceedsLocatorAvailableDisk() throws Exception {
     final InternalCache mockCache = mock(InternalCache.class);
+    final InternalCacheForClientAccess mockCacheFilter = mock(InternalCacheForClientAccess.class);
+    when(mockCache.getCacheForProcessingClientRequests()).thenReturn(mockCacheFilter);
     final ExportLogsCommand realCmd = new ExportLogsCommand();
     ExportLogsCommand spyCmd = spy(realCmd);
 
@@ -198,6 +202,8 @@ public class ExportLogsCommandTest {
   @Test
   public void testTotalEstimateSizeExceedsUserSpecifiedValue() throws Exception {
     final InternalCache mockCache = mock(InternalCache.class);
+    final InternalCacheForClientAccess mockCacheFilter = mock(InternalCacheForClientAccess.class);
+    when(mockCache.getCacheForProcessingClientRequests()).thenReturn(mockCacheFilter);
     final ExportLogsCommand realCmd = new ExportLogsCommand();
     ExportLogsCommand spyCmd = spy(realCmd);
 
@@ -239,6 +245,8 @@ public class ExportLogsCommandTest {
   @Test
   public void estimateLogSizeExceedsServerDisk() throws Exception {
     final InternalCache mockCache = mock(InternalCache.class);
+    final InternalCacheForClientAccess mockCacheFilter = mock(InternalCacheForClientAccess.class);
+    when(mockCache.getCacheForProcessingClientRequests()).thenReturn(mockCacheFilter);
     final ExportLogsCommand realCmd = new ExportLogsCommand();
     ExportLogsCommand spyCmd = spy(realCmd);
 

--- a/geode-dunit/src/main/java/org/apache/geode/management/internal/security/GfshCommandsSecurityTestBase.java
+++ b/geode-dunit/src/main/java/org/apache/geode/management/internal/security/GfshCommandsSecurityTestBase.java
@@ -44,7 +44,8 @@ public class GfshCommandsSecurityTestBase {
   public static ServerStarterRule serverStarter =
       new ServerStarterRule().withJMXManager().withHttpService()
           .withSecurityManager(SimpleTestSecurityManager.class)
-          .withRegion(RegionShortcut.REPLICATE_PERSISTENT, "persistentRegion");
+          .withRegion(RegionShortcut.REPLICATE_PERSISTENT, "persistentRegion")
+          .withEmbeddedLocator();
 
   @Rule
   public GfshCommandRule gfshConnection =
@@ -164,6 +165,15 @@ public class GfshCommandsSecurityTestBase {
       assertThat(((ErrorResultData) result.getResultData()).getErrorCode())
           .describedAs(other.getCommand()).isEqualTo(ResultBuilder.ERRORCODE_UNAUTHORIZED);
     }
+  }
+
+  @Test
+  @ConnectionConfiguration(user = "data,cluster", password = "data,cluster")
+  public void modifyInternalRegionSuperUser() {
+    CommandResult result =
+        gfshConnection.executeCommand("put --key=key1 --value=value1 --region=PdxTypes");
+    assertThat(result.getStatus()).isEqualTo(Result.Status.ERROR);
+    assertThat(result.getMessageFromContent()).contains("Unauthorized");
   }
 
   @Test

--- a/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/controllers/CommonCrudController.java
+++ b/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/controllers/CommonCrudController.java
@@ -77,10 +77,8 @@ public abstract class CommonCrudController extends AbstractBaseController {
     headers.setLocation(toUri());
     final Set<Region<?, ?>> regions = new HashSet<>();
     for (InternalRegion region : getCache().getApplicationRegions()) {
-      if (region instanceof Region) {
-        regions.add(region);
-      }
-    } ;
+      regions.add(region);
+    }
     String listRegionsAsJson = JSONUtils.formulateJsonForListRegions(regions, "regions");
     return new ResponseEntity<>(listRegionsAsJson, headers, HttpStatus.OK);
   }


### PR DESCRIPTION
Modified the management packages to use a filtered cache that doesn't
allow users access to internal regions.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
