### PR TITLE
GEODE-5971: Refactor CreateRegionCommand to extend SingleGfshCommand

### DIFF
--- a/geode-assembly/src/integrationTest/resources/assembly_content.txt
+++ b/geode-assembly/src/integrationTest/resources/assembly_content.txt
@@ -318,6 +318,8 @@ javadoc/org/apache/geode/cache/configuration/PdxType.html
 javadoc/org/apache/geode/cache/configuration/PoolType.Locator.html
 javadoc/org/apache/geode/cache/configuration/PoolType.Server.html
 javadoc/org/apache/geode/cache/configuration/PoolType.html
+javadoc/org/apache/geode/cache/configuration/RegionAttributeGetFunction.html
+javadoc/org/apache/geode/cache/configuration/RegionAttributeSetFunction.html
 javadoc/org/apache/geode/cache/configuration/RegionAttributesDataPolicy.html
 javadoc/org/apache/geode/cache/configuration/RegionAttributesIndexUpdateType.html
 javadoc/org/apache/geode/cache/configuration/RegionAttributesMirrorType.html
@@ -341,6 +343,7 @@ javadoc/org/apache/geode/cache/configuration/RegionAttributesType.html
 javadoc/org/apache/geode/cache/configuration/RegionConfig.Entry.html
 javadoc/org/apache/geode/cache/configuration/RegionConfig.Index.html
 javadoc/org/apache/geode/cache/configuration/RegionConfig.html
+javadoc/org/apache/geode/cache/configuration/RegionConfigFactory.html
 javadoc/org/apache/geode/cache/configuration/ResourceManagerType.html
 javadoc/org/apache/geode/cache/configuration/SerializationRegistrationType.Instantiator.html
 javadoc/org/apache/geode/cache/configuration/SerializationRegistrationType.Serializer.html

--- a/geode-core/build.gradle
+++ b/geode-core/build.gradle
@@ -15,9 +15,12 @@
  * limitations under the License.
  */
 
-
 apply plugin: 'antlr'
 apply plugin: 'me.champeau.gradle.jmh'
