### PR TITLE
GEODE-5342: Fix disk-store validation in commands

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/AlterDiskStoreCommandIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/AlterDiskStoreCommandIntegrationTest.java
@@ -20,13 +20,18 @@ import static org.mockito.Mockito.spy;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import org.apache.geode.management.cli.GfshCommand;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.util.CommandStringBuilder;
 import org.apache.geode.test.junit.rules.GfshParserRule;
 
-public class AlterDiskStoreJUnitTest {
+public class AlterDiskStoreCommandIntegrationTest {
+
+  @Rule
+  public TemporaryFolder tempDir = new TemporaryFolder();
+
   @Rule
   public GfshParserRule gfsh = new GfshParserRule();
 
@@ -38,11 +43,11 @@ public class AlterDiskStoreJUnitTest {
   }
 
   @Test
-  public void removeOptionMustBeUsedAlone() throws Exception {
+  public void removeOptionMustBeUsedAlone() {
     CommandStringBuilder csb = new CommandStringBuilder(CliStrings.ALTER_DISK_STORE);
     csb.addOption(CliStrings.ALTER_DISK_STORE__DISKSTORENAME, "diskStoreName");
     csb.addOption(CliStrings.ALTER_DISK_STORE__REGIONNAME, "regionName");
-    csb.addOption(CliStrings.ALTER_DISK_STORE__DISKDIRS, "./someDirectory");
+    csb.addOption(CliStrings.ALTER_DISK_STORE__DISKDIRS, tempDir.getRoot().toString());
     csb.addOption(CliStrings.ALTER_DISK_STORE__CONCURRENCY__LEVEL, "5");
     csb.addOption(CliStrings.ALTER_DISK_STORE__REMOVE, "true");
     String commandString = csb.toString();

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/AlterOfflineDiskStoreCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/AlterOfflineDiskStoreCommand.java
@@ -12,7 +12,6 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package org.apache.geode.management.internal.cli.commands;
 
 import java.io.File;
@@ -30,7 +29,7 @@ import org.apache.geode.management.internal.cli.result.model.ResultModel;
 
 public class AlterOfflineDiskStoreCommand extends SingleGfshCommand {
   @CliCommand(value = CliStrings.ALTER_DISK_STORE, help = CliStrings.ALTER_DISK_STORE__HELP)
-  @CliMetaData(shellOnly = true, relatedTopic = {CliStrings.TOPIC_GEODE_DISKSTORE})
+  @CliMetaData(shellOnly = true, relatedTopic = CliStrings.TOPIC_GEODE_DISKSTORE)
   public ResultModel alterOfflineDiskStore(
       @CliOption(key = CliStrings.ALTER_DISK_STORE__DISKSTORENAME, mandatory = true,
           help = CliStrings.ALTER_DISK_STORE__DISKSTORENAME__HELP) String diskStoreName,
@@ -59,6 +58,13 @@ public class AlterOfflineDiskStoreCommand extends SingleGfshCommand {
       @CliOption(key = CliStrings.ALTER_DISK_STORE__REMOVE,
           help = CliStrings.ALTER_DISK_STORE__REMOVE__HELP, specifiedDefaultValue = "true",
           unspecifiedDefaultValue = "false") boolean remove) {
+
+    String validatedDirectories = DiskStoreCommandsUtils.validatedDirectories(diskDirs);
+    if (validatedDirectories != null) {
+      throw new IllegalArgumentException(
+          "Could not find " + CliStrings.ALTER_DISK_STORE__DISKDIRS + ": \""
+              + validatedDirectories + "\"");
+    }
 
     try {
       File[] dirs = null;
@@ -124,5 +130,4 @@ public class AlterOfflineDiskStoreCommand extends SingleGfshCommand {
       return ResultModel.createError(e.getMessage());
     }
   }
-
 }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CompactOfflineDiskStoreCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CompactOfflineDiskStoreCommand.java
@@ -12,7 +12,6 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package org.apache.geode.management.internal.cli.commands;
 
 import java.io.BufferedReader;
@@ -39,7 +38,7 @@ import org.apache.geode.management.internal.cli.util.DiskStoreCompacter;
 public class CompactOfflineDiskStoreCommand extends SingleGfshCommand {
   @CliCommand(value = CliStrings.COMPACT_OFFLINE_DISK_STORE,
       help = CliStrings.COMPACT_OFFLINE_DISK_STORE__HELP)
-  @CliMetaData(shellOnly = true, relatedTopic = {CliStrings.TOPIC_GEODE_DISKSTORE})
+  @CliMetaData(shellOnly = true, relatedTopic = CliStrings.TOPIC_GEODE_DISKSTORE)
   public ResultModel compactOfflineDiskStore(
       @CliOption(key = CliStrings.COMPACT_OFFLINE_DISK_STORE__NAME, mandatory = true,
           help = CliStrings.COMPACT_OFFLINE_DISK_STORE__NAME__HELP) String diskStoreName,
@@ -50,20 +49,20 @@ public class CompactOfflineDiskStoreCommand extends SingleGfshCommand {
           help = CliStrings.COMPACT_OFFLINE_DISK_STORE__MAXOPLOGSIZE__HELP) long maxOplogSize,
       @CliOption(key = CliStrings.COMPACT_OFFLINE_DISK_STORE__J,
           help = CliStrings.COMPACT_OFFLINE_DISK_STORE__J__HELP) String[] jvmProps) {
+
+    String validatedDirectories = DiskStoreCommandsUtils.validatedDirectories(diskDirs);
+    if (validatedDirectories != null) {
+      throw new IllegalArgumentException(
+          "Could not find " + CliStrings.COMPACT_OFFLINE_DISK_STORE__DISKDIRS + ": \""
+              + validatedDirectories + "\"");
+    }
+
     ResultModel result = new ResultModel();
     InfoResultModel infoResult = result.addInfo();
     LogWrapper logWrapper = LogWrapper.getInstance(getCache());
-
     Process compactorProcess = null;
 
     try {
-      String validatedDirectories = DiskStoreCommandsUtils.validatedDirectories(diskDirs);
-      if (validatedDirectories != null) {
-        throw new IllegalArgumentException(
-            "Could not find " + CliStrings.COMPACT_OFFLINE_DISK_STORE__DISKDIRS + ": \""
-                + validatedDirectories + "\"");
-      }
-
       List<String> commandList = new ArrayList<>();
       commandList.add(System.getProperty("java.home") + File.separatorChar + "bin"
           + File.separatorChar + "java");

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeOfflineDiskStoreCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeOfflineDiskStoreCommand.java
@@ -12,7 +12,6 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package org.apache.geode.management.internal.cli.commands;
 
 import java.io.ByteArrayOutputStream;
@@ -33,7 +32,7 @@ import org.apache.geode.management.internal.cli.result.model.ResultModel;
 public class DescribeOfflineDiskStoreCommand extends SingleGfshCommand {
   @CliCommand(value = CliStrings.DESCRIBE_OFFLINE_DISK_STORE,
       help = CliStrings.DESCRIBE_OFFLINE_DISK_STORE__HELP)
-  @CliMetaData(shellOnly = true, relatedTopic = {CliStrings.TOPIC_GEODE_DISKSTORE})
+  @CliMetaData(shellOnly = true, relatedTopic = CliStrings.TOPIC_GEODE_DISKSTORE)
   public ResultModel describeOfflineDiskStore(
       @CliOption(key = CliStrings.DESCRIBE_OFFLINE_DISK_STORE__DISKSTORENAME, mandatory = true,
           help = CliStrings.DESCRIBE_OFFLINE_DISK_STORE__DISKSTORENAME__HELP) String diskStoreName,
@@ -43,6 +42,13 @@ public class DescribeOfflineDiskStoreCommand extends SingleGfshCommand {
           help = CliStrings.DESCRIBE_OFFLINE_DISK_STORE__PDX_TYPES__HELP) Boolean listPdxTypes,
       @CliOption(key = CliStrings.DESCRIBE_OFFLINE_DISK_STORE__REGIONNAME,
           help = CliStrings.DESCRIBE_OFFLINE_DISK_STORE__REGIONNAME__HELP) String regionName) {
+
+    String validatedDirectories = DiskStoreCommandsUtils.validatedDirectories(diskDirs);
+    if (validatedDirectories != null) {
+      throw new IllegalArgumentException(
+          "Could not find " + CliStrings.DESCRIBE_OFFLINE_DISK_STORE__DISKDIRS + ": \""
+              + validatedDirectories + "\"");
+    }
 
     try {
       final File[] dirs = new File[diskDirs.length];

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/UpgradeOfflineDiskStoreCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/UpgradeOfflineDiskStoreCommand.java
@@ -12,7 +12,6 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package org.apache.geode.management.internal.cli.commands;
 
 import java.io.BufferedReader;
@@ -39,7 +38,7 @@ import org.apache.geode.management.internal.cli.util.DiskStoreUpgrader;
 public class UpgradeOfflineDiskStoreCommand extends SingleGfshCommand {
   @CliCommand(value = CliStrings.UPGRADE_OFFLINE_DISK_STORE,
       help = CliStrings.UPGRADE_OFFLINE_DISK_STORE__HELP)
-  @CliMetaData(shellOnly = true, relatedTopic = {CliStrings.TOPIC_GEODE_DISKSTORE})
+  @CliMetaData(shellOnly = true, relatedTopic = CliStrings.TOPIC_GEODE_DISKSTORE)
   public ResultModel upgradeOfflineDiskStore(
       @CliOption(key = CliStrings.UPGRADE_OFFLINE_DISK_STORE__NAME, mandatory = true,
           help = CliStrings.UPGRADE_OFFLINE_DISK_STORE__NAME__HELP) String diskStoreName,
@@ -51,6 +50,13 @@ public class UpgradeOfflineDiskStoreCommand extends SingleGfshCommand {
       @CliOption(key = CliStrings.UPGRADE_OFFLINE_DISK_STORE__J,
           help = CliStrings.UPGRADE_OFFLINE_DISK_STORE__J__HELP) String[] jvmProps) {
 
+    String validatedDirectories = DiskStoreCommandsUtils.validatedDirectories(diskDirs);
+    if (validatedDirectories != null) {
+      throw new IllegalArgumentException(
+          "Could not find " + CliStrings.UPGRADE_OFFLINE_DISK_STORE__DISKDIRS + ": \""
+              + validatedDirectories + "\"");
+    }
+
     ResultModel result = new ResultModel();
     InfoResultModel infoResult = result.addInfo();
     LogWrapper logWrapper = LogWrapper.getInstance(getCache());
@@ -58,13 +64,6 @@ public class UpgradeOfflineDiskStoreCommand extends SingleGfshCommand {
     Process upgraderProcess = null;
 
     try {
-      String validatedDirectories = DiskStoreCommandsUtils.validatedDirectories(diskDirs);
-      if (validatedDirectories != null) {
-        throw new IllegalArgumentException(
-            "Could not find " + CliStrings.UPGRADE_OFFLINE_DISK_STORE__DISKDIRS + ": \""
-                + validatedDirectories + "\"");
-      }
-
       List<String> commandList = new ArrayList<>();
       commandList.add(System.getProperty("java.home") + File.separatorChar + "bin"
           + File.separatorChar + "java");

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ValidateDiskStoreCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ValidateDiskStoreCommand.java
@@ -12,7 +12,6 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package org.apache.geode.management.internal.cli.commands;
 
 import java.io.BufferedReader;
@@ -38,7 +37,7 @@ import org.apache.geode.management.internal.cli.util.DiskStoreValidater;
 
 public class ValidateDiskStoreCommand extends GfshCommand {
   @CliCommand(value = CliStrings.VALIDATE_DISK_STORE, help = CliStrings.VALIDATE_DISK_STORE__HELP)
-  @CliMetaData(shellOnly = true, relatedTopic = {CliStrings.TOPIC_GEODE_DISKSTORE})
+  @CliMetaData(shellOnly = true, relatedTopic = CliStrings.TOPIC_GEODE_DISKSTORE)
   public ResultModel validateDiskStore(
       @CliOption(key = CliStrings.VALIDATE_DISK_STORE__NAME, mandatory = true,
           help = CliStrings.VALIDATE_DISK_STORE__NAME__HELP) String diskStoreName,
@@ -46,6 +45,13 @@ public class ValidateDiskStoreCommand extends GfshCommand {
           help = CliStrings.VALIDATE_DISK_STORE__DISKDIRS__HELP) String[] diskDirs,
       @CliOption(key = CliStrings.VALIDATE_DISK_STORE__J,
           help = CliStrings.VALIDATE_DISK_STORE__J__HELP) String[] jvmProps) {
+
+    String validatedDirectories = DiskStoreCommandsUtils.validatedDirectories(diskDirs);
+    if (validatedDirectories != null) {
+      throw new IllegalArgumentException(
+          "Could not find " + CliStrings.VALIDATE_DISK_STORE__DISKDIRS + ": \""
+              + validatedDirectories + "\"");
+    }
 
     ResultModel result = new ResultModel();
     InfoResultModel infoResult = result.addInfo();


### PR DESCRIPTION
GEODE-5342: Fix disk-store validation in commands

- Fixed minor warnings.
- Replaced the usage of `junit.Assert` by `assertj`.
- Offline gfsh comamnds related to disk-stores avoid creating the
  disk-store's folder if it doesn't exist already.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
