### PR TITLE
GEODE-6074: Using a free server port in tests

### DIFF
--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/management/internal/cli/commands/LogsAndDescribeConfigAreFullyRedactedAcceptanceTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/management/internal/cli/commands/LogsAndDescribeConfigAreFullyRedactedAcceptanceTest.java
@@ -107,6 +107,7 @@ public class LogsAndDescribeConfigAreFullyRedactedAcceptanceTest {
           .addOption("security-properties-file", securityPropertyFile.getAbsolutePath())
           .addOption("J", "-Dsecure-username-jd=user-jd")
           .addOption("J", "-Dsecure-password-jd=" + sharedPasswordString + "-password-jd")
+          .addOption("server-port", "0")
           .addOption("classpath", securityJson).getCommandString();
 
       gfsh.execute(startLocatorCmd, startServerCmd);

--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/management/internal/cli/commands/PutCommandWithJsonTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/management/internal/cli/commands/PutCommandWithJsonTest.java
@@ -48,7 +48,8 @@ public class PutCommandWithJsonTest {
   @Test
   public void putWithJsonString() throws Exception {
     GfshExecution execution = GfshScript
-        .of("start locator --name=locator", "start server --name=server", "sleep --time=1",
+        .of("start locator --name=locator", "start server --name=server --server-port=0",
+            "sleep --time=1",
             "deploy --jar=" + jarToDeploy.getAbsolutePath(),
             "create region --name=region --type=REPLICATE", "sleep --time=1",
             "put --region=region --key=key --value=('name':'Jinmei') --value-class=Customer")


### PR DESCRIPTION
GEODE-5590 and GEODE-6074 - Setting the server port to 0 to pick an
unused port. These two tests both failed in CI because port 40404 was in
use.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
