### PR TITLE
GEODE-6078: Allow client cache to use JSONFormatter in multi-user mode

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/management/internal/security/MultiUserAuthenticationDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/internal/security/MultiUserAuthenticationDUnitTest.java
@@ -76,10 +76,9 @@ public class MultiUserAuthenticationDUnitTest {
   public void multiAuthenticatedView() throws Exception {
     int locatorPort = locator.getPort();
     for (int i = 0; i < SESSION_COUNT; i++) {
-      ClientCache cache = client.withCredential("stranger", "stranger")
-          .withCacheSetup(f -> f.setPoolSubscriptionEnabled(true)
-              .setPoolMultiuserAuthentication(true)
-              .addPoolLocator("localhost", locatorPort))
+      ClientCache cache = client.withCacheSetup(f -> f.setPoolSubscriptionEnabled(true)
+          .setPoolMultiuserAuthentication(true)
+          .addPoolLocator("localhost", locatorPort))
           .createCache();
 
       RegionService regionService1 = client.createAuthenticatedView("data", "data");

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/ClientAuthDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/ClientAuthDUnitTest.java
@@ -14,13 +14,11 @@
  */
 package org.apache.geode.security;
 
-import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_CLIENT_AUTH_INIT;
 import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_MANAGER;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Properties;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -34,7 +32,6 @@ import org.apache.geode.cache.client.ClientCache;
 import org.apache.geode.cache.client.ClientRegionFactory;
 import org.apache.geode.cache.client.ClientRegionShortcut;
 import org.apache.geode.cache.client.ServerOperationException;
-import org.apache.geode.security.templates.UserPasswordAuthInit;
 import org.apache.geode.test.dunit.IgnoredException;
 import org.apache.geode.test.dunit.rules.ClientVM;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
@@ -68,10 +65,9 @@ public class ClientAuthDUnitTest {
   public void authWithCorrectPasswordShouldPass() throws Exception {
     int serverPort = server.getPort();
     ClientVM clientVM = lsRule.startClientVM(0, clientVersion,
-        getClientAuthProperties("data", "data"), ccf -> {
-          ccf.setPoolSubscriptionEnabled(true);
-          ccf.addPoolServer("localhost", serverPort);
-        });
+        c -> c.withCredential("data", "data")
+            .withPoolSubscription(true)
+            .withServerConnection(serverPort));
 
     clientVM.invoke(() -> {
       ClientCache clientCache = ClusterStartupRule.getClientCache();
@@ -92,20 +88,17 @@ public class ClientAuthDUnitTest {
     if (Arrays.asList("100", "110", "111", "120", "130", "140").contains(clientVersion)) {
       assertThatThrownBy(
           () -> lsRule.startClientVM(0, clientVersion,
-              getClientAuthProperties("test", "invalidPassword"), ccf -> {
-                ccf.setPoolSubscriptionEnabled(true);
-                ccf.addPoolServer("localhost", serverPort);
-              }))
-                  .isInstanceOf(AuthenticationFailedException.class);
+              c -> c.withCredential("test", "invalidPassword")
+                  .withPoolSubscription(true)
+                  .withServerConnection(serverPort)))
+                      .isInstanceOf(AuthenticationFailedException.class);
       return;
     }
 
     ClientVM clientVM =
-        lsRule.startClientVM(0, clientVersion, getClientAuthProperties("test", "invalidPassword"),
-            ccf -> {
-              ccf.setPoolSubscriptionEnabled(true);
-              ccf.addPoolServer("localhost", serverPort);
-            });
+        lsRule.startClientVM(0, clientVersion, c -> c.withCredential("test", "invalidPassword")
+            .withPoolSubscription(true)
+            .withServerConnection(serverPort));
 
     clientVM.invoke(() -> {
       ClientCache clientCache = ClusterStartupRule.getClientCache();
@@ -121,11 +114,9 @@ public class ClientAuthDUnitTest {
     int serverPort = server.getPort();
     IgnoredException.addIgnoredException(AuthenticationFailedException.class.getName());
     ClientVM clientVM =
-        lsRule.startClientVM(0, clientVersion, getClientAuthProperties("test", "invalidPassword"),
-            ccf -> {
-              ccf.setPoolSubscriptionEnabled(false);
-              ccf.addPoolServer("localhost", serverPort);
-            });
+        lsRule.startClientVM(0, clientVersion, c -> c.withCredential("test", "invalidPassword")
+            .withPoolSubscription(false)
+            .withServerConnection(serverPort));
 
     clientVM.invoke(() -> {
       ClientCache clientCache = ClusterStartupRule.getClientCache();
@@ -135,13 +126,5 @@ public class ClientAuthDUnitTest {
       assertThatThrownBy(() -> region.put("A", "A")).isInstanceOf(ServerOperationException.class)
           .hasCauseInstanceOf(AuthenticationFailedException.class);
     });
-  }
-
-  private Properties getClientAuthProperties(String username, String password) {
-    Properties props = new Properties();
-    props.setProperty(UserPasswordAuthInit.USER_NAME, username);
-    props.setProperty(UserPasswordAuthInit.PASSWORD, password);
-    props.setProperty(SECURITY_CLIENT_AUTH_INIT, UserPasswordAuthInit.class.getName());
-    return props;
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/cache/RegionService.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/RegionService.java
@@ -100,6 +100,11 @@ public interface RegionService extends AutoCloseable {
   QueryService getQueryService();
 
 
+  /**
+   * Returns the JSONFormatter. In the multi-user case, this will return a JSONFormatter
+   * that has the knowledge of the user associated with this region service.
+   *
+   */
   JSONFormatter getJsonFormatter();
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/cache/RegionService.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/RegionService.java
@@ -22,6 +22,7 @@ import org.apache.geode.CancelCriterion;
 import org.apache.geode.cache.client.ClientCache;
 import org.apache.geode.cache.client.ClientCacheFactory;
 import org.apache.geode.cache.query.QueryService;
+import org.apache.geode.pdx.JSONFormatter;
 import org.apache.geode.pdx.PdxInstance;
 import org.apache.geode.pdx.PdxInstanceFactory;
 
@@ -97,6 +98,9 @@ public interface RegionService extends AutoCloseable {
    * returned QueryService will execute queries on the local and peer regions.
    */
   QueryService getQueryService();
+
+
+  JSONFormatter getJsonFormatter();
 
   /**
    * Terminates this region service and releases all its resources. Calls {@link Region#close} on

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/ClientSideHandshakeImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/ClientSideHandshakeImpl.java
@@ -34,6 +34,8 @@ import java.util.Properties;
 
 import javax.net.ssl.SSLSocket;
 
+import org.apache.commons.lang3.StringUtils;
+
 import org.apache.geode.CancelCriterion;
 import org.apache.geode.DataSerializer;
 import org.apache.geode.GemFireConfigException;
@@ -186,8 +188,9 @@ public class ClientSideHandshakeImpl extends Handshake implements ClientSideHand
           this.clientReadTimeout, null, this.credentials, member, false);
 
       String authInit = this.system.getProperties().getProperty(SECURITY_CLIENT_AUTH_INIT);
-      if (!communicationMode.isWAN() && intermediateAcceptanceCode != REPLY_AUTH_NOT_REQUIRED
-          && (authInit != null && authInit.length() != 0)) {
+      if (!communicationMode.isWAN()
+          && intermediateAcceptanceCode != REPLY_AUTH_NOT_REQUIRED
+          && (StringUtils.isNotBlank(authInit) || multiuserSecureMode)) {
         location.compareAndSetRequiresCredentials(true);
       }
       // Read the acceptance code

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/ProxyCache.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/ProxyCache.java
@@ -29,6 +29,7 @@ import org.apache.geode.cache.query.QueryService;
 import org.apache.geode.cache.query.internal.ProxyQueryService;
 import org.apache.geode.distributed.internal.ServerLocation;
 import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.pdx.JSONFormatter;
 import org.apache.geode.pdx.PdxInstance;
 import org.apache.geode.pdx.PdxInstanceFactory;
 import org.apache.geode.pdx.internal.PdxInstanceFactoryImpl;
@@ -112,6 +113,11 @@ public class ProxyCache implements RegionService {
   }
 
   @Override
+  public JSONFormatter getJsonFormatter() {
+    return new JSONFormatter(this);
+  }
+
+  @Override
   public <K, V> Region<K, V> getRegion(String path) {
     preOp();
     if (this.cache.getRegion(path) == null) {
@@ -148,15 +154,6 @@ public class ProxyCache implements RegionService {
   public UserAttributes getUserAttributes() {
     preOp();
     return this.userAttributes;
-  }
-
-  public Object getUserId(Object key) {
-    preOp();
-    if (!(key instanceof ServerLocation)) {
-      throw new IllegalArgumentException(
-          "Key must be of type ServerLocation, but is " + key.getClass());
-    }
-    return this.userAttributes.getServerToId().get(key);
   }
 
   private void preOp() {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
@@ -231,6 +231,7 @@ import org.apache.geode.management.internal.configuration.domain.Configuration;
 import org.apache.geode.management.internal.configuration.messages.ConfigurationResponse;
 import org.apache.geode.memcached.GemFireMemcachedServer;
 import org.apache.geode.memcached.GemFireMemcachedServer.Protocol;
+import org.apache.geode.pdx.JSONFormatter;
 import org.apache.geode.pdx.PdxInstance;
 import org.apache.geode.pdx.PdxInstanceFactory;
 import org.apache.geode.pdx.PdxSerializer;
@@ -4174,6 +4175,12 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
           "Client cache does not have a default pool. Use getQueryService(String poolName) instead.");
     }
     return (InternalQueryService) defaultPool.getQueryService();
+  }
+
+  @Override
+  public JSONFormatter getJsonFormatter() {
+    // only ProxyCache implementation needs a JSONFormatter that has reference to userAttributes
+    return new JSONFormatter();
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCacheForClientAccess.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCacheForClientAccess.java
@@ -88,6 +88,7 @@ import org.apache.geode.internal.offheap.MemoryAllocator;
 import org.apache.geode.internal.security.SecurityService;
 import org.apache.geode.management.internal.JmxManagerAdvisor;
 import org.apache.geode.management.internal.RestAgent;
+import org.apache.geode.pdx.JSONFormatter;
 import org.apache.geode.pdx.PdxInstance;
 import org.apache.geode.pdx.PdxInstanceFactory;
 import org.apache.geode.pdx.PdxSerializer;
@@ -1173,6 +1174,11 @@ public class InternalCacheForClientAccess implements InternalCache {
   @Override
   public InternalQueryService getQueryService() {
     return delegate.getQueryService();
+  }
+
+  @Override
+  public JSONFormatter getJsonFormatter() {
+    return delegate.getJsonFormatter();
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheCreation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheCreation.java
@@ -152,6 +152,7 @@ import org.apache.geode.internal.security.SecurityService;
 import org.apache.geode.internal.security.SecurityServiceFactory;
 import org.apache.geode.management.internal.JmxManagerAdvisor;
 import org.apache.geode.management.internal.RestAgent;
+import org.apache.geode.pdx.JSONFormatter;
 import org.apache.geode.pdx.PdxInstance;
 import org.apache.geode.pdx.PdxInstanceFactory;
 import org.apache.geode.pdx.PdxSerializer;
@@ -1057,6 +1058,11 @@ public class CacheCreation implements InternalCache {
   @Override
   public InternalQueryService getQueryService() {
     return this.queryService;
+  }
+
+  @Override
+  public JSONFormatter getJsonFormatter() {
+    return new JSONFormatter();
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/pdx/JSONFormatter.java
+++ b/geode-core/src/main/java/org/apache/geode/pdx/JSONFormatter.java
@@ -25,6 +25,9 @@ import com.fasterxml.jackson.core.JsonParser.Feature;
 import com.fasterxml.jackson.core.JsonParser.NumberType;
 import com.fasterxml.jackson.core.JsonToken;
 
+import org.apache.geode.cache.RegionService;
+import org.apache.geode.cache.client.internal.ProxyCache;
+import org.apache.geode.cache.client.internal.UserAttributes;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.pdx.internal.json.JSONToPdxMapper;
 import org.apache.geode.pdx.internal.json.PdxInstanceHelper;
@@ -108,7 +111,17 @@ public class JSONFormatter {
     NONE, OBJECT_START, FIELD_NAME, SCALAR_FOUND, LIST_FOUND, LIST_ENDS, OBJECT_ENDS
   }
 
-  private JSONFormatter() {}
+  private RegionService regionService;
+
+  public JSONFormatter() {}
+
+  public JSONFormatter(RegionService regionService) {
+    this.regionService = regionService;
+  }
+
+  public RegionService getRegionService() {
+    return regionService;
+  }
 
   /**
    * Converts a JSON document into a PdxInstance
@@ -117,7 +130,7 @@ public class JSONFormatter {
    * @throws JSONFormatterException if unable to parse the JSON document
    */
   public static PdxInstance fromJSON(String jsonString) {
-    return getPdxInstanceFromJson(jsonString);
+    return new JSONFormatter().fromJson(jsonString);
   }
 
   /**
@@ -127,10 +140,14 @@ public class JSONFormatter {
    * @throws JSONFormatterException if unable to parse the JSON document
    */
   public static PdxInstance fromJSON(byte[] jsonByteArray) {
-    return getPdxInstanceFromJson(jsonByteArray);
+    return new JSONFormatter().fromJson(jsonByteArray);
   }
 
-  private static PdxInstance getPdxInstanceFromJson(Object json) {
+  public PdxInstance fromJson(Object json) {
+    if (regionService != null && regionService instanceof ProxyCache) {
+      ProxyCache proxyCache = (ProxyCache) regionService;
+      UserAttributes.userAttributes.set(proxyCache.getUserAttributes());
+    }
     JsonParser jp = null;
     try {
       if (json instanceof String) {
@@ -142,7 +159,7 @@ public class JSONFormatter {
         throw new JSONFormatterException("Could not parse the " + json.getClass() + " type");
       }
       enableJSONParserFeature(jp);
-      return new JSONFormatter().getPdxInstance(jp, states.NONE, null).getPdxInstance();
+      return getPdxInstance(jp, states.NONE, null).getPdxInstance();
     } catch (JsonParseException jpe) {
       throw new JSONFormatterException("Could not parse JSON document ", jpe);
     } catch (IOException e) {
@@ -151,10 +168,12 @@ public class JSONFormatter {
     } catch (Exception e) {
       throw new JSONFormatterException("Could not parse JSON document: " + jp.getCurrentLocation(),
           e);
+    } finally {
+      UserAttributes.userAttributes.set(null);
     }
   }
 
-  private static void enableJSONParserFeature(JsonParser jp) {
+  private void enableJSONParserFeature(JsonParser jp) {
     jp.enable(Feature.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER);
     jp.enable(Feature.ALLOW_UNQUOTED_FIELD_NAMES);
   }
@@ -166,6 +185,10 @@ public class JSONFormatter {
    * @throws JSONFormatterException if unable to create the JSON document
    */
   public static String toJSON(PdxInstance pdxInstance) {
+    return new JSONFormatter().toJson(pdxInstance);
+  }
+
+  public String toJson(PdxInstance pdxInstance) {
     try {
       PdxToJSON pj = new PdxToJSON(pdxInstance);
       return pj.getJSON();
@@ -181,6 +204,10 @@ public class JSONFormatter {
    * @throws JSONFormatterException if unable to create the JSON document
    */
   public static byte[] toJSONByteArray(PdxInstance pdxInstance) {
+    return new JSONFormatter().toJsonByteArray(pdxInstance);
+  }
+
+  public byte[] toJsonByteArray(PdxInstance pdxInstance) {
     try {
       PdxToJSON pj = new PdxToJSON(pdxInstance);
       return pj.getJSONByteArray();
@@ -189,7 +216,7 @@ public class JSONFormatter {
     }
   }
 
-  private static JSONToPdxMapper createJSONToPdxMapper(String className, JSONToPdxMapper parent) {
+  private JSONToPdxMapper createJSONToPdxMapper(String className, JSONToPdxMapper parent) {
     if (Boolean.getBoolean(SORT_JSON_FIELD_NAMES_PROPERTY)) {
       return new PdxInstanceSortedHelper(className, parent);
     } else {
@@ -198,7 +225,7 @@ public class JSONFormatter {
   }
 
   private JSONToPdxMapper getPdxInstance(JsonParser jp, states currentState,
-      JSONToPdxMapper currentPdxInstance) throws JsonParseException, IOException {
+      JSONToPdxMapper currentPdxInstance) throws IOException {
     String currentFieldName = null;
     if (currentState == states.OBJECT_START && currentPdxInstance == null) {
       currentPdxInstance = createJSONToPdxMapper(null, null);// from getlist

--- a/geode-core/src/main/java/org/apache/geode/pdx/JSONFormatter.java
+++ b/geode-core/src/main/java/org/apache/geode/pdx/JSONFormatter.java
@@ -130,7 +130,7 @@ public class JSONFormatter {
    * @throws JSONFormatterException if unable to parse the JSON document
    */
   public static PdxInstance fromJSON(String jsonString) {
-    return new JSONFormatter().fromJson(jsonString);
+    return new JSONFormatter().toPdxInstance(jsonString);
   }
 
   /**
@@ -140,10 +140,17 @@ public class JSONFormatter {
    * @throws JSONFormatterException if unable to parse the JSON document
    */
   public static PdxInstance fromJSON(byte[] jsonByteArray) {
-    return new JSONFormatter().fromJson(jsonByteArray);
+    return new JSONFormatter().toPdxInstance(jsonByteArray);
   }
 
-  public PdxInstance fromJson(Object json) {
+  /**
+   * Converts a JSON document into a PdxInstance
+   *
+   * @param json either a json string or a byte[]
+   * @return the PdxInstance.
+   * @throws JSONFormatterException if unable to parse the JSON document
+   */
+  public PdxInstance toPdxInstance(Object json) {
     if (regionService != null && regionService instanceof ProxyCache) {
       ProxyCache proxyCache = (ProxyCache) regionService;
       UserAttributes.userAttributes.set(proxyCache.getUserAttributes());
@@ -185,10 +192,16 @@ public class JSONFormatter {
    * @throws JSONFormatterException if unable to create the JSON document
    */
   public static String toJSON(PdxInstance pdxInstance) {
-    return new JSONFormatter().toJson(pdxInstance);
+    return new JSONFormatter().fromPdxInstance(pdxInstance);
   }
 
-  public String toJson(PdxInstance pdxInstance) {
+  /**
+   * Converts a PdxInstance into a JSON document
+   *
+   * @return the JSON string.
+   * @throws JSONFormatterException if unable to create the JSON document
+   */
+  public String fromPdxInstance(PdxInstance pdxInstance) {
     try {
       PdxToJSON pj = new PdxToJSON(pdxInstance);
       return pj.getJSON();
@@ -204,10 +217,16 @@ public class JSONFormatter {
    * @throws JSONFormatterException if unable to create the JSON document
    */
   public static byte[] toJSONByteArray(PdxInstance pdxInstance) {
-    return new JSONFormatter().toJsonByteArray(pdxInstance);
+    return new JSONFormatter().toJsonByteArrayFromPdxInstance(pdxInstance);
   }
 
-  public byte[] toJsonByteArray(PdxInstance pdxInstance) {
+  /**
+   * Converts a PdxInstance into a JSON document in byte-array form
+   *
+   * @return the JSON byte array.
+   * @throws JSONFormatterException if unable to create the JSON document
+   */
+  public byte[] toJsonByteArrayFromPdxInstance(PdxInstance pdxInstance) {
     try {
       PdxToJSON pj = new PdxToJSON(pdxInstance);
       return pj.getJSONByteArray();

--- a/geode-cq/src/distributedTest/java/org/apache/geode/security/MultiUserAPIDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/security/MultiUserAPIDUnitTest.java
@@ -232,7 +232,7 @@ public class MultiUserAPIDUnitTest {
         .hasCauseInstanceOf(UnsupportedOperationException.class);
 
     // need to get the jsonFormatter from the proxy cache
-    PdxInstance value = regionService.getJsonFormatter().fromJson(json);
+    PdxInstance value = regionService.getJsonFormatter().toPdxInstance(json);
     regionView.put("key", value);
   }
 }

--- a/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/rules/tests/ClusterStartupRuleCanSpecifyOlderVersionsDUnitTest.java
+++ b/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/rules/tests/ClusterStartupRuleCanSpecifyOlderVersionsDUnitTest.java
@@ -18,7 +18,6 @@ package org.apache.geode.test.dunit.rules.tests;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
-import java.util.Properties;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -77,7 +76,7 @@ public class ClusterStartupRuleCanSpecifyOlderVersionsDUnitTest {
 
   @Test
   public void clientVersioningTest() throws Exception {
-    ClientVM locator = csRule.startClientVM(0, version, new Properties(), (cf) -> {
+    ClientVM locator = csRule.startClientVM(0, version, c -> {
     });
     String locatorVMVersion = locator.getVM().getVersion();
     String locatorActualVersion = locator.invoke(GemFireVersion::getGemFireVersion);

--- a/geode-dunit/src/main/java/org/apache/geode/test/junit/rules/MemberStarterRule.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/junit/rules/MemberStarterRule.java
@@ -72,6 +72,7 @@ import org.apache.geode.management.internal.MBeanJMXAdapter;
 import org.apache.geode.management.internal.SystemManagementService;
 import org.apache.geode.management.internal.cli.CliUtil;
 import org.apache.geode.security.SecurityManager;
+import org.apache.geode.security.templates.UserPasswordAuthInit;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
 import org.apache.geode.test.junit.rules.serializable.SerializableExternalResource;
 
@@ -185,6 +186,12 @@ public abstract class MemberStarterRule<T> extends SerializableExternalResource 
 
   public T withSecurityManager(Class<? extends SecurityManager> securityManager) {
     properties.setProperty(SECURITY_MANAGER, securityManager.getName());
+    return (T) this;
+  }
+
+  public T withCredential(String username, String password) {
+    properties.setProperty(UserPasswordAuthInit.USER_NAME, username);
+    properties.setProperty(UserPasswordAuthInit.PASSWORD, password);
     return (T) this;
   }
 


### PR DESCRIPTION
* user does not have to provide credentials when creating the client cache in multi-user mode. Credentials are needed only when creating the view.
* CacheProxy should have a reference to the JSONFormatter that is aware of the user attributes
* clean up some tests and add more tests for coverage and usage demo.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
