### PR TITLE
GEODE-6111: Add gradle properties to extend http timeouts.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -46,9 +46,6 @@ buildId = 0
 productName = Apache Geode
 productOrg = Apache Software Foundation (ASF)
 
-org.gradle.daemon = true
-org.gradle.jvmargs = -Xmx3g
-
 minimumGradleVersion = 4.10.1
 # Set this on the command line with -P or in ~/.gradle/gradle.properties
 # to change the buildDir location.  Use an absolute path.
@@ -75,6 +72,10 @@ testJVMVer=8
 repeat = 100
 
 org.gradle.caching = true
-org.gradle.parallel = false
 org.gradle.configureondemand = false
+org.gradle.daemon = true
+org.gradle.jvmargs = -Xmx3g
+org.gradle.parallel = false
 
+org.gradle.internal.http.socketTimeout=60000
+org.gradle.internal.http.connectionTimeout=60000


### PR DESCRIPTION
Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
