### PR TITLE
Added error for no members found in CreateDataSourceCommand

### DIFF
--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/CreateDataSourceCommand.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/CreateDataSourceCommand.java
@@ -138,7 +138,11 @@ public class CreateDataSourceCommand extends SingleGfshCommand {
       result.setConfigObject(configuration);
       return result;
     } else {
-      return ResultModel.createInfo("No members found.");
+      if (service != null) {
+        return ResultModel.createInfo("No members found.");
+      } else {
+        return ResultModel.createError("No members found.");
+      }
     }
   }
 

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/CreateDataSourceCommandTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/CreateDataSourceCommandTest.java
@@ -84,12 +84,20 @@ public class CreateDataSourceCommandTest {
 
   @Test
   public void nonPooledWorks() {
+    InternalConfigurationPersistenceService clusterConfigService =
+        mock(InternalConfigurationPersistenceService.class);
+    doReturn(clusterConfigService).when(command).getConfigurationPersistenceService();
+
     gfsh.executeAndAssertThat(command, COMMAND + " --pooled=false --url=url --name=name")
         .statusIsSuccess();
   }
 
   @Test
   public void pooledWorks() {
+    InternalConfigurationPersistenceService clusterConfigService =
+        mock(InternalConfigurationPersistenceService.class);
+    doReturn(clusterConfigService).when(command).getConfigurationPersistenceService();
+
     gfsh.executeAndAssertThat(command, COMMAND + " --pooled=true --url=url --name=name")
         .statusIsSuccess();
   }
@@ -204,8 +212,7 @@ public class CreateDataSourceCommandTest {
 
     gfsh.executeAndAssertThat(command,
         COMMAND + " --name=name  --url=url")
-        .statusIsSuccess().containsOutput("No members found").containsOutput(
-            "Cluster configuration service is not running. Configuration change is not persisted.");
+        .statusIsError().containsOutput("No members found");
   }
 
   @Test


### PR DESCRIPTION
- Added an error case for when no servers are available when
CreateDataSourceCommand is run and Cluster Config is not enabled

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
