### PR TITLE
GEODE-6105 convert geode-old-versions to xyzTestRuntime dependency

### DIFF
--- a/geode-assembly/build.gradle
+++ b/geode-assembly/build.gradle
@@ -147,6 +147,10 @@ dependencies {
   testCompile(project(':geode-junit')) {
     exclude module: 'geode-core'
   }
+  testRuntime(project(':geode-old-versions'))
+  
+
+  acceptanceTestRuntime(project(':geode-old-versions'))
 
 
   integrationTestCompile(project(':geode-core'))
@@ -203,9 +207,10 @@ dependencies {
   }
   upgradeTestCompile(project(':geode-assembly:geode-assembly-test'))
 
+  upgradeTestRuntime(project(':geode-old-versions'))
+  upgradeTestRuntime(project(':extensions:session-testing-war'))
   upgradeTestRuntime(group: 'org.codehaus.cargo', name: 'cargo-core-uberjar', version: '1.6.3')
   upgradeTestRuntime('org.apache.httpcomponents:httpclient:' + project.'httpclient.version')
-  upgradeTestRuntime(project(':extensions:session-testing-war'))
   upgradeTestRuntime files({ downloadWebServers } )
 
   //Web servers used for session module testing

--- a/geode-core/build.gradle
+++ b/geode-core/build.gradle
@@ -314,12 +314,16 @@ dependencies {
   distributedTestCompile('pl.pragmatists:JUnitParams:' + project.'JUnitParams.version')
   distributedTestCompile('com.jayway.jsonpath:json-path-assert:' + project.'json-path-assert.version')
 
+  distributedTestRuntime(project(':geode-old-versions'))
   distributedTestRuntime('org.apache.derby:derby:' + project.'derby.version')
 
 
   upgradeTestCompile(project(':geode-dunit')) {
     exclude module: 'geode-core'
   }
+
+  upgradeTestRuntime(project(':geode-old-versions'))
+
 
   performanceTestCompile(project(':geode-junit')) {
     exclude module: 'geode-core'

--- a/geode-cq/build.gradle
+++ b/geode-cq/build.gradle
@@ -57,4 +57,6 @@ dependencies {
   upgradeTestCompile('junit:junit:' + project.'junit.version')
   upgradeTestCompile('org.awaitility:awaitility:' + project.'awaitility.version')
   upgradeTestCompile('org.mockito:mockito-core:' + project.'mockito-core.version')
+
+  upgradeTestRuntime(project(':geode-old-versions'))
 }

--- a/geode-dunit/build.gradle
+++ b/geode-dunit/build.gradle
@@ -50,6 +50,9 @@ dependencies {
   compile('junit:junit:' + project.'junit.version') {
     exclude module: 'hamcrest-core'
   }
+
+
+  distributedTestRuntime(project(':geode-old-versions'))
 }
 
 distributedTest {

--- a/geode-junit/build.gradle
+++ b/geode-junit/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 
   testCompile('pl.pragmatists:JUnitParams:' + project.'JUnitParams.version')
 
-  runtimeOnly(project(':geode-old-versions'))
+  testRuntime(project(':geode-old-versions'))
 }
 
 test {

--- a/geode-junit/src/test/resources/expected-pom.xml
+++ b/geode-junit/src/test/resources/expected-pom.xml
@@ -137,11 +137,5 @@
       <version>1.60</version>
       <scope>compile</scope>
     </dependency>
-    <dependency>
-      <groupId>org.apache.geode</groupId>
-      <artifactId>geode-old-versions</artifactId>
-      <version>1.9.0-SNAPSHOT</version>
-      <scope>runtime</scope>
-    </dependency>
   </dependencies>
 </project>

--- a/geode-lucene/build.gradle
+++ b/geode-lucene/build.gradle
@@ -84,6 +84,8 @@ dependencies {
     exclude module: 'geode-core'
   }
 
+  upgradeTestRuntime(project(':geode-old-versions'))
+
 
   performanceTestCompile(project(':geode-junit')) {
     exclude module: 'geode-core'

--- a/geode-wan/build.gradle
+++ b/geode-wan/build.gradle
@@ -30,5 +30,6 @@ dependencies {
   upgradeTestCompile(project(':geode-dunit')) {
     exclude module: 'geode-core'
   }
+  upgradeTestRuntime(project(':geode-old-versions'))
   distributedTestCompile('pl.pragmatists:JUnitParams:' + project.'JUnitParams.version')
 }

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -187,7 +187,6 @@ subprojects {
         }
       }
     }
-
   }
   check.dependsOn('checkPom')
 
@@ -200,9 +199,9 @@ subprojects {
       from actualPomFile
       into expectedPomDir
       rename '.*.xml', "expected-pom.xml"
-
     }
   }
+  checkPom.mustRunAfter(updateExpectedPom)
 } // subprojects
 
 


### PR DESCRIPTION
Old versions are only used by tests, not any production runtime. Do not
publish to Maven that we need it for all runtime. Mark the modules that
need old-versions for testing appropriately.

Authored-by: Robert Houghton <rhoughton@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
