### PR TITLE
GEODE-6101: Builds module for consumption by Java 9+ modules project.

### DIFF
--- a/geode-core/build.gradle
+++ b/geode-core/build.gradle
@@ -162,10 +162,12 @@ dependencies {
   compile('commons-io:commons-io:' + project.'commons-io.version')
   compile('commons-validator:commons-validator:' + project.'commons-validator.version')
   compile('commons-digester:commons-digester:' + project.'commons-digester.version')
-  compile('javax.activation:activation:' + project.'javax-activation.version')
+  compile('com.sun.activation:javax.activation:' + project.'javax-activation.version')
   compile('javax.xml.bind:jaxb-api:' + project.'jaxb.version')
-  compile('com.sun.xml.bind:jaxb-core:' + project.'jaxb.version')
   compile('com.sun.xml.bind:jaxb-impl:' + project.'jaxb.version')
+  runtimeOnly('com.sun.istack:istack-commons-runtime:2.2') {
+    exclude group: '*'
+  }
 
   compile('org.apache.commons:commons-lang3:' + project.'commons-lang3.version')
   compile('commons-modeler:commons-modeler:' + project.'commons-modeler.version') {

--- a/geode-core/src/main/resources/META-INF/services/org.apache.geode.security.internal.server.Authenticator
+++ b/geode-core/src/main/resources/META-INF/services/org.apache.geode.security.internal.server.Authenticator
@@ -1,1 +1,0 @@
-org.apache.geode.security.internal.server.NoOpAuthenticator

--- a/geode-module/build.gradle
+++ b/geode-module/build.gradle
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.gradle.api.internal.artifacts.dependencies.DefaultProjectDependency
+
+ext.moduleName = 'org.apache.geode'
+
+configurations {
+  jarOnly {
+    transitive = false
+  }
+}
+
+dependencies {
+  jarOnly(project(':geode-core'))
+  jarOnly(project(':geode-common'))
+  jarOnly(project(':geode-json'))
+  jarOnly(project(':geode-cq'))
+
+  // TODO find better way to deal with shiro split packages
+  jarOnly('org.apache.shiro:shiro-core:' + project.'shiro.version')
+}
+
+project.afterEvaluate {
+
+  def fqdn = { dependency ->
+    dependency.group + ":" + dependency.name + ":" + dependency.version
+  }
+
+  def excludes = configurations.jarOnly.allDependencies.collect {fqdn(it)}
+
+  configurations.jarOnly.allDependencies.each { dep ->
+    if (dep instanceof DefaultProjectDependency) {
+      configurations.compile.dependencies.addAll(
+          dep.dependencyProject.configurations.compile.dependencies.findAll {!excludes.contains(fqdn(it))})
+      configurations.runtime.dependencies.addAll(
+          dep.dependencyProject.configurations.runtime.dependencies.findAll {!excludes.contains(fqdn(it))})
+      configurations.runtimeOnly.dependencies.addAll(
+          dep.dependencyProject.configurations.runtimeOnly.dependencies.findAll {!excludes.contains(fqdn(it))})
+    }
+  }
+}
+
+jar {
+  inputs.property("moduleName", moduleName)
+  manifest {
+    attributes('Automatic-Module-Name': moduleName)
+  }
+
+  dependsOn configurations.jarOnly
+  from {
+    configurations.jarOnly.collect { zipTree(it) }
+  }
+
+}
+

--- a/gradle/dependency-versions.properties
+++ b/gradle/dependency-versions.properties
@@ -51,12 +51,12 @@ javax.ejb-api.version = 3.0
 javax.jsr250-api.version = 1.0
 javax.mail-api.version = 1.6.2
 javax.persistence-api.version = 2.2.1
-javax.resource-api.version = 1.7
+javax.resource-api.version = 1.7.1
 javax.servlet-api.version = 3.1.0
 javax.transaction-api.version = 1.2
 jedis.version = 2.9.0
-jaxb.version = 2.2.11
-javax-activation.version = 1.1.1
+jaxb.version = 2.3.1
+javax-activation.version = 1.2.0
 javax-annotation.version = 1.3.2
 # The jetty version is also hard-coded in geode-assembly:test
 # at o.a.g.sessions.tests.GenericAppServerInstall.java

--- a/settings.gradle
+++ b/settings.gradle
@@ -55,6 +55,7 @@ include 'geode-experimental-driver'
 include 'geode-protobuf-messages'
 include 'extensions:session-testing-war'
 include 'geode-concurrency-test'
+include 'geode-module'
 
 
 if (GradleVersion.current() < GradleVersion.version(minimumGradleVersion)) {


### PR DESCRIPTION
- Produces a merged jar with contents from
  geode-common
  geode-json
  geode-core
  geode-cq
- Module uses automatic naming for name org.apache.geode

Co-authored-by: Jacob Barrett <jbarrett@pivotal.io>
Co-authored-by: Owen Nichols <onichols@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
