### PR TITLE
GEODE-47: Add CLI option to run locators in foreground

### DIFF
--- a/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/StartLocatorCommandDUnitTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/StartLocatorCommandDUnitTest.java
@@ -59,7 +59,6 @@ import org.apache.geode.management.internal.cli.result.CommandResult;
 import org.apache.geode.management.internal.cli.util.CommandStringBuilder;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
-import org.apache.geode.test.junit.rules.ConcurrencyRule;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
 import org.apache.geode.test.junit.rules.RequiresGeodeHome;
 
@@ -83,9 +82,6 @@ public class StartLocatorCommandDUnitTest {
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   @Rule
-  public ConcurrencyRule concurrencyRule = new ConcurrencyRule();
-
-  @Rule
   public TestName testName = new TestName();
 
   @BeforeClass
@@ -103,7 +99,9 @@ public class StartLocatorCommandDUnitTest {
 
   @AfterClass
   public static void after() throws Exception {
-    gfsh.connectAndVerify(locator);
+    if (!gfsh.isConnected()) {
+      gfsh.connectAndVerify(locator);
+    }
     gfsh.execute("shutdown --include-locators");
   }
 

--- a/geode-assembly/src/test/java/org/apache/geode/management/internal/cli/commands/StartLocatorCommandWorkingDirectoryTest.java
+++ b/geode-assembly/src/test/java/org/apache/geode/management/internal/cli/commands/StartLocatorCommandWorkingDirectoryTest.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
@@ -42,7 +43,7 @@ public class StartLocatorCommandWorkingDirectoryTest {
     startLocatorCommand = spy(new StartLocatorCommand());
 
     doReturn(null).when(startLocatorCommand).doStartLocator(
-        anyString(), isNull(), isNull(), anyBoolean(),
+        anyString(), isNull(), isNull(), anyBoolean(), eq(false),
         isNull(), isNull(), isNull(), anyBoolean(),
         isNull(), isNull(), isNull(), anyInt(),
         anyInt(), anyString(), isNull(), isNull(),
@@ -57,7 +58,7 @@ public class StartLocatorCommandWorkingDirectoryTest {
   public void startLocatorWithRelativeWorkingDirectory() throws Exception {
     workingDirectory = "locator1Directory";
 
-    startLocatorCommand.startLocator(memberName, null, null, false,
+    startLocatorCommand.startLocator(memberName, null, null, false, false,
         null, null, null, false,
         null, null, null, 0,
         0, workingDirectory, null, null,
@@ -75,7 +76,7 @@ public class StartLocatorCommandWorkingDirectoryTest {
   public void startLocatorWithNullWorkingDirectory() throws Exception {
     workingDirectory = null;
 
-    startLocatorCommand.startLocator(memberName, null, null, false,
+    startLocatorCommand.startLocator(memberName, null, null, false, false,
         null, null, null, false,
         null, null, null, 0,
         0, workingDirectory, null, null,
@@ -92,7 +93,7 @@ public class StartLocatorCommandWorkingDirectoryTest {
   public void startLocatorWithEmptyWorkingDirectory() throws Exception {
     workingDirectory = "";
 
-    startLocatorCommand.startLocator(memberName, null, null, false,
+    startLocatorCommand.startLocator(memberName, null, null, false, false,
         null, null, null, false,
         null, null, null, 0,
         0, workingDirectory, null, null,
@@ -109,7 +110,7 @@ public class StartLocatorCommandWorkingDirectoryTest {
   public void startLocatorWithDotWorkingDirectory() throws Exception {
     workingDirectory = ".";
 
-    startLocatorCommand.startLocator(memberName, null, null, false,
+    startLocatorCommand.startLocator(memberName, null, null, false, false,
         null, null, null, false,
         null, null, null, 0,
         0, workingDirectory, null, null,
@@ -127,7 +128,7 @@ public class StartLocatorCommandWorkingDirectoryTest {
   public void startLocatorWithAbsoluteWorkingDirectory() throws Exception {
     workingDirectory = new File(System.getProperty("user.dir")).getAbsolutePath();
 
-    startLocatorCommand.startLocator(memberName, null, null, false,
+    startLocatorCommand.startLocator(memberName, null, null, false, false,
         null, null, null, false,
         null, null, null, 0,
         0, workingDirectory, null, null,
@@ -143,7 +144,7 @@ public class StartLocatorCommandWorkingDirectoryTest {
   private void verifyDoStartLocatorInvoked()
       throws Exception {
     verify(startLocatorCommand).doStartLocator(anyString(), isNull(), isNull(), anyBoolean(),
-        isNull(), isNull(), isNull(), anyBoolean(), isNull(),
+        eq(false), isNull(), isNull(), isNull(), anyBoolean(), isNull(),
         isNull(), isNull(), anyInt(), anyInt(), workingDirectoryCaptor.capture(),
         isNull(), isNull(), isNull(), isNull(), isNull(),
         anyBoolean(), anyBoolean(), anyBoolean(), isNull(), anyInt(), isNull(),

--- a/geode-core/build.gradle
+++ b/geode-core/build.gradle
@@ -260,6 +260,9 @@ dependencies {
   jcaCompile(sourceSets.main.output)
 
 
+  jmhCompile('org.apache.logging.log4j:log4j-core:' + project.'log4j.version')
+
+
   testCompile(project(':geode-junit')) {
     exclude module: 'geode-core'
   }

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/LocatorCommand.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/LocatorCommand.java
@@ -27,6 +27,7 @@ public class LocatorCommand {
   private Command command;
   private String name;
   private boolean force;
+  private boolean foreground;
   private int port;
 
   public LocatorCommand() {
@@ -80,6 +81,15 @@ public class LocatorCommand {
     return this;
   }
 
+  public LocatorCommand foreground() {
+    return foreground(true);
+  }
+
+  public LocatorCommand foreground(final boolean value) {
+    this.foreground = value;
+    return this;
+  }
+
   public LocatorCommand withPort(final int port) {
     this.port = port;
     return this;
@@ -96,6 +106,9 @@ public class LocatorCommand {
     cmd.add(name);
     if (force) {
       cmd.add("--force");
+    }
+    if (foreground) {
+      cmd.add("--foreground");
     }
     cmd.add("--redirect-output");
     if (port > 0) {

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/GfshParserParsingTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/GfshParserParsingTest.java
@@ -76,7 +76,7 @@ public class GfshParserParsingTest {
     GfshParseResult result = parser.parse(buffer);
     assertThat(result).isNotNull();
     Object[] arguments = result.getArguments();
-    int indexOfJvmArgumentsParameterInStartLocator = 18;
+    int indexOfJvmArgumentsParameterInStartLocator = 19;
 
     String[] jvmArgs = (String[]) arguments[indexOfJvmArgumentsParameterInStartLocator];
     assertThat(jvmArgs).hasSize(2);

--- a/geode-core/src/main/java/org/apache/geode/distributed/AbstractLauncher.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/AbstractLauncher.java
@@ -599,6 +599,14 @@ public abstract class AbstractLauncher<T extends Comparable<T>> implements Runna
       return Status.NOT_RESPONDING == getStatus() || Status.STARTING == getStatus();
     }
 
+    public String getUpTimeAsFormattedString() {
+      return toDaysHoursMinutesSeconds(getUptime());
+    }
+
+    public boolean isOnline() {
+      return (isVmWithProcessIdRunning() && (getStatus() == Status.ONLINE));
+    }
+
     public boolean isVmWithProcessIdRunning() {
       // note: this will use JNA if available or return false
       return ProcessUtils.isProcessAlive(this.getPid());

--- a/geode-core/src/main/java/org/apache/geode/distributed/AbstractLauncher.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/AbstractLauncher.java
@@ -72,6 +72,7 @@ public abstract class AbstractLauncher<T extends Comparable<T>> implements Runna
       "The working directory for the %s could not be found.";
 
   protected static final Boolean DEFAULT_FORCE = Boolean.FALSE;
+  protected static final Boolean DEFAULT_FOREGROUND = Boolean.FALSE;
 
   /**
    * @deprecated This timeout is no longer needed.

--- a/geode-core/src/main/java/org/apache/geode/distributed/AbstractLauncher.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/AbstractLauncher.java
@@ -603,10 +603,6 @@ public abstract class AbstractLauncher<T extends Comparable<T>> implements Runna
       return toDaysHoursMinutesSeconds(getUptime());
     }
 
-    public boolean isOnline() {
-      return (isVmWithProcessIdRunning() && (getStatus() == Status.ONLINE));
-    }
-
     public boolean isVmWithProcessIdRunning() {
       // note: this will use JNA if available or return false
       return ProcessUtils.isProcessAlive(this.getPid());

--- a/geode-core/src/main/java/org/apache/geode/distributed/ConfigurationProperties.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/ConfigurationProperties.java
@@ -1418,6 +1418,16 @@ public interface ConfigurationProperties {
    */
   String REMOVE_UNRESPONSIVE_CLIENT = "remove-unresponsive-client";
   /**
+   * <p>
+   * The static String definition of the <i>"foreground"</i> property
+   * </p>
+   * <p>
+   * <U>Description:</U> If set to true, causes the process to start in the foreground. The GFSH
+   * command will not return as long as the process is running.
+   * </p>
+   */
+  String FOREGROUND = "foreground";
+  /**
    * The static String definition of the <i>"roles"</i> property <a name="roles"/a>
    * </p>
    * <U>Description</U>: Specifies the application roles that this member performs in the

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartLocatorCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartLocatorCommand.java
@@ -363,12 +363,16 @@ public class StartLocatorCommand extends InternalGfshCommand {
       Gfsh.println();
 
       do {
+        if (Thread.interrupted()) {
+          return result;
+        }
+
         locatorState = LocatorLauncher.LocatorState.fromDirectory(workingDirectory, memberName);
         Gfsh.print("\rUptime: " + locatorState.getUpTimeAsFormattedString());
         synchronized (this) {
           TimeUnit.MILLISECONDS.timedWait(this, 1000);
         }
-      } while (locatorState.isOnline());
+      } while (locatorState.getStatus().equals(AbstractLauncher.Status.ONLINE));
     }
 
     return result;

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartLocatorCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartLocatorCommand.java
@@ -364,11 +364,11 @@ public class StartLocatorCommand extends InternalGfshCommand {
 
       do {
         locatorState = LocatorLauncher.LocatorState.fromDirectory(workingDirectory, memberName);
-        Gfsh.print("\rUptime: " + locatorState.getUptime().toString());
+        Gfsh.print("\rUptime: " + locatorState.getUpTimeAsFormattedString());
         synchronized (this) {
           TimeUnit.MILLISECONDS.timedWait(this, 1000);
         }
-      } while (locatorState.getStatus().equals(AbstractLauncher.Status.ONLINE));
+      } while (locatorState.isOnline());
     }
 
     return result;

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/i18n/CliStrings.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/i18n/CliStrings.java
@@ -2355,6 +2355,9 @@ public class CliStrings {
   public static final String START_LOCATOR__FORCE = "force";
   public static final String START_LOCATOR__FORCE__HELP =
       "Whether to allow the PID file from a previous Locator run to be overwritten.";
+  public static final String START_LOCATOR__FOREGROUND = "foreground";
+  public static final String START_LOCATOR__FOREGROUND_HELP =
+      "Starts the process in the foreground. GFSH will not return while the process is running.";
   public static final String START_LOCATOR__GROUP__HELP = "Group(s) the Locator will be a part of.";
   public static final String START_LOCATOR__HOSTNAME_FOR_CLIENTS = "hostname-for-clients";
 

--- a/geode-core/src/test/java/org/apache/geode/distributed/LocatorLauncherBuilderTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/LocatorLauncherBuilderTest.java
@@ -33,7 +33,7 @@ import org.apache.geode.distributed.LocatorLauncher.Command;
 import org.apache.geode.distributed.internal.DistributionConfig;
 
 /**
- * Unit tests for {@link LocatorLauncher.Builder}. Extracted from {@link LocatorLauncherTest}.
+ * Unit tests for {@link LocatorLauncher.Builder}
  */
 public class LocatorLauncherBuilderTest {
 
@@ -48,12 +48,12 @@ public class LocatorLauncherBuilderTest {
   }
 
   @Test
-  public void defaultCommandIsUnspecified() throws Exception {
+  public void defaultCommandIsUnspecified() {
     assertThat(Builder.DEFAULT_COMMAND).isEqualTo(Command.UNSPECIFIED);
   }
 
   @Test
-  public void getCommandReturnsUnspecifiedByDefault() throws Exception {
+  public void getCommandReturnsUnspecifiedByDefault() {
     assertThat(new Builder().getCommand()).isEqualTo(Builder.DEFAULT_COMMAND);
   }
 
@@ -63,81 +63,93 @@ public class LocatorLauncherBuilderTest {
   }
 
   @Test
-  public void getBindAddressReturnsNullByDefault() throws Exception {
+  public void getForegroundReturnsFalseByDefault() {
+    assertThat(new Builder().getForeground()).isFalse();
+  }
+
+  @Test
+  public void getBindAddressReturnsNullByDefault() {
     Builder builder = new Builder();
 
     assertThat(builder.getBindAddress()).isNull();
   }
 
   @Test
-  public void getHostnameForClientsReturnsNullByDefault() throws Exception {
+  public void getHostnameForClientsReturnsNullByDefault() {
     assertThat(new Builder().getHostnameForClients()).isNull();
   }
 
   @Test
-  public void getMemberNameReturnsNullByDefault() throws Exception {
+  public void getMemberNameReturnsNullByDefault() {
     assertThat(new Builder().getMemberName()).isNull();
   }
 
   @Test
-  public void getPidReturnsNullByDefault() throws Exception {
+  public void getPidReturnsNullByDefault() {
     assertThat(new Builder().getPid()).isNull();
   }
 
   @Test
-  public void getRedirectOutputReturnsNullByDefault() throws Exception {
+  public void getRedirectOutputReturnsNullByDefault() {
     assertThat(new LocatorLauncher.Builder().getRedirectOutput()).isNull();
   }
 
   @Test
-  public void getPortReturnsDefaultLocatorPortByDefault() throws Exception {
+  public void getPortReturnsDefaultLocatorPortByDefault() {
     assertThat(new Builder().getPort()).isEqualTo(Integer.valueOf(DEFAULT_LOCATOR_PORT));
   }
 
   @Test
-  public void setCommandReturnsBuilderInstance() throws Exception {
+  public void setCommandReturnsBuilderInstance() {
     Builder builder = new Builder();
 
     assertThat(builder.setCommand(Command.STATUS)).isSameAs(builder);
   }
 
   @Test
-  public void setForceReturnsBuilderInstance() throws Exception {
+  public void setForceReturnsBuilderInstance() {
     Builder builder = new Builder();
 
     assertThat(builder.setForce(true)).isSameAs(builder);
   }
 
   @Test
-  public void setHostNameForClientsReturnsBuilderInstance() throws Exception {
+  public void setForegroundReturnsBuilderInstance() {
+    Builder builder = new Builder();
+
+    assertThat(builder.setForeground(true)).isSameAs(builder);
+  }
+
+  @Test
+  public void setHostNameForClientsReturnsBuilderInstance() {
     Builder builder = new Builder();
 
     assertThat(builder.setHostnameForClients("Pegasus")).isSameAs(builder);
   }
 
   @Test
-  public void setMemberNameReturnsBuilderInstance() throws Exception {
+  public void setMemberNameReturnsBuilderInstance() {
     Builder builder = new Builder();
 
     assertThat(builder.setMemberName("serverOne")).isSameAs(builder);
   }
 
   @Test
-  public void setBindAddressReturnsBuilderInstance() throws Exception {
+  public void setBindAddressReturnsBuilderInstance() {
     Builder builder = new Builder();
 
     assertThat(builder.setBindAddress(null)).isSameAs(builder);
   }
 
   @Test
-  public void setPortReturnsBuilderInstance() throws Exception {
+  public void setPortReturnsBuilderInstance() {
     Builder builder = new Builder();
 
     assertThat(builder.setPort(null)).isSameAs(builder);
   }
 
   @Test
-  public void setCommandWithNullResultsInDefaultCommand() throws Exception {
+  public void setCommandWithNullResultsInDefaultCommand() {
     Builder builder = new Builder();
 
     new Builder().setCommand(null);
@@ -146,7 +158,7 @@ public class LocatorLauncherBuilderTest {
   }
 
   @Test
-  public void setCommandToStatusResultsInStatus() throws Exception {
+  public void setCommandToStatusResultsInStatus() {
     Builder builder = new Builder();
 
     builder.setCommand(Command.STATUS);
@@ -155,7 +167,7 @@ public class LocatorLauncherBuilderTest {
   }
 
   @Test
-  public void setBindAddressToNullResultsInNull() throws Exception {
+  public void setBindAddressToNullResultsInNull() {
     Builder builder = new Builder();
 
     builder.setBindAddress(null);
@@ -164,7 +176,7 @@ public class LocatorLauncherBuilderTest {
   }
 
   @Test
-  public void setBindAddressToEmptyStringResultsInNull() throws Exception {
+  public void setBindAddressToEmptyStringResultsInNull() {
     Builder builder = new Builder();
 
     builder.setBindAddress("");
@@ -173,7 +185,7 @@ public class LocatorLauncherBuilderTest {
   }
 
   @Test
-  public void setBindAddressToBlankStringResultsInNull() throws Exception {
+  public void setBindAddressToBlankStringResultsInNull() {
     Builder builder = new Builder();
 
     builder.setBindAddress("  ");
@@ -211,7 +223,7 @@ public class LocatorLauncherBuilderTest {
   }
 
   @Test
-  public void setForceToTrueUsesValue() throws Exception {
+  public void setForceToTrueUsesValue() {
     ServerLauncher.Builder builder = new ServerLauncher.Builder();
 
     builder.setForce(true);
@@ -220,7 +232,14 @@ public class LocatorLauncherBuilderTest {
   }
 
   @Test
-  public void setHostnameForClientsToStringUsesValue() throws Exception {
+  public void setForegroundToTrueUsesValue() {
+    Builder builder = new Builder().setForeground(true);
+
+    assertThat(builder.getForeground()).isTrue();
+  }
+
+  @Test
+  public void setHostnameForClientsToStringUsesValue() {
     Builder builder = new Builder();
 
     builder.setHostnameForClients("Pegasus");
@@ -248,7 +267,7 @@ public class LocatorLauncherBuilderTest {
   }
 
   @Test
-  public void setMemberNameToStringUsesValue() throws Exception {
+  public void setMemberNameToStringUsesValue() {
     Builder builder = new Builder();
 
     builder.setMemberName("locatorOne");
@@ -275,7 +294,7 @@ public class LocatorLauncherBuilderTest {
   }
 
   @Test
-  public void setPidToZeroOrGreaterUsesValue() throws Exception {
+  public void setPidToZeroOrGreaterUsesValue() {
     Builder builder = new Builder();
 
     builder.setPid(0);
@@ -292,7 +311,7 @@ public class LocatorLauncherBuilderTest {
   }
 
   @Test
-  public void setPidToNullResultsInNull() throws Exception {
+  public void setPidToNullResultsInNull() {
     Builder builder = new Builder();
 
     builder.setPid(null);
@@ -306,14 +325,14 @@ public class LocatorLauncherBuilderTest {
   }
 
   @Test
-  public void setPortToNullUsesDefaultLocatorPort() throws Exception {
+  public void setPortToNullUsesDefaultLocatorPort() {
     Builder builder = new Builder();
 
     assertThat(builder.setPort(null).getPort()).isEqualTo(Integer.valueOf(DEFAULT_LOCATOR_PORT));
   }
 
   @Test
-  public void setPortToZeroOrGreaterUsesValue() throws Exception {
+  public void setPortToZeroOrGreaterUsesValue() {
     Builder builder = new Builder();
 
     builder.setPort(0);
@@ -333,7 +352,7 @@ public class LocatorLauncherBuilderTest {
   }
 
   @Test
-  public void setPortAboveMaxValueThrowsIllegalArgumentException() throws Exception {
+  public void setPortAboveMaxValueThrowsIllegalArgumentException() {
     assertThatThrownBy(() -> new Builder().setPort(65536))
         .isInstanceOf(IllegalArgumentException.class);
   }
@@ -345,14 +364,14 @@ public class LocatorLauncherBuilderTest {
   }
 
   @Test
-  public void setRedirectOutputReturnsBuilderInstance() throws Exception {
+  public void setRedirectOutputReturnsBuilderInstance() {
     LocatorLauncher.Builder builder = new LocatorLauncher.Builder();
 
     assertThat(builder.setRedirectOutput(Boolean.TRUE)).isSameAs(builder);
   }
 
   @Test
-  public void parseArgumentsWithForceSetsForceToTrue() throws Exception {
+  public void parseArgumentsWithForceSetsForceToTrue() {
     Builder builder = new Builder();
 
     builder.parseArguments("start", "--force");
@@ -368,7 +387,7 @@ public class LocatorLauncherBuilderTest {
   }
 
   @Test
-  public void parseCommandWithNullStringArrayResultsInDefaultCommand() throws Exception {
+  public void parseCommandWithNullStringArrayResultsInDefaultCommand() {
     Builder builder = new Builder();
 
     builder.parseCommand((String[]) null);
@@ -377,7 +396,7 @@ public class LocatorLauncherBuilderTest {
   }
 
   @Test
-  public void parseCommandWithEmptyStringArrayResultsInDefaultCommand() throws Exception {
+  public void parseCommandWithEmptyStringArrayResultsInDefaultCommand() {
     Builder builder = new Builder();
 
     builder.parseCommand(); // empty String array
@@ -386,7 +405,7 @@ public class LocatorLauncherBuilderTest {
   }
 
   @Test
-  public void parseCommandWithStartResultsInStartCommand() throws Exception {
+  public void parseCommandWithStartResultsInStartCommand() {
     Builder builder = new Builder();
 
     builder.parseCommand(Command.START.getName());
@@ -395,7 +414,7 @@ public class LocatorLauncherBuilderTest {
   }
 
   @Test
-  public void parseCommandWithStatusResultsInStatusCommand() throws Exception {
+  public void parseCommandWithStatusResultsInStatusCommand() {
     Builder builder = new Builder();
 
     builder.parseCommand("Status");
@@ -404,7 +423,7 @@ public class LocatorLauncherBuilderTest {
   }
 
   @Test
-  public void parseCommandWithMixedCaseResultsInCorrectCase() throws Exception {
+  public void parseCommandWithMixedCaseResultsInCorrectCase() {
     Builder builder = new Builder();
 
     builder.parseCommand("sToP");
@@ -413,7 +432,7 @@ public class LocatorLauncherBuilderTest {
   }
 
   @Test
-  public void parseCommandWithTwoCommandsWithSwitchesUsesFirstCommand() throws Exception {
+  public void parseCommandWithTwoCommandsWithSwitchesUsesFirstCommand() {
     Builder builder = new Builder();
 
     builder.parseCommand("--opt", "START", "-o", Command.STATUS.getName());
@@ -422,7 +441,7 @@ public class LocatorLauncherBuilderTest {
   }
 
   @Test
-  public void parseCommandWithTwoCommandsWithoutSwitchesUsesFirstCommand() throws Exception {
+  public void parseCommandWithTwoCommandsWithoutSwitchesUsesFirstCommand() {
     Builder builder = new Builder();
 
     builder.parseCommand("START", Command.STATUS.getName());
@@ -431,7 +450,7 @@ public class LocatorLauncherBuilderTest {
   }
 
   @Test
-  public void parseCommandWithBadInputResultsInDefaultCommand() throws Exception {
+  public void parseCommandWithBadInputResultsInDefaultCommand() {
     Builder builder = new Builder();
 
     builder.parseCommand("badCommandName", "--start", "stat");
@@ -440,7 +459,7 @@ public class LocatorLauncherBuilderTest {
   }
 
   @Test
-  public void parseMemberNameWithNullStringArrayResultsInNull() throws Exception {
+  public void parseMemberNameWithNullStringArrayResultsInNull() {
     Builder builder = new Builder();
 
     builder.parseMemberName((String[]) null);
@@ -449,7 +468,7 @@ public class LocatorLauncherBuilderTest {
   }
 
   @Test
-  public void parseMemberNameWithEmptyStringArrayResultsInNull() throws Exception {
+  public void parseMemberNameWithEmptyStringArrayResultsInNull() {
     Builder builder = new Builder();
 
     builder.parseMemberName(); // empty String array
@@ -458,7 +477,7 @@ public class LocatorLauncherBuilderTest {
   }
 
   @Test
-  public void parseMemberNameWithCommandAndOptionsResultsInNull() throws Exception {
+  public void parseMemberNameWithCommandAndOptionsResultsInNull() {
     Builder builder = new Builder();
 
     builder.parseMemberName(Command.START.getName(), "--opt", "-o");
@@ -467,7 +486,7 @@ public class LocatorLauncherBuilderTest {
   }
 
   @Test
-  public void parseMemberNameWithStringUsesValue() throws Exception {
+  public void parseMemberNameWithStringUsesValue() {
     Builder builder = new Builder();
 
     builder.parseMemberName("memberOne");
@@ -477,15 +496,16 @@ public class LocatorLauncherBuilderTest {
 
 
   @Test
-  public void buildCreatesLocatorLauncherWithBuilderValues() throws Exception {
+  public void buildCreatesLocatorLauncherWithBuilderValues() {
     Builder builder = new Builder();
 
     LocatorLauncher launcher = builder.setCommand(Command.START).setDebug(true)
         .setHostnameForClients("beanstock.vmware.com").setMemberName("Beanstock").setPort(8192)
-        .setRedirectOutput(Boolean.TRUE).build();
+        .setRedirectOutput(Boolean.TRUE).setForeground(false).build();
 
     assertThat(launcher.getCommand()).isEqualTo(builder.getCommand());
     assertThat(launcher.isDebugging()).isTrue();
+    assertThat(launcher.isForeground()).isFalse();
     assertThat(launcher.getHostnameForClients()).isEqualTo(builder.getHostnameForClients());
     assertThat(launcher.getMemberName()).isEqualTo(builder.getMemberName());
     assertThat(launcher.getPort()).isEqualTo(builder.getPort());


### PR DESCRIPTION
* add a command line option to start locators in the foreground. The gfsh command will not return until the locator stops running.

* add unit tests for new CLI option

* add distributed unit tests for new CLI option

* add unit test for new Builder options

* add CLI Strings for foreground option

* add jmh compile dependency to fix intelliJ build in case it isn't inherited from main

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
