### PR TITLE
GEODE-6115: add log4j dependency to jmh compile

### DIFF
--- a/geode-core/build.gradle
+++ b/geode-core/build.gradle
@@ -260,6 +260,7 @@ dependencies {
 
   jcaCompile(sourceSets.main.output)
 
+  jmhCompile('org.apache.logging.log4j:log4j-core:' + project.'log4j.version')
 
   testCompile(project(':geode-junit')) {
     exclude module: 'geode-core'


### PR DESCRIPTION
This will fix the issue of IntelliJ builds sometimes not inheriting the
dependency from main at compile time. At worst, this line will be
redundant, at best it will provide the required dependency for the
build.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
