### PR TITLE
GEODE-6034 Protobuf clients should not access or modify internal regions

### DIFF
--- a/geode-protobuf/src/integrationTest/java/org/apache/geode/internal/protocol/protobuf/v1/AuthenticationIntegrationTest.java
+++ b/geode-protobuf/src/integrationTest/java/org/apache/geode/internal/protocol/protobuf/v1/AuthenticationIntegrationTest.java
@@ -112,7 +112,7 @@ public class AuthenticationIntegrationTest {
 
     @Override
     public boolean authorize(Object principal, ResourcePermission permission) {
-      return principal == authorizedPrincipal;
+      return principal.equals(authorizedPrincipal);
     }
   }
 

--- a/geode-protobuf/src/integrationTest/java/org/apache/geode/internal/protocol/protobuf/v1/AuthorizationIntegrationTest.java
+++ b/geode-protobuf/src/integrationTest/java/org/apache/geode/internal/protocol/protobuf/v1/AuthorizationIntegrationTest.java
@@ -100,7 +100,7 @@ public class AuthorizationIntegrationTest {
     @Override
     public boolean authorize(Object principal, ResourcePermission permission) {
       // Only allow data operations and only from the expected principal
-      if (principal != securityPrincipal
+      if (!principal.equals(securityPrincipal)
           || permission.getResource() != ResourcePermission.Resource.DATA) {
         return false;
       }

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/security/SecureCacheImpl.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/security/SecureCacheImpl.java
@@ -52,7 +52,7 @@ public class SecureCacheImpl implements SecureCache {
   private final SecureFunctionService functionService;
 
   public SecureCacheImpl(InternalCache cache, Security security) {
-    this.cache = cache.getCacheForProcessingClientRequests();
+    this.cache = cache;
     this.security = security;
     this.functionService = new SecureFunctionServiceImpl(cache, security);
   }

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/security/SecureCacheImpl.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/security/SecureCacheImpl.java
@@ -52,7 +52,7 @@ public class SecureCacheImpl implements SecureCache {
   private final SecureFunctionService functionService;
 
   public SecureCacheImpl(InternalCache cache, Security security) {
-    this.cache = cache;
+    this.cache = cache.getCacheForProcessingClientRequests();
     this.security = security;
     this.functionService = new SecureFunctionServiceImpl(cache, security);
   }

--- a/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/ServerMessageExecutionContext.java
+++ b/geode-protobuf/src/main/java/org/apache/geode/internal/protocol/protobuf/v1/ServerMessageExecutionContext.java
@@ -41,10 +41,10 @@ public class ServerMessageExecutionContext extends MessageExecutionContext {
   public ServerMessageExecutionContext(InternalCache cache, ClientStatistics statistics,
       SecurityService securityService) {
     super(statistics, securityService);
-    this.cache = cache;
+    this.cache = cache.getCacheForProcessingClientRequests();
     Security security =
         securityService.isIntegratedSecurity() ? new NotLoggedInSecurity() : new NoSecurity();
-    this.secureCache = new SecureCacheImpl(cache, security);
+    this.secureCache = new SecureCacheImpl(this.cache, security);
   }
 
   @Override

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/cache/tier/sockets/OutputCapturingServerConnectionTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/cache/tier/sockets/OutputCapturingServerConnectionTest.java
@@ -33,7 +33,6 @@ import org.junit.contrib.java.lang.system.SystemOutRule;
 import org.junit.experimental.categories.Category;
 
 import org.apache.geode.cache.IncompatibleVersionException;
-import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.InternalCacheForClientAccess;
 import org.apache.geode.internal.cache.client.protocol.ClientProtocolProcessor;
 import org.apache.geode.internal.cache.tier.CachedRegionHelper;
@@ -88,7 +87,7 @@ public class OutputCapturingServerConnectionTest {
     when(socketMock.getRemoteSocketAddress()).thenReturn(inetSocketAddressStub);
     when(socketMock.getInetAddress()).thenReturn(inetAddressStub);
 
-    InternalCache cache = mock(InternalCacheForClientAccess.class);
+    InternalCacheForClientAccess cache = mock(InternalCacheForClientAccess.class);
     when(cache.getCacheForProcessingClientRequests()).thenReturn(cache);
     CachedRegionHelper cachedRegionHelper = mock(CachedRegionHelper.class);
     when(cachedRegionHelper.getCache()).thenReturn(cache);

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/cache/tier/sockets/OutputCapturingServerConnectionTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/cache/tier/sockets/OutputCapturingServerConnectionTest.java
@@ -34,6 +34,7 @@ import org.junit.experimental.categories.Category;
 
 import org.apache.geode.cache.IncompatibleVersionException;
 import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.InternalCacheForClientAccess;
 import org.apache.geode.internal.cache.client.protocol.ClientProtocolProcessor;
 import org.apache.geode.internal.cache.tier.CachedRegionHelper;
 import org.apache.geode.internal.cache.tier.CommunicationMode;
@@ -87,7 +88,8 @@ public class OutputCapturingServerConnectionTest {
     when(socketMock.getRemoteSocketAddress()).thenReturn(inetSocketAddressStub);
     when(socketMock.getInetAddress()).thenReturn(inetAddressStub);
 
-    InternalCache cache = mock(InternalCache.class);
+    InternalCache cache = mock(InternalCacheForClientAccess.class);
+    when(cache.getCacheForProcessingClientRequests()).thenReturn(cache);
     CachedRegionHelper cachedRegionHelper = mock(CachedRegionHelper.class);
     when(cachedRegionHelper.getCache()).thenReturn(cache);
     return new ProtobufServerConnection(socketMock, cache, cachedRegionHelper,

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/cache/tier/sockets/ProtobufServerConnectionTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/cache/tier/sockets/ProtobufServerConnectionTest.java
@@ -35,7 +35,6 @@ import org.mockito.Mockito;
 
 import org.apache.geode.cache.IncompatibleVersionException;
 import org.apache.geode.internal.Assert;
-import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.InternalCacheForClientAccess;
 import org.apache.geode.internal.cache.client.protocol.ClientProtocolProcessor;
 import org.apache.geode.internal.cache.tier.CachedRegionHelper;
@@ -127,7 +126,7 @@ public class ProtobufServerConnectionTest {
     when(socketMock.getRemoteSocketAddress()).thenReturn(inetSocketAddressStub);
     when(socketMock.getInetAddress()).thenReturn(inetAddressStub);
 
-    InternalCache cache = mock(InternalCacheForClientAccess.class);
+    InternalCacheForClientAccess cache = mock(InternalCacheForClientAccess.class);
     when(cache.getCacheForProcessingClientRequests()).thenReturn(cache);
     CachedRegionHelper cachedRegionHelper = mock(CachedRegionHelper.class);
     when(cachedRegionHelper.getCache()).thenReturn(cache);

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/cache/tier/sockets/ProtobufServerConnectionTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/cache/tier/sockets/ProtobufServerConnectionTest.java
@@ -36,6 +36,7 @@ import org.mockito.Mockito;
 import org.apache.geode.cache.IncompatibleVersionException;
 import org.apache.geode.internal.Assert;
 import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.InternalCacheForClientAccess;
 import org.apache.geode.internal.cache.client.protocol.ClientProtocolProcessor;
 import org.apache.geode.internal.cache.tier.CachedRegionHelper;
 import org.apache.geode.internal.cache.tier.CommunicationMode;
@@ -126,7 +127,8 @@ public class ProtobufServerConnectionTest {
     when(socketMock.getRemoteSocketAddress()).thenReturn(inetSocketAddressStub);
     when(socketMock.getInetAddress()).thenReturn(inetAddressStub);
 
-    InternalCache cache = mock(InternalCache.class);
+    InternalCache cache = mock(InternalCacheForClientAccess.class);
+    when(cache.getCacheForProcessingClientRequests()).thenReturn(cache);
     CachedRegionHelper cachedRegionHelper = mock(CachedRegionHelper.class);
     when(cachedRegionHelper.getCache()).thenReturn(cache);
     return new ProtobufServerConnection(socketMock, cache, cachedRegionHelper,

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/ProtobufStreamProcessorTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/ProtobufStreamProcessorTest.java
@@ -26,7 +26,6 @@ import java.io.OutputStream;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.InternalCacheForClientAccess;
 import org.apache.geode.internal.protocol.TestExecutionContext;
 import org.apache.geode.internal.protocol.protobuf.v1.ProtobufStreamProcessor;
@@ -40,7 +39,7 @@ public class ProtobufStreamProcessorTest {
     OutputStream outputStream = new ByteArrayOutputStream(2);
 
     ProtobufStreamProcessor protobufStreamProcessor = new ProtobufStreamProcessor();
-    InternalCache mockInternalCache = mock(InternalCacheForClientAccess.class);
+    InternalCacheForClientAccess mockInternalCache = mock(InternalCacheForClientAccess.class);
     when(mockInternalCache.getCacheForProcessingClientRequests()).thenReturn(mockInternalCache);
     protobufStreamProcessor.receiveMessage(inputStream, outputStream,
         TestExecutionContext.getNoAuthCacheExecutionContext(mockInternalCache));

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/ProtobufStreamProcessorTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/ProtobufStreamProcessorTest.java
@@ -15,6 +15,7 @@
 package org.apache.geode.internal.protocol.protobuf;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -26,6 +27,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.InternalCacheForClientAccess;
 import org.apache.geode.internal.protocol.TestExecutionContext;
 import org.apache.geode.internal.protocol.protobuf.v1.ProtobufStreamProcessor;
 import org.apache.geode.test.junit.categories.ClientServerTest;
@@ -38,7 +40,8 @@ public class ProtobufStreamProcessorTest {
     OutputStream outputStream = new ByteArrayOutputStream(2);
 
     ProtobufStreamProcessor protobufStreamProcessor = new ProtobufStreamProcessor();
-    InternalCache mockInternalCache = mock(InternalCache.class);
+    InternalCache mockInternalCache = mock(InternalCacheForClientAccess.class);
+    when(mockInternalCache.getCacheForProcessingClientRequests()).thenReturn(mockInternalCache);
     protobufStreamProcessor.receiveMessage(inputStream, outputStream,
         TestExecutionContext.getNoAuthCacheExecutionContext(mockInternalCache));
   }

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/security/SecureCacheImplTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/security/SecureCacheImplTest.java
@@ -53,6 +53,7 @@ import org.apache.geode.cache.query.internal.StructImpl;
 import org.apache.geode.cache.query.internal.types.ObjectTypeImpl;
 import org.apache.geode.cache.query.internal.types.StructTypeImpl;
 import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.InternalCacheForClientAccess;
 import org.apache.geode.security.NotAuthorizedException;
 import org.apache.geode.security.ResourcePermission;
 import org.apache.geode.test.junit.categories.ClientServerTest;
@@ -68,7 +69,8 @@ public class SecureCacheImplTest {
 
   @Before
   public void setUp() {
-    cache = mock(InternalCache.class);
+    cache = mock(InternalCacheForClientAccess.class);
+    when(cache.getCacheForProcessingClientRequests()).thenReturn(cache);
     region = mock(Region.class);
     when(cache.getRegion(REGION)).thenReturn(region);
     security = mock(Security.class);

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/security/SecureCacheImplTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/security/SecureCacheImplTest.java
@@ -24,6 +24,7 @@ import static org.assertj.core.data.MapEntry.entry;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -70,7 +71,7 @@ public class SecureCacheImplTest {
   @Before
   public void setUp() {
     cache = mock(InternalCacheForClientAccess.class);
-    when(cache.getCacheForProcessingClientRequests()).thenReturn(cache);
+    doReturn(cache).when(cache).getCacheForProcessingClientRequests();
     region = mock(Region.class);
     when(cache.getRegion(REGION)).thenReturn(region);
     security = mock(Security.class);
@@ -82,7 +83,7 @@ public class SecureCacheImplTest {
   }
 
   @Test
-  public void getAllSuccesses() throws Exception {
+  public void getAllSuccesses() {
     authorize(DATA, READ, REGION, "a");
     authorize(DATA, READ, REGION, "b");
     Map<Object, Object> okValues = new HashMap<>();
@@ -99,7 +100,7 @@ public class SecureCacheImplTest {
   }
 
   @Test
-  public void getAllWithRegionLevelAuthorizationSucceeds() throws Exception {
+  public void getAllWithRegionLevelAuthorizationSucceeds() {
     authorize(DATA, READ, REGION, ALL);
     Map<Object, Object> okValues = new HashMap<>();
     Map<Object, Exception> exceptionValues = new HashMap<>();
@@ -115,7 +116,7 @@ public class SecureCacheImplTest {
   }
 
   @Test
-  public void getAllWithFailure() throws Exception {
+  public void getAllWithFailure() {
     authorize(DATA, READ, REGION, "b");
     Map<Object, Object> okValues = new HashMap<>();
     Map<Object, Exception> exceptionValues = new HashMap<>();
@@ -133,7 +134,7 @@ public class SecureCacheImplTest {
   }
 
   @Test
-  public void getAllIsPostProcessed() throws Exception {
+  public void getAllIsPostProcessed() {
     authorize(DATA, READ, REGION, "a");
     authorize(DATA, READ, REGION, "b");
     when(security.postProcess(any(), any(), any())).thenReturn("spam");
@@ -156,20 +157,20 @@ public class SecureCacheImplTest {
   }
 
   @Test
-  public void get() throws Exception {
+  public void get() {
     authorize(DATA, READ, REGION, "a");
     when(region.get("a")).thenReturn("value");
     assertEquals("value", authorizingCache.get(REGION, "a"));
   }
 
   @Test
-  public void getWithFailure() throws Exception {
+  public void getWithFailure() {
     assertThatThrownBy(() -> authorizingCache.get(REGION, "a"))
         .isInstanceOf(NotAuthorizedException.class);
   }
 
   @Test
-  public void getIsPostProcessed() throws Exception {
+  public void getIsPostProcessed() {
     authorize(DATA, READ, REGION, "a");
     when(security.postProcess(REGION, "a", "value")).thenReturn("spam");
     when(region.get("a")).thenReturn("value");
@@ -177,20 +178,20 @@ public class SecureCacheImplTest {
   }
 
   @Test
-  public void put() throws Exception {
+  public void put() {
     authorize(DATA, WRITE, REGION, "a");
     authorizingCache.put(REGION, "a", "value");
     verify(region).put("a", "value");
   }
 
   @Test
-  public void putWithFailure() throws Exception {
+  public void putWithFailure() {
     assertThatThrownBy(() -> authorizingCache.put(REGION, "a", "value"))
         .isInstanceOf(NotAuthorizedException.class);
   }
 
   @Test
-  public void putAll() throws Exception {
+  public void putAll() {
     authorize(DATA, WRITE, REGION, "a");
     authorize(DATA, WRITE, REGION, "c");
     Map<Object, Object> entries = new HashMap<>();
@@ -207,7 +208,7 @@ public class SecureCacheImplTest {
   }
 
   @Test
-  public void putAllWithRegionLevelAuthorizationSucceeds() throws Exception {
+  public void putAllWithRegionLevelAuthorizationSucceeds() {
     authorize(DATA, WRITE, REGION, ALL);
     Map<Object, Object> entries = new HashMap<>();
     entries.put("a", "b");
@@ -223,7 +224,7 @@ public class SecureCacheImplTest {
   }
 
   @Test
-  public void putAllWithFailure() throws Exception {
+  public void putAllWithFailure() {
     authorize(DATA, WRITE, REGION, "a");
     Map<Object, Object> entries = new HashMap<>();
     entries.put("a", "b");
@@ -241,20 +242,20 @@ public class SecureCacheImplTest {
   }
 
   @Test
-  public void remove() throws Exception {
+  public void remove() {
     authorize(DATA, WRITE, REGION, "a");
     authorizingCache.remove(REGION, "a");
     verify(region).remove("a");
   }
 
   @Test
-  public void removeWithoutAuthorization() throws Exception {
+  public void removeWithoutAuthorization() {
     assertThatThrownBy(() -> authorizingCache.remove(REGION, "a"))
         .isInstanceOf(NotAuthorizedException.class);
   }
 
   @Test
-  public void removeIsPostProcessed() throws Exception {
+  public void removeIsPostProcessed() {
     authorize(DATA, WRITE, REGION, "a");
     when(region.remove("a")).thenReturn("value");
     when(security.postProcess(REGION, "a", "value")).thenReturn("spam");
@@ -264,7 +265,7 @@ public class SecureCacheImplTest {
   }
 
   @Test
-  public void getRegionNames() throws Exception {
+  public void getRegionNames() {
     authorize(DATA, READ, ALL, ALL);
     Set<Region<?, ?>> regions = new HashSet<>();
     regions.add(region);
@@ -286,59 +287,59 @@ public class SecureCacheImplTest {
   }
 
   @Test
-  public void getRegionNamesWithoutAuthorization() throws Exception {
+  public void getRegionNamesWithoutAuthorization() {
     assertThatThrownBy(() -> authorizingCache.getRegionNames())
         .isInstanceOf(NotAuthorizedException.class);
   }
 
   @Test
-  public void getSize() throws Exception {
+  public void getSize() {
     authorize(DATA, READ, REGION, ALL);
     authorizingCache.getSize(REGION);
     verify(region).size();
   }
 
   @Test
-  public void getSizeWithoutAuthorization() throws Exception {
+  public void getSizeWithoutAuthorization() {
     assertThatThrownBy(() -> authorizingCache.getSize(REGION))
         .isInstanceOf(NotAuthorizedException.class);
   }
 
   @Test
-  public void keySet() throws Exception {
+  public void keySet() {
     authorize(DATA, READ, REGION, ALL);
     authorizingCache.keySet(REGION);
     verify(region).keySet();
   }
 
   @Test
-  public void keySetWithoutAuthorization() throws Exception {
+  public void keySetWithoutAuthorization() {
     assertThatThrownBy(() -> authorizingCache.keySet(REGION))
         .isInstanceOf(NotAuthorizedException.class);
   }
 
   @Test
-  public void clear() throws Exception {
+  public void clear() {
     authorize(DATA, WRITE, REGION, ALL);
     authorizingCache.clear(REGION);
     verify(region).clear();
   }
 
   @Test
-  public void clearWithoutAuthorization() throws Exception {
+  public void clearWithoutAuthorization() {
     assertThatThrownBy(() -> authorizingCache.clear(REGION))
         .isInstanceOf(NotAuthorizedException.class);
   }
 
   @Test
-  public void putIfAbsent() throws Exception {
+  public void putIfAbsent() {
     authorize(DATA, WRITE, REGION, "a");
     String oldValue = authorizingCache.putIfAbsent(REGION, "a", "b");
     verify(region).putIfAbsent("a", "b");
   }
 
   @Test
-  public void putIfAbsentIsPostProcessed() throws Exception {
+  public void putIfAbsentIsPostProcessed() {
     authorize(DATA, WRITE, REGION, "a");
     when(region.putIfAbsent(any(), any())).thenReturn("value");
     when(security.postProcess(REGION, "a", "value")).thenReturn("spam");
@@ -348,7 +349,7 @@ public class SecureCacheImplTest {
   }
 
   @Test
-  public void putIfAbsentWithoutAuthorization() throws Exception {
+  public void putIfAbsentWithoutAuthorization() {
     assertThatThrownBy(() -> authorizingCache.putIfAbsent(REGION, "a", "b"))
         .isInstanceOf(NotAuthorizedException.class);
   }

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/security/SecureFunctionServiceImplTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/security/SecureFunctionServiceImplTest.java
@@ -36,6 +36,7 @@ import org.apache.geode.cache.Region;
 import org.apache.geode.cache.execute.Function;
 import org.apache.geode.cache.execute.FunctionService;
 import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.InternalCacheForClientAccess;
 import org.apache.geode.security.NotAuthorizedException;
 import org.apache.geode.security.ResourcePermission;
 import org.apache.geode.test.junit.categories.ClientServerTest;
@@ -52,7 +53,8 @@ public class SecureFunctionServiceImplTest {
 
   @Before
   public void setUp() {
-    cache = mock(InternalCache.class);
+    cache = mock(InternalCacheForClientAccess.class);
+    when(cache.getCacheForProcessingClientRequests()).thenReturn(cache);
     region = mock(Region.class);
     when(cache.getRegion(REGION)).thenReturn(region);
     security = mock(Security.class);

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/security/SecureFunctionServiceImplTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/security/SecureFunctionServiceImplTest.java
@@ -20,6 +20,7 @@ import static org.apache.geode.security.ResourcePermission.Resource.CLUSTER;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -54,7 +55,7 @@ public class SecureFunctionServiceImplTest {
   @Before
   public void setUp() {
     cache = mock(InternalCacheForClientAccess.class);
-    when(cache.getCacheForProcessingClientRequests()).thenReturn(cache);
+    doReturn(cache).when(cache).getCacheForProcessingClientRequests();
     region = mock(Region.class);
     when(cache.getRegion(REGION)).thenReturn(region);
     security = mock(Security.class);

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/operations/ExecuteFunctionOnGroupRequestOperationHandlerJUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/operations/ExecuteFunctionOnGroupRequestOperationHandlerJUnitTest.java
@@ -40,6 +40,7 @@ import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.InternalCacheForClientAccess;
 import org.apache.geode.internal.protocol.protobuf.statistics.ProtobufClientStatistics;
 import org.apache.geode.internal.protocol.protobuf.v1.FunctionAPI;
 import org.apache.geode.internal.protocol.protobuf.v1.ProtobufSerializationService;
@@ -88,7 +89,8 @@ public class ExecuteFunctionOnGroupRequestOperationHandlerJUnitTest {
 
   @Before
   public void setUp() throws Exception {
-    cacheStub = mock(InternalCache.class);
+    cacheStub = mock(InternalCacheForClientAccess.class);
+    when(cacheStub.getCacheForProcessingClientRequests()).thenReturn(cacheStub);
     serializationService = new ProtobufSerializationService();
     when(cacheStub.getSecurityService()).thenReturn(mock(SecurityService.class));
 

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/operations/ExecuteFunctionOnGroupRequestOperationHandlerJUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/operations/ExecuteFunctionOnGroupRequestOperationHandlerJUnitTest.java
@@ -39,7 +39,6 @@ import org.apache.geode.distributed.DistributedSystemDisconnectedException;
 import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
-import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.InternalCacheForClientAccess;
 import org.apache.geode.internal.protocol.protobuf.statistics.ProtobufClientStatistics;
 import org.apache.geode.internal.protocol.protobuf.v1.FunctionAPI;
@@ -57,7 +56,7 @@ public class ExecuteFunctionOnGroupRequestOperationHandlerJUnitTest {
   private static final String TEST_GROUP2 = "group2";
   private static final String TEST_FUNCTION_ID = "testFunction";
   public static final String NOT_A_GROUP = "notAGroup";
-  private InternalCache cacheStub;
+  private InternalCacheForClientAccess cacheStub;
   private DistributionManager distributionManager;
   private ExecuteFunctionOnGroupRequestOperationHandler operationHandler;
   private ProtobufSerializationService serializationService;

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/operations/ExecuteFunctionOnMemberRequestOperationHandlerJUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/operations/ExecuteFunctionOnMemberRequestOperationHandlerJUnitTest.java
@@ -36,6 +36,7 @@ import org.apache.geode.distributed.DistributedSystemDisconnectedException;
 import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.InternalCacheForClientAccess;
 import org.apache.geode.internal.protocol.protobuf.statistics.ProtobufClientStatistics;
 import org.apache.geode.internal.protocol.protobuf.v1.FunctionAPI;
 import org.apache.geode.internal.protocol.protobuf.v1.ProtobufSerializationService;
@@ -83,7 +84,8 @@ public class ExecuteFunctionOnMemberRequestOperationHandlerJUnitTest {
 
   @Before
   public void setUp() throws Exception {
-    cacheStub = mock(InternalCache.class);
+    cacheStub = mock(InternalCacheForClientAccess.class);
+    when(cacheStub.getCacheForProcessingClientRequests()).thenReturn(cacheStub);
     serializationService = new ProtobufSerializationService();
     when(cacheStub.getSecurityService()).thenReturn(mock(SecurityService.class));
 

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/operations/ExecuteFunctionOnMemberRequestOperationHandlerJUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/operations/ExecuteFunctionOnMemberRequestOperationHandlerJUnitTest.java
@@ -35,7 +35,6 @@ import org.apache.geode.cache.execute.FunctionService;
 import org.apache.geode.distributed.DistributedSystemDisconnectedException;
 import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
-import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.InternalCacheForClientAccess;
 import org.apache.geode.internal.protocol.protobuf.statistics.ProtobufClientStatistics;
 import org.apache.geode.internal.protocol.protobuf.v1.FunctionAPI;
@@ -53,7 +52,7 @@ public class ExecuteFunctionOnMemberRequestOperationHandlerJUnitTest {
   private static final String TEST_MEMBER2 = "member2";
   private static final String TEST_FUNCTION_ID = "testFunction";
   public static final String NOT_A_MEMBER = "notAMember";
-  private InternalCache cacheStub;
+  private InternalCacheForClientAccess cacheStub;
   private DistributionManager distributionManager;
   private ExecuteFunctionOnMemberRequestOperationHandler operationHandler;
   private ProtobufSerializationService serializationService;

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/operations/ExecuteFunctionOnRegionRequestOperationHandlerJUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/operations/ExecuteFunctionOnRegionRequestOperationHandlerJUnitTest.java
@@ -35,6 +35,7 @@ import org.apache.geode.cache.execute.Function;
 import org.apache.geode.cache.execute.FunctionContext;
 import org.apache.geode.cache.execute.FunctionService;
 import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.InternalCacheForClientAccess;
 import org.apache.geode.internal.cache.LocalRegion;
 import org.apache.geode.internal.protocol.protobuf.statistics.ProtobufClientStatistics;
 import org.apache.geode.internal.protocol.protobuf.v1.FunctionAPI;
@@ -87,7 +88,8 @@ public class ExecuteFunctionOnRegionRequestOperationHandlerJUnitTest {
   @Before
   public void setUp() {
     regionStub = mock(LocalRegion.class);
-    cacheStub = mock(InternalCache.class);
+    cacheStub = mock(InternalCacheForClientAccess.class);
+    when(cacheStub.getCacheForProcessingClientRequests()).thenReturn(cacheStub);
     serializationService = new ProtobufSerializationService();
 
     when(cacheStub.getRegion(TEST_REGION)).thenReturn(regionStub);

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/operations/ExecuteFunctionOnRegionRequestOperationHandlerJUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/operations/ExecuteFunctionOnRegionRequestOperationHandlerJUnitTest.java
@@ -15,6 +15,7 @@
 package org.apache.geode.internal.protocol.protobuf.v1.operations;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -89,7 +90,7 @@ public class ExecuteFunctionOnRegionRequestOperationHandlerJUnitTest {
   public void setUp() {
     regionStub = mock(LocalRegion.class);
     cacheStub = mock(InternalCacheForClientAccess.class);
-    when(cacheStub.getCacheForProcessingClientRequests()).thenReturn(cacheStub);
+    doReturn(cacheStub).when(cacheStub).getCacheForProcessingClientRequests();
     serializationService = new ProtobufSerializationService();
 
     when(cacheStub.getRegion(TEST_REGION)).thenReturn(regionStub);

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/operations/GetRegionNamesRequestOperationHandlerJUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/operations/GetRegionNamesRequestOperationHandlerJUnitTest.java
@@ -16,6 +16,7 @@ package org.apache.geode.internal.protocol.protobuf.v1.operations;
 
 import static org.apache.geode.internal.Assert.assertTrue;
 import static org.apache.geode.internal.protocol.TestExecutionContext.getNoAuthCacheExecutionContext;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -88,7 +89,7 @@ public class GetRegionNamesRequestOperationHandlerJUnitTest extends OperationHan
   @Test
   public void processReturnsNoCacheRegions() throws Exception {
     InternalCache emptyCache = mock(InternalCacheForClientAccess.class);
-    when(emptyCache.getCacheForProcessingClientRequests()).thenReturn(emptyCache);
+    doReturn(emptyCache).when(emptyCache).getCacheForProcessingClientRequests();
     when(emptyCache.rootRegions())
         .thenReturn(Collections.unmodifiableSet(new HashSet<Region<String, String>>()));
     Result result = operationHandler.process(serializationService,

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/operations/GetRegionNamesRequestOperationHandlerJUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/operations/GetRegionNamesRequestOperationHandlerJUnitTest.java
@@ -31,6 +31,7 @@ import org.junit.experimental.categories.Category;
 
 import org.apache.geode.cache.Region;
 import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.InternalCacheForClientAccess;
 import org.apache.geode.internal.protocol.protobuf.v1.ProtobufRequestUtilities;
 import org.apache.geode.internal.protocol.protobuf.v1.RegionAPI;
 import org.apache.geode.internal.protocol.protobuf.v1.Result;
@@ -86,7 +87,8 @@ public class GetRegionNamesRequestOperationHandlerJUnitTest extends OperationHan
 
   @Test
   public void processReturnsNoCacheRegions() throws Exception {
-    InternalCache emptyCache = mock(InternalCache.class);
+    InternalCache emptyCache = mock(InternalCacheForClientAccess.class);
+    when(emptyCache.getCacheForProcessingClientRequests()).thenReturn(emptyCache);
     when(emptyCache.rootRegions())
         .thenReturn(Collections.unmodifiableSet(new HashSet<Region<String, String>>()));
     Result result = operationHandler.process(serializationService,

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/operations/GetSizeRequestOperationHandlerJUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/operations/GetSizeRequestOperationHandlerJUnitTest.java
@@ -15,6 +15,7 @@
 package org.apache.geode.internal.protocol.protobuf.v1.operations;
 
 import static org.apache.geode.internal.protocol.TestExecutionContext.getNoAuthCacheExecutionContext;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -79,7 +80,7 @@ public class GetSizeRequestOperationHandlerJUnitTest extends OperationHandlerJUn
   @Test
   public void processReturnsNoCacheRegions() throws Exception {
     InternalCache emptyCache = mock(InternalCacheForClientAccess.class);
-    when(emptyCache.getCacheForProcessingClientRequests()).thenReturn(emptyCache);
+    doReturn(emptyCache).when(emptyCache).getCacheForProcessingClientRequests();
     when(emptyCache.rootRegions())
         .thenReturn(Collections.unmodifiableSet(new HashSet<Region<String, String>>()));
     String unknownRegionName = "UNKNOWN_REGION";

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/operations/GetSizeRequestOperationHandlerJUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/operations/GetSizeRequestOperationHandlerJUnitTest.java
@@ -34,6 +34,7 @@ import org.apache.geode.cache.RegionAttributes;
 import org.apache.geode.cache.RegionDestroyedException;
 import org.apache.geode.cache.Scope;
 import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.InternalCacheForClientAccess;
 import org.apache.geode.internal.protocol.protobuf.v1.MessageUtil;
 import org.apache.geode.internal.protocol.protobuf.v1.RegionAPI;
 import org.apache.geode.internal.protocol.protobuf.v1.Result;
@@ -77,7 +78,8 @@ public class GetSizeRequestOperationHandlerJUnitTest extends OperationHandlerJUn
 
   @Test
   public void processReturnsNoCacheRegions() throws Exception {
-    InternalCache emptyCache = mock(InternalCache.class);
+    InternalCache emptyCache = mock(InternalCacheForClientAccess.class);
+    when(emptyCache.getCacheForProcessingClientRequests()).thenReturn(emptyCache);
     when(emptyCache.rootRegions())
         .thenReturn(Collections.unmodifiableSet(new HashSet<Region<String, String>>()));
     String unknownRegionName = "UNKNOWN_REGION";

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/operations/OperationHandlerJUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/operations/OperationHandlerJUnitTest.java
@@ -14,8 +14,8 @@
  */
 package org.apache.geode.internal.protocol.protobuf.v1.operations;
 
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import org.junit.Before;
 import org.junit.experimental.categories.Category;
@@ -36,7 +36,7 @@ public class OperationHandlerJUnitTest {
   @Before
   public void setUpForChildJUnitTests() throws Exception {
     cacheStub = mock(InternalCacheForClientAccess.class);
-    when(cacheStub.getCacheForProcessingClientRequests()).thenReturn(cacheStub);
+    doReturn(cacheStub).when(cacheStub).getCacheForProcessingClientRequests();
     serializationService = new ProtobufSerializationService();
   }
 }

--- a/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/operations/OperationHandlerJUnitTest.java
+++ b/geode-protobuf/src/test/java/org/apache/geode/internal/protocol/protobuf/v1/operations/OperationHandlerJUnitTest.java
@@ -15,11 +15,13 @@
 package org.apache.geode.internal.protocol.protobuf.v1.operations;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.junit.Before;
 import org.junit.experimental.categories.Category;
 
 import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.InternalCacheForClientAccess;
 import org.apache.geode.internal.protocol.operations.ProtobufOperationHandler;
 import org.apache.geode.internal.protocol.protobuf.v1.ProtobufSerializationService;
 import org.apache.geode.test.junit.categories.ClientServerTest;
@@ -33,7 +35,8 @@ public class OperationHandlerJUnitTest {
   // if we name this setUp, then our children override, which is all kinds of annoying.
   @Before
   public void setUpForChildJUnitTests() throws Exception {
-    cacheStub = mock(InternalCache.class);
+    cacheStub = mock(InternalCacheForClientAccess.class);
+    when(cacheStub.getCacheForProcessingClientRequests()).thenReturn(cacheStub);
     serializationService = new ProtobufSerializationService();
   }
 }


### PR DESCRIPTION
The Protobuf API now disallows access to internal cache regions



Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
