### PR TITLE
GEODE-6107: in test start locators one at a time

### DIFF
--- a/geode-core/build.gradle
+++ b/geode-core/build.gradle
@@ -260,6 +260,7 @@ dependencies {
 
   jcaCompile(sourceSets.main.output)
 
+  jmhCompile('org.apache.logging.log4j:log4j-core:' + project.'log4j.version')
 
   testCompile(project(':geode-junit')) {
     exclude module: 'geode-core'

--- a/geode-core/src/distributedTest/java/org/apache/geode/management/JMXMBeanReconnectDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/JMXMBeanReconnectDUnitTest.java
@@ -87,9 +87,7 @@ public class JMXMBeanReconnectDUnitTest {
   public void before() throws Exception {
     locator1 = lsRule.startLocatorVM(LOCATOR_1_VM_INDEX, locator1Properties());
 
-    System.out.println("GEODE-6107: waiting for locator to start");
     locator1.waitTilLocatorFullyStarted();
-    System.out.println("GEODE-6107: done waiting for locator to start");
 
     locator2 = lsRule.startLocatorVM(LOCATOR_2_VM_INDEX, locator2Properties(), locator1.getPort());
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/management/JMXMBeanReconnectDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/JMXMBeanReconnectDUnitTest.java
@@ -86,6 +86,11 @@ public class JMXMBeanReconnectDUnitTest {
   @Before
   public void before() throws Exception {
     locator1 = lsRule.startLocatorVM(LOCATOR_1_VM_INDEX, locator1Properties());
+
+    System.out.println("GEODE-6107: waiting for locator to start");
+    locator1.waitTilLocatorFullyStarted();
+    System.out.println("GEODE-6107: done waiting for locator to start");
+
     locator2 = lsRule.startLocatorVM(LOCATOR_2_VM_INDEX, locator2Properties(), locator1.getPort());
 
     server1 = lsRule.startServerVM(SERVER_1_VM_INDEX, locator1.getPort());

--- a/geode-core/src/distributedTest/java/org/apache/geode/management/JMXMBeanReconnectDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/JMXMBeanReconnectDUnitTest.java
@@ -86,10 +86,10 @@ public class JMXMBeanReconnectDUnitTest {
   @Before
   public void before() throws Exception {
     locator1 = lsRule.startLocatorVM(LOCATOR_1_VM_INDEX, locator1Properties());
-
     locator1.waitTilLocatorFullyStarted();
 
     locator2 = lsRule.startLocatorVM(LOCATOR_2_VM_INDEX, locator2Properties(), locator1.getPort());
+    locator2.waitTilLocatorFullyStarted();
 
     server1 = lsRule.startServerVM(SERVER_1_VM_INDEX, locator1.getPort());
     // start an extra server to have more MBeans, but we don't need to use it in these tests

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/rules/MemberVM.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/rules/MemberVM.java
@@ -130,6 +130,34 @@ public class MemberVM extends VMProvider implements Member {
     });
   }
 
+  public void waitTilLocatorFullyStarted() {
+    vm.invoke(() -> {
+      try {
+        await().until(() -> {
+          InternalLocator intLocator = ClusterStartupRule.getLocator();
+          InternalCache cache = ClusterStartupRule.getCache();
+          return intLocator != null && cache != null && intLocator.getDistributedSystem()
+              .isConnected();
+        });
+      } catch (Exception e) {
+        // provide more information when condition is not satisfied after awaitility timeout
+        InternalLocator intLocator = ClusterStartupRule.getLocator();
+        InternalCache cache = ClusterStartupRule.getCache();
+        DistributedSystem ds = intLocator.getDistributedSystem();
+        logger.info("locator is: " + (intLocator != null ? "not null" : "null"));
+        logger.info("cache is: " + (cache != null ? "not null" : "null"));
+        if (ds != null) {
+          logger
+              .info("distributed system is: " + (ds.isConnected() ? "connected" : "not connected"));
+        } else {
+          logger.info("distributed system is: null");
+        }
+        throw e;
+      }
+
+    });
+  }
+
   public void waitTilLocatorFullyReconnected() {
     vm.invoke(() -> {
       try {


### PR DESCRIPTION
There exists a known race condition in starting locators such that if
two locators are started simultaneously, not all the MBeans get
federated to both members. This was causing intermittent test failures
in the before() of JMXMBeanReconnectDUnitTest. To fix this, a wait has
been added so that the first member has enough time to start before the
second one.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
