### PR TITLE
GEODE-6122: Make log4j core optional

### DIFF
--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/management/internal/cli/commands/GfshStartLocatorLogAcceptanceTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/management/internal/cli/commands/GfshStartLocatorLogAcceptanceTest.java
@@ -23,7 +23,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import org.apache.geode.internal.Banner;
+import org.apache.geode.internal.logging.Banner;
 import org.apache.geode.test.assertj.LogFileAssert;
 import org.apache.geode.test.junit.categories.GfshTest;
 import org.apache.geode.test.junit.categories.LoggingTest;

--- a/geode-common/src/main/java/org/apache/geode/annotations/TestingOnly.java
+++ b/geode-common/src/main/java/org/apache/geode/annotations/TestingOnly.java
@@ -20,7 +20,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 
 @Documented
-@Target({ElementType.TYPE, ElementType.CONSTRUCTOR, ElementType.METHOD})
+@Target({ElementType.TYPE, ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.FIELD})
 public @interface TestingOnly {
 
   /** Optional description */

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/logging/LoggingWithReconnectDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/logging/LoggingWithReconnectDistributedTest.java
@@ -22,7 +22,7 @@ import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.MAX_WAIT_TIME_RECONNECT;
 import static org.apache.geode.distributed.ConfigurationProperties.MEMBER_TIMEOUT;
 import static org.apache.geode.distributed.internal.membership.gms.MembershipManagerHelper.getMembershipManager;
-import static org.apache.geode.internal.Banner.BannerHeader.displayValues;
+import static org.apache.geode.internal.logging.Banner.BannerHeader.displayValues;
 import static org.apache.geode.internal.logging.Configuration.STARTUP_CONFIGURATION;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.getTimeout;

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/logging/BannerLoggingIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/logging/BannerLoggingIntegrationTest.java
@@ -19,7 +19,6 @@ import static org.apache.commons.io.FileUtils.readLines;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.LOG_FILE;
 import static org.apache.geode.internal.logging.Banner.BannerHeader.displayValues;
-import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
@@ -81,13 +80,12 @@ public class BannerLoggingIntegrationTest {
 
   @Test
   public void bannerIsLoggedToFile() {
-    await().untilAsserted(() -> LogFileAssert.assertThat(mainLogFile).contains(displayValues()));
+    LogFileAssert.assertThat(mainLogFile).contains(displayValues());
   }
 
   @Test
   public void bannerIsLoggedToFileOnlyOnce() {
-    await().untilAsserted(
-        () -> LogFileAssert.assertThat(mainLogFile).containsOnlyOnce(displayValues()));
+    LogFileAssert.assertThat(mainLogFile).containsOnlyOnce(displayValues());
   }
 
   /**

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/logging/BannerLoggingIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/logging/BannerLoggingIntegrationTest.java
@@ -19,6 +19,7 @@ import static org.apache.commons.io.FileUtils.readLines;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.LOG_FILE;
 import static org.apache.geode.internal.logging.Banner.BannerHeader.displayValues;
+import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
@@ -80,12 +81,12 @@ public class BannerLoggingIntegrationTest {
 
   @Test
   public void bannerIsLoggedToFile() {
-    LogFileAssert.assertThat(mainLogFile).contains(displayValues());
+    await().untilAsserted(() -> LogFileAssert.assertThat(mainLogFile).contains(displayValues()));
   }
 
   @Test
   public void bannerIsLoggedToFileOnlyOnce() {
-    LogFileAssert.assertThat(mainLogFile).containsOnlyOnce(displayValues());
+    await().untilAsserted(() ->LogFileAssert.assertThat(mainLogFile).containsOnlyOnce(displayValues()));
   }
 
   /**

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/logging/BannerLoggingIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/logging/BannerLoggingIntegrationTest.java
@@ -86,7 +86,8 @@ public class BannerLoggingIntegrationTest {
 
   @Test
   public void bannerIsLoggedToFileOnlyOnce() {
-    await().untilAsserted(() ->LogFileAssert.assertThat(mainLogFile).containsOnlyOnce(displayValues()));
+    await().untilAsserted(
+        () -> LogFileAssert.assertThat(mainLogFile).containsOnlyOnce(displayValues()));
   }
 
   /**

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/logging/BannerLoggingIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/logging/BannerLoggingIntegrationTest.java
@@ -18,7 +18,7 @@ import static java.nio.charset.Charset.defaultCharset;
 import static org.apache.commons.io.FileUtils.readLines;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.LOG_FILE;
-import static org.apache.geode.internal.Banner.BannerHeader.displayValues;
+import static org.apache.geode.internal.logging.Banner.BannerHeader.displayValues;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
@@ -36,7 +36,6 @@ import org.junit.rules.TestName;
 
 import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
-import org.apache.geode.internal.Banner;
 import org.apache.geode.test.assertj.LogFileAssert;
 import org.apache.geode.test.junit.categories.LoggingTest;
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/logging/ConfigurationIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/logging/ConfigurationIntegrationTest.java
@@ -14,13 +14,13 @@
  */
 package org.apache.geode.internal.logging;
 
-import static org.apache.geode.internal.logging.Configuration.LogLevelUpdateOccurs.ALWAYS;
-import static org.apache.geode.internal.logging.Configuration.LogLevelUpdateScope.ALL_LOGGERS;
-import static org.apache.geode.internal.logging.Configuration.LogLevelUpdateScope.GEODE_AND_APPLICATION_LOGGERS;
-import static org.apache.geode.internal.logging.Configuration.LogLevelUpdateScope.GEODE_AND_SECURITY_LOGGERS;
-import static org.apache.geode.internal.logging.Configuration.LogLevelUpdateScope.GEODE_LOGGERS;
 import static org.apache.geode.internal.logging.Configuration.MAIN_LOGGER_NAME;
 import static org.apache.geode.internal.logging.Configuration.SECURITY_LOGGER_NAME;
+import static org.apache.geode.internal.logging.LogLevelUpdateOccurs.ALWAYS;
+import static org.apache.geode.internal.logging.LogLevelUpdateScope.ALL_LOGGERS;
+import static org.apache.geode.internal.logging.LogLevelUpdateScope.GEODE_AND_APPLICATION_LOGGERS;
+import static org.apache.geode.internal.logging.LogLevelUpdateScope.GEODE_AND_SECURITY_LOGGERS;
+import static org.apache.geode.internal.logging.LogLevelUpdateScope.GEODE_LOGGERS;
 import static org.apache.geode.internal.logging.LogWriterLevel.INFO;
 import static org.apache.geode.internal.logging.LogWriterLevel.WARNING;
 import static org.apache.geode.internal.logging.log4j.Log4jAgent.getLoggerConfig;

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/logging/FileSystemCanaryIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/logging/FileSystemCanaryIntegrationTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.geode.internal.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestName;
+
+import org.apache.geode.test.junit.categories.LoggingTest;
+
+/**
+ * Integration tests to confirm that writing to file system works properly in stressTest
+ */
+@Category(LoggingTest.class)
+public class FileSystemCanaryIntegrationTest {
+
+  private File file;
+  private Collection<String> lines;
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Rule
+  public TestName testName = new TestName();
+
+  @Before
+  public void setUp() {
+    String name = testName.getMethodName();
+    file = new File(temporaryFolder.getRoot(), name + "-main.log");
+
+    lines = new ArrayList<>();
+    for (int i = 1; i <= 10; i++) {
+      lines.add("Line-" + i);
+    }
+  }
+
+  @Test
+  public void readLinesReturnsSameLinesThatWereJustWritten() throws IOException {
+    FileUtils.writeLines(file, lines);
+
+    assertThat(FileUtils.readLines(file, Charset.defaultCharset())).isEqualTo(lines);
+  }
+
+}

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/logging/LoggingWithLocatorLauncherIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/logging/LoggingWithLocatorLauncherIntegrationTest.java
@@ -14,7 +14,7 @@
  */
 package org.apache.geode.internal.logging;
 
-import static org.apache.geode.internal.Banner.BannerHeader.displayValues;
+import static org.apache.geode.internal.logging.Banner.BannerHeader.displayValues;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.After;

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/logging/LoggingWithServerLauncherIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/logging/LoggingWithServerLauncherIntegrationTest.java
@@ -14,7 +14,7 @@
  */
 package org.apache.geode.internal.logging;
 
-import static org.apache.geode.internal.Banner.BannerHeader.displayValues;
+import static org.apache.geode.internal.logging.Banner.BannerHeader.displayValues;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.After;

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/logging/StartupConfigurationLoggingIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/logging/StartupConfigurationLoggingIntegrationTest.java
@@ -41,7 +41,6 @@ import org.junit.rules.TestName;
 import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
-import org.apache.geode.internal.Banner;
 import org.apache.geode.test.assertj.LogFileAssert;
 import org.apache.geode.test.junit.categories.LoggingTest;
 
@@ -77,7 +76,7 @@ public class StartupConfigurationLoggingIntegrationTest {
 
     system = (InternalDistributedSystem) DistributedSystem.connect(config);
 
-    banner = Banner.getString(null);
+    banner = new Banner().getString();
 
     DistributionConfig distributionConfig = system.getConfig();
     startupConfiguration = StringUtils

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/logging/log4j/ConfigurationWithLogLevelChangesIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/logging/log4j/ConfigurationWithLogLevelChangesIntegrationTest.java
@@ -14,10 +14,10 @@
  */
 package org.apache.geode.internal.logging.log4j;
 
-import static org.apache.geode.internal.logging.Configuration.DEFAULT_LOGWRITER_LEVEL;
 import static org.apache.geode.internal.logging.Configuration.create;
-import static org.apache.geode.internal.logging.InternalLogWriter.FINE_LEVEL;
-import static org.apache.geode.internal.logging.InternalLogWriter.WARNING_LEVEL;
+import static org.apache.geode.internal.logging.LogWriterLevel.CONFIG;
+import static org.apache.geode.internal.logging.LogWriterLevel.FINE;
+import static org.apache.geode.internal.logging.LogWriterLevel.WARNING;
 import static org.apache.geode.test.util.ResourceUtils.createFileFromResource;
 import static org.apache.geode.test.util.ResourceUtils.getResource;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,10 +41,10 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestName;
 
 import org.apache.geode.internal.logging.Configuration;
-import org.apache.geode.internal.logging.Configuration.LogLevelUpdateOccurs;
-import org.apache.geode.internal.logging.Configuration.LogLevelUpdateScope;
 import org.apache.geode.internal.logging.LogConfig;
 import org.apache.geode.internal.logging.LogConfigSupplier;
+import org.apache.geode.internal.logging.LogLevelUpdateOccurs;
+import org.apache.geode.internal.logging.LogLevelUpdateScope;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.test.junit.categories.LoggingTest;
 
@@ -88,8 +88,8 @@ public class ConfigurationWithLogLevelChangesIntegrationTest {
   @Before
   public void setUp() throws Exception {
     config = mock(LogConfig.class);
-    when(config.getLogLevel()).thenReturn(DEFAULT_LOGWRITER_LEVEL);
-    when(config.getSecurityLogLevel()).thenReturn(DEFAULT_LOGWRITER_LEVEL);
+    when(config.getLogLevel()).thenReturn(CONFIG.intLevel());
+    when(config.getSecurityLogLevel()).thenReturn(CONFIG.intLevel());
 
     LogConfigSupplier logConfigSupplier = mock(LogConfigSupplier.class);
     when(logConfigSupplier.getLogConfig()).thenReturn(config);
@@ -124,7 +124,7 @@ public class ConfigurationWithLogLevelChangesIntegrationTest {
   @Test
   public void geodeLoggerDebugLoggedAfterLoweringLogLevelToFine() {
     // arrange
-    when(config.getLogLevel()).thenReturn(FINE_LEVEL);
+    when(config.getLogLevel()).thenReturn(FINE.intLevel());
     configuration.configChanged();
 
     // act
@@ -141,12 +141,12 @@ public class ConfigurationWithLogLevelChangesIntegrationTest {
   @Test
   public void geodeLoggerDebugNotLoggedAfterRestoringLogLevelToDefault() {
     // arrange
-    when(config.getLogLevel()).thenReturn(FINE_LEVEL);
+    when(config.getLogLevel()).thenReturn(FINE.intLevel());
     configuration.configChanged();
 
     // re-arrange
     geodeConsoleAppender.clearLogEvents();
-    when(config.getLogLevel()).thenReturn(DEFAULT_LOGWRITER_LEVEL);
+    when(config.getLogLevel()).thenReturn(CONFIG.intLevel());
     configuration.configChanged();
 
     // act
@@ -159,7 +159,7 @@ public class ConfigurationWithLogLevelChangesIntegrationTest {
   @Test
   public void applicationLoggerBelowLevelUnaffectedByLoweringLogLevelChanges() {
     // arrange
-    when(config.getLogLevel()).thenReturn(FINE_LEVEL);
+    when(config.getLogLevel()).thenReturn(FINE.intLevel());
     configuration.configChanged();
 
     // act
@@ -186,7 +186,7 @@ public class ConfigurationWithLogLevelChangesIntegrationTest {
   public void applicationLoggerAboveLevelUnaffectedByLoweringLogLevelChanges() {
     // arrange
     geodeConsoleAppender.clearLogEvents();
-    when(config.getLogLevel()).thenReturn(FINE_LEVEL);
+    when(config.getLogLevel()).thenReturn(FINE.intLevel());
     configuration.configChanged();
 
     // act
@@ -200,7 +200,7 @@ public class ConfigurationWithLogLevelChangesIntegrationTest {
   public void applicationLoggerAboveLevelUnaffectedByRaisingLogLevelChanges() {
     // arrange
     geodeConsoleAppender.clearLogEvents();
-    when(config.getLogLevel()).thenReturn(WARNING_LEVEL);
+    when(config.getLogLevel()).thenReturn(WARNING.intLevel());
     configuration.configChanged();
 
     // act
@@ -214,7 +214,7 @@ public class ConfigurationWithLogLevelChangesIntegrationTest {
   public void infoStatementNotLoggedAfterRaisingLogLevelToWarning() {
     // arrange
     geodeConsoleAppender.clearLogEvents();
-    when(config.getLogLevel()).thenReturn(WARNING_LEVEL);
+    when(config.getLogLevel()).thenReturn(WARNING.intLevel());
     configuration.configChanged();
 
     // act

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/logging/log4j/DistributedSystemWithLogLevelChangesIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/logging/log4j/DistributedSystemWithLogLevelChangesIntegrationTest.java
@@ -15,10 +15,10 @@
 package org.apache.geode.internal.logging.log4j;
 
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
-import static org.apache.geode.internal.logging.Configuration.DEFAULT_LOGWRITER_LEVEL;
 import static org.apache.geode.internal.logging.Configuration.LOG_LEVEL_UPDATE_OCCURS_PROPERTY;
-import static org.apache.geode.internal.logging.InternalLogWriter.FINE_LEVEL;
-import static org.apache.geode.internal.logging.InternalLogWriter.WARNING_LEVEL;
+import static org.apache.geode.internal.logging.LogWriterLevel.CONFIG;
+import static org.apache.geode.internal.logging.LogWriterLevel.FINE;
+import static org.apache.geode.internal.logging.LogWriterLevel.WARNING;
 import static org.apache.geode.test.util.ResourceUtils.createFileFromResource;
 import static org.apache.geode.test.util.ResourceUtils.getResource;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -46,7 +46,7 @@ import org.junit.rules.TestName;
 import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
-import org.apache.geode.internal.logging.Configuration.LogLevelUpdateOccurs;
+import org.apache.geode.internal.logging.LogLevelUpdateOccurs;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.test.junit.categories.LoggingTest;
 
@@ -122,7 +122,7 @@ public class DistributedSystemWithLogLevelChangesIntegrationTest {
 
   @Test
   public void debugLoggedAfterLoweringLogLevelToFine() {
-    distributionConfig.setLogLevel(FINE_LEVEL);
+    distributionConfig.setLogLevel(FINE.intLevel());
 
     geodeLogger.debug(logMessage);
 
@@ -131,9 +131,9 @@ public class DistributedSystemWithLogLevelChangesIntegrationTest {
 
   @Test
   public void debugNotLoggedAfterRestoringLogLevelToDefault() {
-    distributionConfig.setLogLevel(FINE_LEVEL);
+    distributionConfig.setLogLevel(FINE.intLevel());
 
-    system.getConfig().setLogLevel(DEFAULT_LOGWRITER_LEVEL);
+    system.getConfig().setLogLevel(CONFIG.intLevel());
     geodeLogger.debug(logMessage);
 
     assertThatLogEventsDoesNotContain(logMessage, geodeLogger.getName(), Level.DEBUG);
@@ -148,7 +148,7 @@ public class DistributedSystemWithLogLevelChangesIntegrationTest {
 
   @Test
   public void applicationLoggerBelowLevelUnaffectedByLoweringLogLevelChanges() {
-    distributionConfig.setLogLevel(FINE_LEVEL);
+    distributionConfig.setLogLevel(FINE.intLevel());
 
     applicationLogger.debug(logMessage);
 
@@ -157,7 +157,7 @@ public class DistributedSystemWithLogLevelChangesIntegrationTest {
 
   @Test
   public void applicationLoggerAboveLevelUnaffectedByLoweringLogLevelChanges() {
-    distributionConfig.setLogLevel(FINE_LEVEL);
+    distributionConfig.setLogLevel(FINE.intLevel());
 
     applicationLogger.info(logMessage);
 
@@ -166,7 +166,7 @@ public class DistributedSystemWithLogLevelChangesIntegrationTest {
 
   @Test
   public void applicationLoggerAboveLevelUnaffectedByRaisingLogLevelChanges() {
-    distributionConfig.setLogLevel(WARNING_LEVEL);
+    distributionConfig.setLogLevel(WARNING.intLevel());
 
     applicationLogger.info(logMessage);
 
@@ -175,7 +175,7 @@ public class DistributedSystemWithLogLevelChangesIntegrationTest {
 
   @Test
   public void infoStatementNotLoggedAfterRaisingLogLevelToWarning() {
-    distributionConfig.setLogLevel(WARNING_LEVEL);
+    distributionConfig.setLogLevel(WARNING.intLevel());
 
     geodeLogger.info(logMessage);
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/logging/log4j/FastLoggerIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/logging/log4j/FastLoggerIntegrationTest.java
@@ -14,9 +14,9 @@
  */
 package org.apache.geode.internal.logging.log4j;
 
-import static org.apache.geode.internal.logging.Configuration.DEFAULT_LOGWRITER_LEVEL;
 import static org.apache.geode.internal.logging.Configuration.MAIN_LOGGER_NAME;
 import static org.apache.geode.internal.logging.Configuration.create;
+import static org.apache.geode.internal.logging.LogWriterLevel.CONFIG;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -41,10 +41,10 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
 
 import org.apache.geode.internal.logging.Configuration;
-import org.apache.geode.internal.logging.Configuration.LogLevelUpdateOccurs;
-import org.apache.geode.internal.logging.Configuration.LogLevelUpdateScope;
 import org.apache.geode.internal.logging.LogConfig;
 import org.apache.geode.internal.logging.LogConfigSupplier;
+import org.apache.geode.internal.logging.LogLevelUpdateOccurs;
+import org.apache.geode.internal.logging.LogLevelUpdateScope;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.test.junit.categories.LoggingTest;
 
@@ -98,8 +98,8 @@ public class FastLoggerIntegrationTest {
     assertThat(logger.getLevel()).isEqualTo(Level.WARN);
 
     LogConfig logConfig = mock(LogConfig.class);
-    when(logConfig.getLogLevel()).thenReturn(DEFAULT_LOGWRITER_LEVEL);
-    when(logConfig.getSecurityLogLevel()).thenReturn(DEFAULT_LOGWRITER_LEVEL);
+    when(logConfig.getLogLevel()).thenReturn(CONFIG.intLevel());
+    when(logConfig.getSecurityLogLevel()).thenReturn(CONFIG.intLevel());
 
     LogConfigSupplier logConfigSupplier = mock(LogConfigSupplier.class);
     when(logConfigSupplier.getLogConfig()).thenReturn(logConfig);

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/logging/log4j/FastLoggerWithDefaultConfigIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/logging/log4j/FastLoggerWithDefaultConfigIntegrationTest.java
@@ -25,10 +25,10 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import org.apache.geode.internal.logging.Configuration;
-import org.apache.geode.internal.logging.Configuration.LogLevelUpdateOccurs;
-import org.apache.geode.internal.logging.Configuration.LogLevelUpdateScope;
 import org.apache.geode.internal.logging.LogConfig;
 import org.apache.geode.internal.logging.LogConfigSupplier;
+import org.apache.geode.internal.logging.LogLevelUpdateOccurs;
+import org.apache.geode.internal.logging.LogLevelUpdateScope;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.test.junit.categories.LoggingTest;
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/logging/log4j/LogServiceWithCustomLogConfigIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/logging/log4j/LogServiceWithCustomLogConfigIntegrationTest.java
@@ -14,7 +14,7 @@
  */
 package org.apache.geode.internal.logging.log4j;
 
-import static org.apache.geode.internal.logging.log4j.Log4jAgent.getConfigurationInfo;
+import static org.apache.geode.internal.logging.log4j.Log4jAgent.getConfigurationInfoString;
 import static org.apache.geode.test.util.ResourceUtils.createFileFromResource;
 import static org.apache.geode.test.util.ResourceUtils.getResource;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -94,7 +94,7 @@ public class LogServiceWithCustomLogConfigIntegrationTest {
 
   @Test
   public void isUsingGemFireDefaultConfigIsFalse() {
-    assertThat(Log4jAgent.isUsingGemFireDefaultConfig()).as(getConfigurationInfo()).isFalse();
+    assertThat(Log4jAgent.isUsingGemFireDefaultConfig()).as(getConfigurationInfoString()).isFalse();
   }
 
   @Test

--- a/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/excludedClasses.txt
+++ b/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/excludedClasses.txt
@@ -14,7 +14,6 @@ org/apache/geode/distributed/internal/membership/gms/mgr/GMSMembershipManager$Bo
 org/apache/geode/distributed/internal/tcpserver/LocatorCancelException
 org/apache/geode/internal/AbstractConfig$SortedProperties
 org/apache/geode/internal/AvailablePort$Keeper
-org/apache/geode/internal/Banner$BannerHeader
 org/apache/geode/internal/DSCODE
 org/apache/geode/internal/ExitCode
 org/apache/geode/internal/JarDeployer
@@ -50,8 +49,9 @@ org/apache/geode/internal/hll/HyperLogLogPlus$Builder
 org/apache/geode/internal/hll/HyperLogLogPlus$Format
 org/apache/geode/internal/hll/HyperLogLogPlus$HyperLogLogPlusMergeException
 org/apache/geode/internal/hll/HyperLogLogPlus$SerializationHolder
-org/apache/geode/internal/logging/Configuration$LogLevelUpdateOccurs
-org/apache/geode/internal/logging/Configuration$LogLevelUpdateScope
+org/apache/geode/internal/logging/Banner$BannerHeader
+org/apache/geode/internal/logging/LogLevelUpdateOccurs
+org/apache/geode/internal/logging/LogLevelUpdateScope
 org/apache/geode/internal/logging/LogMessageRegex$Group
 org/apache/geode/internal/logging/LogWriterLevel
 org/apache/geode/internal/logging/SessionContext$State

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/AdminDistributedSystemImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/AdminDistributedSystemImpl.java
@@ -73,7 +73,6 @@ import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.InternalLocator;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.Assert;
-import org.apache.geode.internal.Banner;
 import org.apache.geode.internal.admin.ApplicationVM;
 import org.apache.geode.internal.admin.GemFireVM;
 import org.apache.geode.internal.admin.GfManagerAgent;
@@ -90,6 +89,7 @@ import org.apache.geode.internal.admin.remote.RevokePersistentIDRequest;
 import org.apache.geode.internal.admin.remote.ShutdownAllRequest;
 import org.apache.geode.internal.cache.backup.BackupOperation;
 import org.apache.geode.internal.cache.persistence.PersistentMemberPattern;
+import org.apache.geode.internal.logging.Banner;
 import org.apache.geode.internal.logging.InternalLogWriter;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.logging.LogWriterFactory;
@@ -231,7 +231,7 @@ public class AdminDistributedSystemImpl implements org.apache.geode.admin.AdminD
       this.logWriter = LogWriterFactory.createLogWriterLogger(this.config.createLogConfig(), false);
       if (!Boolean.getBoolean(InternalLocator.INHIBIT_DM_BANNER)) {
         // LOG: changed statement from config to info
-        this.logWriter.info(Banner.getString(null));
+        this.logWriter.info(new Banner().getString());
       } else {
         logger.debug("skipping banner - " + InternalLocator.INHIBIT_DM_BANNER + " is set to true");
       }

--- a/geode-core/src/main/java/org/apache/geode/internal/VersionDescription.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/VersionDescription.java
@@ -76,9 +76,9 @@ public class VersionDescription {
    */
   public static final String BUILD_JAVA_VERSION = "Build-Java-Version";
 
-  static final String NATIVE_VERSION = "Native version";
+  public static final String NATIVE_VERSION = "Native version";
 
-  static final String RUNNING_ON = "Running on";
+  public static final String RUNNING_ON = "Running on";
 
   /**
    * the version properties

--- a/geode-core/src/main/java/org/apache/geode/internal/logging/Configuration.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/logging/Configuration.java
@@ -15,26 +15,26 @@
 package org.apache.geode.internal.logging;
 
 import static org.apache.geode.internal.lang.SystemPropertyHelper.GEODE_PREFIX;
-import static org.apache.geode.internal.logging.Configuration.LogLevelUpdateOccurs.ONLY_WHEN_USING_DEFAULT_CONFIG;
-import static org.apache.geode.internal.logging.Configuration.LogLevelUpdateScope.GEODE_LOGGERS;
-import static org.apache.geode.internal.logging.InternalLogWriter.CONFIG_LEVEL;
-
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.status.StatusLogger;
+import static org.apache.geode.internal.logging.LogLevelUpdateOccurs.ONLY_WHEN_USING_DEFAULT_CONFIG;
+import static org.apache.geode.internal.logging.LogLevelUpdateScope.GEODE_LOGGERS;
 
 import org.apache.geode.annotations.TestingOnly;
-import org.apache.geode.internal.ClassPathLoader;
+import org.apache.geode.cache.Cache;
 
 /**
- * Provides logging configuration by managing an {@link ProviderAgent} for the logging backend
- * provider.
+ * Provides logging configuration by managing a {@link ProviderAgent} for the logging backend.
  */
 public class Configuration implements LogConfigListener {
 
-  private static final Logger LOGGER = StatusLogger.getLogger();
+  /**
+   * The default {@link LogWriterLevel} is {@link LogWriterLevel#CONFIG}.
+   */
+  @TestingOnly
+  public static final int DEFAULT_LOGWRITER_LEVEL = LogWriterLevel.CONFIG.intLevel();
 
-  public static final int DEFAULT_LOGWRITER_LEVEL = CONFIG_LEVEL;
-
+  /**
+   * Header for logging the Startup Configuration during {@code Cache} creation.
+   */
   public static final String STARTUP_CONFIGURATION = "Startup Configuration: ";
 
   /**
@@ -42,8 +42,19 @@ public class Configuration implements LogConfigListener {
    */
   public static final String CLI_CONFIG = "/log4j2-cli.xml";
 
+  /**
+   * The root name of all Geode loggers.
+   */
   public static final String GEODE_LOGGER_PREFIX = "org.apache.geode";
+
+  /**
+   * The name of the main Geode logger returned by {@link Cache#getLogger()}.
+   */
   public static final String MAIN_LOGGER_NAME = GEODE_LOGGER_PREFIX;
+
+  /**
+   * The name of the security Geode logger returned by {@link Cache#getSecurityLogger()}.
+   */
   public static final String SECURITY_LOGGER_NAME = GEODE_LOGGER_PREFIX + ".security";
 
   /**
@@ -58,28 +69,6 @@ public class Configuration implements LogConfigListener {
   static final String LOG_LEVEL_UPDATE_SCOPE_PROPERTY =
       GEODE_PREFIX + "LOG_LEVEL_UPDATE_SCOPE";
 
-  /**
-   * System property that may be used to override which {@code ProviderAgent} to use.
-   */
-  static final String PROVIDER_AGENT_NAME_PROPERTY = GEODE_PREFIX + "PROVIDER_AGENT_NAME";
-
-  /**
-   * The default {@code ProviderAgent} is {@code Log4jAgent}.
-   */
-  static final String DEFAULT_PROVIDER_AGENT_NAME =
-      "org.apache.geode.internal.logging.log4j.Log4jAgent";
-
-  /**
-   * The default {@code LogLevelUpdateOccurs} is {@code ONLY_WHEN_USING_DEFAULT_CONFIG}.
-   */
-  private static final LogLevelUpdateOccurs DEFAULT_LOG_LEVEL_UPDATE_OCCURS =
-      ONLY_WHEN_USING_DEFAULT_CONFIG;
-
-  /**
-   * The default {@code LogLevelUpdateScope} is {@code GEODE_LOGGERS}.
-   */
-  private static final LogLevelUpdateScope DEFAULT_LOG_LEVEL_UPDATE_SCOPE = GEODE_LOGGERS;
-
   private final LogLevelUpdateOccurs logLevelUpdateOccurs;
   private final LogLevelUpdateScope logLevelUpdateScope;
 
@@ -91,7 +80,8 @@ public class Configuration implements LogConfigListener {
   private LogConfigSupplier logConfigSupplier;
 
   public static Configuration create() {
-    return create(getLogLevelUpdateOccurs(), getLogLevelUpdateScope(), createProviderAgent());
+    return create(getLogLevelUpdateOccurs(), getLogLevelUpdateScope(), new ProviderAgentLoader()
+        .findProviderAgent());
   }
 
   @TestingOnly
@@ -102,7 +92,8 @@ public class Configuration implements LogConfigListener {
   @TestingOnly
   public static Configuration create(final LogLevelUpdateOccurs logLevelUpdateOccurs,
       final LogLevelUpdateScope logLevelUpdateScope) {
-    return create(logLevelUpdateOccurs, logLevelUpdateScope, createProviderAgent());
+    return create(logLevelUpdateOccurs, logLevelUpdateScope,
+        new ProviderAgentLoader().findProviderAgent());
   }
 
   @TestingOnly
@@ -121,33 +112,19 @@ public class Configuration implements LogConfigListener {
   static LogLevelUpdateOccurs getLogLevelUpdateOccurs() {
     try {
       return LogLevelUpdateOccurs.valueOf(System.getProperty(LOG_LEVEL_UPDATE_OCCURS_PROPERTY,
-          DEFAULT_LOG_LEVEL_UPDATE_OCCURS.name()).toUpperCase());
+          ONLY_WHEN_USING_DEFAULT_CONFIG.name()).toUpperCase());
     } catch (IllegalArgumentException e) {
-      return DEFAULT_LOG_LEVEL_UPDATE_OCCURS;
+      return ONLY_WHEN_USING_DEFAULT_CONFIG;
     }
   }
 
   static LogLevelUpdateScope getLogLevelUpdateScope() {
     try {
       return LogLevelUpdateScope.valueOf(System.getProperty(LOG_LEVEL_UPDATE_SCOPE_PROPERTY,
-          DEFAULT_LOG_LEVEL_UPDATE_SCOPE.name()).toUpperCase());
+          GEODE_LOGGERS.name()).toUpperCase());
     } catch (IllegalArgumentException e) {
-      return DEFAULT_LOG_LEVEL_UPDATE_SCOPE;
+      return GEODE_LOGGERS;
     }
-  }
-
-  static ProviderAgent createProviderAgent() {
-    String agentClassName =
-        System.getProperty(PROVIDER_AGENT_NAME_PROPERTY, DEFAULT_PROVIDER_AGENT_NAME);
-    try {
-      Class<? extends ProviderAgent> agentClass =
-          ClassPathLoader.getLatest().forName(agentClassName).asSubclass(ProviderAgent.class);
-      return agentClass.newInstance();
-    } catch (ClassNotFoundException | ClassCastException | InstantiationException
-        | IllegalAccessException e) {
-      LOGGER.warn("Unable to create ProviderAgent of type {}", agentClassName, e);
-    }
-    return new NullProviderAgent();
   }
 
   /**
@@ -175,17 +152,6 @@ public class Configuration implements LogConfigListener {
     providerAgent.configure(logConfig, logLevelUpdateOccurs, logLevelUpdateScope);
   }
 
-  void enableLoggingToStandardOutput() {
-    providerAgent.enableLoggingToStandardOutput();
-  }
-
-  void disableLoggingToStandardOutputIfLoggingToFile() {
-    LogConfig logConfig = logConfigSupplier.getLogConfig();
-    if (logConfig.getLogFile().exists()) {
-      providerAgent.disableLoggingToStandardOutput();
-    }
-  }
-
   /**
    * Removes this configuration as a {@code LogConfigListener} if it's currently registered and
    * cleans up the {@code ProviderAgent}.
@@ -199,39 +165,26 @@ public class Configuration implements LogConfigListener {
     providerAgent.cleanup();
   }
 
+  String getConfigurationInfo() {
+    return providerAgent.getConfigurationInfo();
+  }
+
+  void enableLoggingToStandardOutput() {
+    LogConfig logConfig = logConfigSupplier.getLogConfig();
+    if (logConfig.getLogFile().exists()) {
+      providerAgent.enableLoggingToStandardOutput();
+    }
+  }
+
+  void disableLoggingToStandardOutputIfLoggingToFile() {
+    LogConfig logConfig = logConfigSupplier.getLogConfig();
+    if (logConfig.getLogFile().exists()) {
+      providerAgent.disableLoggingToStandardOutput();
+    }
+  }
+
   @TestingOnly
   synchronized LogConfigSupplier getLogConfigSupplier() {
     return logConfigSupplier;
-  }
-
-  /**
-   * Controls whether or not log level updates should be triggered.
-   */
-  public enum LogLevelUpdateOccurs {
-    NEVER,
-    ONLY_WHEN_USING_DEFAULT_CONFIG,
-    ALWAYS;
-
-    public boolean never() {
-      return this == NEVER;
-    }
-
-    public boolean always() {
-      return this == ALWAYS;
-    }
-
-    public boolean onlyWhenUsingDefaultConfig() {
-      return this == ONLY_WHEN_USING_DEFAULT_CONFIG;
-    }
-  }
-
-  /**
-   * Controls the scope of which packages of loggers are updated when the log level changes.
-   */
-  public enum LogLevelUpdateScope {
-    GEODE_LOGGERS,
-    GEODE_AND_SECURITY_LOGGERS,
-    GEODE_AND_APPLICATION_LOGGERS,
-    ALL_LOGGERS
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/logging/ConfigurationInfo.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/logging/ConfigurationInfo.java
@@ -14,43 +14,13 @@
  */
 package org.apache.geode.internal.logging;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.status.StatusLogger;
-
-import org.apache.geode.internal.ClassPathLoader;
-
 /**
- * Fetches the configuration info from {@code Log4jAgent} without direct class dependency.
- *
- * <p>
- * This could potentially be modified to support any logging backend but currently the only caller
- * is the log Banner which is static.
+ * Fetches the configuration info from {@link ProviderAgent} for invocation from static context.
+ * Note: this may instantiate a new instance of {@link ProviderAgent}.
  */
 public class ConfigurationInfo {
 
-  private static final Logger LOGGER = StatusLogger.getLogger();
-
-  /**
-   * Fetches the configuration info from Log4jAgent without direct class dependency.
-   *
-   * <p>
-   * If the Log4J2 Core classes are not in the classpath, the return value is simply
-   * "No configuration info found."
-   */
   public static String getConfigurationInfo() {
-    try {
-      Class<? extends ProviderAgent> agentClass =
-          ClassPathLoader.getLatest().forName(Configuration.DEFAULT_PROVIDER_AGENT_NAME)
-              .asSubclass(ProviderAgent.class);
-      Method method = agentClass.getMethod("getConfigurationInfo", null);
-      return (String) method.invoke(null, null);
-    } catch (ClassNotFoundException | ClassCastException | NoSuchMethodException
-        | IllegalAccessException | InvocationTargetException e) {
-      LOGGER.debug("Unable to invoke Log4jAgent.getConfigurationInfo()", e);
-      return "No configuration info found";
-    }
+    return new ProviderAgentLoader().findProviderAgent().getConfigurationInfo();
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/logging/LogLevelUpdateOccurs.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/logging/LogLevelUpdateOccurs.java
@@ -14,22 +14,24 @@
  */
 package org.apache.geode.internal.logging;
 
-import static org.apache.geode.internal.logging.ConfigurationInfo.getConfigurationInfo;
-import static org.assertj.core.api.Assertions.assertThat;
-
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-
-import org.apache.geode.test.junit.categories.LoggingTest;
-
 /**
- * Integration tests for {@link ConfigurationInfo}.
+ * Controls whether or not log level updates should be triggered. Default is
+ * {@link #ONLY_WHEN_USING_DEFAULT_CONFIG}.
  */
-@Category(LoggingTest.class)
-public class ConfigurationInfoIntegrationTest {
+public enum LogLevelUpdateOccurs {
+  NEVER,
+  ONLY_WHEN_USING_DEFAULT_CONFIG,
+  ALWAYS;
 
-  @Test
-  public void getConfigurationInfoContainsLog4j2Xml() {
-    assertThat(getConfigurationInfo()).contains("log4j2.xml");
+  public boolean never() {
+    return this == NEVER;
+  }
+
+  public boolean always() {
+    return this == ALWAYS;
+  }
+
+  public boolean onlyWhenUsingDefaultConfig() {
+    return this == ONLY_WHEN_USING_DEFAULT_CONFIG;
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/logging/LogLevelUpdateScope.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/logging/LogLevelUpdateScope.java
@@ -14,22 +14,13 @@
  */
 package org.apache.geode.internal.logging;
 
-import static org.apache.geode.internal.logging.ConfigurationInfo.getConfigurationInfo;
-import static org.assertj.core.api.Assertions.assertThat;
-
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-
-import org.apache.geode.test.junit.categories.LoggingTest;
-
 /**
- * Integration tests for {@link ConfigurationInfo}.
+ * Controls the scope of which packages of loggers are updated when the log level changes. Default
+ * is {@link #GEODE_LOGGERS}
  */
-@Category(LoggingTest.class)
-public class ConfigurationInfoIntegrationTest {
-
-  @Test
-  public void getConfigurationInfoContainsLog4j2Xml() {
-    assertThat(getConfigurationInfo()).contains("log4j2.xml");
-  }
+public enum LogLevelUpdateScope {
+  GEODE_LOGGERS,
+  GEODE_AND_SECURITY_LOGGERS,
+  GEODE_AND_APPLICATION_LOGGERS,
+  ALL_LOGGERS
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/logging/LogWriterLevel.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/logging/LogWriterLevel.java
@@ -33,7 +33,7 @@ import org.apache.geode.LogWriter;
  * </ul>
  *
  * <p>
- * Default level in Geode is {@link #INFO}.
+ * Default level in Geode is {@link #CONFIG}.
  */
 public enum LogWriterLevel {
 
@@ -41,7 +41,7 @@ public enum LogWriterLevel {
   FINEST(InternalLogWriter.FINEST_LEVEL),
   FINER(InternalLogWriter.FINER_LEVEL),
   FINE(InternalLogWriter.FINE_LEVEL),
-  CONFIG(InternalLogWriter.CONFIG_LEVEL),
+  CONFIG(InternalLogWriter.CONFIG_LEVEL), // default
   INFO(InternalLogWriter.INFO_LEVEL),
   WARNING(InternalLogWriter.WARNING_LEVEL),
   ERROR(InternalLogWriter.ERROR_LEVEL),

--- a/geode-core/src/main/java/org/apache/geode/internal/logging/LoggingSession.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/logging/LoggingSession.java
@@ -24,7 +24,6 @@ import java.util.Optional;
 import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.annotations.TestingOnly;
-import org.apache.geode.internal.Banner;
 
 /**
  * Configures the logging {@code Configuration} and provides lifecycle to Geode logging.
@@ -80,7 +79,7 @@ public class LoggingSession implements SessionContext {
     configuration.disableLoggingToStandardOutputIfLoggingToFile();
 
     if (logBanner) {
-      logger.info(Banner.getString(null));
+      logger.info(new Banner(configuration.getConfigurationInfo()).getString());
     }
     if (logConfiguration) {
       String configInfo = configuration.getLogConfigSupplier().getLogConfig().toLoggerString();

--- a/geode-core/src/main/java/org/apache/geode/internal/logging/NullProviderAgent.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/logging/NullProviderAgent.java
@@ -14,9 +14,6 @@
  */
 package org.apache.geode.internal.logging;
 
-import org.apache.geode.internal.logging.Configuration.LogLevelUpdateOccurs;
-import org.apache.geode.internal.logging.Configuration.LogLevelUpdateScope;
-
 /**
  * {@link ProviderAgent} that does nothing.
  */
@@ -30,16 +27,6 @@ public class NullProviderAgent implements ProviderAgent {
 
   @Override
   public void cleanup() {
-    // nothing
-  }
-
-  @Override
-  public void enableLoggingToStandardOutput() {
-    // nothing
-  }
-
-  @Override
-  public void disableLoggingToStandardOutput() {
     // nothing
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/logging/ProviderAgent.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/logging/ProviderAgent.java
@@ -14,26 +14,56 @@
  */
 package org.apache.geode.internal.logging;
 
-import org.apache.geode.internal.logging.Configuration.LogLevelUpdateOccurs;
-import org.apache.geode.internal.logging.Configuration.LogLevelUpdateScope;
+import org.apache.geode.distributed.ConfigurationProperties;
 
 /**
- * Provides custom configuration of the logging backend for Geode logging.
+ * Provides custom configuration of the logging backend for Geode Logging.
  */
 public interface ProviderAgent {
 
   /**
-   * Updates the logging backend with custom configuration.
+   * Updates the logging backend with any custom configuration. Invoked by Geode during
+   * {@code Cache} creation and anytime Geode configuration of logging changes, such as when
+   * {@link ConfigurationProperties#LOG_LEVEL} is adjusted.
    */
   void configure(final LogConfig logConfig, final LogLevelUpdateOccurs logLevelUpdateOccurs,
       final LogLevelUpdateScope logLevelUpdateScope);
 
   /**
-   * Removes any custom configuration from the logging backend.
+   * Removes any custom configuration from the logging backend. Invoked by Geode after closing
+   * the {@code Cache}.
    */
   void cleanup();
 
-  void enableLoggingToStandardOutput();
+  /**
+   * Returns configuration info to be logged as part of the Geode Logging {@link Banner}. Default
+   * implementation returns the class name. Geode out-of-box returns the path to the log4j2.xml
+   * configuration file.
+   */
+  default String getConfigurationInfo() {
+    return getClass().getName();
+  }
 
-  void disableLoggingToStandardOutput();
+  /**
+   * Optional: Invoked by Geode during {@code Cache} creation if
+   * {@link ConfigurationProperties#LOG_FILE} is specified.
+   *
+   * <p>
+   * Geode out-of-box disables logging to stdout when {@code Cache} creation starts logging to a
+   * file.
+   */
+  default void disableLoggingToStandardOutput() {
+    // override to disable logging to stdout
+  }
+
+  /**
+   * Optional: Invoked by Geode when closing a {@code Cache} that was logging to a file.
+   *
+   * <p>
+   * Geode out-of-box re-enables logging to stdout after closing a {@code Cache} that was logging
+   * to a file.
+   */
+  default void enableLoggingToStandardOutput() {
+    // override to enable logging to stdout
+  }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/logging/ProviderAgentLoader.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/logging/ProviderAgentLoader.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.logging;
+
+import static org.apache.geode.internal.lang.SystemPropertyHelper.GEODE_PREFIX;
+import static org.apache.geode.internal.logging.ProviderAgentLoader.DefaultProvider.DEFAULT_PROVIDER_AGENT_NAME;
+
+import java.util.ServiceLoader;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.status.StatusLogger;
+
+import org.apache.geode.annotations.TestingOnly;
+import org.apache.geode.internal.ClassPathLoader;
+
+/**
+ * Loads a {@link ProviderAgent} using this order of preference:
+ *
+ * <pre>
+ * 1. {@code META-INF/services/org.apache.geode.internal.logging.ProviderAgent} if found
+ * 2. System Property {@code geode.PROVIDER_AGENT_NAME} if specified
+ * 3. {@code org.apache.geode.internal.logging.log4j.Log4jAgent} if
+ * {@code org.apache.logging.log4j.core.Logger} can be class loaded
+ * 4. The no-op implementation {@code NullProviderAgent} as last resort
+ * </pre>
+ *
+ * <p>
+ * TODO: extract logging.log4j package to geode-logging module and use ServiceLoader only
+ */
+public class ProviderAgentLoader {
+
+  private static final Logger LOGGER = StatusLogger.getLogger();
+
+  /**
+   * System property that may be used to override which {@code ProviderAgent} to use.
+   */
+  static final String PROVIDER_AGENT_NAME_PROPERTY = GEODE_PREFIX + "PROVIDER_AGENT_NAME";
+
+  private final AvailabilityChecker availabilityChecker;
+
+  public ProviderAgentLoader() {
+    this(new DefaultProvider());
+  }
+
+  @TestingOnly
+  ProviderAgentLoader(final AvailabilityChecker availabilityChecker) {
+    this.availabilityChecker = availabilityChecker;
+  }
+
+  /**
+   * Returns true if the default provider {@code Log4j Core} is available.
+   */
+  public boolean isDefaultAvailable() {
+    return availabilityChecker.isAvailable();
+  }
+
+  public ProviderAgent findProviderAgent() {
+    ServiceLoader<ProviderAgent> serviceLoaderFromExt =
+        ServiceLoader.loadInstalled(ProviderAgent.class);
+    if (serviceLoaderFromExt.iterator().hasNext()) {
+      ProviderAgent providerAgent = serviceLoaderFromExt.iterator().next();
+      LOGGER.info("Using {} from Extension ClassLoader for service {}",
+          providerAgent.getClass().getName(), ProviderAgent.class.getName());
+      return providerAgent;
+    }
+
+    ServiceLoader<ProviderAgent> serviceLoaderFromTccl = ServiceLoader.load(ProviderAgent.class);
+    if (serviceLoaderFromTccl.iterator().hasNext()) {
+      ProviderAgent providerAgent = serviceLoaderFromTccl.iterator().next();
+      LOGGER.info("Using {} from Thread Context ClassLoader for service {}",
+          providerAgent.getClass().getName(), ProviderAgent.class.getName());
+      return providerAgent;
+    }
+
+    ServiceLoader<ProviderAgent> serviceLoaderFromSys =
+        ServiceLoader.load(ProviderAgent.class, null);
+    if (serviceLoaderFromSys.iterator().hasNext()) {
+      ProviderAgent providerAgent = serviceLoaderFromSys.iterator().next();
+      LOGGER.info("Using {} from System ClassLoader for service {}",
+          providerAgent.getClass().getName(), ProviderAgent.class.getName());
+      return providerAgent;
+    }
+
+    return createProviderAgent();
+  }
+
+  ProviderAgent createProviderAgent() {
+    if (System.getProperty(PROVIDER_AGENT_NAME_PROPERTY) == null && !isDefaultAvailable()) {
+      return new NullProviderAgent();
+    }
+
+    String agentClassName =
+        System.getProperty(PROVIDER_AGENT_NAME_PROPERTY, DEFAULT_PROVIDER_AGENT_NAME);
+    try {
+      Class<? extends ProviderAgent> agentClass =
+          ClassPathLoader.getLatest().forName(agentClassName).asSubclass(ProviderAgent.class);
+
+      ProviderAgent providerAgent = agentClass.newInstance();
+      if (DEFAULT_PROVIDER_AGENT_NAME.equals(providerAgent.getClass().getName())) {
+        LOGGER.info("Using {} by default for service {}", providerAgent.getClass().getName(),
+            ProviderAgent.class.getName());
+      } else {
+        LOGGER.info("Using {} from System Property {} for service {}",
+            providerAgent.getClass().getName(), PROVIDER_AGENT_NAME_PROPERTY,
+            ProviderAgent.class.getName());
+      }
+
+      return providerAgent;
+
+    } catch (ClassNotFoundException | ClassCastException | InstantiationException
+        | IllegalAccessException e) {
+      LOGGER.warn("Unable to create ProviderAgent of type {}", agentClassName, e);
+    }
+    LOGGER.info("Using {} for service {}", NullProviderAgent.class.getName(),
+        PROVIDER_AGENT_NAME_PROPERTY, ProviderAgent.class.getName());
+    return new NullProviderAgent();
+  }
+
+  interface AvailabilityChecker {
+    boolean isAvailable();
+  }
+
+  static class DefaultProvider implements AvailabilityChecker {
+
+    /**
+     * The default {@code ProviderAgent} is {@code Log4jAgent}.
+     */
+    static final String DEFAULT_PROVIDER_AGENT_NAME =
+        "org.apache.geode.internal.logging.log4j.Log4jAgent";
+
+    static final String DEFAULT_PROVIDER_CLASS_NAME = "org.apache.logging.log4j.core.Logger";
+
+    @Override
+    public boolean isAvailable() {
+      try {
+        ClassPathLoader.getLatest().forName(DEFAULT_PROVIDER_CLASS_NAME);
+        LOGGER.info("Log4j Core is available");
+        return true;
+      } catch (ClassNotFoundException | ClassCastException e) {
+        LOGGER.info("Unable to find Log4j Core");
+      }
+      return false;
+    }
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/logging/log4j/Log4jAgent.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/logging/log4j/Log4jAgent.java
@@ -34,9 +34,9 @@ import org.apache.logging.log4j.core.filter.AbstractFilterable;
 import org.apache.logging.log4j.core.lookup.StrLookup;
 import org.apache.logging.log4j.core.lookup.StrSubstitutor;
 
-import org.apache.geode.internal.logging.Configuration.LogLevelUpdateOccurs;
-import org.apache.geode.internal.logging.Configuration.LogLevelUpdateScope;
 import org.apache.geode.internal.logging.LogConfig;
+import org.apache.geode.internal.logging.LogLevelUpdateOccurs;
+import org.apache.geode.internal.logging.LogLevelUpdateScope;
 import org.apache.geode.internal.logging.LogWriterLevel;
 import org.apache.geode.internal.logging.ProviderAgent;
 
@@ -70,7 +70,10 @@ public class Log4jAgent implements ProviderAgent {
     return ((Logger) logger).get();
   }
 
-  public static String getConfigurationInfo() {
+  /**
+   * TODO:KIRK: delete getConfigurationInfoString
+   */
+  public static String getConfigurationInfoString() {
     return getConfiguration().getConfigurationSource().toString();
   }
 
@@ -142,6 +145,11 @@ public class Log4jAgent implements ProviderAgent {
   }
 
   @Override
+  public String getConfigurationInfo() {
+    return getConfiguration().getConfigurationSource().toString();
+  }
+
+  @Override
   public void enableLoggingToStandardOutput() {
     Configuration log4jConfiguration = getRootLoggerContext().getConfiguration();
     Appender appender = log4jConfiguration.getAppender(GEODE_CONSOLE_APPENDER_NAME);
@@ -159,6 +167,12 @@ public class Log4jAgent implements ProviderAgent {
       GeodeConsoleAppender geodeConsoleAppender = (GeodeConsoleAppender) appender;
       geodeConsoleAppender.pause();
     }
+  }
+
+  @Override
+  public String toString() {
+    return new StringBuilder().append(super.toString()).append(": {configuredSecurityAppenders=")
+        .append(configuredSecurityAppenders).append("}").toString();
   }
 
   private void updateLogLevel(final LogConfig logConfig,

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/shell/Gfsh.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/shell/Gfsh.java
@@ -43,9 +43,9 @@ import org.springframework.shell.core.JLineShell;
 import org.springframework.shell.core.Parser;
 import org.springframework.shell.event.ShellStatus.Status;
 
-import org.apache.geode.internal.Banner;
 import org.apache.geode.internal.GemFireVersion;
 import org.apache.geode.internal.lang.ClassUtils;
+import org.apache.geode.internal.logging.Banner;
 import org.apache.geode.internal.logging.LoggingThread;
 import org.apache.geode.internal.process.signal.AbstractSignalNotificationHandler;
 import org.apache.geode.internal.util.ArgumentRedactor;
@@ -188,8 +188,8 @@ public class Gfsh extends JLineShell {
     this.gfshFileLogger.configure(this.gfshConfig);
     this.ansiHandler = ANSIHandler.getInstance(this.gfshConfig.isANSISupported());
 
-    /* 3. log system properties & gfsh environment */
-    this.gfshFileLogger.info(Banner.getString(args));
+    // 3. log system properties & gfsh environment TODO: change GFSH to use Geode logging
+    this.gfshFileLogger.info(new Banner().getString());
 
     // 4. Customized History implementation
     this.gfshHistory = new GfshHistory();

--- a/geode-core/src/test/java/org/apache/geode/internal/BannerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/BannerTest.java
@@ -20,6 +20,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import org.apache.geode.internal.logging.Banner;
 import org.apache.geode.test.junit.categories.LoggingTest;
 
 /**
@@ -32,7 +33,7 @@ public class BannerTest {
 
   @Before
   public void setUp() {
-    banner = Banner.getString(null);
+    banner = new Banner().getString();
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/internal/logging/ConfigurationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/logging/ConfigurationTest.java
@@ -16,7 +16,6 @@ package org.apache.geode.internal.logging;
 
 import static org.apache.geode.internal.logging.Configuration.LOG_LEVEL_UPDATE_OCCURS_PROPERTY;
 import static org.apache.geode.internal.logging.Configuration.LOG_LEVEL_UPDATE_SCOPE_PROPERTY;
-import static org.apache.geode.internal.logging.Configuration.PROVIDER_AGENT_NAME_PROPERTY;
 import static org.apache.geode.internal.logging.LogWriterLevel.INFO;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -34,9 +33,6 @@ import org.junit.Test;
 import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.junit.experimental.categories.Category;
 
-import org.apache.geode.internal.logging.Configuration.LogLevelUpdateOccurs;
-import org.apache.geode.internal.logging.Configuration.LogLevelUpdateScope;
-import org.apache.geode.internal.logging.log4j.Log4jAgent;
 import org.apache.geode.test.junit.categories.LoggingTest;
 
 /**
@@ -301,46 +297,6 @@ public class ConfigurationTest {
     assertThat(Configuration.getLogLevelUpdateScope()).isEqualTo(LogLevelUpdateScope.GEODE_LOGGERS);
   }
 
-  @Test
-  public void createProviderAgent_defaultsTo_Log4jAgent() {
-    assertThat(Configuration.createProviderAgent()).isInstanceOf(Log4jAgent.class);
-  }
-
-  @Test
-  public void createProviderAgent_usesSystemPropertySetTo_Log4jAgent() {
-    System.setProperty(PROVIDER_AGENT_NAME_PROPERTY, Log4jAgent.class.getName());
-
-    assertThat(Configuration.createProviderAgent()).isInstanceOf(Log4jAgent.class);
-  }
-
-  @Test
-  public void createProviderAgent_usesSystemPropertySetTo_NullProviderAgent() {
-    System.setProperty(PROVIDER_AGENT_NAME_PROPERTY, NullProviderAgent.class.getName());
-
-    assertThat(Configuration.createProviderAgent()).isInstanceOf(NullProviderAgent.class);
-  }
-
-  @Test
-  public void createProviderAgent_usesSystemPropertySetTo_SimpleProviderAgent() {
-    System.setProperty(PROVIDER_AGENT_NAME_PROPERTY, SimpleProviderAgent.class.getName());
-
-    assertThat(Configuration.createProviderAgent()).isInstanceOf(SimpleProviderAgent.class);
-  }
-
-  @Test
-  public void createProviderAgent_usesNullProviderAgent_whenClassNotFoundException() {
-    System.setProperty(PROVIDER_AGENT_NAME_PROPERTY, SimpleProviderAgent.class.getSimpleName());
-
-    assertThat(Configuration.createProviderAgent()).isInstanceOf(NullProviderAgent.class);
-  }
-
-  @Test
-  public void createProviderAgent_usesNullProviderAgent_whenClassCastException() {
-    System.setProperty(PROVIDER_AGENT_NAME_PROPERTY, NotProviderAgent.class.getName());
-
-    assertThat(Configuration.createProviderAgent()).isInstanceOf(NullProviderAgent.class);
-  }
-
   private LogConfigSupplier mockLogConfigSupplier() {
     LogConfigSupplier logConfigSupplier = mock(LogConfigSupplier.class);
 
@@ -349,34 +305,5 @@ public class ConfigurationTest {
     when(logConfig.getSecurityLogLevel()).thenReturn(INFO.intLevel());
 
     return logConfigSupplier;
-  }
-
-  public static class SimpleProviderAgent implements ProviderAgent {
-
-    @Override
-    public void configure(LogConfig logConfig,
-        LogLevelUpdateOccurs logLevelUpdateOccurs,
-        LogLevelUpdateScope logLevelUpdateScope) {
-      // nothing
-    }
-
-    @Override
-    public void cleanup() {
-      // nothing
-    }
-
-    @Override
-    public void enableLoggingToStandardOutput() {
-      // nothing
-    }
-
-    @Override
-    public void disableLoggingToStandardOutput() {
-      // nothing
-    }
-  }
-
-  public static class NotProviderAgent {
-
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/logging/LoggingSessionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/logging/LoggingSessionTest.java
@@ -180,7 +180,7 @@ public class LoggingSessionTest {
   @Test
   public void stopSessionThrowsIfSessionNotCreated() {
     assertThatThrownBy(() -> loggingSession.stopSession())
-        .isInstanceOf(IllegalStateException.class);
+        .isInstanceOf(NullPointerException.class);
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/internal/logging/NullProviderAgentTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/logging/NullProviderAgentTest.java
@@ -14,22 +14,27 @@
  */
 package org.apache.geode.internal.logging;
 
-import static org.apache.geode.internal.logging.ConfigurationInfo.getConfigurationInfo;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.Before;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
-
-import org.apache.geode.test.junit.categories.LoggingTest;
 
 /**
- * Integration tests for {@link ConfigurationInfo}.
+ * Unit tests for {@link NullProviderAgent}.
  */
-@Category(LoggingTest.class)
-public class ConfigurationInfoIntegrationTest {
+public class NullProviderAgentTest {
+
+  private NullProviderAgent nullProviderAgent;
+
+  @Before
+  public void setUp() {
+    nullProviderAgent = new NullProviderAgent();
+  }
 
   @Test
-  public void getConfigurationInfoContainsLog4j2Xml() {
-    assertThat(getConfigurationInfo()).contains("log4j2.xml");
+  public void getConfigurationInfoReturnsClassName() {
+    String configurationInfo = nullProviderAgent.getConfigurationInfo();
+
+    assertThat(configurationInfo).isEqualTo(NullProviderAgent.class.getName());
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/logging/ProviderAgentLoaderTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/logging/ProviderAgentLoaderTest.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.logging;
+
+import static org.apache.geode.internal.logging.ProviderAgentLoader.PROVIDER_AGENT_NAME_PROPERTY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.internal.logging.ProviderAgentLoader.AvailabilityChecker;
+import org.apache.geode.internal.logging.log4j.Log4jAgent;
+import org.apache.geode.test.junit.categories.LoggingTest;
+
+/**
+ * Unit tests for {@link ProviderAgentLoader}.
+ */
+@Category(LoggingTest.class)
+public class ProviderAgentLoaderTest {
+
+  private ProviderAgentLoader providerAgentLoader;
+
+  @Rule
+  public RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
+
+  @Before
+  public void setUp() {
+    providerAgentLoader = new ProviderAgentLoader();
+  }
+
+  @Test
+  public void createProviderAgent_defaultsTo_Log4jAgent() {
+    assertThat(providerAgentLoader.createProviderAgent()).isInstanceOf(Log4jAgent.class);
+  }
+
+  @Test
+  public void createProviderAgent_usesSystemPropertySetTo_Log4jAgent() {
+    System.setProperty(PROVIDER_AGENT_NAME_PROPERTY, Log4jAgent.class.getName());
+
+    assertThat(providerAgentLoader.createProviderAgent()).isInstanceOf(Log4jAgent.class);
+  }
+
+  @Test
+  public void createProviderAgent_usesSystemPropertySetTo_NullProviderAgent() {
+    System.setProperty(PROVIDER_AGENT_NAME_PROPERTY, NullProviderAgent.class.getName());
+
+    assertThat(providerAgentLoader.createProviderAgent()).isInstanceOf(NullProviderAgent.class);
+  }
+
+  @Test
+  public void createProviderAgent_usesSystemPropertySetTo_SimpleProviderAgent() {
+    System.setProperty(PROVIDER_AGENT_NAME_PROPERTY, SimpleProviderAgent.class.getName());
+
+    assertThat(providerAgentLoader.createProviderAgent()).isInstanceOf(
+        SimpleProviderAgent.class);
+  }
+
+  @Test
+  public void createProviderAgent_usesNullProviderAgent_whenClassNotFoundException() {
+    System.setProperty(PROVIDER_AGENT_NAME_PROPERTY, SimpleProviderAgent.class.getSimpleName());
+
+    assertThat(providerAgentLoader.createProviderAgent()).isInstanceOf(NullProviderAgent.class);
+  }
+
+  @Test
+  public void createProviderAgent_usesNullProviderAgent_whenClassCastException() {
+    System.setProperty(PROVIDER_AGENT_NAME_PROPERTY, NotProviderAgent.class.getName());
+
+    assertThat(providerAgentLoader.createProviderAgent()).isInstanceOf(NullProviderAgent.class);
+  }
+
+  @Test
+  public void findProviderAgent_defaultsTo_createProviderAgent() {
+    assertThat(providerAgentLoader.findProviderAgent()).isInstanceOf(Log4jAgent.class);
+  }
+
+  @Test
+  public void isLog4jCoreAvailable_isTrue() {
+    assertThat(providerAgentLoader.isDefaultAvailable()).isTrue();
+  }
+
+  @Test
+  public void isLog4jCoreAvailable_usesProvidedAvailabilityChecker() {
+    providerAgentLoader = new ProviderAgentLoader(mock(AvailabilityChecker.class));
+
+    assertThat(providerAgentLoader.isDefaultAvailable()).isFalse();
+  }
+
+  @Test
+  public void createProviderAgent_usesNullProviderAgent_whenIsDefaultAvailableIsFalse() {
+    providerAgentLoader = new ProviderAgentLoader(mock(AvailabilityChecker.class));
+
+    assertThat(providerAgentLoader.createProviderAgent()).isInstanceOf(NullProviderAgent.class);
+  }
+
+  static class SimpleProviderAgent implements ProviderAgent {
+
+    @Override
+    public void configure(LogConfig logConfig,
+        LogLevelUpdateOccurs logLevelUpdateOccurs,
+        LogLevelUpdateScope logLevelUpdateScope) {
+      // nothing
+    }
+
+    @Override
+    public void cleanup() {
+      // nothing
+    }
+  }
+
+  @SuppressWarnings("all")
+  static class NotProviderAgent {
+
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/util/ArgumentRedactorJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/util/ArgumentRedactorJUnitTest.java
@@ -31,7 +31,7 @@ import java.util.List;
 
 import org.junit.Test;
 
-import org.apache.geode.internal.Banner;
+import org.apache.geode.internal.logging.Banner;
 
 public class ArgumentRedactorJUnitTest {
   private static final String someProperty = "redactorTest.someProperty";
@@ -210,7 +210,7 @@ public class ArgumentRedactorJUnitTest {
 
       List<String> args = ArrayUtils.asList("--user=me", "--password=isRedacted",
           "--another-password-for-some-reason =isRedacted", "--yet-another-password = isRedacted");
-      String banner = Banner.getString(args.toArray(new String[0]));
+      String banner = new Banner().getString(args.toArray(new String[0]));
       assertThat(banner).doesNotContain("isRedacted");
     } finally {
       System.clearProperty(someProperty);

--- a/geode-junit/src/main/java/org/apache/geode/internal/logging/TestLogWriterFactory.java
+++ b/geode-junit/src/main/java/org/apache/geode/internal/logging/TestLogWriterFactory.java
@@ -26,7 +26,6 @@ import org.apache.geode.GemFireIOException;
 import org.apache.geode.LogWriter;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.InternalLocator;
-import org.apache.geode.internal.Banner;
 import org.apache.geode.internal.OSProcess;
 import org.apache.geode.internal.process.ProcessLauncherContext;
 import org.apache.geode.internal.util.LogFileUtils;
@@ -100,7 +99,7 @@ public class TestLogWriterFactory extends Assert {
     if (mlw.infoEnabled()) {
       if (!isLoner || /* do this on a loner to fix bug 35602 */
           !Boolean.getBoolean(InternalLocator.INHIBIT_DM_BANNER)) {
-        mlw.info(Banner.getString(null));
+        mlw.info(new Banner().getString(null));
       }
     }
     logger = mlw;


### PR DESCRIPTION
* Add Logging ProviderAgent support for ServiceLoader
* Test for availability of Log4j Core before defaulting to Log4jAgent
* Change optional ProviderAgent methods to have default impls
* Extract LogLevelUpdateOccurs enum to top level class
* Extract LogLevelUpdateScope enum to top level class
* Move Banner to internal.logging package
* Break Banner's hard dependency on Log4J Core
* Improve javadocs
* Add field type to TestingOnly annotation
* Replace use of InternalLogWriter constants with LogWriterLevel enum
