### PR TITLE
GEODE-6067: add list data-source gfsh command

### DIFF
--- a/geode-connectors/src/distributedTest/java/org/apache/geode/connectors/jdbc/internal/cli/ListDataSourceCommandDUnitTest.java
+++ b/geode-connectors/src/distributedTest/java/org/apache/geode/connectors/jdbc/internal/cli/ListDataSourceCommandDUnitTest.java
@@ -65,9 +65,11 @@ public class ListDataSourceCommandDUnitTest {
     gfsh.executeAndAssertThat("create region --name=region1 --type=REPLICATE").statusIsSuccess();
     gfsh.executeAndAssertThat("create region --name=region2 --type=PARTITION").statusIsSuccess();
     gfsh.executeAndAssertThat(
-        "create jdbc-mapping --region=region1 --data-source=simple --pdx-name=myPdx");
+        "create jdbc-mapping --region=region1 --data-source=simple --pdx-name=myPdx")
+        .statusIsSuccess();
     gfsh.executeAndAssertThat(
-        "create jdbc-mapping --region=region2 --data-source=simple --pdx-name=myPdx");
+        "create jdbc-mapping --region=region2 --data-source=simple --pdx-name=myPdx")
+        .statusIsSuccess();
 
     CommandResultAssert result = gfsh.executeAndAssertThat("list data-source");
 
@@ -79,11 +81,12 @@ public class ListDataSourceCommandDUnitTest {
   @Test
   public void listDataSourceForPooledDataSource() {
     gfsh.executeAndAssertThat(
-        "create data-source --name=pooled --pooled --url=\"jdbc:derby:newDB;create=true\" --pooled-data-source-factory-class=org.apache.geode.internal.jta.CacheJTAPooledDataSourceFactory --pool-properties={'name':'prop1','value':'value1'},{'name':'pool.prop2','value':'value2'}")
+        "create data-source --name=pooledDataSource --pooled --url=\"jdbc:derby:newDB;create=true\" --pooled-data-source-factory-class=org.apache.geode.internal.jta.CacheJTAPooledDataSourceFactory --pool-properties={'name':'prop1','value':'value1'},{'name':'pool.prop2','value':'value2'}")
         .statusIsSuccess().tableHasColumnOnlyWithValues("Member", "server-1");
 
     gfsh.executeAndAssertThat("list data-source").statusIsSuccess()
-        .tableHasRowWithValues("name", "pooled", "in use", "url", "pooled", "true", "false",
+        .tableHasRowWithValues("name", "pooled", "in use", "url", "pooledDataSource", "true",
+            "false",
             "jdbc:derby:newDB;create=true");
   }
 
@@ -93,11 +96,12 @@ public class ListDataSourceCommandDUnitTest {
         "create data-source --name=simple --url=\"jdbc:derby:newDB;create=true\" --username=joe --password=myPassword")
         .statusIsSuccess().tableHasColumnOnlyWithValues("Member", "server-1");
     gfsh.executeAndAssertThat(
-        "create data-source --name=pooled --pooled --url=\"jdbc:derby:newDB;create=true\" --pooled-data-source-factory-class=org.apache.geode.internal.jta.CacheJTAPooledDataSourceFactory --pool-properties={'name':'prop1','value':'value1'},{'name':'pool.prop2','value':'value2'}")
+        "create data-source --name=pooledDataSource --pooled --url=\"jdbc:derby:newDB;create=true\" --pooled-data-source-factory-class=org.apache.geode.internal.jta.CacheJTAPooledDataSourceFactory --pool-properties={'name':'prop1','value':'value1'},{'name':'pool.prop2','value':'value2'}")
         .statusIsSuccess().tableHasColumnOnlyWithValues("Member", "server-1");
 
     gfsh.executeAndAssertThat("list data-source").statusIsSuccess()