+
+repositories {
+  mavenCentral()
+}
 
 sourceSets {
   jca {

--- a/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/CreateRegionCommandDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/CreateRegionCommandDUnitTest.java
@@ -431,11 +431,12 @@ public class CreateRegionCommandDUnitTest {
   }
 
   @Test
-  public void startWithReplicateProxyThenPartitionRegion() {
+  public void startWithReplicateProxyThenPartitionRegion() throws Exception {
     String regionName = testName.getMethodName();
     gfsh.executeAndAssertThat(
         "create region --type=REPLICATE_PROXY --group=group1 --name=" + regionName)
         .statusIsSuccess().tableHasRowWithValues("Member", "server-1");
+
     gfsh.executeAndAssertThat("create region --type=PARTITION --group=group2 --name=" + regionName)
         .statusIsError().containsOutput("The existing region is not a partitioned region");
     gfsh.executeAndAssertThat(

--- a/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/CreateRegionCommandPersistsConfigurationDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/CreateRegionCommandPersistsConfigurationDUnitTest.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.management.internal.cli.commands;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.apache.commons.math3.stat.clustering.Cluster;
+import org.apache.geode.cache.Region;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TestName;
+
+import org.apache.geode.cache.configuration.CacheConfig;
+import org.apache.geode.cache.configuration.ExpirationAttributesType;
+import org.apache.geode.cache.configuration.RegionAttributesType;
+import org.apache.geode.cache.configuration.RegionConfig;
+import org.apache.geode.distributed.internal.InternalConfigurationPersistenceService;
+import org.apache.geode.test.dunit.rules.ClusterStartupRule;
+import org.apache.geode.test.dunit.rules.MemberVM;
+import org.apache.geode.test.junit.categories.RegionsTest;
+import org.apache.geode.test.junit.rules.GfshCommandRule;
+import org.apache.geode.test.junit.rules.serializable.SerializableTestName;
+
+@Category({RegionsTest.class})
+public class CreateRegionCommandPersistsConfigurationDUnitTest {
+
+  private MemberVM locator, server1, server2;
+
+  @Rule
+  public ClusterStartupRule clusterRule = new ClusterStartupRule();
+
+  @Rule
+  public GfshCommandRule gfsh = new GfshCommandRule();
+
+  @Rule
+  public TestName testName = new SerializableTestName();
+
+  @Before
+  public void before() throws Exception {
+    locator = clusterRule.startLocatorVM(0);
+    server1 = clusterRule.startServerVM(1, locator.getPort());
+    server2 = clusterRule.startServerVM(2, locator.getPort());
+
+    gfsh.connectAndVerify(locator);
+  }
+
+  @Test
+  public void testCreateRegionPersistsConfig() {
+    String regionName = testName.getMethodName();
+    gfsh.executeAndAssertThat("create region --name=" + regionName + " --type=REPLICATE")
+        .statusIsSuccess();
+
+    server1.getVM().bounce();
+    server2.getVM().bounce();
+    server1 = clusterRule.startServerVM(1, "group1", locator.getPort());
+    server2 = clusterRule.startServerVM(2, "group2", locator.getPort());
+
+    gfsh.executeAndAssertThat("list regions")
+        .statusIsSuccess().containsOutput(regionName);
+
+    locator.invoke(() -> {
+      InternalConfigurationPersistenceService cc =
+          ClusterStartupRule.getLocator().getConfigurationPersistenceService();
+      CacheConfig config = cc.getCacheConfig("cluster");
+
+      List<RegionConfig> regions = config.getRegions();
+      assertThat(regions).isNotEmpty();
+      RegionConfig regionConfig = regions.get(0);
+      assertThat(regionConfig).isNotNull();
+      assertThat(regionConfig.getName()).isEqualTo(regionName);
+      assertThat(regionConfig.getIndexes()).isEmpty();
+      assertThat(regionConfig.getRegions()).isEmpty();
+      assertThat(regionConfig.getEntries()).isEmpty();
+      assertThat(regionConfig.getCustomRegionElements()).isEmpty();
+      assertThat(regionConfig.getRegionAttributes()).isEmpty();
+    });
+  }
+
+  @Test
+  public void testCreateRegionPersistsConfigParams() {
+    String regionName = testName.getMethodName();
+    gfsh.executeAndAssertThat("create region --name=" + regionName + " --type=PARTITION"
+        + " --enable-statistics=true" + " --enable-async-conflation=true"
+        + " --entry-idle-time-expiration=100").statusIsSuccess();
+
+    server1.getVM().bounce();
+    server2.getVM().bounce();
+    server1 = clusterRule.startServerVM(1, "group1", locator.getPort());
+    server2 = clusterRule.startServerVM(2, "group2", locator.getPort());
+
+    gfsh.executeAndAssertThat("list regions")
+        .statusIsSuccess().containsOutput(regionName);
+
+    locator.invoke(() -> {
+      InternalConfigurationPersistenceService cc =
+          ClusterStartupRule.getLocator().getConfigurationPersistenceService();
+      CacheConfig config = cc.getCacheConfig("cluster");
+
+      List<RegionConfig> regions = config.getRegions();
+      assertThat(regions).isNotEmpty();
+      RegionConfig regionConfig = regions.get(0);
+      assertThat(regionConfig).isNotNull();
+      assertThat(regionConfig.getName()).isEqualTo(regionName);
+      assertThat(regionConfig.getRegionAttributes()).hasSize(1);
+
+      RegionAttributesType attr = regionConfig.getRegionAttributes().get(0);
+      assertThat(attr.isStatisticsEnabled()).isTrue();
+      assertThat(attr.isEnableAsyncConflation()).isTrue();
+
+      ExpirationAttributesType entryIdleTimeExp = attr.getEntryIdleTime().getExpirationAttributes();
+      assertThat(entryIdleTimeExp.getTimeout()).isEqualTo("100");
+    });
+
+    server1.invoke(() -> {
+      Region<?, ?> region = ClusterStartupRule.getCache().getRegion(regionName);
+      assertThat(region.getAttributes().getStatisticsEnabled())
+              .describedAs("Expecting statistics to be enabled")
+              .isTrue();
+      assertThat(region.getAttributes().getEnableAsyncConflation())
+              .describedAs("Expecting async conflation to be enabled")
+              .isTrue();
+      assertThat(region.getAttributes().getEntryIdleTimeout().getTimeout())
+              .describedAs("Expecting entry idle time exp timeout to be 100")
+              .isEqualTo(100);
+    });
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/cache/ExpirationAction.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/ExpirationAction.java
@@ -120,6 +120,21 @@ public class ExpirationAction implements Serializable {
     return this.name;
   }
 
+  public String toXmlString() {
+    switch (this.name) {
+      case "INVALIDATE":
+        return "invalidate";
+      case "DESTROY":
+        return "destroy";
+      case "LOCAL_DESTROY":
+        return "local-destroy";
+      case "LOCAL_INVALIDATE":
+        return "local-invalidate";
+      default:
+        return null;
+    }
+  }
+
   // The 4 declarations below are necessary for serialization
   private static int nextOrdinal = 0;
   public final int ordinal = nextOrdinal++;

--- a/geode-core/src/main/java/org/apache/geode/cache/ExpirationAttributes.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/ExpirationAttributes.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 
 import org.apache.geode.DataSerializable;
 import org.apache.geode.DataSerializer;
+import org.apache.geode.cache.configuration.ExpirationAttributesType;
 import org.apache.geode.internal.InternalDataSerializer;
 
 /**
@@ -149,12 +150,20 @@ public class ExpirationAttributes implements DataSerializable {
 
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
     this.timeout = in.readInt();
-    this.action = (ExpirationAction) DataSerializer.readObject(in);
+    this.action = DataSerializer.readObject(in);
 
   }
 
   public void toData(DataOutput out) throws IOException {
     out.writeInt(this.timeout);
     DataSerializer.writeObject(this.action, out);
+  }
+
+  public ExpirationAttributesType toConfigType() {
+    ExpirationAttributesType t = new ExpirationAttributesType();
+    t.setTimeout(Integer.toString(this.timeout));
+    t.setAction(this.action.toXmlString());
+
+    return t;
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/cache/configuration/RegionAttributeGetFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/configuration/RegionAttributeGetFunction.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache.configuration;
+
+@FunctionalInterface
+public interface RegionAttributeGetFunction {
+  Object getValue(RegionAttributesType attributesType);
+}

--- a/geode-core/src/main/java/org/apache/geode/cache/configuration/RegionAttributeSetFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/configuration/RegionAttributeSetFunction.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache.configuration;
+
+@FunctionalInterface
+public interface RegionAttributeSetFunction {
+  void setAttributeValue(RegionAttributesType attributesType);
+}

--- a/geode-core/src/main/java/org/apache/geode/cache/configuration/RegionAttributesType.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/configuration/RegionAttributesType.java
@@ -1795,6 +1795,17 @@ public class RegionAttributesType {
     @XmlElement(name = "lru-memory-size", namespace = "http://geode.apache.org/schema/cache")
     protected RegionAttributesType.EvictionAttributes.LruMemorySize lruMemorySize;
 
+    public String toStringRep() {
+      return "lru-entry-count: " +
+          this.lruEntryCount.getMaximum() + ", " +
+          this.lruEntryCount.getAction().toString() + ", " +
+          "\nlru-heap-percentage: " +
+          this.lruHeapPercentage.getAction().toString() +
+          "\nlru-memory-size: " +
+          this.lruMemorySize.getMaximum() +
+          this.lruMemorySize.getAction().toString();
+    }
+
     /**
      * Gets the value of the lruEntryCount property.
      *

--- a/geode-core/src/main/java/org/apache/geode/cache/configuration/RegionConfigFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/configuration/RegionConfigFactory.java
@@ -1,0 +1,244 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache.configuration;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.apache.geode.management.internal.cli.functions.RegionFunctionArgs;
+
+public class RegionConfigFactory {
+  public RegionConfig generate(RegionFunctionArgs args) {
+    RegionConfig regionConfig = new RegionConfig();
+    regionConfig.setName(getLeafRegion(args.getRegionPath()));
+
+    if (args.getRegionShortcut() != null) {
+      regionConfig.setRefid(args.getRegionShortcut().toString());
+    }
+
+    if (args.getKeyConstraint() != null) {
+      addAttribute(regionConfig, a -> a.setKeyConstraint(args.getKeyConstraint()));
+    }
+
+    if (args.getValueConstraint() != null) {
+      addAttribute(regionConfig, a -> a.setValueConstraint(args.getValueConstraint()));
+    }
+
+    if (args.getStatisticsEnabled() != null) {
+      addAttribute(regionConfig, a -> a.setStatisticsEnabled(args.getStatisticsEnabled()));
+    }
+
+    if (args.getEntryExpirationIdleTime() != null) {
+      RegionAttributesType.EntryIdleTime entryIdleTime = new RegionAttributesType.EntryIdleTime();
+      entryIdleTime.setExpirationAttributes(
+          args.getEntryExpirationIdleTime().getExpirationAttributes().toConfigType());
+      addAttribute(regionConfig, a -> a.setEntryIdleTime(entryIdleTime));
+    }
+
+    if (args.getEntryExpirationTTL() != null) {
+      RegionAttributesType.EntryTimeToLive entryExpTime =
+          new RegionAttributesType.EntryTimeToLive();
+      entryExpTime.setExpirationAttributes(
+          args.getEntryExpirationTTL().getExpirationAttributes().toConfigType());
+      addAttribute(regionConfig, a -> a.setEntryTimeToLive(entryExpTime));
+    }
+
+    if (args.getRegionExpirationIdleTime() != null) {
+      RegionAttributesType.RegionIdleTime regionIdleTime =
+          new RegionAttributesType.RegionIdleTime();
+      regionIdleTime.setExpirationAttributes(
+          args.getRegionExpirationIdleTime().getExpirationAttributes().toConfigType());
+      addAttribute(regionConfig, a -> a.setRegionIdleTime(regionIdleTime));
+    }
+
+    if (args.getRegionExpirationTTL() != null) {
+      RegionAttributesType.RegionTimeToLive regionExpTime =
+          new RegionAttributesType.RegionTimeToLive();
+      regionExpTime.setExpirationAttributes(
+          args.getRegionExpirationTTL().getExpirationAttributes().toConfigType());
+      addAttribute(regionConfig, a -> a.setRegionTimeToLive(regionExpTime));
+    }
+
+    if (args.getEntryTTLCustomExpiry() != null) {
+      Object maybeEntryTTLAttr = getRegionAttributeValue(regionConfig, a -> a.getEntryTimeToLive());
+      RegionAttributesType.EntryTimeToLive entryTimeToLive =
+          maybeEntryTTLAttr != null ? (RegionAttributesType.EntryTimeToLive) maybeEntryTTLAttr
+              : new RegionAttributesType.EntryTimeToLive();
+      ExpirationAttributesType expirationAttributes =
+          entryTimeToLive.getExpirationAttributes() == null ? new ExpirationAttributesType()
+              : entryTimeToLive.getExpirationAttributes();
+
+      DeclarableType customExpiry = new DeclarableType();
+      customExpiry.setClassName(args.getEntryTTLCustomExpiry().getClassName());
+      expirationAttributes.setCustomExpiry(customExpiry);
+      entryTimeToLive.setExpirationAttributes(expirationAttributes);
+
+      if (maybeEntryTTLAttr == null) {
+        addAttribute(regionConfig, a -> a.setEntryTimeToLive(entryTimeToLive));
+      }
+    }
+
+    if (args.getEntryIdleTimeCustomExpiry() != null) {
+      Object maybeEntryIdleAttr = getRegionAttributeValue(regionConfig, a -> a.getEntryIdleTime());
+      RegionAttributesType.EntryIdleTime entryIdleTime =
+          maybeEntryIdleAttr != null ? (RegionAttributesType.EntryIdleTime) maybeEntryIdleAttr
+              : new RegionAttributesType.EntryIdleTime();
+      ExpirationAttributesType expirationAttributes =
+          entryIdleTime.getExpirationAttributes() == null ? new ExpirationAttributesType()
+              : entryIdleTime.getExpirationAttributes();
+
+      DeclarableType customExpiry = new DeclarableType();
+      customExpiry.setClassName(args.getEntryIdleTimeCustomExpiry().getClassName());
+      expirationAttributes.setCustomExpiry(customExpiry);
+      entryIdleTime.setExpirationAttributes(expirationAttributes);
+
+      if (maybeEntryIdleAttr == null) {
+        addAttribute(regionConfig, a -> a.setEntryIdleTime(entryIdleTime));
+      }
+    }
+
+    if (args.getDiskStore() != null) {
+      addAttribute(regionConfig, a -> a.setDiskStoreName(args.getDiskStore()));
+    }
+
+    if (args.getDiskSynchronous() != null) {
+      addAttribute(regionConfig, a -> a.setDiskSynchronous(args.getDiskSynchronous()));
+    }
+
+    if (args.getEnableAsyncConflation() != null) {
+      addAttribute(regionConfig, a -> a.setEnableAsyncConflation(args.getEnableAsyncConflation()));
+    }
+
+    if (args.getEnableSubscriptionConflation() != null) {
+      addAttribute(regionConfig,
+          a -> a.setEnableSubscriptionConflation(args.getEnableSubscriptionConflation()));
+    }
+
+    if (args.getConcurrencyChecksEnabled() != null) {
+      addAttribute(regionConfig, a -> a.setConcurrencyChecksEnabled(
+          args.getConcurrencyChecksEnabled()));
+    }
+
+    if (args.getCloningEnabled() != null) {
+      addAttribute(regionConfig, a -> a.setCloningEnabled(args.getCloningEnabled()));
+    }
+
+    if (args.getOffHeap() != null) {
+      addAttribute(regionConfig, a -> a.setOffHeap(args.getOffHeap()));
+    }
+
+    if (args.getMcastEnabled() != null) {
+      addAttribute(regionConfig, a -> a.setMulticastEnabled(args.getMcastEnabled()));
+    }
+
+    if (args.getPartitionArgs() != null) {
+      RegionAttributesType.PartitionAttributes partitionAttributes =
+          new RegionAttributesType.PartitionAttributes();
+      RegionFunctionArgs.PartitionArgs partitionArgs = args.getPartitionArgs();
+      partitionAttributes.setColocatedWith(partitionArgs.getPrColocatedWith());
+      partitionAttributes.setLocalMaxMemory(int2string(partitionArgs.getPrLocalMaxMemory()));
+      partitionAttributes.setRecoveryDelay(long2string(partitionArgs.getPrRecoveryDelay()));
+      partitionAttributes.setRedundantCopies(int2string(partitionArgs.getPrRedundantCopies()));
+      partitionAttributes
+          .setStartupRecoveryDelay(long2string(partitionArgs.getPrStartupRecoveryDelay()));
+      partitionAttributes.setTotalMaxMemory(long2string(partitionArgs.getPrTotalMaxMemory()));
+      partitionAttributes.setTotalNumBuckets(int2string(partitionArgs.getPrTotalNumBuckets()));
+
+      DeclarableType partitionResolverType = new DeclarableType();
+      partitionResolverType.setClassName(partitionArgs.getPartitionResolver());
+      partitionAttributes.setPartitionResolver(partitionResolverType);
+
+      addAttribute(regionConfig, a -> a.setPartitionAttributes(partitionAttributes));
+    }
+
+    if (args.getGatewaySenderIds() != null && !args.getGatewaySenderIds().isEmpty()) {
+      addAttribute(regionConfig, a -> a.setGatewaySenderIds(String.join(",",
+          args.getGatewaySenderIds())));
+    }
+
+    if (args.getEvictionAttributes() != null) {
+      addAttribute(regionConfig, a -> a.setEvictionAttributes(
+          args.getEvictionAttributes().convertToConfigEvictionAttributes()));
+    }
+
+    if (args.getAsyncEventQueueIds() != null && !args.getAsyncEventQueueIds().isEmpty()) {
+      addAttribute(regionConfig,
+          a -> a.setAsyncEventQueueIds(String.join(",", args.getAsyncEventQueueIds())));
+    }
+
+    if (args.getCacheListeners() != null && !args.getCacheListeners().isEmpty()) {
+      addAttribute(regionConfig, a -> a.getCacheListeners().addAll(
+          args.getCacheListeners().stream().map(l -> {
+            DeclarableType declarableType = new DeclarableType();
+            declarableType.setClassName(l.getClassName());
+            return declarableType;
+          }).collect(Collectors.toList())));
+    }
+
+    if (args.getCacheLoader() != null) {
+      DeclarableType declarableType = new DeclarableType();
+      declarableType.setClassName(args.getCacheLoader().getClassName());
+      addAttribute(regionConfig, a -> a.setCacheLoader(declarableType));
+    }
+
+    if (args.getCacheWriter() != null) {
+      DeclarableType declarableType = new DeclarableType();
+      declarableType.setClassName(args.getCacheWriter().getClassName());
+      addAttribute(regionConfig, a -> a.setCacheWriter(declarableType));
+    }
+
+    if (args.getCompressor() != null) {
+      addAttribute(regionConfig, a -> a.setCompressor(new ClassNameType(args.getCompressor())));
+    }
+
+    if (args.getConcurrencyLevel() != null) {
+      addAttribute(regionConfig, a -> a.setConcurrencyLevel(args.getConcurrencyLevel().toString()));
+    }
+
+    return regionConfig;
+  }
+
+  private String int2string(Integer i) {
+    return Optional.ofNullable(i).map(j -> j.toString()).orElse(null);
+  }
+
+  private String long2string(Long i) {
+    return Optional.ofNullable(i).map(j -> j.toString()).orElse(null);
+  }
+
+  private String getLeafRegion(String fullPath) {
+    String regionPath = fullPath;
+    String[] regions = regionPath.split("/");
+
+    return regions[regions.length - 1];
+  }
+
+  private void addAttribute(RegionConfig config, RegionAttributeSetFunction func) {
+    final List<RegionAttributesType> regionAttributes = config.getRegionAttributes();
+    if (regionAttributes.isEmpty()) {
+      regionAttributes.add(new RegionAttributesType());
+    }
+
+    func.setAttributeValue(regionAttributes.get(0));
+  }
+
+  private Object getRegionAttributeValue(RegionConfig config, RegionAttributeGetFunction function) {
+    return config.getRegionAttributes().stream()
+        .findFirst()
+        .map(a -> function.getValue(a))
+        .orElse(null);
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/AlterRegionCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/AlterRegionCommand.java
@@ -26,7 +26,6 @@ import org.apache.geode.cache.CacheWriter;
 import org.apache.geode.cache.CustomExpiry;
 import org.apache.geode.cache.ExpirationAction;
 import org.apache.geode.distributed.DistributedMember;
-import org.apache.geode.distributed.internal.InternalConfigurationPersistenceService;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
@@ -139,7 +138,7 @@ public class AlterRegionCommand extends InternalGfshCommand {
     XmlEntity xmlEntity = findXmlEntity(regionAlterResults);
     if (xmlEntity != null) {
       persistClusterConfiguration(result,
-          () -> ((InternalConfigurationPersistenceService) getConfigurationPersistenceService())
+          () -> getConfigurationPersistenceService()
               .addXmlEntity(xmlEntity, groups));
     }
     return result;

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateRegionCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateRegionCommand.java
@@ -39,9 +39,13 @@ import org.apache.geode.cache.ExpirationAction;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionAttributes;
 import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.cache.configuration.CacheConfig;
+import org.apache.geode.cache.configuration.RegionConfig;
+import org.apache.geode.cache.configuration.RegionConfigFactory;
 import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.management.DistributedRegionMXBean;
 import org.apache.geode.management.DistributedSystemMXBean;
 import org.apache.geode.management.ManagementService;
@@ -50,6 +54,7 @@ import org.apache.geode.management.RegionMXBean;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
+import org.apache.geode.management.cli.SingleGfshCommand;
 import org.apache.geode.management.internal.cli.AbstractCliAroundInterceptor;
 import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.management.internal.cli.GfshParseResult;
@@ -63,18 +68,18 @@ import org.apache.geode.management.internal.cli.functions.RegionCreateFunction;
 import org.apache.geode.management.internal.cli.functions.RegionFunctionArgs;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
+import org.apache.geode.management.internal.cli.result.model.ResultModel;
 import org.apache.geode.management.internal.cli.util.RegionPath;
-import org.apache.geode.management.internal.configuration.domain.XmlEntity;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class CreateRegionCommand extends InternalGfshCommand {
+public class CreateRegionCommand extends SingleGfshCommand {
   @CliCommand(value = CliStrings.CREATE_REGION, help = CliStrings.CREATE_REGION__HELP)
   @CliMetaData(relatedTopic = CliStrings.TOPIC_GEODE_REGION,
       interceptor = "org.apache.geode.management.internal.cli.commands.CreateRegionCommand$Interceptor")
   @ResourceOperation(resource = ResourcePermission.Resource.DATA,
       operation = ResourcePermission.Operation.MANAGE)
-  public Result createRegion(
+  public ResultModel createRegion(
       @CliOption(key = CliStrings.CREATE_REGION__REGION, mandatory = true,
           optionContext = ConverterHint.REGION_PATH,
           help = CliStrings.CREATE_REGION__REGION__HELP) String regionPath,
@@ -180,15 +185,13 @@ public class CreateRegionCommand extends InternalGfshCommand {
           help = CliStrings.CREATE_REGION__VALUECONSTRAINT__HELP) String valueConstraint
   // NOTICE: keep the region attributes params in alphabetical order
   ) {
-    Result result;
-
     if (regionShortcut != null && templateRegion != null) {
-      return ResultBuilder.createUserErrorResult(
+      return ResultModel.createError(
           CliStrings.CREATE_REGION__MSG__ONLY_ONE_OF_REGIONSHORTCUT_AND_USEATTRIBUESFROM_CAN_BE_SPECIFIED);
     }
 
     if (regionShortcut == null && templateRegion == null) {
-      return ResultBuilder.createUserErrorResult(
+      return ResultModel.createError(
           CliStrings.CREATE_REGION__MSG__ONE_OF_REGIONSHORTCUT_AND_USEATTRIBUTESFROM_IS_REQUIRED);
     }
 
@@ -217,6 +220,7 @@ public class CreateRegionCommand extends InternalGfshCommand {
 
       // we first make sure E and C have the compatible data policy
       if (regionShortcut.isPartition() && !existingDataPolicy.contains("PARTITION")) {
+        LogService.getLogger().info("Create region command: got EntityExists exception");
         throw new EntityExistsException("The existing region is not a partitioned region",
             ifNotExists);
       }
@@ -244,7 +248,7 @@ public class CreateRegionCommand extends InternalGfshCommand {
     String parentRegionPath = regionPathData.getParent();
     if (parentRegionPath != null && !Region.SEPARATOR.equals(parentRegionPath)) {
       if (!regionExists(cache, parentRegionPath)) {
-        return ResultBuilder.createUserErrorResult(
+        return ResultModel.createError(
             CliStrings.format(CliStrings.CREATE_REGION__MSG__PARENT_REGION_FOR_0_DOES_NOT_EXIST,
                 new Object[] {regionPath}));
       }
@@ -282,7 +286,7 @@ public class CreateRegionCommand extends InternalGfshCommand {
     RegionAttributes<?, ?> regionAttributes = null;
     if (regionShortcut != null) {
       if (!regionShortcut.name().startsWith("PARTITION") && functionArgs.hasPartitionAttributes()) {
-        return ResultBuilder.createUserErrorResult(CliStrings.format(
+        return ResultModel.createError(CliStrings.format(
             CliStrings.CREATE_REGION__MSG__OPTION_0_CAN_BE_USED_ONLY_FOR_PARTITIONEDREGION,
             functionArgs.getPartitionArgs().getUserSpecifiedPartitionAttributes()) + " "
             + CliStrings.format(CliStrings.CREATE_REGION__MSG__0_IS_NOT_A_PARITIONEDREGION,
@@ -291,7 +295,7 @@ public class CreateRegionCommand extends InternalGfshCommand {
       functionArgs.setRegionShortcut(regionShortcut);
     } else { // templateRegion != null
       if (!regionExists(cache, templateRegion)) {
-        return ResultBuilder.createUserErrorResult(CliStrings.format(
+        return ResultModel.createError(CliStrings.format(
             CliStrings.CREATE_REGION__MSG__SPECIFY_VALID_REGION_PATH_FOR_0_REGIONPATH_1_NOT_FOUND,
             CliStrings.CREATE_REGION__USEATTRIBUTESFROM, templateRegion));
       }
@@ -299,14 +303,14 @@ public class CreateRegionCommand extends InternalGfshCommand {
       RegionAttributesWrapper<?, ?> wrappedAttributes = getRegionAttributes(cache, templateRegion);
 
       if (wrappedAttributes == null) {
-        return ResultBuilder.createGemFireErrorResult(CliStrings.format(
+        return ResultModel.createError(CliStrings.format(
             CliStrings.CREATE_REGION__MSG__COULD_NOT_RETRIEVE_REGION_ATTRS_FOR_PATH_0_VERIFY_REGION_EXISTS,
             templateRegion));
       }
 
       if (wrappedAttributes.getRegionAttributes().getPartitionAttributes() == null
           && functionArgs.hasPartitionAttributes()) {
-        return ResultBuilder.createUserErrorResult(CliStrings.format(
+        return ResultModel.createError(CliStrings.format(
             CliStrings.CREATE_REGION__MSG__OPTION_0_CAN_BE_USED_ONLY_FOR_PARTITIONEDREGION,
             functionArgs.getPartitionArgs().getUserSpecifiedPartitionAttributes()) + " "
             + CliStrings.format(CliStrings.CREATE_REGION__MSG__0_IS_NOT_A_PARITIONEDREGION,
@@ -358,14 +362,14 @@ public class CreateRegionCommand extends InternalGfshCommand {
         DistributedRegionMXBean distributedRegionMXBean =
             mgmtService.getDistributedRegionMXBean(prColocatedWith);
         if (distributedRegionMXBean == null) {
-          return ResultBuilder.createUserErrorResult(CliStrings.format(
+          return ResultModel.createError(CliStrings.format(
               CliStrings.CREATE_REGION__MSG__SPECIFY_VALID_REGION_PATH_FOR_0_REGIONPATH_1_NOT_FOUND,
               CliStrings.CREATE_REGION__COLOCATEDWITH, prColocatedWith));
         }
         String regionType = distributedRegionMXBean.getRegionType();
         if (!(DataPolicy.PARTITION.toString().equals(regionType)
             || DataPolicy.PERSISTENT_PARTITION.toString().equals(regionType))) {
-          return ResultBuilder.createUserErrorResult(CliStrings.format(
+          return ResultModel.createError(CliStrings.format(
               CliStrings.CREATE_REGION__MSG__COLOCATEDWITH_REGION_0_IS_NOT_PARTITIONEDREGION,
               new Object[] {prColocatedWith}));
         }
@@ -377,14 +381,14 @@ public class CreateRegionCommand extends InternalGfshCommand {
       Set<String> existingGatewaySenders =
           Arrays.stream(dsMBean.listGatewaySenders()).collect(Collectors.toSet());
       if (existingGatewaySenders.size() == 0) {
-        return ResultBuilder
-            .createUserErrorResult(CliStrings.CREATE_REGION__MSG__NO_GATEWAYSENDERS_IN_THE_SYSTEM);
+        return ResultModel
+            .createError(CliStrings.CREATE_REGION__MSG__NO_GATEWAYSENDERS_IN_THE_SYSTEM);
       } else {
         Set<String> specifiedGatewaySenders =
             Arrays.stream(gatewaySenderIds).collect(Collectors.toSet());
         specifiedGatewaySenders.removeAll(existingGatewaySenders);
         if (!specifiedGatewaySenders.isEmpty()) {
-          return ResultBuilder.createUserErrorResult(CliStrings.format(
+          return ResultModel.createError(CliStrings.format(
               CliStrings.CREATE_REGION__MSG__SPECIFY_VALID_GATEWAYSENDER_ID_UNKNOWN_0,
               (Object[]) gatewaySenderIds));
         }
@@ -402,11 +406,11 @@ public class CreateRegionCommand extends InternalGfshCommand {
                 CliStrings.CREATE_REGION__MSG__USE_ATTRIBUTES_FROM_REGION_0_IS_NOT_WITH_PERSISTENCE,
                 new Object[] {String.valueOf(functionArgs.getTemplateRegion())});
 
-        return ResultBuilder.createUserErrorResult(message);
+        return ResultModel.createError(message);
       }
 
       if (!diskStoreExists(cache, diskStore)) {
-        return ResultBuilder.createUserErrorResult(CliStrings.format(
+        return ResultModel.createError(CliStrings.format(
             CliStrings.CREATE_REGION__MSG__SPECIFY_VALID_DISKSTORE_UNKNOWN_DISKSTORE_0,
             new Object[] {diskStore}));
       }
@@ -425,9 +429,9 @@ public class CreateRegionCommand extends InternalGfshCommand {
     // just in case we found no members with this group name
     if (membersToCreateRegionOn.isEmpty()) {
       if (groups == null || groups.length == 0) {
-        return ResultBuilder.createUserErrorResult(CliStrings.NO_MEMBERS_FOUND_MESSAGE);
+        return ResultModel.createError(CliStrings.NO_MEMBERS_FOUND_MESSAGE);
       } else {
-        return ResultBuilder.createUserErrorResult(
+        return ResultModel.createError(
             CliStrings.format(CliStrings.CREATE_REGION__MSG__GROUPS_0_ARE_INVALID,
                 (Object[]) groups));
       }
@@ -436,14 +440,66 @@ public class CreateRegionCommand extends InternalGfshCommand {
     List<CliFunctionResult> regionCreateResults = executeAndGetFunctionResult(
         RegionCreateFunction.INSTANCE, functionArgs, membersToCreateRegionOn);
 
-    result = ResultBuilder.buildResult(regionCreateResults);
-    XmlEntity xmlEntity = findXmlEntity(regionCreateResults);
-    if (xmlEntity != null) {
+    ResultModel resultModel = ResultModel.createMemberStatusResult(regionCreateResults);
+    if (regionCreateResults.stream().anyMatch(CliFunctionResult::isSuccessful)) {
       verifyDistributedRegionMbean(cache, regionPath);
-      persistClusterConfiguration(result,
-          () -> getConfigurationPersistenceService().addXmlEntity(xmlEntity, groups));
+      RegionConfig config = (new RegionConfigFactory()).generate(functionArgs);
+      resultModel.setConfigObject(new CreateRegionResultConfig(config,
+          functionArgs.getRegionPath()));
     }
-    return result;
+
+    return resultModel;
+  }
+
+  private class CreateRegionResultConfig {
+    RegionConfig getRegionConfig() {
+      return regionConfig;
+    }
+
+    String getFullRegionPath() {
+      return fullRegionPath;
+    }
+
+    private final RegionConfig regionConfig;
+    private final String fullRegionPath;
+
+    public CreateRegionResultConfig(RegionConfig regionConfig, String fullRegionPath) {
+      this.regionConfig = regionConfig;
+      this.fullRegionPath = fullRegionPath;
+    }
+  }
+
+  @Override
+  public void updateClusterConfig(String group, CacheConfig config, Object configObject) {
+    if (configObject != null) {
+      CreateRegionResultConfig regionResultConfigObject = (CreateRegionResultConfig) configObject;
+      RegionConfig regionConfig = regionResultConfigObject.getRegionConfig();
+      String regionPath = regionResultConfigObject.getFullRegionPath();
+
+      RegionPath regionPathData = new RegionPath(regionPath);
+      if (regionPathData.getParent() == null) {
+        config.getRegions().add(regionConfig);
+        return;
+      }
+
+      String[] regionsOnPath = regionPathData.getRegionsOnParentPath();
+      RegionConfig rootConfig = config.getRegions().stream()
+          .filter(r -> r.getName().equals(regionsOnPath[0]))
+          .findFirst()
+          .get();
+
+      RegionConfig currentConfig = rootConfig;
+      for (int i = 1; i < regionsOnPath.length; i++) {
+        final String curRegionName = regionsOnPath[i];
+        currentConfig = currentConfig.getRegions()
+            .stream()
+            .filter(r -> r.getName().equals(curRegionName))
+            .findFirst()
+            .get();
+      }
+
+      currentConfig.getRegions().add(regionConfig);
+    }
   }
 
   boolean verifyDistributedRegionMbean(InternalCache cache, String regionName) {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/GatewayReceiverCreateFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/GatewayReceiverCreateFunction.java
@@ -123,7 +123,7 @@ public class GatewayReceiverCreateFunction implements InternalFunction {
       gatewayReceiverFactory.setSocketBufferSize(socketBufferSize);
     }
 
-    Boolean manualStart = gatewayReceiverCreateArgs.isManualStart();
+    Boolean manualStart = gatewayReceiverCreateArgs.getManualStart();
     if (manualStart != null) {
       gatewayReceiverFactory.setManualStart(manualStart);
     }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/GatewayReceiverFunctionArgs.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/GatewayReceiverFunctionArgs.java
@@ -24,23 +24,14 @@ import org.apache.geode.cache.configuration.DeclarableType;
  */
 public class GatewayReceiverFunctionArgs implements Serializable {
   private static final long serialVersionUID = -5158224572470173267L;
-
   private final Boolean manualStart;
-
   private final Integer startPort;
-
   private final Integer endPort;
-
   private final String bindAddress;
-
   private final Integer socketBufferSize;
-
   private final Integer maximumTimeBetweenPings;
-
   private final String[] gatewayTransportFilters;
-
   private final String hostnameForSenders;
-
   private final Boolean ifNotExists;
 
   public GatewayReceiverFunctionArgs(GatewayReceiver configuration, Boolean ifNotExists) {
@@ -62,7 +53,7 @@ public class GatewayReceiverFunctionArgs implements Serializable {
     this.ifNotExists = ifNotExists;
   }
 
-  public Boolean isManualStart() {
+  public Boolean getManualStart() {
     return this.manualStart;
   }
 
@@ -91,10 +82,10 @@ public class GatewayReceiverFunctionArgs implements Serializable {
   }
 
   public String getHostnameForSenders() {
-    return hostnameForSenders;
+    return this.hostnameForSenders;
   }
 
   public Boolean getIfNotExists() {
-    return ifNotExists;
+    return this.ifNotExists;
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/GatewaySenderCreateFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/GatewaySenderCreateFunction.java
@@ -72,12 +72,12 @@ public class GatewaySenderCreateFunction implements InternalFunction {
       GatewaySenderFunctionArgs gatewaySenderCreateArgs) {
     GatewaySenderFactory gateway = cache.createGatewaySenderFactory();
 
-    Boolean isParallel = gatewaySenderCreateArgs.isParallel();
+    Boolean isParallel = gatewaySenderCreateArgs.getParallel();
     if (isParallel != null) {
       gateway.setParallel(isParallel);
     }
 
-    Boolean manualStart = gatewaySenderCreateArgs.isManualStart();
+    Boolean manualStart = gatewaySenderCreateArgs.getManualStart();
     if (manualStart != null) {
       gateway.setManualStart(manualStart);
     }
@@ -97,7 +97,7 @@ public class GatewaySenderCreateFunction implements InternalFunction {
       gateway.setBatchTimeInterval(batchTimeInterval);
     }
 
-    Boolean enableBatchConflation = gatewaySenderCreateArgs.isBatchConflationEnabled();
+    Boolean enableBatchConflation = gatewaySenderCreateArgs.getEnableBatchConflation();
     if (enableBatchConflation != null) {
       gateway.setBatchConflationEnabled(enableBatchConflation);
     }
@@ -125,7 +125,7 @@ public class GatewaySenderCreateFunction implements InternalFunction {
       gateway.setOrderPolicy(OrderPolicy.valueOf(orderPolicy));
     }
 
-    Boolean isPersistenceEnabled = gatewaySenderCreateArgs.isPersistenceEnabled();
+    Boolean isPersistenceEnabled = gatewaySenderCreateArgs.getEnablePersistence();
     if (isPersistenceEnabled != null) {
       gateway.setPersistenceEnabled(isPersistenceEnabled);
     }
@@ -135,12 +135,12 @@ public class GatewaySenderCreateFunction implements InternalFunction {
       gateway.setDiskStoreName(diskStoreName);
     }
 
-    Boolean isDiskSynchronous = gatewaySenderCreateArgs.isDiskSynchronous();
+    Boolean isDiskSynchronous = gatewaySenderCreateArgs.getDiskSynchronous();
     if (isDiskSynchronous != null) {
       gateway.setDiskSynchronous(isDiskSynchronous);
     }
 
-    List<String> gatewayEventFilters = gatewaySenderCreateArgs.getGatewayEventFilter();
+    List<String> gatewayEventFilters = gatewaySenderCreateArgs.getGatewayEventFilters();
     if (gatewayEventFilters != null) {
       for (String gatewayEventFilter : gatewayEventFilters) {
         Class gatewayEventFilterKlass =
@@ -150,7 +150,7 @@ public class GatewaySenderCreateFunction implements InternalFunction {
       }
     }
 
-    List<String> gatewayTransportFilters = gatewaySenderCreateArgs.getGatewayTransportFilter();
+    List<String> gatewayTransportFilters = gatewaySenderCreateArgs.getGatewayTransportFilters();
     if (gatewayTransportFilters != null) {
       for (String gatewayTransportFilter : gatewayTransportFilters) {
         Class gatewayTransportFilterKlass = forName(gatewayTransportFilter,
@@ -160,7 +160,7 @@ public class GatewaySenderCreateFunction implements InternalFunction {
       }
     }
     return gateway.create(gatewaySenderCreateArgs.getId(),
-        gatewaySenderCreateArgs.getRemoteDistributedSystemId());
+        gatewaySenderCreateArgs.getRemoteDSId());
   }
 
   @SuppressWarnings("unchecked")

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/GatewaySenderFunctionArgs.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/GatewaySenderFunctionArgs.java
@@ -22,10 +22,8 @@ import java.util.stream.Collectors;
 import org.apache.geode.cache.configuration.CacheConfig;
 import org.apache.geode.cache.configuration.DeclarableType;
 
-
 public class GatewaySenderFunctionArgs implements Serializable {
   private static final long serialVersionUID = 4636678328980816780L;
-
   private final String id;
   private final Integer remoteDSId;
   private final Boolean parallel;
@@ -63,18 +61,12 @@ public class GatewaySenderFunctionArgs implements Serializable {
     this.alertThreshold = string2int(sender.getAlertThreshold());
     this.dispatcherThreads = string2int(sender.getDispatcherThreads());
     this.orderPolicy = sender.getOrderPolicy();
-    this.gatewayEventFilters =
-        Optional.of(sender.getGatewayEventFilters())
-            .map(filters -> filters
-                .stream().map(DeclarableType::getClassName)
-                .collect(Collectors.toList()))
-            .orElse(null);
-    this.gatewayTransportFilters =
-        Optional.of(sender.getGatewayTransportFilters())
-            .map(filters -> filters
-                .stream().map(DeclarableType::getClassName)
-                .collect(Collectors.toList()))
-            .orElse(null);
+    this.gatewayEventFilters = Optional.of(sender.getGatewayEventFilters()).map(
+        filters -> filters.stream().map(DeclarableType::getClassName).collect(Collectors.toList()))
+        .orElse(null);
+    this.gatewayTransportFilters = Optional.of(sender.getGatewayTransportFilters()).map(
+        filters -> filters.stream().map(DeclarableType::getClassName).collect(Collectors.toList()))
+        .orElse(null);
   }
 
   private Integer string2int(String x) {
@@ -85,15 +77,15 @@ public class GatewaySenderFunctionArgs implements Serializable {
     return this.id;
   }
 
-  public Integer getRemoteDistributedSystemId() {
+  public Integer getRemoteDSId() {
     return this.remoteDSId;
   }
 
-  public Boolean isParallel() {
+  public Boolean getParallel() {
     return this.parallel;
   }
 
-  public Boolean isManualStart() {
+  public Boolean getManualStart() {
     return this.manualStart;
   }
 
@@ -105,7 +97,7 @@ public class GatewaySenderFunctionArgs implements Serializable {
     return this.socketReadTimeout;
   }
 
-  public Boolean isBatchConflationEnabled() {
+  public Boolean getEnableBatchConflation() {
     return this.enableBatchConflation;
   }
 
@@ -117,7 +109,7 @@ public class GatewaySenderFunctionArgs implements Serializable {
     return this.batchTimeInterval;
   }
 
-  public Boolean isPersistenceEnabled() {
+  public Boolean getEnablePersistence() {
     return this.enablePersistence;
   }
 
@@ -125,7 +117,7 @@ public class GatewaySenderFunctionArgs implements Serializable {
     return this.diskStoreName;
   }
 
-  public Boolean isDiskSynchronous() {
+  public Boolean getDiskSynchronous() {
     return this.diskSynchronous;
   }
 
@@ -145,11 +137,11 @@ public class GatewaySenderFunctionArgs implements Serializable {
     return this.orderPolicy;
   }
 
-  public List<String> getGatewayEventFilter() {
+  public List<String> getGatewayEventFilters() {
     return this.gatewayEventFilters;
   }
 
-  public List<String> getGatewayTransportFilter() {
+  public List<String> getGatewayTransportFilters() {
     return this.gatewayTransportFilters;
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/RegionAlterFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/RegionAlterFunction.java
@@ -110,8 +110,8 @@ public class RegionAlterFunction implements InternalFunction {
 
     AttributesMutator mutator = region.getAttributesMutator();
 
-    if (regionAlterArgs.isCloningEnabled() != null) {
-      mutator.setCloningEnabled(regionAlterArgs.isCloningEnabled());
+    if (regionAlterArgs.getCloningEnabled() != null) {
+      mutator.setCloningEnabled(regionAlterArgs.getCloningEnabled());
       if (logger.isDebugEnabled()) {
         logger.debug("Region successfully altered - cloning");
       }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/RegionCreateFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/RegionCreateFunction.java
@@ -16,6 +16,7 @@ package org.apache.geode.management.internal.cli.functions;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
@@ -83,21 +84,22 @@ public class RegionCreateFunction implements InternalFunction {
     if (regionCreateArgs.isIfNotExists()) {
       Region<Object, Object> region = cache.getRegion(regionCreateArgs.getRegionPath());
       if (region != null) {
-        resultSender.lastResult(new CliFunctionResult(memberNameOrId, true,
-            CliStrings.format(
-                CliStrings.CREATE_REGION__MSG__SKIPPING_0_REGION_PATH_1_ALREADY_EXISTS,
-                memberNameOrId, regionCreateArgs.getRegionPath())));
+        resultSender
+            .lastResult(new CliFunctionResult(memberNameOrId, CliFunctionResult.StatusState.OK,
+                CliStrings.format(
+                    CliStrings.CREATE_REGION__MSG__SKIPPING_0_REGION_PATH_1_ALREADY_EXISTS,
+                    memberNameOrId, regionCreateArgs.getRegionPath())));
         return;
       }
     }
 
     try {
       Region<?, ?> createdRegion = createRegion(cache, regionCreateArgs);
-      XmlEntity xmlEntity = getXmlEntityForRegion(createdRegion);
 
-      resultSender.lastResult(new CliFunctionResult(memberNameOrId, xmlEntity,
-          CliStrings.format(CliStrings.CREATE_REGION__MSG__REGION_0_CREATED_ON_1,
-              createdRegion.getFullPath(), memberNameOrId)));
+      resultSender
+          .lastResult(new CliFunctionResult(memberNameOrId, CliFunctionResult.StatusState.OK,
+              CliStrings.format(CliStrings.CREATE_REGION__MSG__REGION_0_CREATED_ON_1,
+                  createdRegion.getFullPath(), memberNameOrId)));
     } catch (IllegalStateException e) {
       String exceptionMsg = e.getMessage();
       String localizedString =
@@ -196,7 +198,7 @@ public class RegionCreateFunction implements InternalFunction {
     // Expiration attributes
     final RegionFunctionArgs.ExpirationAttrs entryExpirationIdleTime =
         regionCreateArgs.getEntryExpirationIdleTime();
-    if (entryExpirationIdleTime.isTimeOrActionSet()) {
+    if (entryExpirationIdleTime != null && entryExpirationIdleTime.isTimeOrActionSet()) {
       factory.setEntryIdleTimeout(entryExpirationIdleTime.getExpirationAttributes());
     }
 
@@ -212,21 +214,23 @@ public class RegionCreateFunction implements InternalFunction {
 
     final RegionFunctionArgs.ExpirationAttrs entryExpirationTTL =
         regionCreateArgs.getEntryExpirationTTL();
-    if (entryExpirationTTL.isTimeOrActionSet()) {
+    if (entryExpirationTTL != null && entryExpirationTTL.isTimeOrActionSet()) {
       factory.setEntryTimeToLive(entryExpirationTTL.getExpirationAttributes());
     }
     final RegionFunctionArgs.ExpirationAttrs regionExpirationIdleTime =
         regionCreateArgs.getRegionExpirationIdleTime();
-    if (regionExpirationIdleTime.isTimeOrActionSet()) {
+    if (regionExpirationIdleTime != null && regionExpirationIdleTime.isTimeOrActionSet()) {
       factory.setRegionIdleTimeout(regionExpirationIdleTime.getExpirationAttributes());
     }
     final RegionFunctionArgs.ExpirationAttrs regionExpirationTTL =
         regionCreateArgs.getRegionExpirationTTL();
-    if (regionExpirationTTL.isTimeOrActionSet()) {
+    if (regionExpirationTTL != null && regionExpirationTTL.isTimeOrActionSet()) {
       factory.setRegionTimeToLive(regionExpirationTTL.getExpirationAttributes());
     }
 
-    EvictionAttributes evictionAttributes = regionCreateArgs.getEvictionAttributes();
+    EvictionAttributes evictionAttributes = Optional
+        .ofNullable(regionCreateArgs.getEvictionAttributes())
+        .map(a -> a.convertToEvictionAttributes()).orElse(null);
     if (evictionAttributes != null) {
       ObjectSizer sizer = evictionAttributes.getObjectSizer();
       if (sizer != null && !(sizer instanceof Declarable)) {
@@ -242,24 +246,24 @@ public class RegionCreateFunction implements InternalFunction {
       factory.setDiskStoreName(diskStore);
     }
 
-    if (regionCreateArgs.isDiskSynchronous() != null) {
-      factory.setDiskSynchronous(regionCreateArgs.isDiskSynchronous());
+    if (regionCreateArgs.getDiskSynchronous() != null) {
+      factory.setDiskSynchronous(regionCreateArgs.getDiskSynchronous());
     }
 
-    if (regionCreateArgs.isOffHeap() != null) {
-      factory.setOffHeap(regionCreateArgs.isOffHeap());
+    if (regionCreateArgs.getOffHeap() != null) {
+      factory.setOffHeap(regionCreateArgs.getOffHeap());
     }
 
-    if (regionCreateArgs.isStatisticsEnabled() != null) {
-      factory.setStatisticsEnabled(regionCreateArgs.isStatisticsEnabled());
+    if (regionCreateArgs.getStatisticsEnabled() != null) {
+      factory.setStatisticsEnabled(regionCreateArgs.getStatisticsEnabled());
     }
 
-    if (regionCreateArgs.isEnableAsyncConflation() != null) {
-      factory.setEnableAsyncConflation(regionCreateArgs.isEnableAsyncConflation());
+    if (regionCreateArgs.getEnableAsyncConflation() != null) {
+      factory.setEnableAsyncConflation(regionCreateArgs.getEnableAsyncConflation());
     }
 
-    if (regionCreateArgs.isEnableSubscriptionConflation() != null) {
-      factory.setEnableSubscriptionConflation(regionCreateArgs.isEnableSubscriptionConflation());
+    if (regionCreateArgs.getEnableSubscriptionConflation() != null) {
+      factory.setEnableSubscriptionConflation(regionCreateArgs.getEnableSubscriptionConflation());
     }
 
     // Gateway Sender Ids
@@ -278,20 +282,20 @@ public class RegionCreateFunction implements InternalFunction {
       }
     }
 
-    if (regionCreateArgs.isConcurrencyChecksEnabled() != null) {
-      factory.setConcurrencyChecksEnabled(regionCreateArgs.isConcurrencyChecksEnabled());
+    if (regionCreateArgs.getConcurrencyChecksEnabled() != null) {
+      factory.setConcurrencyChecksEnabled(regionCreateArgs.getConcurrencyChecksEnabled());
     }
 
     if (regionCreateArgs.getConcurrencyLevel() != null) {
       factory.setConcurrencyLevel(regionCreateArgs.getConcurrencyLevel());
     }
 
-    if (regionCreateArgs.isCloningEnabled() != null) {
-      factory.setCloningEnabled(regionCreateArgs.isCloningEnabled());
+    if (regionCreateArgs.getCloningEnabled() != null) {
+      factory.setCloningEnabled(regionCreateArgs.getCloningEnabled());
     }
 
-    if (regionCreateArgs.isMcastEnabled() != null) {
-      factory.setMulticastEnabled(regionCreateArgs.isMcastEnabled());
+    if (regionCreateArgs.getMcastEnabled() != null) {
+      factory.setMulticastEnabled(regionCreateArgs.getMcastEnabled());
     }
 
     // Set plugins
@@ -340,9 +344,8 @@ public class RegionCreateFunction implements InternalFunction {
   @SuppressWarnings("unchecked")
   private static <K, V> PartitionAttributes<K, V> extractPartitionAttributes(Cache cache,
       RegionAttributes<K, V> regionAttributes, RegionFunctionArgs regionCreateArgs) {
-    RegionFunctionArgs.PartitionArgs partitionArgs = regionCreateArgs.getPartitionArgs();
 
-    PartitionAttributesFactory<K, V> prAttrFactory = null;
+    PartitionAttributesFactory<K, V> prAttrFactory;
 
     PartitionAttributes<K, V> partitionAttributes = regionAttributes.getPartitionAttributes();
     if (partitionAttributes != null) {
@@ -351,46 +354,49 @@ public class RegionCreateFunction implements InternalFunction {
       prAttrFactory = new PartitionAttributesFactory<>();
     }
 
-    String colocatedWith = partitionArgs.getPrColocatedWith();
-    if (colocatedWith != null) {
-      Region<Object, Object> colocatedWithRegion = cache.getRegion(colocatedWith);
-      if (colocatedWithRegion == null) {
-        throw new IllegalArgumentException(CliStrings.format(
-            CliStrings.CREATE_REGION__MSG__COLOCATEDWITH_REGION_0_DOES_NOT_EXIST, colocatedWith));
+    if (regionCreateArgs.hasPartitionAttributes()) {
+      RegionFunctionArgs.PartitionArgs partitionArgs = regionCreateArgs.getPartitionArgs();
+      String colocatedWith = partitionArgs.getPrColocatedWith();
+      if (colocatedWith != null) {
+        Region<Object, Object> colocatedWithRegion = cache.getRegion(colocatedWith);
+        if (colocatedWithRegion == null) {
+          throw new IllegalArgumentException(CliStrings.format(
+              CliStrings.CREATE_REGION__MSG__COLOCATEDWITH_REGION_0_DOES_NOT_EXIST, colocatedWith));
+        }
+        if (!colocatedWithRegion.getAttributes().getDataPolicy().withPartitioning()) {
+          throw new IllegalArgumentException(CliStrings.format(
+              CliStrings.CREATE_REGION__MSG__COLOCATEDWITH_REGION_0_IS_NOT_PARTITIONEDREGION,
+              colocatedWith));
+        }
+        prAttrFactory.setColocatedWith(colocatedWith);
       }
-      if (!colocatedWithRegion.getAttributes().getDataPolicy().withPartitioning()) {
-        throw new IllegalArgumentException(CliStrings.format(
-            CliStrings.CREATE_REGION__MSG__COLOCATEDWITH_REGION_0_IS_NOT_PARTITIONEDREGION,
-            colocatedWith));
+      if (partitionArgs.getPrLocalMaxMemory() != null) {
+        prAttrFactory.setLocalMaxMemory(partitionArgs.getPrLocalMaxMemory());
       }
-      prAttrFactory.setColocatedWith(colocatedWith);
-    }
-    if (partitionArgs.getPrLocalMaxMemory() != null) {
-      prAttrFactory.setLocalMaxMemory(partitionArgs.getPrLocalMaxMemory());
-    }
-    if (partitionArgs.getPrTotalMaxMemory() != null) {
-      prAttrFactory.setTotalMaxMemory(partitionArgs.getPrTotalMaxMemory());
-    }
-    if (partitionArgs.getPrTotalNumBuckets() != null) {
-      prAttrFactory.setTotalNumBuckets(partitionArgs.getPrTotalNumBuckets());
-    }
-    if (partitionArgs.getPrRedundantCopies() != null) {
-      prAttrFactory.setRedundantCopies(partitionArgs.getPrRedundantCopies());
-    }
-    if (partitionArgs.getPrRecoveryDelay() != null) {
-      prAttrFactory.setRecoveryDelay(partitionArgs.getPrRecoveryDelay());
-    }
-    if (partitionArgs.getPrStartupRecoveryDelay() != null) {
-      prAttrFactory.setStartupRecoveryDelay(partitionArgs.getPrStartupRecoveryDelay());
-    }
+      if (partitionArgs.getPrTotalMaxMemory() != null) {
+        prAttrFactory.setTotalMaxMemory(partitionArgs.getPrTotalMaxMemory());
+      }
+      if (partitionArgs.getPrTotalNumBuckets() != null) {
+        prAttrFactory.setTotalNumBuckets(partitionArgs.getPrTotalNumBuckets());
+      }
+      if (partitionArgs.getPrRedundantCopies() != null) {
+        prAttrFactory.setRedundantCopies(partitionArgs.getPrRedundantCopies());
+      }
+      if (partitionArgs.getPrRecoveryDelay() != null) {
+        prAttrFactory.setRecoveryDelay(partitionArgs.getPrRecoveryDelay());
+      }
+      if (partitionArgs.getPrStartupRecoveryDelay() != null) {
+        prAttrFactory.setStartupRecoveryDelay(partitionArgs.getPrStartupRecoveryDelay());
+      }
 
-    if (regionCreateArgs.getPartitionArgs().getPartitionResolver() != null) {
-      Class<PartitionResolver> partitionResolverClass =
-          forName(regionCreateArgs.getPartitionArgs().getPartitionResolver(),
-              CliStrings.CREATE_REGION__PARTITION_RESOLVER);
-      prAttrFactory
-          .setPartitionResolver((PartitionResolver<K, V>) newInstance(partitionResolverClass,
-              CliStrings.CREATE_REGION__PARTITION_RESOLVER));
+      if (regionCreateArgs.getPartitionArgs().getPartitionResolver() != null) {
+        Class<PartitionResolver> partitionResolverClass =
+            forName(regionCreateArgs.getPartitionArgs().getPartitionResolver(),
+                CliStrings.CREATE_REGION__PARTITION_RESOLVER);
+        prAttrFactory
+            .setPartitionResolver((PartitionResolver<K, V>) newInstance(partitionResolverClass,
+                CliStrings.CREATE_REGION__PARTITION_RESOLVER));
+      }
     }
     return prAttrFactory.create();
   }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/remote/CommandExecutor.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/remote/CommandExecutor.java
@@ -83,9 +83,11 @@ public class CommandExecutor {
     // if entity not found, depending on the thrower's intention, report either as success or error
     // no need to log since this is a user error
     catch (EntityNotFoundException e) {
+      logger.info("Got EntityNotFound exception: " + e.getMessage());
       if (e.isStatusOK()) {
         return ResultModel.createInfo("Skipping: " + e.getMessage());
       } else {
+        logger.info("Got EntityNotFound exception: " + e.getMessage());
         return ResultModel.createError(e.getMessage());
       }
     }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/util/RegionPath.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/util/RegionPath.java
@@ -14,7 +14,9 @@
  */
 package org.apache.geode.management.internal.cli.util;
 
+import java.util.ArrayList;
 import java.util.LinkedList;
+import java.util.List;
 
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.Region;
@@ -65,6 +67,20 @@ public class RegionPath {
 
   public String getParent() {
     return regionParentPath;
+  }
+
+  public String[] getRegionsOnParentPath() {
+    String[] regionsOnPath = getParent().split(Region.SEPARATOR);
+
+    // Ignore preceding separator if there is one
+    int start = regionsOnPath[0] == null || regionsOnPath[0].isEmpty() ? 1 : 0;
+
+    List<String> regions = new ArrayList<>();
+    for (int i = start; i < regionsOnPath.length; i++) {
+      regions.add(regionsOnPath[i]);
+    }
+
+    return regions.toArray(new String[] {});
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/redis/internal/RegionProvider.java
+++ b/geode-core/src/main/java/org/apache/geode/redis/internal/RegionProvider.java
@@ -41,9 +41,9 @@ import org.apache.geode.cache.query.QueryService;
 import org.apache.geode.cache.query.RegionNotFoundException;
 import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.hll.HyperLogLogPlus;
-import org.apache.geode.management.cli.Result;
 import org.apache.geode.management.cli.Result.Status;
 import org.apache.geode.management.internal.cli.commands.CreateRegionCommand;
+import org.apache.geode.management.internal.cli.result.model.ResultModel;
 import org.apache.geode.redis.GeodeRedisServer;
 import org.apache.geode.redis.internal.executor.ExpirationExecutor;
 import org.apache.geode.redis.internal.executor.ListQuery;
@@ -399,17 +399,19 @@ public class RegionProvider implements Closeable {
       return r;
     do {
       createRegionCmd.setCache(cache);
-      Result result = createRegionCmd.createRegion(regionPath, defaultRegionType, null, null, true,
-          null, null, null, null, null, null, null, null, false, false, true, false, false, false,
-          true, null, null, null, null, null, null, null, null, null, null, null, null, null, false,
-          null, null, null, null, null, null, null, null, null, null, null);
+      ResultModel resultModel =
+          createRegionCmd.createRegion(regionPath, defaultRegionType, null, null, true,
+              null, null, null, null, null, null, null, null, false, false, true, false, false,
+              false,
+              true, null, null, null, null, null, null, null, null, null, null, null, null, null,
+              false,
+              null, null, null, null, null, null, null, null, null, null, null);
 
       r = cache.getRegion(regionPath);
-      if (result.getStatus() == Status.ERROR && r == null) {
+      if (resultModel.getStatus() == Status.ERROR && r == null) {
         String err = "Unable to create region named \"" + regionPath + "\":\n";
-        while (result.hasNextLine())
-          err += result.nextLine();
-        throw new RegionCreationException(err);
+        // TODO: check this
+        throw new RegionCreationException(err + resultModel.toJson());
       }
     } while (r == null); // The region can be null in the case that it is concurrently destroyed by
     // a remote even triggered internally by Geode

--- a/geode-core/src/test/java/org/apache/geode/cache/configuration/RegionConfigFactoryTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/configuration/RegionConfigFactoryTest.java
@@ -1,0 +1,278 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.geode.cache.EvictionAction;
+import org.apache.geode.cache.ExpirationAction;
+import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.management.internal.cli.domain.ClassName;
+import org.apache.geode.management.internal.cli.functions.RegionFunctionArgs;
+
+public class RegionConfigFactoryTest {
+
+  RegionConfigFactory subject;
+  RegionFunctionArgs args;
+
+  @Before
+  public void setup() {
+    subject = new RegionConfigFactory();
+    args = new RegionFunctionArgs();
+    args.setRegionPath("region-name");
+  }
+
+  @Test
+  public void generatesConfigForRegion() {
+    RegionConfig config = subject.generate(args);
+    assertThat(config.getName()).isEqualTo("region-name");
+  }
+
+  @Test
+  public void generatesConfigForSubRegion() {
+    args.setRegionPath("region-name/subregion");
+
+    RegionConfig config = subject.generate(args);
+    assertThat(config.getName()).isEqualTo("subregion");
+  }
+
+  @Test
+  public void generatesWithRegionShortcut() {
+    args.setRegionShortcut(RegionShortcut.LOCAL);
+
+    RegionConfig config = subject.generate(args);
+    assertThat(config.getRefid()).isEqualTo(RegionShortcut.LOCAL.toString());
+  }
+
+  @Test
+  public void generatesWithNoAttributes() {
+    RegionConfig config = subject.generate(args);
+    assertThat(config.getRegionAttributes()).isEmpty();
+  }
+
+  @Test
+  public void generatesWithConstraintAttributes() {
+    args.setKeyConstraint("key-const");
+    args.setValueConstraint("value-const");
+
+    RegionConfig config = subject.generate(args);
+    assertThat(getRegionAttributeValue(config, t -> t.getKeyConstraint())).isEqualTo("key-const");
+    assertThat(getRegionAttributeValue(config, t -> t.getValueConstraint()))
+        .isEqualTo("value-const");
+  }
+
+  @Test
+  public void generatesWithExpirationIdleTimeAttributes() {
+    args.setRegionExpirationTTL(10, ExpirationAction.DESTROY);
+    args.setRegionExpirationIdleTime(3, ExpirationAction.INVALIDATE);
+    args.setEntryExpirationTTL(1, ExpirationAction.LOCAL_DESTROY);
+    args.setEntryExpirationIdleTime(12, ExpirationAction.LOCAL_DESTROY);
+    args.setEntryIdleTimeCustomExpiry(new ClassName<>("java.lang.String"));
+
+    RegionConfig config = subject.generate(args);
+    RegionAttributesType.RegionTimeToLive regionTimeToLive =
+        (RegionAttributesType.RegionTimeToLive) getRegionAttributeValue(config,
+            t -> t.getRegionTimeToLive());
+    assertThat(regionTimeToLive.getExpirationAttributes().getTimeout()).isEqualTo("10");
+
+    RegionAttributesType.EntryTimeToLive entryTimeToLive =
+        (RegionAttributesType.EntryTimeToLive) getRegionAttributeValue(config,
+            t -> t.getEntryTimeToLive());
+    assertThat(entryTimeToLive.getExpirationAttributes().getAction())
+        .isEqualTo(ExpirationAction.LOCAL_DESTROY.toXmlString());
+
+    RegionAttributesType.EntryIdleTime entryIdleTime =
+        (RegionAttributesType.EntryIdleTime) getRegionAttributeValue(config,
+            t -> t.getEntryIdleTime());
+    DeclarableType customExpiry = entryIdleTime.getExpirationAttributes().getCustomExpiry();
+    assertThat(customExpiry.getClassName()).isEqualTo("java.lang.String");
+    assertThat(entryIdleTime.getExpirationAttributes().getAction())
+        .isEqualTo(ExpirationAction.LOCAL_DESTROY.toXmlString());
+    assertThat(entryIdleTime.getExpirationAttributes().getTimeout())
+        .isEqualTo("12");
+  }
+
+  @Test
+  public void generatesWithDiskAttributes() {
+    args.setDiskStore("disk-store");
+    args.setDiskSynchronous(false);
+
+    RegionConfig config = subject.generate(args);
+    assertThat(getRegionAttributeValue(config, t -> t.getDiskStoreName())).isEqualTo("disk-store");
+    assertThat(getRegionAttributeValue(config, t -> t.isDiskSynchronous())).isEqualTo(false);
+  }
+
+  @Test
+  public void generatesWithPrAttributes() {
+    args.setPartitionArgs("colo-with", 100,
+        100L, 100, 100L,
+        100L, 100, "java.lang.String");
+
+    RegionConfig config = subject.generate(args);
+    RegionAttributesType.PartitionAttributes partitionAttributes =
+        (RegionAttributesType.PartitionAttributes) getRegionAttributeValue(config,
+            t -> t.getPartitionAttributes());
+    assertThat(partitionAttributes).isNotNull();
+    assertThat(partitionAttributes.getColocatedWith()).isEqualTo("colo-with");
+    assertThat(partitionAttributes.getLocalMaxMemory()).isEqualTo("100");
+    assertThat(partitionAttributes.getRecoveryDelay()).isEqualTo("100");
+    assertThat(partitionAttributes.getRedundantCopies()).isEqualTo("100");
+    assertThat(partitionAttributes.getStartupRecoveryDelay()).isEqualTo("100");
+    assertThat(partitionAttributes.getTotalMaxMemory()).isEqualTo("100");
+    assertThat(partitionAttributes.getTotalNumBuckets()).isEqualTo("100");
+
+    DeclarableType partitionResolverType = partitionAttributes.getPartitionResolver();
+    assertThat(partitionResolverType.getClassName()).isEqualTo("java.lang.String");
+  }
+
+  @Test
+  public void generatesWithMiscBooleanFlags() {
+    args.setStatisticsEnabled(false);
+    args.setEnableAsyncConflation(false);
+    args.setConcurrencyChecksEnabled(true);
+    args.setEnableSubscriptionConflation(true);
+    args.setMcastEnabled(false);
+    args.setCloningEnabled(false);
+    args.setOffHeap(true);
+    RegionConfig config = subject.generate(args);
+
+    assertThat(getRegionAttributeValue(config, t -> t.isStatisticsEnabled())).isEqualTo(false);
+    assertThat(getRegionAttributeValue(config, t -> t.isEnableSubscriptionConflation()))
+        .isEqualTo(true);
+    assertThat(getRegionAttributeValue(config, t -> t.isConcurrencyChecksEnabled()))
+        .isEqualTo(true);
+    assertThat(getRegionAttributeValue(config, t -> t.isEnableSubscriptionConflation()))
+        .isEqualTo(true);
+    assertThat(getRegionAttributeValue(config, t -> t.isMulticastEnabled()))
+        .isEqualTo(false);
+    assertThat(getRegionAttributeValue(config, t -> t.isCloningEnabled())).isEqualTo(false);
+    assertThat(getRegionAttributeValue(config, t -> t.isOffHeap())).isEqualTo(true);
+  }
+
+  @Test
+  public void generatesWithGatewayFlags() {
+    args.setGatewaySenderIds(new String[] {"some-id", "some-other-id"});
+    RegionConfig config = subject.generate(args);
+
+    assertThat((String) getRegionAttributeValue(config, t -> t.getGatewaySenderIds()))
+        .contains("some-id");
+    assertThat((String) getRegionAttributeValue(config, t -> t.getGatewaySenderIds()))
+        .contains("some-other-id");
+  }
+
+  @Test
+  public void generatesWithEvictionHeapPercentageFlags() {
+    args.setEvictionAttributes(EvictionAction.LOCAL_DESTROY.toString(), null, null,
+        "java.lang.String");
+    RegionConfig config = subject.generate(args);
+
+    RegionAttributesType.EvictionAttributes evictionAttributes =
+        (RegionAttributesType.EvictionAttributes) getRegionAttributeValue(config,
+            t -> t.getEvictionAttributes());
+    assertThat(evictionAttributes).isNotNull();
+    assertThat(evictionAttributes.getLruHeapPercentage().getAction())
+        .isSameAs(EnumActionDestroyOverflow.LOCAL_DESTROY);
+    assertThat(evictionAttributes.getLruHeapPercentage().getClassName())
+        .isEqualTo("java.lang.String");
+  }
+
+  @Test
+  public void generatesWithEvictionMaxMemory() {
+    args.setEvictionAttributes(EvictionAction.LOCAL_DESTROY.toString(), 100, null,
+        null);
+    RegionConfig config = subject.generate(args);
+
+    RegionAttributesType.EvictionAttributes evictionAttributes =
+        (RegionAttributesType.EvictionAttributes) getRegionAttributeValue(config,
+            t -> t.getEvictionAttributes());
+    assertThat(evictionAttributes).isNotNull();
+    assertThat(evictionAttributes.getLruMemorySize().getAction())
+        .isSameAs(EnumActionDestroyOverflow.LOCAL_DESTROY);
+    assertThat(evictionAttributes.getLruMemorySize().getMaximum()).isEqualTo("100");
+  }
+
+  @Test
+  public void generatesWithEvictionMaxEntry() {
+    args.setEvictionAttributes(EvictionAction.OVERFLOW_TO_DISK.toString(), null, 1,
+        null);
+    RegionConfig config = subject.generate(args);
+    RegionAttributesType.EvictionAttributes evictionAttributes =
+        (RegionAttributesType.EvictionAttributes) getRegionAttributeValue(config,
+            t -> t.getEvictionAttributes());
+    assertThat(evictionAttributes).isNotNull();
+    assertThat(evictionAttributes.getLruEntryCount().getAction())
+        .isSameAs(EnumActionDestroyOverflow.OVERFLOW_TO_DISK);
+    assertThat(evictionAttributes.getLruEntryCount().getMaximum()).isEqualTo("1");
+  }
+
+  @Test
+  public void generatesWithAsyncEventQueueIds() {
+    args.setAsyncEventQueueIds(new String[] {"id-1", "id-2"});
+    RegionConfig config = subject.generate(args);
+
+    assertThat((String) getRegionAttributeValue(config, t -> t.getAsyncEventQueueIds()))
+        .contains("id-1");
+    assertThat((String) getRegionAttributeValue(config, t -> t.getAsyncEventQueueIds()))
+        .contains("id-2");
+  }
+
+  @Test
+  public void generatesWithCacheClasses() {
+    args.setCacheListeners(new ClassName[] {new ClassName("java.lang.String")});
+    args.setCacheLoader(new ClassName("java.lang.String"));
+    args.setCacheWriter(new ClassName("java.lang.String"));
+    RegionConfig config = subject.generate(args);
+
+    List<DeclarableType> cacheListeners = config.getRegionAttributes().stream()
+        .filter(a -> !a.getCacheListeners().isEmpty())
+        .findFirst()
+        .map(a -> a.getCacheListeners())
+        .orElse(null);
+
+    assertThat(cacheListeners).isNotNull();
+    assertThat(cacheListeners.get(0).getClassName()).isEqualTo("java.lang.String");
+    assertThat(
+        ((DeclarableType) getRegionAttributeValue(config, t -> t.getCacheLoader())).getClassName())
+            .isEqualTo("java.lang.String");
+    assertThat(
+        ((DeclarableType) getRegionAttributeValue(config, t -> t.getCacheWriter())).getClassName())
+            .isEqualTo("java.lang.String");
+  }
+
+  @Test
+  public void generatesWithOtherMiscSimpleFlags() {
+    args.setCompressor("java.lang.String");
+    args.setConcurrencyLevel(1);
+
+    RegionConfig config = subject.generate(args);
+
+    assertThat(
+        ((ClassNameType) getRegionAttributeValue(config, t -> t.getCompressor())).getClassName())
+            .isEqualTo("java.lang.String");
+    assertThat(getRegionAttributeValue(config, t -> t.getConcurrencyLevel())).isEqualTo("1");
+  }
+
+  private Object getRegionAttributeValue(RegionConfig config, RegionAttributeGetFunction function) {
+    return config.getRegionAttributes().stream()
+        .findFirst()
+        .map(a -> function.getValue(a))
+        .orElse(null);
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateGatewaySenderCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateGatewaySenderCommandTest.java
@@ -138,11 +138,11 @@ public class CreateGatewaySenderCommandTest {
         any(Set.class));
     assertThat(argsArgumentCaptor.getValue().getOrderPolicy()).isEqualTo(
         GatewaySender.OrderPolicy.THREAD.toString());
-    assertThat(argsArgumentCaptor.getValue().getRemoteDistributedSystemId()).isEqualTo(1);
+    assertThat(argsArgumentCaptor.getValue().getRemoteDSId()).isEqualTo(1);
     assertThat(argsArgumentCaptor.getValue().getDispatcherThreads()).isEqualTo(2);
-    assertThat(argsArgumentCaptor.getValue().getGatewayEventFilter()).containsExactly("test1",
+    assertThat(argsArgumentCaptor.getValue().getGatewayEventFilters()).containsExactly("test1",
         "test2");
-    assertThat(argsArgumentCaptor.getValue().getGatewayTransportFilter()).containsExactly("test1",
+    assertThat(argsArgumentCaptor.getValue().getGatewayTransportFilters()).containsExactly("test1",
         "test2");
   }
 

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateRegionCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateRegionCommandTest.java
@@ -172,31 +172,31 @@ public class CreateRegionCommandTest {
     assertThat(args.isIfNotExists()).isFalse();
     assertThat(args.getKeyConstraint()).isNull();
     assertThat(args.getValueConstraint()).isNull();
-    assertThat(args.isStatisticsEnabled()).isNull();
+    assertThat(args.getStatisticsEnabled()).isNull();
 
     ExpirationAttrs empty = new ExpirationAttrs(null, null);
-    assertThat(args.getEntryExpirationIdleTime()).isEqualTo(empty);
-    assertThat(args.getEntryExpirationTTL()).isEqualTo(empty);
-    assertThat(args.getRegionExpirationIdleTime()).isEqualTo(empty);
-    assertThat(args.getRegionExpirationTTL()).isEqualTo(empty);
+    assertThat(args.getEntryExpirationIdleTime()).isNull();
+    assertThat(args.getEntryExpirationTTL()).isNull();
+    assertThat(args.getRegionExpirationIdleTime()).isNull();
+    assertThat(args.getRegionExpirationTTL()).isNull();
 
     assertThat(args.getDiskStore()).isNull();
-    assertThat(args.isDiskSynchronous()).isNull();
-    assertThat(args.isEnableAsyncConflation()).isNull();
-    assertThat(args.isEnableSubscriptionConflation()).isNull();
+    assertThat(args.getDiskSynchronous()).isNull();
+    assertThat(args.getEnableAsyncConflation()).isNull();
+    assertThat(args.getEnableSubscriptionConflation()).isNull();
     assertThat(args.getCacheListeners()).isEmpty();
     assertThat(args.getCacheLoader()).isNull();
     assertThat(args.getCacheWriter()).isNull();
     assertThat(args.getAsyncEventQueueIds()).isEmpty();
     assertThat(args.getGatewaySenderIds()).isEmpty();
-    assertThat(args.isConcurrencyChecksEnabled()).isNull();
-    assertThat(args.isCloningEnabled()).isNull();
-    assertThat(args.isMcastEnabled()).isNull();
+    assertThat(args.getConcurrencyChecksEnabled()).isNull();
+    assertThat(args.getCloningEnabled()).isNull();
+    assertThat(args.getMcastEnabled()).isNull();
     assertThat(args.getConcurrencyLevel()).isNull();
-    assertThat(args.getPartitionArgs()).isNotNull();
+    assertThat(args.getPartitionArgs()).isNull();
     assertThat(args.getEvictionMax()).isNull();
     assertThat(args.getCompressor()).isNull();
-    assertThat(args.isOffHeap()).isNull();
+    assertThat(args.getOffHeap()).isNull();
     assertThat(args.getRegionAttributes()).isNull();
   }
 

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/functions/RegionFunctionArgsTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/functions/RegionFunctionArgsTest.java
@@ -37,13 +37,37 @@ public class RegionFunctionArgsTest {
 
   @Test
   public void defaultRegionFunctionArgs() throws Exception {
-    assertThat(args.isDiskSynchronous()).isNull();
-    assertThat(args.isCloningEnabled()).isNull();
-    assertThat(args.isConcurrencyChecksEnabled()).isNull();
+    assertThat(args.getDiskSynchronous()).isNull();
+    assertThat(args.getCloningEnabled()).isNull();
+    assertThat(args.getConcurrencyChecksEnabled()).isNull();
     assertThat(args.getConcurrencyLevel()).isNull();
-    assertThat(args.getPartitionArgs()).isNotNull();
-    assertThat(args.getPartitionArgs().hasPartitionAttributes()).isFalse();
+    assertThat(args.getPartitionArgs()).isNull();
+    assertThat(args.hasPartitionAttributes()).isFalse();
     assertThat(args.getEvictionAttributes()).isNull();
+  }
+
+  @Test
+  public void emptyPartitionArgsShouldBeNull() throws Exception {
+    args.setPartitionArgs(null, null, null,
+        null, null, null,
+        null, null);
+    assertThat(args.getPartitionArgs()).isNull();
+    assertThat(args.hasPartitionAttributes()).isFalse();
+  }
+
+  @Test
+  public void emptyExpirationAttributesShouldBeNull() throws Exception {
+    args.setEntryExpirationIdleTime(null, null);
+    assertThat(args.getEntryExpirationIdleTime()).isNull();
+
+    args.setEntryExpirationTTL(null, null);
+    assertThat(args.getEntryExpirationTTL()).isNull();
+
+    args.setRegionExpirationIdleTime(null, null);
+    assertThat(args.getRegionExpirationIdleTime()).isNull();
+
+    args.setRegionExpirationTTL(null, null);
+    assertThat(args.getRegionExpirationTTL()).isNull();
   }
 
   @Test
@@ -64,19 +88,22 @@ public class RegionFunctionArgsTest {
     assertThat(args.getEvictionAttributes()).isNull();
 
     args.setEvictionAttributes("local-destroy", null, null, null);
-    EvictionAttributes attributes = args.getEvictionAttributes();
+    EvictionAttributes attributes = args.getEvictionAttributes()
+        .convertToEvictionAttributes();
     assertThat(attributes.getAlgorithm()).isEqualTo(EvictionAlgorithm.LRU_HEAP);
     assertThat(attributes.getAction()).isEqualTo(EvictionAction.LOCAL_DESTROY);
     assertThat(attributes.getMaximum()).isEqualTo(0);
 
     args.setEvictionAttributes("overflow-to-disk", 1000, null, null);
-    EvictionAttributes attributes1 = args.getEvictionAttributes();
+    EvictionAttributes attributes1 = args.getEvictionAttributes()
+        .convertToEvictionAttributes();
     assertThat(attributes1.getAlgorithm()).isEqualTo(EvictionAlgorithm.LRU_MEMORY);
     assertThat(attributes1.getAction()).isEqualTo(EvictionAction.OVERFLOW_TO_DISK);
     assertThat(attributes1.getMaximum()).isEqualTo(1000);
 
     args.setEvictionAttributes("local-destroy", null, 1000, null);
-    EvictionAttributes attributes2 = args.getEvictionAttributes();
+    EvictionAttributes attributes2 = args.getEvictionAttributes()
+        .convertToEvictionAttributes();
     assertThat(attributes2.getAlgorithm()).isEqualTo(EvictionAlgorithm.LRU_ENTRY);
     assertThat(attributes2.getAction()).isEqualTo(EvictionAction.LOCAL_DESTROY);
     assertThat(attributes2.getMaximum()).isEqualTo(1000);
@@ -85,7 +112,7 @@ public class RegionFunctionArgsTest {
   @Test
   public void evictionAttributesWithNullAction() throws Exception {
     args.setEvictionAttributes(null, null, 1000, null);
-    EvictionAttributes attributes3 = args.getEvictionAttributes();
+    RegionFunctionArgs.EvictionAttrs attributes3 = args.getEvictionAttributes();
     assertThat(attributes3).isNull();
   }
 }


### PR DESCRIPTION
- Store config via generating a RegionConfig object rather than an XML entity
- For clarity, rename getters that return a "Boolean" object rather than a boolean primitive as prefixed by "get" rather than "is". This communicates nullability to the caller. A bit of history here -- this code was originally generated by lombok (https://projectlombok.org/), which we subsequently backed out. But we like the clarity of this pattern.
- Create a "RegionConfigFactory" to generate a RegionConfig object from RegionFunctionArgs.
- Reduce null-related side effects in some setters in RegionFunctionArgs.

Signed-off-by: Peter Tran <ptran@pivotal.io>
Signed-off-by: Aditya Anchuri <aanchuri@pivotal.io>
Signed-off-by: Peter Tran <ptran@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
