### PR TITLE
GEODE-1168 Improves build to automatically add jars to runtime classpath

### DIFF
--- a/geode-assembly/build.gradle
+++ b/geode-assembly/build.gradle
@@ -248,76 +248,38 @@ task defaultCacheConfig(type: JavaExec, dependsOn: classes) {
 def cp = {
   // first add all the dependent project jars
   def jars = configurations.archives.dependencies.collect { it.dependencyProject }
-    .findAll { !(it.name.contains('web') || it.name.contains('pulse')) }
+    .findAll { !(it.name.contains('geode-web') || it.name.contains('geode-pulse')) }
     .collect { it.jar.archiveName }
-    .join(' ')
 
   // then add all the dependencies of the dependent jars
-  jars += ' ' + configurations.archives.dependencies.collect {
-    it.dependencyProject.findAll { !(it.name.contains('web-api') || it.name.contains('pulse')) }
-      .collect { it.configurations.runtimeClasspath.collect { it.getName() }.findAll {
-        // depedencies from geode-core
-        it.contains('activation') ||
-        it.contains('antlr') ||
-        it.contains('commons-io') ||
-        it.contains('classgraph') ||
-        it.contains('commons-collections') ||
-        it.contains('commons-lang3') ||
-        it.contains('commons-logging') ||
-        it.contains('commons-validator') ||
-        it.contains('commons-beanutils') ||
-        it.contains('commons-codec') ||
-        it.contains('fastutil') ||
-        it.contains('jackson-annotations') ||
-        it.contains('jackson-core') ||
-        it.contains('jackson-databind') ||
-        it.contains('jansi') ||
-        it.contains('javax.resource-api') ||
-        it.contains('javax.servlet-api') ||
-        it.contains('javax.transaction-api') ||
-        it.contains('jaxb') ||
-        it.contains('jetty-http') ||
-        it.contains('jetty-io') ||
-        it.contains('jetty-security') ||
-        it.contains('jetty-server') ||
-        it.contains('jetty-servlet') ||
-        it.contains('jetty-webapp') ||
-        it.contains('jetty-util') ||
-        it.contains('jetty-xml') ||
-        it.contains('jline') ||
-        it.contains('jna') ||
-        it.contains('jopt-simple') ||
-        it.contains('log4j-api') ||
-        it.contains('log4j-core') ||
-        it.contains('log4j-jcl') ||
-        it.contains('log4j-jul') ||
-        it.contains('log4j-slf4j-impl') ||
-        it.contains('rmiio') ||
-        it.contains('shiro') ||
-        it.contains('slf4j-api') ||
-        it.contains('spring-core') ||
-        it.contains('spring-shell') ||
-        it.contains('snappy') ||
-        it.contains('jgroups') ||
-        it.contains('netty') ||
+  def depJars = configurations.archives.dependencies.collect {
+    it.dependencyProject.findAll { !(it.name.contains('geode-web') || it.name.contains('geode-pulse')) }
+      .collect { it.configurations.runtimeClasspath.collect { it.getName() }.findAll { !(
+        // exclude mx4j, once the deprecated code is deleted we can remove these entirely
+        it.contains('commons-digester') ||
+        it.contains('commons-modeler') ||
+        it.contains('javax.mail-api') ||
+        it.contains('mx4j') ||
 
-        // dependencies from geode-lucene
-        it.contains('lucene-analyzers-common') ||
-        it.contains('lucene-core') ||
-        it.contains('lucene-queries') ||
-        it.contains('lucene-queryparser') ||
-        it.contains('lucene-analyzers-phonetic') ||
+        // misc jars, these should be removed from the lib dir
+        it.contains('findbugs-annotations') ||
+        it.contains('geode-dependencies') ||
+        it.contains('geode-jca') ||
+        it.contains('geode-web') ||
+        it.contains('gfsh-dependencies') ||
+        it.contains('ra.jar') ||
 
-        // dependencies from geode-protobuf
-        it.contains('protobuf-java') ||
-
-        // dependencies from geode-connectors
-        it.contains('HikariCP')
-      }
+        // spring web deps that shouldn't be here either
+        it.contains('spring-aop') ||
+        it.contains('spring-beans') ||
+        it.contains('spring-context') ||
+        it.contains('spring-expression') ||
+        it.contains('spring-web')
+      )}
     }
-  }.flatten().unique().join(' ')
+  }.flatten()
 
-  return jars
+  return jars.plus(depJars).unique().join(' ')
 }
 
 // Note: this dependency doesn't work if you change a library version from

--- a/geode-assembly/src/integrationTest/resources/dependency_classpath.txt
+++ b/geode-assembly/src/integrationTest/resources/dependency_classpath.txt
@@ -35,7 +35,10 @@ log4j-jcl-2.11.1.jar
 jna-4.1.0.jar
 geode-rebalancer-1.9.0-SNAPSHOT.jar
 rmiio-2.1.2.jar
+grumpy-core-0.2.2.jar
 commons-codec-1.10.jar
+geo-0.7.1.jar
+commons-math3-3.2.jar
 log4j-api-2.11.1.jar
 jetty-server-9.4.12.v20180830.jar
 geode-connectors-1.9.0-SNAPSHOT.jar


### PR DESCRIPTION
Flips the generation of the geode-dependencies classpath from an
include list to an exclude list.  Every dependent jar that is not
specifically excluded will be added to the classpath automatically.

Eventually we should include lib/* and remove auxillary jars to
alternate locations.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