-        .tableHasRowWithValues("name", "pooled", "in use", "url", "pooled", "true", "false",
+        .tableHasRowWithValues("name", "pooled", "in use", "url", "pooledDataSource", "true",
+            "false",
             "jdbc:derby:newDB;create=true")
         .tableHasRowWithValues("name", "pooled", "in use", "url", "simple", "false", "false",
             "jdbc:derby:newDB;create=true");

--- a/geode-connectors/src/distributedTest/java/org/apache/geode/connectors/jdbc/internal/cli/ListDataSourceCommandDUnitTest.java
+++ b/geode-connectors/src/distributedTest/java/org/apache/geode/connectors/jdbc/internal/cli/ListDataSourceCommandDUnitTest.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.connectors.jdbc.internal.cli;
+
+import java.util.Properties;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.apache.geode.test.dunit.rules.ClusterStartupRule;
+import org.apache.geode.test.dunit.rules.MemberVM;
+import org.apache.geode.test.junit.assertions.CommandResultAssert;
+import org.apache.geode.test.junit.rules.GfshCommandRule;
+
+public class ListDataSourceCommandDUnitTest {
+
+  private MemberVM locator, server;
+
+  @Rule
+  public ClusterStartupRule cluster = new ClusterStartupRule();
+
+  @Rule
+  public GfshCommandRule gfsh = new GfshCommandRule();
+
+  @Before
+  public void before() throws Exception {
+    locator = cluster.startLocatorVM(0);
+    server = cluster.startServerVM(1, new Properties(), locator.getPort());
+
+    gfsh.connectAndVerify(locator);
+  }
+
+  @Test
+  public void listDataSourceForSimpleDataSource() {
+    gfsh.executeAndAssertThat(
+        "create data-source --name=simple --url=\"jdbc:derby:newDB;create=true\" --username=joe --password=myPassword")
+        .statusIsSuccess().tableHasColumnOnlyWithValues("Member", "server-1");
+
+    CommandResultAssert result = gfsh.executeAndAssertThat("list data-source");
+
+    result.statusIsSuccess()
+        .tableHasRowWithValues("name", "pooled", "in use", "url", "simple", "false", "false",
+            "jdbc:derby:newDB;create=true");
+  }
+
+  @Test
+  public void listDataSourceUsedByRegionsHasCorrectOutput() {
+    gfsh.executeAndAssertThat(
+        "create data-source --name=simple --url=\"jdbc:derby:newDB;create=true\"")
+        .statusIsSuccess().tableHasColumnOnlyWithValues("Member", "server-1");
+    gfsh.executeAndAssertThat("create region --name=region1 --type=REPLICATE").statusIsSuccess();
+    gfsh.executeAndAssertThat("create region --name=region2 --type=PARTITION").statusIsSuccess();
+    gfsh.executeAndAssertThat(
+        "create jdbc-mapping --region=region1 --data-source=simple --pdx-name=myPdx");
+    gfsh.executeAndAssertThat(
+        "create jdbc-mapping --region=region2 --data-source=simple --pdx-name=myPdx");
+
+    CommandResultAssert result = gfsh.executeAndAssertThat("list data-source");
+
+    result.statusIsSuccess()
+        .tableHasRowWithValues("name", "pooled", "in use", "url", "simple", "false", "true",
+            "jdbc:derby:newDB;create=true");
+  }
+
+  @Test
+  public void listDataSourceForPooledDataSource() {
+    gfsh.executeAndAssertThat(
+        "create data-source --name=pooled --pooled --url=\"jdbc:derby:newDB;create=true\" --pooled-data-source-factory-class=org.apache.geode.internal.jta.CacheJTAPooledDataSourceFactory --pool-properties={'name':'prop1','value':'value1'},{'name':'pool.prop2','value':'value2'}")
+        .statusIsSuccess().tableHasColumnOnlyWithValues("Member", "server-1");
+
+    gfsh.executeAndAssertThat("list data-source").statusIsSuccess()
+        .tableHasRowWithValues("name", "pooled", "in use", "url", "pooled", "true", "false",
+            "jdbc:derby:newDB;create=true");
+  }
+
+  @Test
+  public void listDataSourceWithMultipleDataSourcesListsAll() {
+    gfsh.executeAndAssertThat(
+        "create data-source --name=simple --url=\"jdbc:derby:newDB;create=true\" --username=joe --password=myPassword")
+        .statusIsSuccess().tableHasColumnOnlyWithValues("Member", "server-1");
+    gfsh.executeAndAssertThat(
+        "create data-source --name=pooled --pooled --url=\"jdbc:derby:newDB;create=true\" --pooled-data-source-factory-class=org.apache.geode.internal.jta.CacheJTAPooledDataSourceFactory --pool-properties={'name':'prop1','value':'value1'},{'name':'pool.prop2','value':'value2'}")
+        .statusIsSuccess().tableHasColumnOnlyWithValues("Member", "server-1");
+
+    gfsh.executeAndAssertThat("list data-source").statusIsSuccess()
+        .tableHasRowWithValues("name", "pooled", "in use", "url", "pooled", "true", "false",
+            "jdbc:derby:newDB;create=true")
+        .tableHasRowWithValues("name", "pooled", "in use", "url", "simple", "false", "false",
+            "jdbc:derby:newDB;create=true");
+  }
+
+  @Test
+  public void listDataSourceWithNoDataSources() {
+    gfsh.executeAndAssertThat("list data-source").statusIsSuccess()
+        .containsOutput("No data sources found");
+  }
+}

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/ListDataSourceCommand.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/ListDataSourceCommand.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.connectors.jdbc.internal.cli;
+
+import org.springframework.shell.core.annotation.CliAvailabilityIndicator;
+import org.springframework.shell.core.annotation.CliCommand;
+
+import org.apache.geode.annotations.Experimental;
+import org.apache.geode.cache.configuration.CacheConfig;
+import org.apache.geode.cache.configuration.CacheElement;
+import org.apache.geode.cache.configuration.JndiBindingsType;
+import org.apache.geode.cache.configuration.RegionConfig;
+import org.apache.geode.connectors.jdbc.internal.configuration.RegionMapping;
+import org.apache.geode.distributed.internal.InternalConfigurationPersistenceService;
+import org.apache.geode.management.cli.CliMetaData;
+import org.apache.geode.management.internal.cli.commands.CreateJndiBindingCommand.DATASOURCE_TYPE;
+import org.apache.geode.management.internal.cli.commands.InternalGfshCommand;
+import org.apache.geode.management.internal.cli.result.model.ResultModel;
+import org.apache.geode.management.internal.cli.result.model.TabularResultModel;
+import org.apache.geode.management.internal.security.ResourceOperation;
+import org.apache.geode.security.ResourcePermission;
+
+@Experimental
+public class ListDataSourceCommand extends InternalGfshCommand {
+  static final String LIST_DATA_SOURCE = "list data-source";
+  private static final String LIST_DATA_SOURCE__HELP = EXPERIMENTAL +
+      "List each existing data source.";
+
+  static final String DATA_SOURCE_PROPERTIES_SECTION = "data-source-properties";
+
+  @CliCommand(value = LIST_DATA_SOURCE, help = LIST_DATA_SOURCE__HELP)
+  @CliMetaData
+  @ResourceOperation(resource = ResourcePermission.Resource.CLUSTER,
+      operation = ResourcePermission.Operation.READ)
+  public ResultModel listDataSources() {
+
+    ResultModel resultModel = new ResultModel();
+    resultModel.setHeader(EXPERIMENTAL);
+    TabularResultModel tabularData = resultModel.addTable(DATA_SOURCE_PROPERTIES_SECTION);
+    tabularData.setColumnHeader("name", "pooled", "in use", "url");
+
+    InternalConfigurationPersistenceService ccService = getConfigurationPersistenceService();
+    if (ccService == null) {
+      return ResultModel.createError("Cluster configuration service must be enabled.");
+    }
+    CacheConfig cacheConfig = ccService.getCacheConfig(null);
+    if (cacheConfig == null) {
+      return ResultModel.createInfo("No data sources found");
+    }
+
+    cacheConfig.getJndiBindings().stream()
+        .forEach(dataSource -> addDataSourceToResult(dataSource, cacheConfig, tabularData));
+
+    return resultModel;
+  }
+
+  private void addDataSourceToResult(JndiBindingsType.JndiBinding binding, CacheConfig cacheConfig,
+      TabularResultModel tabularData) {
+    boolean pooled;
+    String type = binding.getType();
+    if (DATASOURCE_TYPE.SIMPLE.getType().equals(type)) {
+      pooled = false;
+    } else if (DATASOURCE_TYPE.POOLED.getType().equals(type)) {
+      pooled = true;
+    } else {
+      // skip this binding since it was not created as a data-source
+      return;
+    }
+
+    String dataSourceName = binding.getJndiName();
+    tabularData.addRow(dataSourceName, Boolean.toString(pooled),
+        Boolean.toString(isDataSourceUsedByRegion(cacheConfig, dataSourceName)),
+        binding.getConnectionUrl());
+
+  }
+
+  boolean isDataSourceUsedByRegion(CacheConfig cacheConfig, String dataSourceName) {
+    return cacheConfig.getRegions().stream()
+        .anyMatch(regionConfig -> hasJdbcMappingThatUsesDataSource(regionConfig, dataSourceName));
+  }
+
+  private boolean hasJdbcMappingThatUsesDataSource(RegionConfig regionConfig,
+      String dataSourceName) {
+    return regionConfig.getCustomRegionElements()
+        .stream()
+        .anyMatch(cacheElement -> isRegionMappingUsingDataSource(cacheElement, dataSourceName));
+  }
+
+  private boolean isRegionMappingUsingDataSource(CacheElement cacheElement, String dataSourceName) {
+    if (!(cacheElement instanceof RegionMapping)) {
+      return false;
+    }
+    RegionMapping regionMapping = (RegionMapping) cacheElement;
+    return dataSourceName.equals(regionMapping.getDataSourceName());
+  }
+
+  @CliAvailabilityIndicator({LIST_DATA_SOURCE})
+  public boolean commandAvailable() {
+    return isOnlineCommandAvailable();
+  }
+}

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/ListDataSourceCommand.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/ListDataSourceCommand.java
@@ -24,17 +24,17 @@ import org.apache.geode.cache.configuration.CacheElement;
 import org.apache.geode.cache.configuration.JndiBindingsType;
 import org.apache.geode.cache.configuration.RegionConfig;
 import org.apache.geode.connectors.jdbc.internal.configuration.RegionMapping;
-import org.apache.geode.distributed.internal.InternalConfigurationPersistenceService;
+import org.apache.geode.distributed.ConfigurationPersistenceService;
 import org.apache.geode.management.cli.CliMetaData;
+import org.apache.geode.management.cli.GfshCommand;
 import org.apache.geode.management.internal.cli.commands.CreateJndiBindingCommand.DATASOURCE_TYPE;
-import org.apache.geode.management.internal.cli.commands.InternalGfshCommand;
 import org.apache.geode.management.internal.cli.result.model.ResultModel;
 import org.apache.geode.management.internal.cli.result.model.TabularResultModel;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
 @Experimental
-public class ListDataSourceCommand extends InternalGfshCommand {
+public class ListDataSourceCommand extends GfshCommand {
   static final String LIST_DATA_SOURCE = "list data-source";
   private static final String LIST_DATA_SOURCE__HELP = EXPERIMENTAL +
       "List each existing data source.";
@@ -52,7 +52,7 @@ public class ListDataSourceCommand extends InternalGfshCommand {
     TabularResultModel tabularData = resultModel.addTable(DATA_SOURCE_PROPERTIES_SECTION);
     tabularData.setColumnHeader("name", "pooled", "in use", "url");
 
-    InternalConfigurationPersistenceService ccService = getConfigurationPersistenceService();
+    ConfigurationPersistenceService ccService = getConfigurationPersistenceService();
     if (ccService == null) {
       return ResultModel.createError("Cluster configuration service must be enabled.");
     }

--- a/geode-connectors/src/main/resources/META-INF/services/org.springframework.shell.core.CommandMarker
+++ b/geode-connectors/src/main/resources/META-INF/services/org.springframework.shell.core.CommandMarker
@@ -20,4 +20,5 @@ org.apache.geode.connectors.jdbc.internal.cli.CreateMappingCommand
 org.apache.geode.connectors.jdbc.internal.cli.DescribeDataSourceCommand
 org.apache.geode.connectors.jdbc.internal.cli.DestroyMappingCommand
 org.apache.geode.connectors.jdbc.internal.cli.DescribeMappingCommand
+org.apache.geode.connectors.jdbc.internal.cli.ListDataSourceCommand
 org.apache.geode.connectors.jdbc.internal.cli.ListMappingCommand


### PR DESCRIPTION
list data-source uses the cluster config to determine what data sources exist.
It will show the following items for each data-source: name, is it pooled, is it in use, and the url.
Internally, data sources are stored as jndi-bindings. If a jndi-binding exists that could not have been created by create data-source, then list data-source will ignore that jndi-binding.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
