### PR TITLE
GEODE-6046 - Java memory allocation issue JDK-8207200

### DIFF
--- a/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneIndexDestroyDUnitTest.java
+++ b/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneIndexDestroyDUnitTest.java
@@ -72,6 +72,9 @@ public class LuceneIndexDestroyDUnitTest extends LuceneDUnitTest {
   public void postSetUp() throws Exception {
     super.postSetUp();
     accessor = Host.getHost(0).getVM(3);
+
+    // Add ignored exceptions to ignore IllegalArgumentException from MemoryUsage java obj
+    IgnoredException.addIgnoredException("committed = 538968064 should be < max = 536870912");
   }
 
   private Object[] parametersForIndexDestroys() {
@@ -181,8 +184,6 @@ public class LuceneIndexDestroyDUnitTest extends LuceneDUnitTest {
       throws Exception {
     // Add ignored exceptions to ignore RegionDestroyExceptions
     IgnoredException.addIgnoredException(RegionDestroyedException.class.getSimpleName());
-    // Add ignored exceptions to ignore IllegalArgumentException from MemoryUsage java obj
-    IgnoredException.addIgnoredException("committed = 538968064 should be < max = 536870912");
 
     // Create index and region
     dataStore1.invoke(() -> initDataStore(createIndex(), regionType));

--- a/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneIndexDestroyDUnitTest.java
+++ b/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneIndexDestroyDUnitTest.java
@@ -181,6 +181,8 @@ public class LuceneIndexDestroyDUnitTest extends LuceneDUnitTest {
       throws Exception {
     // Add ignored exceptions to ignore RegionDestroyExceptions
     IgnoredException.addIgnoredException(RegionDestroyedException.class.getSimpleName());
+    // Add ignored exceptions to ignore IllegalArgumentException from MemoryUsage java obj
+    IgnoredException.addIgnoredException("committed = 538968064 should be < max = 536870912");
 
     // Create index and region
     dataStore1.invoke(() -> initDataStore(createIndex(), regionType));


### PR DESCRIPTION
Java MemoryUsage object has a new exception in Java9+ that is not fixed
until Java 12. Add an ignore to the log checker to ignore the suspect
string.

Authored-by: Robert Houghton <rhoughton@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
