### PR TITLE
GEODE-4110: improve junit ClientCacheRule

### DIFF
--- a/geode-assembly/src/distributedTest/java/org/apache/geode/rest/internal/web/controllers/RestAPIsWithSSLDUnitTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/rest/internal/web/controllers/RestAPIsWithSSLDUnitTest.java
@@ -128,8 +128,8 @@ public class RestAPIsWithSSLDUnitTest {
         .withProperties(sslProperties)
         .withConnectionToLocator(locatorPort)
         .withRegion(RegionShortcut.REPLICATE, PEOPLE_REGION_NAME));
-    client = cluster.startClientVM(1,
-        c -> c.addPoolLocator("localhost", locatorPort).setPdxReadSerialized(true));
+    client = cluster.startClientVM(1, c -> c.withLocatorConnection(locatorPort)
+        .withCacheSetup(cf -> cf.setPdxReadSerialized(true)));
 
     client.invoke(() -> {
       ClientCache clientCache = ClusterStartupRule.getClientCache();

--- a/geode-connectors/src/acceptanceTest/java/org/apache/geode/connectors/jdbc/JdbcDistributedTest.java
+++ b/geode-connectors/src/acceptanceTest/java/org/apache/geode/connectors/jdbc/JdbcDistributedTest.java
@@ -28,7 +28,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Date;
-import java.util.Properties;
 
 import org.junit.After;
 import org.junit.Before;
@@ -605,7 +604,7 @@ public abstract class JdbcDistributedTest implements Serializable {
       cf.setPdxSerializer(
           new ReflectionBasedAutoSerializer(ClassWithSupportedPdxFields.class.getName()));
     };
-    return startupRule.startClientVM(2, new Properties(), cacheSetup);
+    return startupRule.startClientVM(2, c -> c.withCacheSetup(cacheSetup));
   }
 
   private void createClientRegion(ClientVM client) {

--- a/geode-core/src/distributedTest/java/org/apache/geode/management/ClientHealthStatsDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/ClientHealthStatsDUnitTest.java
@@ -21,6 +21,7 @@ import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.Serializable;
+import java.util.Properties;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -62,8 +63,12 @@ public class ClientHealthStatsDUnitTest implements Serializable {
 
   @Test
   public void testClientHealthStats_SubscriptionEnabled() throws Exception {
-    client1 = cluster.startClientVM(2, true, server.getPort());
-    client2 = cluster.startClientVM(3, true, server.getPort());
+    client1 =
+        cluster.startClientVM(2,
+            c1 -> c1.withPoolSubscription(true).withServerConnection(server.getPort()));
+    client2 =
+        cluster.startClientVM(3,
+            c -> c.withPoolSubscription(true).withServerConnection(server.getPort()));
 
     VMProvider.invokeInEveryMember(() -> {
       ClientRegionFactory<String, String> regionFactory =
@@ -80,8 +85,12 @@ public class ClientHealthStatsDUnitTest implements Serializable {
 
   @Test
   public void testClientHealthStats_SubscriptionDisabled() throws Exception {
-    client1 = cluster.startClientVM(2, false, server.getPort());
-    client2 = cluster.startClientVM(3, false, server.getPort());
+    client1 =
+        cluster.startClientVM(2,
+            c1 -> c1.withPoolSubscription(false).withServerConnection(server.getPort()));
+    client2 =
+        cluster.startClientVM(3,
+            c -> c.withPoolSubscription(false).withServerConnection(server.getPort()));
     VMProvider.invokeInEveryMember(() -> {
       ClientRegionFactory<String, String> regionFactory =
           ClusterStartupRule.getClientCache()
@@ -171,7 +180,7 @@ public class ClientHealthStatsDUnitTest implements Serializable {
   }
 
   private ClientVM createDurableClient(int index) throws Exception {
-    ClientVM client = cluster.startClientVM(index, ccf -> {
+    ClientVM client = cluster.startClientVM(index, new Properties(), ccf -> {
       ccf.setPoolSubscriptionEnabled(true);
       ccf.addPoolServer("localhost", server.getPort());
       ccf.set(DURABLE_CLIENT_ID, "client" + index);

--- a/geode-core/src/distributedTest/java/org/apache/geode/management/internal/security/MultiClientDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/internal/security/MultiClientDUnitTest.java
@@ -77,12 +77,20 @@ public class MultiClientDUnitTest {
       cache.createRegionFactory(RegionShortcut.PARTITION).create("region");
     }, server1, server2);
 
-    client3 = lsRule.startClientVM(3, "data", "data", false, server1.getPort(), server2.getPort());
-    client4 = lsRule.startClientVM(4, "stranger", "stranger", false, server1.getPort(),
-        server2.getPort());
-    client5 = lsRule.startClientVM(5, "data", "data", false, server1.getPort(), server2.getPort());
-    client6 = lsRule.startClientVM(6, "dataWithWrongPswd", "data", false, server1.getPort(),
-        server2.getPort());
+    int server1Port = server1.getPort();
+    int server2Port = server2.getPort();
+    client3 = lsRule.startClientVM(3, c -> c.withCredential("data", "data")
+        .withPoolSubscription(false)
+        .withServerConnection(server1Port, server2Port));
+    client4 = lsRule.startClientVM(4, c -> c.withCredential("stranger", "stranger")
+        .withPoolSubscription(false)
+        .withServerConnection(server1Port, server2Port));
+    client5 = lsRule.startClientVM(5, c -> c.withCredential("data", "data")
+        .withPoolSubscription(false)
+        .withServerConnection(server1Port, server2Port));
+    client6 = lsRule.startClientVM(6, c -> c.withCredential("dataWithWrongPswd", "data")
+        .withPoolSubscription(false)
+        .withServerConnection(server1Port, server2Port));
   }
 
   @Test

--- a/geode-core/src/distributedTest/java/org/apache/geode/management/internal/security/MultiUserAuthenticationDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/internal/security/MultiUserAuthenticationDUnitTest.java
@@ -15,31 +15,27 @@
 
 package org.apache.geode.management.internal.security;
 
-import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
-import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
-import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_CLIENT_AUTH_INIT;
-import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_MANAGER;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Properties;
 
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionService;
 import org.apache.geode.cache.client.ClientCache;
-import org.apache.geode.cache.client.ClientCacheFactory;
 import org.apache.geode.cache.client.ClientRegionShortcut;
 import org.apache.geode.cache.client.ServerOperationException;
 import org.apache.geode.examples.SimpleSecurityManager;
-import org.apache.geode.security.templates.UserPasswordAuthInit;
 import org.apache.geode.test.dunit.IgnoredException;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.junit.categories.SecurityTest;
+import org.apache.geode.test.junit.rules.ClientCacheRule;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
 
 @Category({SecurityTest.class})
@@ -51,23 +47,25 @@ public class MultiUserAuthenticationDUnitTest {
   @ClassRule
   public static ClusterStartupRule lsRule = new ClusterStartupRule();
 
+  @Rule
+  public ClientCacheRule client = new ClientCacheRule();
+
   @ClassRule
   public static GfshCommandRule gfsh = new GfshCommandRule();
 
-  private static MemberVM locator, server1, server2;
+  private static MemberVM locator;
 
   @BeforeClass
   public static void beforeClass() throws Exception {
     IgnoredException.addIgnoredException("org.apache.geode.security.AuthenticationFailedException");
-    Properties locatorProps = new Properties();
-    locatorProps.setProperty(SECURITY_MANAGER, SimpleSecurityManager.class.getCanonicalName());
-    locator = lsRule.startLocatorVM(0, locatorProps);
+
+    locator = lsRule.startLocatorVM(0, l -> l.withSecurityManager(SimpleSecurityManager.class));
 
     Properties serverProps = new Properties();
     serverProps.setProperty("security-username", "cluster");
     serverProps.setProperty("security-password", "cluster");
-    server1 = lsRule.startServerVM(1, serverProps, locator.getPort());
-    server2 = lsRule.startServerVM(2, serverProps, locator.getPort());
+    lsRule.startServerVM(1, serverProps, locator.getPort());
+    lsRule.startServerVM(2, serverProps, locator.getPort());
 
     // create region and put in some values
     gfsh.connectAndVerify(locator);
@@ -78,14 +76,14 @@ public class MultiUserAuthenticationDUnitTest {
   public void multiAuthenticatedView() throws Exception {
     int locatorPort = locator.getPort();
     for (int i = 0; i < SESSION_COUNT; i++) {
-      ClientCache cache = new ClientCacheFactory(getClientCacheProperties("stranger", "stranger"))
-          .setPoolSubscriptionEnabled(true).setPoolMultiuserAuthentication(true)
-          .addPoolLocator("localhost", locatorPort).create();
+      ClientCache cache = client.withCredential("stranger", "stranger")
+          .withCacheSetup(f -> f.setPoolSubscriptionEnabled(true)
+              .setPoolMultiuserAuthentication(true)
+              .addPoolLocator("localhost", locatorPort))
+          .createCache();
 
-      RegionService regionService1 =
-          cache.createAuthenticatedView(getClientCacheProperties("data", "data"));
-      RegionService regionService2 =
-          cache.createAuthenticatedView(getClientCacheProperties("cluster", "cluster"));
+      RegionService regionService1 = client.createAuthenticatedView("data", "data");
+      RegionService regionService2 = client.createAuthenticatedView("cluster", "cluster");
 
       cache.createClientRegionFactory(ClientRegionShortcut.PROXY).create("region");
 
@@ -102,15 +100,4 @@ public class MultiUserAuthenticationDUnitTest {
       cache.close();
     }
   }
-
-  private static Properties getClientCacheProperties(String username, String password) {
-    Properties props = new Properties();
-    props.setProperty(UserPasswordAuthInit.USER_NAME, username);
-    props.setProperty(UserPasswordAuthInit.PASSWORD, password);
-    props.setProperty(SECURITY_CLIENT_AUTH_INIT, UserPasswordAuthInit.class.getName());
-    props.setProperty(LOCATORS, "");
-    props.setProperty(MCAST_PORT, "0");
-    return props;
-  }
-
 }

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/ClientAuthDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/ClientAuthDUnitTest.java
@@ -67,10 +67,11 @@ public class ClientAuthDUnitTest {
   @Test
   public void authWithCorrectPasswordShouldPass() throws Exception {
     int serverPort = server.getPort();
-    ClientVM clientVM = lsRule.startClientVM(0, getClientAuthProperties("data", "data"), ccf -> {
-      ccf.setPoolSubscriptionEnabled(true);
-      ccf.addPoolServer("localhost", serverPort);
-    }, clientVersion);
+    ClientVM clientVM = lsRule.startClientVM(0, clientVersion,
+        getClientAuthProperties("data", "data"), ccf -> {
+          ccf.setPoolSubscriptionEnabled(true);
+          ccf.addPoolServer("localhost", serverPort);
+        });
 
     clientVM.invoke(() -> {
       ClientCache clientCache = ClusterStartupRule.getClientCache();
@@ -90,19 +91,21 @@ public class ClientAuthDUnitTest {
     // authentication error will happen at this step.
     if (Arrays.asList("100", "110", "111", "120", "130", "140").contains(clientVersion)) {
       assertThatThrownBy(
-          () -> lsRule.startClientVM(0, getClientAuthProperties("test", "invalidPassword"), ccf -> {
-            ccf.setPoolSubscriptionEnabled(true);
-            ccf.addPoolServer("localhost", serverPort);
-          }, clientVersion))
-              .isInstanceOf(AuthenticationFailedException.class);
+          () -> lsRule.startClientVM(0, clientVersion,
+              getClientAuthProperties("test", "invalidPassword"), ccf -> {
+                ccf.setPoolSubscriptionEnabled(true);
+                ccf.addPoolServer("localhost", serverPort);
+              }))
+                  .isInstanceOf(AuthenticationFailedException.class);
       return;
     }
 
     ClientVM clientVM =
-        lsRule.startClientVM(0, getClientAuthProperties("test", "invalidPassword"), ccf -> {
-          ccf.setPoolSubscriptionEnabled(true);
-          ccf.addPoolServer("localhost", serverPort);
-        }, clientVersion);
+        lsRule.startClientVM(0, clientVersion, getClientAuthProperties("test", "invalidPassword"),
+            ccf -> {
+              ccf.setPoolSubscriptionEnabled(true);
+              ccf.addPoolServer("localhost", serverPort);
+            });
 
     clientVM.invoke(() -> {
       ClientCache clientCache = ClusterStartupRule.getClientCache();
@@ -118,10 +121,11 @@ public class ClientAuthDUnitTest {
     int serverPort = server.getPort();
     IgnoredException.addIgnoredException(AuthenticationFailedException.class.getName());
     ClientVM clientVM =
-        lsRule.startClientVM(0, getClientAuthProperties("test", "invalidPassword"), ccf -> {
-          ccf.setPoolSubscriptionEnabled(false);
-          ccf.addPoolServer("localhost", serverPort);
-        }, clientVersion);
+        lsRule.startClientVM(0, clientVersion, getClientAuthProperties("test", "invalidPassword"),
+            ccf -> {
+              ccf.setPoolSubscriptionEnabled(false);
+              ccf.addPoolServer("localhost", serverPort);
+            });
 
     clientVM.invoke(() -> {
       ClientCache clientCache = ClusterStartupRule.getClientCache();

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/ClientAuthorizationLegacyConfigurationDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/ClientAuthorizationLegacyConfigurationDUnitTest.java
@@ -33,13 +33,11 @@ import org.junit.runners.Parameterized;
 
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.Region;
-import org.apache.geode.cache.RegionFactory;
 import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.cache.client.ClientCache;
 import org.apache.geode.cache.client.ClientRegionFactory;
 import org.apache.geode.cache.client.ClientRegionShortcut;
 import org.apache.geode.security.templates.SimpleAccessController;
-import org.apache.geode.security.templates.SimpleAuthenticator;
 import org.apache.geode.security.templates.UserPasswordAuthInit;
 import org.apache.geode.test.dunit.rules.ClientVM;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
@@ -86,39 +84,20 @@ public class ClientAuthorizationLegacyConfigurationDUnitTest {
 
   @Test
   public void everythingFailsWithInvalidAuthenticator() throws Exception {
-    Properties clusterProps = new Properties();
-    clusterProps.setProperty(SECURITY_CLIENT_AUTHENTICATOR,
-        "org.apache.geode.no.such.authenticator.create");
-    clusterProps.setProperty(SECURITY_CLIENT_ACCESSOR,
-        SimpleAccessController.class.getName() + ".create");
-    clusterProps.setProperty(UserPasswordAuthInit.USER_NAME, "cluster,data");
-    clusterProps.setProperty(UserPasswordAuthInit.PASSWORD, "cluster,data");
-    clusterProps.setProperty(SECURITY_CLIENT_AUTH_INIT,
-        UserPasswordAuthInit.class.getCanonicalName() + ".create");
+    Properties clusterProps = getClusterProperties();
 
     locator = csRule.startLocatorVM(0, clusterProps);
     server = csRule.startServerVM(1, clusterProps, locator.getPort());
     server.invoke(() -> {
       Cache cache = ClusterStartupRule.getCache();
-      RegionFactory<String, String> rf = cache.createRegionFactory(RegionShortcut.PARTITION);
-      Region<String, String> region = rf.create(regionName);
+      Region region = cache.createRegionFactory(RegionShortcut.PARTITION).create(regionName);
       region.put(initKey, initValue);
     });
 
-    Properties clientProps = new Properties();
-    clusterProps.setProperty(SECURITY_CLIENT_AUTHENTICATOR,
-        "org.apache.geode.no.such.authenticator.create");
-    clusterProps.setProperty(SECURITY_CLIENT_ACCESSOR,
-        SimpleAccessController.class.getName() + ".create");
-    clientProps.setProperty(UserPasswordAuthInit.USER_NAME, "data");
-    clientProps.setProperty(UserPasswordAuthInit.PASSWORD, "data");
-    clientProps.setProperty(SECURITY_CLIENT_AUTH_INIT,
-        UserPasswordAuthInit.class.getCanonicalName() + ".create");
-
     int locatorPort = locator.getPort();
 
-    ClientVM client = csRule.startClientVM(2, clientProps, cf -> cf
-        .addPoolLocator("localhost", locatorPort), clientVersion);
+    ClientVM client = csRule.startClientVM(2, clientVersion, c -> c.withCredential("data", "data")
+        .withLocatorConnection(locatorPort));
 
     client.invoke(() -> {
       ClientCache cache = ClusterStartupRule.getClientCache();
@@ -148,44 +127,24 @@ public class ClientAuthorizationLegacyConfigurationDUnitTest {
 
   @Test
   public void everythingFailsWithInvalidAccessor() throws Exception {
-    Properties clusterProps = new Properties();
-    clusterProps.setProperty(SECURITY_CLIENT_AUTHENTICATOR,
-        SimpleAuthenticator.class.getCanonicalName() + ".create");
-    clusterProps.setProperty(SECURITY_CLIENT_ACCESSOR, "org.apache.geode.no.such.accessor.create");
-    // give cluster members super-user permissions for ease of testing / RMI invocation
-    clusterProps.setProperty(UserPasswordAuthInit.USER_NAME, "cluster,data");
-    clusterProps.setProperty(UserPasswordAuthInit.PASSWORD, "cluster,data");
-    clusterProps.setProperty(SECURITY_CLIENT_AUTH_INIT,
-        UserPasswordAuthInit.class.getCanonicalName() + ".create");
+    Properties clusterProps = getClusterProperties();
 
     locator = csRule.startLocatorVM(0, clusterProps);
     server = csRule.startServerVM(1, clusterProps, locator.getPort());
     server.invoke(() -> {
       Cache cache = ClusterStartupRule.getCache();
-      RegionFactory<String, String> rf = cache.createRegionFactory(RegionShortcut.PARTITION);
-      Region<String, String> region = rf.create(regionName);
+      Region region = cache.createRegionFactory(RegionShortcut.PARTITION).create(regionName);
       region.put(initKey, initValue);
     });
 
-    Properties clientProps = new Properties();
-    clientProps.setProperty(SECURITY_CLIENT_AUTHENTICATOR,
-        SimpleAuthenticator.class.getCanonicalName() + ".create");
-    clientProps.setProperty(SECURITY_CLIENT_ACCESSOR, "org.apache.geode.no.such.accessor.create");
-    // give cluster members super-user permissions for ease of testing / RMI invocation
-    clientProps.setProperty(UserPasswordAuthInit.USER_NAME, "data");
-    clientProps.setProperty(UserPasswordAuthInit.PASSWORD, "data");
-    clientProps.setProperty(SECURITY_CLIENT_AUTH_INIT,
-        UserPasswordAuthInit.class.getCanonicalName() + ".create");
-
     int locatorPort = locator.getPort();
 
-    ClientVM client = csRule.startClientVM(2, clientProps, cf -> cf
-        .addPoolLocator("localhost", locatorPort), clientVersion);
+    ClientVM client = csRule.startClientVM(2, clientVersion,
+        c -> c.withCredential("data", "data").withLocatorConnection(locatorPort));
     client.invoke(() -> {
       ClientCache cache = ClusterStartupRule.getClientCache();
-      ClientRegionFactory<String, String> rf =
-          cache.createClientRegionFactory(ClientRegionShortcut.PROXY);
-      Region<String, String> region = rf.create(regionName);
+      Region region =
+          cache.createClientRegionFactory(ClientRegionShortcut.PROXY).create(regionName);
 
       // Assert that everything is horrible
       assertThatThrownBy(() -> region.get(initKey))
@@ -207,5 +166,16 @@ public class ClientAuthorizationLegacyConfigurationDUnitTest {
     });
   }
 
-
+  private Properties getClusterProperties() {
+    Properties clusterProps = new Properties();
+    clusterProps.setProperty(SECURITY_CLIENT_AUTHENTICATOR,
+        "org.apache.geode.no.such.authenticator.create");
+    clusterProps.setProperty(SECURITY_CLIENT_ACCESSOR,
+        SimpleAccessController.class.getName() + ".create");
+    clusterProps.setProperty(UserPasswordAuthInit.USER_NAME, "cluster,data");
+    clusterProps.setProperty(UserPasswordAuthInit.PASSWORD, "cluster,data");
+    clusterProps.setProperty(SECURITY_CLIENT_AUTH_INIT,
+        UserPasswordAuthInit.class.getCanonicalName() + ".create");
+    return clusterProps;
+  }
 }

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/ClientDataAuthorizationUsingLegacySecurityDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/ClientDataAuthorizationUsingLegacySecurityDUnitTest.java
@@ -119,8 +119,8 @@ public class ClientDataAuthorizationUsingLegacySecurityDUnitTest {
     Properties props = getVMPropertiesWithPermission("dataWrite");
     int locatorPort = locator.getPort();
 
-    ClientVM clientVM = csRule.startClientVM(2, props, cf -> cf
-        .addPoolLocator("localhost", locatorPort), clientVersion);
+    ClientVM clientVM = csRule.startClientVM(2, clientVersion, props, cf -> cf
+        .addPoolLocator("localhost", locatorPort));
 
     // Client adds data
     clientVM.invoke(() -> {
@@ -152,8 +152,8 @@ public class ClientDataAuthorizationUsingLegacySecurityDUnitTest {
     }
     int locatorPort = locator.getPort();
 
-    ClientVM client = csRule.startClientVM(2, props, cf -> cf
-        .addPoolLocator("localhost", locatorPort), clientVersion);
+    ClientVM client = csRule.startClientVM(2, clientVersion, props, cf -> cf
+        .addPoolLocator("localhost", locatorPort));
 
     // Client cannot get through any avenue
     client.invoke(() -> {
@@ -178,8 +178,8 @@ public class ClientDataAuthorizationUsingLegacySecurityDUnitTest {
     Properties props = getVMPropertiesWithPermission("dataRead");
     int locatorPort = locator.getPort();
 
-    ClientVM client = csRule.startClientVM(2, props, cf -> cf
-        .addPoolLocator("localhost", locatorPort), clientVersion);
+    ClientVM client = csRule.startClientVM(2, clientVersion, props, cf -> cf
+        .addPoolLocator("localhost", locatorPort));
 
     // Add some values for the client to get
     server.invoke(() -> {
@@ -214,8 +214,8 @@ public class ClientDataAuthorizationUsingLegacySecurityDUnitTest {
 
     int locatorPort = locator.getPort();
 
-    ClientVM clientVM = csRule.startClientVM(2, props, cf -> cf
-        .addPoolLocator("localhost", locatorPort), clientVersion);
+    ClientVM clientVM = csRule.startClientVM(2, clientVersion, props, cf -> cf
+        .addPoolLocator("localhost", locatorPort));
 
     clientVM.invoke(() -> {
       ClientCache cache = ClusterStartupRule.getClientCache();

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/ClientDataAuthorizationUsingLegacySecurityWithFailoverDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/ClientDataAuthorizationUsingLegacySecurityWithFailoverDUnitTest.java
@@ -326,9 +326,9 @@ public class ClientDataAuthorizationUsingLegacySecurityWithFailoverDUnitTest {
     int server1Port = this.server1.getPort();
     int server2Port = this.server2.getPort();
 
-    ClientVM client1 = csRule.startClientVM(3, props, cf -> cf
+    ClientVM client1 = csRule.startClientVM(3, clientVersion, props, cf -> cf
         .addPoolServer("localhost", server1Port).addPoolServer("localhost", server2Port)
-        .setPoolSubscriptionEnabled(true).setPoolSubscriptionRedundancy(2), clientVersion);
+        .setPoolSubscriptionEnabled(true).setPoolSubscriptionRedundancy(2));
 
     // Initialize cache
     client1.invoke(() -> {
@@ -384,9 +384,9 @@ public class ClientDataAuthorizationUsingLegacySecurityWithFailoverDUnitTest {
           "org.apache.geode.security.templates.UsernamePrincipal");
     }
 
-    ClientVM client = csRule.startClientVM(3, props, cf -> cf
+    ClientVM client = csRule.startClientVM(3, clientVersion, props, cf -> cf
         .addPoolServer("localhost", server1Port).addPoolServer("localhost", server2Port)
-        .setPoolSubscriptionEnabled(true).setPoolSubscriptionRedundancy(2), clientVersion);
+        .setPoolSubscriptionEnabled(true).setPoolSubscriptionRedundancy(2));
 
     // Initialize cache
     client.invoke(() -> {

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/ClientDestroyInvalidateAuthDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/ClientDestroyInvalidateAuthDUnitTest.java
@@ -57,7 +57,10 @@ public class ClientDestroyInvalidateAuthDUnitTest {
 
   @Test
   public void testDestroyInvalidate() throws Exception {
-    client1 = lsRule.startClientVM(1, "data", "data", true, server.getPort());
+    int serverPort = server.getPort();
+    client1 = lsRule.startClientVM(1, c1 -> c1.withCredential("data", "data")
+        .withPoolSubscription(true)
+        .withServerConnection(serverPort));
     // Delete one key and invalidate another key with an authorized user.
     client1.invoke(() -> {
       ClientCache cache = ClusterStartupRule.getClientCache();
@@ -76,7 +79,9 @@ public class ClientDestroyInvalidateAuthDUnitTest {
       cache.close();
     });
 
-    client2 = lsRule.startClientVM(2, "dataRead", "dataRead", true, server.getPort());
+    client2 = lsRule.startClientVM(2, c -> c.withCredential("dataRead", "dataRead")
+        .withPoolSubscription(true)
+        .withServerConnection(serverPort));
     // Delete one key and invalidate another key with an unauthorized user.
     client2.invoke(() -> {
       ClientCache cache = ClusterStartupRule.getClientCache();

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/ClientExecuteFunctionAuthDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/ClientExecuteFunctionAuthDUnitTest.java
@@ -62,8 +62,13 @@ public class ClientExecuteFunctionAuthDUnitTest {
     server.invoke(() -> {
       ClusterStartupRule.getCache().createRegionFactory(RegionShortcut.REPLICATE).create("region");
     });
-    client1 = cluster.startClientVM(1, "dataRead", "dataRead", true, server.getPort());
-    client2 = cluster.startClientVM(2, "dataWrite", "dataWrite", true, server.getPort());
+    int serverPort = server.getPort();
+    client1 = cluster.startClientVM(1, c1 -> c1.withCredential("dataRead", "dataRead")
+        .withPoolSubscription(true)
+        .withServerConnection(serverPort));
+    client2 = cluster.startClientVM(2, c -> c.withCredential("dataWrite", "dataWrite")
+        .withPoolSubscription(true)
+        .withServerConnection(serverPort));
 
     VMProvider.invokeInEveryMember(() -> {
       writeFunction = new WriteFunction();

--- a/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/dunit/QueryMonitorDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/dunit/QueryMonitorDUnitTest.java
@@ -18,6 +18,7 @@ import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.junit.Assert.fail;
 
 import java.io.File;
+import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.After;
@@ -102,8 +103,12 @@ public class QueryMonitorDUnitTest {
   @Test
   public void testMultipleClientToOneServer() throws Exception {
     int server1Port = server1.getPort();
-    client3 = cluster.startClientVM(3, true, server1Port);
-    client4 = cluster.startClientVM(4, true, server1Port);
+    client3 =
+        cluster.startClientVM(3,
+            c1 -> c1.withPoolSubscription(true).withServerConnection(server1Port));
+    client4 =
+        cluster.startClientVM(4,
+            c -> c.withPoolSubscription(true).withServerConnection(server1Port));
 
     gfsh.executeAndAssertThat("create region --name=exampleRegion --type=REPLICATE")
         .statusIsSuccess();
@@ -119,7 +124,9 @@ public class QueryMonitorDUnitTest {
   public void testOneClientToMultipleServerOnReplicateRegion() throws Exception {
     int server1Port = server1.getPort();
     int server2Port = server2.getPort();
-    client3 = cluster.startClientVM(3, true, server1Port, server2Port);
+    client3 =
+        cluster.startClientVM(3, c -> c.withPoolSubscription(true)
+            .withServerConnection(new int[] {server1Port, server2Port}));
 
     gfsh.executeAndAssertThat("create region --name=exampleRegion --type=REPLICATE")
         .statusIsSuccess();
@@ -136,8 +143,12 @@ public class QueryMonitorDUnitTest {
     // client3 connects to server1, client4 connects to server2
     int server1Port = server1.getPort();
     int server2Port = server2.getPort();
-    client3 = cluster.startClientVM(3, true, server1Port);
-    client4 = cluster.startClientVM(4, true, server2Port);
+    client3 =
+        cluster.startClientVM(3,
+            c1 -> c1.withPoolSubscription(true).withServerConnection(server1Port));
+    client4 =
+        cluster.startClientVM(4,
+            c -> c.withPoolSubscription(true).withServerConnection(server2Port));
 
     gfsh.executeAndAssertThat("create region --name=exampleRegion --type=PARTITION")
         .statusIsSuccess();
@@ -199,11 +210,11 @@ public class QueryMonitorDUnitTest {
     // client3 connects to server1, client4 connects to server2
     int server1Port = server1.getPort();
     int server2Port = server2.getPort();
-    client3 = cluster.startClientVM(3, ccf -> {
+    client3 = cluster.startClientVM(3, new Properties(), ccf -> {
       configureClientCacheFactory(ccf, server1Port);
     });
 
-    client4 = cluster.startClientVM(4, ccf -> {
+    client4 = cluster.startClientVM(4, new Properties(), ccf -> {
       configureClientCacheFactory(ccf, server2Port);
     });
     client3.invoke(() -> executeQuery());
@@ -232,8 +243,12 @@ public class QueryMonitorDUnitTest {
     // client3 connects to server1, client4 connects to server2
     int server1Port = server1.getPort();
     int server2Port = server2.getPort();
-    client3 = cluster.startClientVM(3, true, server1Port);
-    client4 = cluster.startClientVM(4, true, server2Port);
+    client3 =
+        cluster.startClientVM(3,
+            c1 -> c1.withPoolSubscription(true).withServerConnection(server1Port));
+    client4 =
+        cluster.startClientVM(4,
+            c -> c.withPoolSubscription(true).withServerConnection(server2Port));
 
     client3.invoke(() -> executeQuery());
     client4.invoke(() -> executeQuery());
@@ -252,7 +267,7 @@ public class QueryMonitorDUnitTest {
     server1.invoke(() -> populateRegion(0, 100));
 
     int server1Port = server1.getPort();
-    client3 = cluster.startClientVM(3, ccf -> {
+    client3 = cluster.startClientVM(3, new Properties(), ccf -> {
       configureClientCacheFactory(ccf, server1Port);
     });
 

--- a/geode-cq/src/distributedTest/java/org/apache/geode/security/MultiUserAPIDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/security/MultiUserAPIDUnitTest.java
@@ -14,311 +14,142 @@
  */
 package org.apache.geode.security;
 
-import static org.apache.geode.security.SecurityTestUtils.NO_EXCEPTION;
-import static org.apache.geode.test.dunit.Assert.fail;
-import static org.apache.geode.test.dunit.LogWriterUtils.getLogWriter;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.io.IOException;
 import java.util.Properties;
 
-import javax.net.ssl.SSLException;
-import javax.net.ssl.SSLHandshakeException;
-
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 
 import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionService;
+import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.cache.client.ClientCache;
 import org.apache.geode.cache.client.Pool;
 import org.apache.geode.cache.execute.FunctionService;
 import org.apache.geode.cache.query.CqAttributesFactory;
-import org.apache.geode.cache.query.CqException;
 import org.apache.geode.cache.query.CqQuery;
 import org.apache.geode.cache.query.Query;
-import org.apache.geode.distributed.ConfigurationProperties;
-import org.apache.geode.internal.cache.GemFireCacheImpl;
-import org.apache.geode.internal.cache.PoolManagerImpl;
-import org.apache.geode.security.generator.CredentialGenerator;
-import org.apache.geode.security.generator.DummyCredentialGenerator;
-import org.apache.geode.test.junit.categories.SecurityTest;
+import org.apache.geode.examples.SimpleSecurityManager;
+import org.apache.geode.test.dunit.rules.ClusterStartupRule;
+import org.apache.geode.test.dunit.rules.MemberVM;
+import org.apache.geode.test.junit.rules.ClientCacheRule;
 
-@Category({SecurityTest.class})
-public class MultiUserAPIDUnitTest extends ClientAuthorizationTestCase {
+public class MultiUserAPIDUnitTest {
+  @ClassRule
+  public static ClusterStartupRule cluster = new ClusterStartupRule();
 
-  private static final String[] serverIgnoredExceptions =
-      {AuthenticationRequiredException.class.getName(),
-          AuthenticationFailedException.class.getName(), GemFireSecurityException.class.getName(),
-          ClassNotFoundException.class.getName(), IOException.class.getName(),
-          SSLException.class.getName(), SSLHandshakeException.class.getName()};
+  private static MemberVM server1, server2;
 
-  private static final String[] clientIgnoredExceptions =
-      {AuthenticationRequiredException.class.getName(),
-          AuthenticationFailedException.class.getName(), SSLHandshakeException.class.getName()};
+  @Rule
+  public ClientCacheRule client = new ClientCacheRule();
 
-  @Test
-  public void testSingleUserUnsupportedAPIs() {
-    // Start servers
-    // Start clients with multiuser-authentication set to false
-    setUpVMs(new DummyCredentialGenerator(), false);
-    client1.invoke(() -> verifyDisallowedOps(false));
+  @BeforeClass
+  public static void setUp() throws Exception {
+    server1 = cluster.startServerVM(0, s -> s.withSecurityManager(SimpleSecurityManager.class)
+        .withConnectionToLocator(ClusterStartupRule.getDUnitLocatorPort()));
+    server2 = cluster.startServerVM(0, s -> s.withSecurityManager(SimpleSecurityManager.class)
+        .withConnectionToLocator(ClusterStartupRule.getDUnitLocatorPort()));
+    server1.invoke(() -> {
+      ClusterStartupRule.memberStarter.createRegion(RegionShortcut.REPLICATE, "authRegion");
+    });
   }
 
   @Test
-  public void testMultiUserUnsupportedAPIs() {
-    // Start servers.
-    // Start clients with multiuser-authentication set to true.
-    setUpVMs(new DummyCredentialGenerator(), true);
-    client1.invoke(() -> verifyDisallowedOps(true));
+  public void testSingleUserUnsupportedAPIs() throws Exception {
+    client.withCredential("stranger", "stranger").withMultiUser(false)
+        .withServerConnection(server1.getPort(), server2.getPort());
+    ClientCache clientCache = client.createCache();
+
+    assertThatThrownBy(() -> clientCache.createAuthenticatedView(new Properties()))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("did not have multiuser-authentication set to true");
   }
 
-  private void verifyDisallowedOps(final boolean multiUserMode) throws Exception {
-    String op = "unknown";
-    boolean success = false;
+  @Test
+  public void testMultiUserUnsupportedAPIs() throws Exception {
+    client.withCredential("stranger", "stranger")
+        .withPoolSubscription(true)
+        .withMultiUser(true)
+        .withServerConnection(server1.getPort(), server2.getPort());
+    client.createCache();
+    Region realRegion = client.createProxyRegion("authRegion");
+    Pool pool = client.getCache().getDefaultPool();
 
-    if (!multiUserMode) {
-      success = false;
+    RegionService proxyCache = client.createAuthenticatedView("data", "data");
+    Region proxyRegion = proxyCache.getRegion("authRegion");
 
-      try {
-        // Attempt cache.createAuthenticatedCacheView() and expect an exception, fail otherwise
-        op = "Pool.createSecureUserCache()";
-        GemFireCacheImpl.getInstance().createAuthenticatedView(new Properties(), "testPool");
-      } catch (IllegalStateException uoe) {
-        getLogWriter().info(op + ": Got expected exception: " + uoe);
-        success = true;
-      }
+    assertThatThrownBy(() -> realRegion.create("key", "value"))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> realRegion.put("key", "value"))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> realRegion.get("key"))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> realRegion.containsKeyOnServer("key"))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> realRegion.remove("key"))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> realRegion.destroy("key"))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> realRegion.destroyRegion())
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> realRegion.registerInterest("key"))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> realRegion.clear()).isInstanceOf(UnsupportedOperationException.class);
 
-      if (!success) {
-        fail("Did not get exception while doing " + op);
-      }
 
-    } else { // multiuser mode
-      Region realRegion = GemFireCacheImpl.getInstance().getRegion(SecurityTestUtils.REGION_NAME);
-      Region proxyRegion =
-          SecurityTestUtils.getProxyCaches(0).getRegion(SecurityTestUtils.REGION_NAME);
-      Pool pool = PoolManagerImpl.getPMI().find("testPool");
+    assertThatThrownBy(() -> proxyRegion.createSubregion("subRegion", null))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> proxyRegion.forceRolling())
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> proxyRegion.getAttributesMutator())
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> proxyRegion.loadSnapshot(null))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> proxyRegion.saveSnapshot(null))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> proxyRegion.registerInterest("key"))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> proxyRegion.setUserAttribute(null))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> proxyRegion.unregisterInterestRegex("*"))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> proxyRegion.localDestroy("key"))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> proxyRegion.localInvalidate("key"))
+        .isInstanceOf(UnsupportedOperationException.class);
 
-      for (int i = 0; i <= 27; i++) {
-        success = false;
-        try {
-          switch (i) {
-            // Attempt (real) Region.create/put/get/containsKeyOnServer/destroy/
-            // destroyRegion/clear/remove/registerInterest/unregisterInterest()
-            // and expect an exception, fail otherwise.
-            case 0:
-              op = "Region.create()";
-              realRegion.create("key", "value");
-              break;
-            case 1:
-              op = "Region.put()";
-              realRegion.put("key", "value");
-              break;
-            case 2:
-              op = "Region.get()";
-              realRegion.get("key");
-              break;
-            case 3:
-              op = "Region.containsKeyOnServer()";
-              realRegion.containsKeyOnServer("key");
-              break;
-            case 4:
-              op = "Region.remove()";
-              realRegion.remove("key");
-              break;
-            case 5:
-              op = "Region.destroy()";
-              realRegion.destroy("key");
-              break;
-            case 6:
-              op = "Region.destroyRegion()";
-              realRegion.destroyRegion();
-              break;
-            case 7:
-              op = "Region.registerInterest()";
-              realRegion.registerInterest("key");
-              break;
-            // case 8:
-            // op = "Region.unregisterInterest()";
-            // realRegion.unregisterInterest("key");
-            // break;
-            case 8:
-              op = "Region.clear()";
-              realRegion.clear();
-              break;
-            // Attempt ProxyRegion.createSubregion/forceRolling/
-            // getAttributesMutator/registerInterest/loadSnapShot/saveSnapshot/
-            // setUserAttribute/unregisterInterest/writeToDisk
-            // and expect an exception, fail otherwise.
-            case 9:
-              op = "ProxyRegion.createSubregion()";
-              proxyRegion.createSubregion("subregion", null);
-              break;
-            case 10:
-              op = "ProxyRegion.forceRolling()";
-              proxyRegion.forceRolling();
-              break;
-            case 11:
-              op = "ProxyRegion.getAttributesMutator()";
-              proxyRegion.getAttributesMutator();
-              break;
-            case 12:
-              op = "ProxyRegion.registerInterest()";
-              proxyRegion.registerInterest("key");
-              break;
-            case 13:
-              op = "ProxyRegion.loadSnapshot()";
-              proxyRegion.loadSnapshot(null);
-              break;
-            case 14:
-              op = "ProxyRegion.saveSnapshot()";
-              proxyRegion.saveSnapshot(null);
-              break;
-            case 15:
-              op = "ProxyRegion.setUserAttribute()";
-              proxyRegion.setUserAttribute(null);
-              break;
-            case 16:
-              op = "ProxyRegion.unregisterInterestRegex()";
-              proxyRegion.unregisterInterestRegex("*");
-              break;
-            // Attempt FunctionService.onRegion/onServer/s(pool) and expect an
-            // exception, fail otherwise.
-            case 17:
-              op = "FunctionService.onRegion()";
-              FunctionService.onRegion(realRegion);
-              break;
-            case 18:
-              op = "FunctionService.onServer(pool)";
-              FunctionService.onServer(pool);
-              break;
-            case 19:
-              op = "FunctionService.onServers(pool)";
-              FunctionService.onServers(pool);
-              break;
-            // Attempt
-            // QueryService.newQuery().execute()/newCq().execute/executeWithInitialResults()
-            case 20:
-              op = "QueryService.newQuery.execute()";
-              Query query = pool.getQueryService()
-                  .newQuery("SELECT * FROM /" + SecurityTestUtils.REGION_NAME);
-              query.execute();
-              break;
-            case 21:
-              op = "QueryService.newCq.execute()";
-              CqQuery cqQuery =
-                  pool.getQueryService().newCq("SELECT * FROM /" + SecurityTestUtils.REGION_NAME,
-                      new CqAttributesFactory().create());
-              try {
-                cqQuery.execute();
-              } catch (CqException ce) {
-                throw (Exception) ce.getCause();
-              }
-              break;
-            case 22:
-              op = "QueryService.newCq.executeWithInitialResults()";
-              cqQuery =
-                  pool.getQueryService().newCq("SELECT * FROM /" + SecurityTestUtils.REGION_NAME,
-                      new CqAttributesFactory().create());
-              try {
-                cqQuery.executeWithInitialResults();
-              } catch (CqException ce) {
-                throw (Exception) ce.getCause();
-              }
-              break;
-            // Attempt ProxyQueryService.getIndex/createIndex/removeIndex() and
-            // expect an exception, fail otherwise.
-            case 23:
-              op = "ProxyQueryService().getIndexes()";
-              SecurityTestUtils.getProxyCaches(0).getQueryService().getIndexes(null);
-              break;
-            case 24:
-              op = "ProxyQueryService().createIndex()";
-              SecurityTestUtils.getProxyCaches(0).getQueryService().createIndex(null, null, null);
-              break;
-            case 25:
-              op = "ProxyQueryService().removeIndexes()";
-              SecurityTestUtils.getProxyCaches(0).getQueryService().removeIndexes();
-              break;
-            case 26:
-              op = "ProxyRegion.localDestroy()";
-              proxyRegion.localDestroy("key");
-              break;
-            case 27:
-              op = "ProxyRegion.localInvalidate()";
-              proxyRegion.localInvalidate("key");
-              break;
-            default:
-              fail("Unknown op code: " + i);
-              break;
-          }
+    assertThatThrownBy(() -> FunctionService.onRegion(realRegion))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> FunctionService.onServer(pool))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> FunctionService.onServers(pool))
+        .isInstanceOf(UnsupportedOperationException.class);
 
-        } catch (UnsupportedOperationException uoe) {
-          getLogWriter().info(op + ": Got expected exception: " + uoe);
-          success = true;
-        }
-        if (!success) {
-          fail("Did not get exception while doing " + op);
-        }
-      }
-    }
-  }
 
-  private void setUpVMs(final CredentialGenerator gen, final boolean multiUser) {
-    Properties extraProps = gen.getSystemProperties();
-    Properties javaProps = gen.getJavaProperties();
-    String authenticator = gen.getAuthenticator();
-    String authInit = gen.getAuthInit();
+    assertThatThrownBy(() -> {
+      Query query = pool.getQueryService().newQuery("SELECT * FROM /authRegion");
+      query.execute();
+    }).isInstanceOf(UnsupportedOperationException.class);
+    CqQuery cqQuery =
+        pool.getQueryService().newCq("SELECT * FROM /authRegion",
+            new CqAttributesFactory().create());
+    assertThatThrownBy(() -> cqQuery.execute())
+        .hasCauseInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> cqQuery.executeWithInitialResults())
+        .hasCauseInstanceOf(UnsupportedOperationException.class);
 
-    getLogWriter().info("testValidCredentials: Using scheme: " + gen.classCode());
-    getLogWriter().info("testValidCredentials: Using authenticator: " + authenticator);
-    getLogWriter().info("testValidCredentials: Using authinit: " + authInit);
+    assertThatThrownBy(() -> proxyCache.getQueryService().getIndexes())
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> proxyCache.getQueryService().getIndexes(null))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> proxyCache.getQueryService().createIndex(null, null, null))
+        .isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(() -> proxyCache.getQueryService().removeIndexes())
+        .isInstanceOf(UnsupportedOperationException.class);
 
-    // Start the servers
-    int port1 = server1
-        .invoke(() -> createCacheServer(authenticator, extraProps, javaProps));
-    int port2 = server2
-        .invoke(() -> createCacheServer(authenticator, extraProps, javaProps));
 
-    // Start the clients with valid credentials
-    Properties credentials1 = gen.getValidCredentials(1);
-    Properties javaProps1 = gen.getJavaProperties();
-    getLogWriter().info(
-        "testValidCredentials: For first client credentials: " + credentials1 + " : " + javaProps1);
-
-    Properties credentials2 = gen.getValidCredentials(2);
-    Properties javaProps2 = gen.getJavaProperties();
-    getLogWriter().info("testValidCredentials: For second client credentials: " + credentials2
-        + " : " + javaProps2);
-
-    client1.invoke(() -> createCacheClient(authInit, credentials1, javaProps1, port1, port2, 0,
-        multiUser, NO_EXCEPTION));
-  }
-
-  private int createCacheServer(final String authenticator, final Properties extraProps,
-      final Properties javaProps) {
-    Properties authProps = new Properties();
-    if (extraProps != null) {
-      authProps.putAll(extraProps);
-    }
-
-    if (authenticator != null) {
-      authProps.setProperty(ConfigurationProperties.SECURITY_CLIENT_AUTHENTICATOR, authenticator);
-    }
-
-    return SecurityTestUtils.createCacheServer(authProps, javaProps, 0, NO_EXCEPTION);
-  }
-
-  // a
-  protected static void createCacheClient(final String authInit, final Properties authProps,
-      final Properties javaProps, final int[] ports, final int numConnections,
-      final boolean multiUserMode, final int expectedResult) {
-    SecurityTestUtils.createCacheClient(authInit, authProps, javaProps, ports, numConnections,
-        multiUserMode, expectedResult); // invokes SecurityTestUtils 2
-  }
-
-  // b
-  private void createCacheClient(final String authInit, final Properties authProps,
-      final Properties javaProps, final int port1, final int port2, final int numConnections,
-      final boolean multiUserMode, final int expectedResult) {
-    createCacheClient(authInit, authProps, javaProps, new int[] {port1, port2}, numConnections,
-        multiUserMode, expectedResult); // invokes a
   }
 }

--- a/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/rules/tests/ClusterStartupRuleCanSpecifyOlderVersionsDUnitTest.java
+++ b/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/rules/tests/ClusterStartupRuleCanSpecifyOlderVersionsDUnitTest.java
@@ -77,8 +77,8 @@ public class ClusterStartupRuleCanSpecifyOlderVersionsDUnitTest {
 
   @Test
   public void clientVersioningTest() throws Exception {
-    ClientVM locator = csRule.startClientVM(0, new Properties(), (cf) -> {
-    }, version);
+    ClientVM locator = csRule.startClientVM(0, version, new Properties(), (cf) -> {
+    });
     String locatorVMVersion = locator.getVM().getVersion();
     String locatorActualVersion = locator.invoke(GemFireVersion::getGemFireVersion);
     assertThat(locatorVMVersion).isEqualTo(version);

--- a/geode-dunit/src/main/java/org/apache/geode/security/SecurityTestUtil.java
+++ b/geode-dunit/src/main/java/org/apache/geode/security/SecurityTestUtil.java
@@ -32,13 +32,18 @@ import org.apache.geode.cache.client.ClientRegionShortcut;
 import org.apache.geode.internal.Version;
 import org.apache.geode.security.templates.UserPasswordAuthInit;
 
+/**
+ * @deprecated use @org.apache.geode.test.junit.rules.ClientCacheRule instead
+ */
 public class SecurityTestUtil {
 
+  @Deprecated
   public static ClientCache createClientCache(String username, String password, int serverPort) {
     Properties props = new Properties();
     return createClientCache(username, password, serverPort, props);
   }
 
+  @Deprecated
   public static ClientCache createClientCache(String username, String password, int serverPort,
       Properties extraProperties) {
     Properties props = new Properties();
@@ -56,10 +61,12 @@ public class SecurityTestUtil {
     return cache;
   }
 
+  @Deprecated
   public static Region createProxyRegion(ClientCache cache, String regionName) {
     return cache.createClientRegionFactory(ClientRegionShortcut.PROXY).create(regionName);
   }
 
+  @Deprecated
   public static void assertNotAuthorized(ThrowableAssert.ThrowingCallable shouldRaiseThrowable,
       String permString) {
     assertThatThrownBy(shouldRaiseThrowable).hasMessageContaining(permString);

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/rules/MemberVM.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/rules/MemberVM.java
@@ -32,7 +32,7 @@ import org.apache.geode.test.junit.rules.Server;
 import org.apache.geode.test.junit.rules.VMProvider;
 
 public class MemberVM extends VMProvider implements Member {
-  private Logger logger = LogService.getLogger();
+  private static Logger logger = LogService.getLogger();
   protected Member member;
   protected VM vm;
 

--- a/geode-dunit/src/main/java/org/apache/geode/test/junit/rules/ServerStarterRule.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/junit/rules/ServerStarterRule.java
@@ -22,11 +22,8 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
-import java.util.function.Consumer;
 
 import org.apache.geode.cache.CacheFactory;
-import org.apache.geode.cache.PartitionAttributesFactory;
-import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionFactory;
 import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.cache.server.CacheServer;
@@ -161,36 +158,6 @@ public class ServerStarterRule extends MemberStarterRule<ServerStarterRule> impl
     this.autoStart = true;
     regions.put(name, type);
     return this;
-  }
-
-  /**
-   * convenience method to create a region with customized regionFactory
-   *
-   * @param regionFactoryConsumer a lamda that allows you to customize the regionFactory
-   */
-  public Region createRegion(RegionShortcut type, String name,
-      Consumer<RegionFactory> regionFactoryConsumer) {
-    RegionFactory regionFactory = getCache().createRegionFactory(type);
-    regionFactoryConsumer.accept(regionFactory);
-    return regionFactory.create(name);
-  }
-
-  /**
-   * convenience method to create a partition region with customized regionFactory and a customized
-   * PartitionAttributeFactory
-   *
-   * @param regionFactoryConsumer a lamda that allows you to customize the regionFactory
-   * @param attributesFactoryConsumer a lamda that allows you to customize the
-   *        partitionAttributeFactory
-   */
-  public Region createPartitionRegion(String name, Consumer<RegionFactory> regionFactoryConsumer,
-      Consumer<PartitionAttributesFactory> attributesFactoryConsumer) {
-    return createRegion(RegionShortcut.PARTITION, name, rf -> {
-      regionFactoryConsumer.accept(rf);
-      PartitionAttributesFactory attributeFactory = new PartitionAttributesFactory();
-      attributesFactoryConsumer.accept(attributeFactory);
-      rf.setPartitionAttributes(attributeFactory.create());
-    });
   }
 
   public void startServer(Properties properties, int locatorPort) {


### PR DESCRIPTION
* refactored a couple of MultiUser tests to use the ClientCacheRule
* add more convenience methods in ClientCacheRule
* clean up the ClusterStarterRule.startClient interface
* deprecate the SecurityTestUtils to favor using rules

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
