### PR TITLE
GEODE-6122: Use LogWriterLevel instead of InternalLogWriter

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/ConnectionPoolDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/ConnectionPoolDUnitTest.java
@@ -15,6 +15,7 @@
 package org.apache.geode.cache;
 
 import static org.apache.geode.internal.cache.tier.sockets.CacheClientNotifier.getInstance;
+import static org.apache.geode.internal.logging.LogWriterLevel.ALL;
 import static org.apache.geode.test.dunit.Assert.assertEquals;
 import static org.apache.geode.test.dunit.Assert.assertFalse;
 import static org.apache.geode.test.dunit.Assert.assertNotNull;
@@ -65,7 +66,6 @@ import org.apache.geode.internal.cache.PoolStats;
 import org.apache.geode.internal.cache.tier.sockets.CacheClientNotifier;
 import org.apache.geode.internal.cache.tier.sockets.CacheClientNotifierStats;
 import org.apache.geode.internal.cache.tier.sockets.ClientProxyMembershipID;
-import org.apache.geode.internal.logging.InternalLogWriter;
 import org.apache.geode.internal.logging.LocalLogWriter;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
 import org.apache.geode.test.dunit.AsyncInvocation;
@@ -1154,7 +1154,7 @@ public class ConnectionPoolDUnitTest extends JUnit4CacheTestCase {
 
     vm2.invoke(new SerializableRunnable() {
       public void run() {
-        LogWriter bgexecLogger = new LocalLogWriter(InternalLogWriter.ALL_LEVEL, System.out);
+        LogWriter bgexecLogger = new LocalLogWriter(ALL.intLevel(), System.out);
         bgexecLogger.info(addExpected);
       }
     });
@@ -1187,7 +1187,7 @@ public class ConnectionPoolDUnitTest extends JUnit4CacheTestCase {
     } finally {
       vm2.invoke(new SerializableRunnable() {
         public void run() {
-          LogWriter bgexecLogger = new LocalLogWriter(InternalLogWriter.ALL_LEVEL, System.out);
+          LogWriter bgexecLogger = new LocalLogWriter(ALL.intLevel(), System.out);
           bgexecLogger.info(removeExpected);
         }
       });

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/client/internal/LocatorLoadBalancingDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/client/internal/LocatorLoadBalancingDUnitTest.java
@@ -48,8 +48,6 @@ import org.apache.geode.distributed.internal.ServerLocator;
 import org.apache.geode.distributed.internal.tcpserver.TcpClient;
 import org.apache.geode.internal.cache.CacheServerImpl;
 import org.apache.geode.internal.cache.PoolFactoryImpl;
-import org.apache.geode.internal.logging.InternalLogWriter;
-import org.apache.geode.internal.logging.LocalLogWriter;
 import org.apache.geode.internal.net.SocketCreatorFactory;
 import org.apache.geode.test.dunit.Host;
 import org.apache.geode.test.dunit.LogWriterUtils;
@@ -426,7 +424,6 @@ public class LocatorLoadBalancingDUnitTest extends LocatorTestBase {
     Assert.assertEquals(1, locators.size());
     InternalLocator locator = (InternalLocator) locators.get(0);
     final ServerLocator sl = locator.getServerLocatorAdvisee();
-    InternalLogWriter log = new LocalLogWriter(InternalLogWriter.FINEST_LEVEL, System.out);
     sl.getDistributionAdvisor().dumpProfiles("PROFILES= ");
     await().timeout(300, TimeUnit.SECONDS)
         .until(() -> expected.equals(sl.getLoadMap()));

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache30/PartitionedRegionDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache30/PartitionedRegionDUnitTest.java
@@ -15,6 +15,7 @@
 package org.apache.geode.cache30;
 
 import static org.apache.geode.distributed.ConfigurationProperties.SERIALIZABLE_OBJECT_FILTER;
+import static org.apache.geode.internal.logging.LogWriterLevel.INFO;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -47,7 +48,6 @@ import org.apache.geode.cache.Scope;
 import org.apache.geode.cache.SubscriptionAttributes;
 import org.apache.geode.cache.util.CacheListenerAdapter;
 import org.apache.geode.internal.cache.PartitionedRegionException;
-import org.apache.geode.internal.logging.InternalLogWriter;
 import org.apache.geode.internal.logging.PureLogWriter;
 import org.apache.geode.test.dunit.Assert;
 import org.apache.geode.test.dunit.Host;
@@ -62,7 +62,6 @@ import org.apache.geode.test.dunit.VM;
  *
  * @since GemFire 5.1
  */
-
 public class PartitionedRegionDUnitTest extends MultiVMRegionTestCase {
 
   public static boolean InvalidateInvoked = false;
@@ -159,7 +158,7 @@ public class PartitionedRegionDUnitTest extends MultiVMRegionTestCase {
   void setVMInfoLogLevel() {
     SerializableRunnable runnable = new SerializableRunnable() {
       public void run() {
-        oldLogLevel = setLogLevel(getCache().getLogger(), InternalLogWriter.INFO_LEVEL);
+        oldLogLevel = setLogLevel(getCache().getLogger(), INFO.intLevel());
       }
     };
     for (int i = 0; i < 4; i++) {

--- a/geode-core/src/distributedTest/java/org/apache/geode/distributed/LocatorDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/distributed/LocatorDUnitTest.java
@@ -14,7 +14,6 @@
  */
 package org.apache.geode.distributed;
 
-
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.geode.distributed.ConfigurationProperties.DISABLE_AUTO_RECONNECT;
 import static org.apache.geode.distributed.ConfigurationProperties.ENABLE_CLUSTER_CONFIGURATION;
@@ -38,6 +37,7 @@ import static org.apache.geode.distributed.ConfigurationProperties.SSL_TRUSTSTOR
 import static org.apache.geode.distributed.ConfigurationProperties.SSL_TRUSTSTORE_PASSWORD;
 import static org.apache.geode.distributed.ConfigurationProperties.START_LOCATOR;
 import static org.apache.geode.distributed.ConfigurationProperties.USE_CLUSTER_CONFIGURATION;
+import static org.apache.geode.internal.logging.LogWriterLevel.ALL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
@@ -84,7 +84,6 @@ import org.apache.geode.distributed.internal.tcpserver.LocatorCancelException;
 import org.apache.geode.internal.AvailablePort;
 import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.internal.cache.GemFireCacheImpl;
-import org.apache.geode.internal.logging.InternalLogWriter;
 import org.apache.geode.internal.logging.LocalLogWriter;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.security.SecurableCommunicationChannel;
@@ -700,7 +699,7 @@ public class LocatorDUnitTest extends JUnit4DistributedTestCase {
       if (locator != null) {
         locator.stop();
       }
-      LogWriter bLogger = new LocalLogWriter(InternalLogWriter.ALL_LEVEL, System.out);
+      LogWriter bLogger = new LocalLogWriter(ALL.intLevel(), System.out);
       bLogger.info("<ExpectedException action=remove>service failure</ExpectedException>");
       bLogger
           .info("<ExpectedException action=remove>java.net.ConnectException</ExpectedException>");
@@ -1098,7 +1097,7 @@ public class LocatorDUnitTest extends JUnit4DistributedTestCase {
     final String removeExpected =
         "<ExpectedException action=remove>" + expected + "</ExpectedException>";
 
-    LogWriter bgexecLogger = new LocalLogWriter(InternalLogWriter.ALL_LEVEL, System.out);
+    LogWriter bgexecLogger = new LocalLogWriter(ALL.intLevel(), System.out);
     bgexecLogger.info(addExpected);
 
     boolean exceptionOccurred = true;
@@ -1262,7 +1261,7 @@ public class LocatorDUnitTest extends JUnit4DistributedTestCase {
           .until(() -> !tempCoord.equals(MembershipManagerHelper.getCoordinator(system)));
 
       system.disconnect();
-      LogWriter bgexecLogger = new LocalLogWriter(InternalLogWriter.ALL_LEVEL, System.out);
+      LogWriter bgexecLogger = new LocalLogWriter(ALL.intLevel(), System.out);
       bgexecLogger.info(removeExpected);
 
       checkConnectionAndPrintInfo(vm1);
@@ -1873,7 +1872,7 @@ public class LocatorDUnitTest extends JUnit4DistributedTestCase {
       }
       // connectExceptions occur during disconnect, so we need the
       // ExpectedException hint to be in effect until this point
-      LogWriter bLogger = new LocalLogWriter(InternalLogWriter.ALL_LEVEL, System.out);
+      LogWriter bLogger = new LocalLogWriter(ALL.intLevel(), System.out);
       bLogger
           .info("<ExpectedException action=remove>java.net.ConnectException</ExpectedException>");
     });

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/ColocationFailoverDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/ColocationFailoverDUnitTest.java
@@ -40,7 +40,6 @@ import org.apache.geode.cache.Region;
 import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.internal.cache.partitioned.RegionAdvisor;
-import org.apache.geode.internal.logging.InternalLogWriter;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
 import org.apache.geode.test.dunit.Assert;
 import org.apache.geode.test.dunit.Host;
@@ -51,7 +50,6 @@ import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.Wait;
 import org.apache.geode.test.dunit.WaitCriterion;
 import org.apache.geode.test.dunit.internal.JUnit4DistributedTestCase;
-
 
 public class ColocationFailoverDUnitTest extends JUnit4DistributedTestCase {
 
@@ -213,7 +211,6 @@ public class ColocationFailoverDUnitTest extends JUnit4DistributedTestCase {
 
 
   protected static void dump() {
-    final InternalLogWriter logger = LogWriterUtils.getLogWriter();
     ((PartitionedRegion) customerPR).dumpAllBuckets(false);
     ((PartitionedRegion) orderPR).dumpAllBuckets(false);
     ((PartitionedRegion) shipmentPR).dumpAllBuckets(false);

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/client/internal/QueueManagerJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/client/internal/QueueManagerJUnitTest.java
@@ -16,6 +16,7 @@ package org.apache.geode.cache.client.internal;
 
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
+import static org.apache.geode.internal.logging.LogWriterLevel.FINEST;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -53,7 +54,6 @@ import org.apache.geode.distributed.internal.membership.InternalDistributedMembe
 import org.apache.geode.internal.cache.PoolStats;
 import org.apache.geode.internal.cache.tier.sockets.ClientProxyMembershipID;
 import org.apache.geode.internal.cache.tier.sockets.ServerQueueStatus;
-import org.apache.geode.internal.logging.InternalLogWriter;
 import org.apache.geode.internal.logging.LocalLogWriter;
 import org.apache.geode.internal.util.StopWatch;
 import org.apache.geode.test.junit.categories.ClientServerTest;
@@ -78,7 +78,7 @@ public class QueueManagerJUnitTest {
 
   @Before
   public void setUp() {
-    this.logger = new LocalLogWriter(InternalLogWriter.FINEST_LEVEL, System.out);
+    this.logger = new LocalLogWriter(FINEST.intLevel(), System.out);
     Properties properties = new Properties();
     properties.put(MCAST_PORT, "0");
     properties.put(LOCATORS, "");

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/client/internal/pooling/ConnectionManagerJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/client/internal/pooling/ConnectionManagerJUnitTest.java
@@ -16,6 +16,7 @@ package org.apache.geode.cache.client.internal.pooling;
 
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
+import static org.apache.geode.internal.logging.LogWriterLevel.FINEST;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
@@ -83,7 +84,7 @@ public class ConnectionManagerJUnitTest {
 
   @Before
   public void setUp() {
-    this.logger = new LocalLogWriter(InternalLogWriter.FINEST_LEVEL, System.out);
+    this.logger = new LocalLogWriter(FINEST.intLevel(), System.out);
     factory = new DummyFactory();
 
     Properties properties = new Properties();

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/logging/MergeLogFilesIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/logging/MergeLogFilesIntegrationTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.logging;
 
+import static org.apache.geode.internal.logging.LogWriterLevel.ALL;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -186,7 +187,7 @@ public class MergeLogFilesIntegrationTest {
     public void run() {
       ByteArrayOutputStream baos = new ByteArrayOutputStream();
       LogWriter logger =
-          new LocalLogWriter(InternalLogWriter.ALL_LEVEL, new PrintStream(baos, true));
+          new LocalLogWriter(ALL.intLevel(), new PrintStream(baos, true));
       for (int i = 0; i < 100; i++) {
         int n;
         synchronized (MergeLogFilesIntegrationTest.this) {

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/logging/log4j/LogWriterAppenderWithLimitsIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/logging/log4j/LogWriterAppenderWithLimitsIntegrationTest.java
@@ -14,7 +14,7 @@
  */
 package org.apache.geode.internal.logging.log4j;
 
-import static org.apache.geode.internal.logging.Configuration.DEFAULT_LOGWRITER_LEVEL;
+import static org.apache.geode.internal.logging.LogWriterLevel.CONFIG;
 import static org.apache.geode.test.util.ResourceUtils.createFileFromResource;
 import static org.apache.geode.test.util.ResourceUtils.getResource;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -88,7 +88,7 @@ public class LogWriterAppenderWithLimitsIntegrationTest {
     config = mock(LogConfig.class);
     when(config.getName()).thenReturn(name);
     when(config.getLogFile()).thenReturn(logFile);
-    when(config.getLogLevel()).thenReturn(DEFAULT_LOGWRITER_LEVEL);
+    when(config.getLogLevel()).thenReturn(CONFIG.intLevel());
     when(config.getLogDiskSpaceLimit()).thenReturn(MAX_LOG_DISK_SPACE_LIMIT);
     when(config.getLogFileSizeLimit()).thenReturn(MAX_LOG_FILE_SIZE_LIMIT);
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfig.java
@@ -198,9 +198,9 @@ import org.apache.geode.distributed.ConfigurationProperties;
 import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.internal.Config;
 import org.apache.geode.internal.ConfigSource;
-import org.apache.geode.internal.logging.InternalLogWriter;
 import org.apache.geode.internal.logging.LogConfig;
 import org.apache.geode.internal.logging.LogWriterImpl;
+import org.apache.geode.internal.logging.LogWriterLevel;
 import org.apache.geode.internal.security.SecurableCommunicationChannel;
 import org.apache.geode.internal.statistics.StatisticsConfig;
 import org.apache.geode.internal.tcp.Connection;
@@ -637,21 +637,21 @@ public interface DistributionConfig extends Config, LogConfig, StatisticsConfig 
   /**
    * The default {@link ConfigurationProperties#LOG_LEVEL}.
    * <p>
-   * Actual value of this constant is {@link InternalLogWriter#CONFIG_LEVEL}.
+   * Actual value of this constant is {@link LogWriterLevel#CONFIG#intLevel()}.
    */
-  int DEFAULT_LOG_LEVEL = InternalLogWriter.CONFIG_LEVEL;
+  int DEFAULT_LOG_LEVEL = LogWriterLevel.CONFIG.intLevel();
   /**
    * The minimum {@link ConfigurationProperties#LOG_LEVEL}.
    * <p>
-   * Actual value of this constant is {@link InternalLogWriter#ALL_LEVEL}.
+   * Actual value of this constant is {@link LogWriterLevel#ALL#intLevel()}.
    */
-  int MIN_LOG_LEVEL = InternalLogWriter.ALL_LEVEL;
+  int MIN_LOG_LEVEL = LogWriterLevel.ALL.intLevel();
   /**
    * The maximum {@link ConfigurationProperties#LOG_LEVEL}.
    * <p>
-   * Actual value of this constant is {@link InternalLogWriter#NONE_LEVEL}.
+   * Actual value of this constant is {@link LogWriterLevel#NONE#intLevel()}.
    */
-  int MAX_LOG_LEVEL = InternalLogWriter.NONE_LEVEL;
+  int MAX_LOG_LEVEL = LogWriterLevel.NONE.intLevel();
 
   /**
    * The name of the {@link ConfigurationProperties#LOG_LEVEL} property

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/ProductUseLog.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/ProductUseLog.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.distributed.internal;
 
+import static org.apache.geode.internal.logging.LogWriterLevel.INFO;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
@@ -54,7 +56,7 @@ public class ProductUseLog implements MembershipListener {
   public ProductUseLog(File productUseLogFile) {
     // GEODE-4180, use absolute paths
     this.productUseLogFile = productUseLogFile.getAbsoluteFile();
-    this.logLevel = InternalLogWriter.INFO_LEVEL;
+    this.logLevel = INFO.intLevel();
     createLogWriter();
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheCreation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheCreation.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache.xmlcache;
 
+import static org.apache.geode.internal.logging.LogWriterLevel.ALL;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -277,7 +279,7 @@ public class CacheCreation implements InternalCache {
    * A logger that is used in debugging
    */
   private final InternalLogWriter logWriter =
-      new LocalLogWriter(InternalLogWriter.ALL_LEVEL, System.out);
+      new LocalLogWriter(ALL.intLevel(), System.out);
 
   private final InternalLogWriter securityLogWriter =
       LogWriterFactory.toSecurityLogWriter(this.logWriter);

--- a/geode-core/src/main/java/org/apache/geode/internal/jta/TransactionUtils.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/jta/TransactionUtils.java
@@ -14,8 +14,9 @@
  */
 package org.apache.geode.internal.jta;
 
+import static org.apache.geode.internal.logging.LogWriterLevel.SEVERE;
+
 import org.apache.geode.LogWriter;
-import org.apache.geode.internal.logging.InternalLogWriter;
 import org.apache.geode.internal.logging.PureLogWriter;
 
 /**
@@ -38,7 +39,7 @@ public class TransactionUtils {
     } else if (purelogWriter != null) {
       return purelogWriter;
     } else {
-      purelogWriter = new PureLogWriter(InternalLogWriter.SEVERE_LEVEL);
+      purelogWriter = new PureLogWriter(SEVERE.intLevel());
       return purelogWriter;
     }
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/logging/LogFileParser.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/logging/LogFileParser.java
@@ -15,6 +15,7 @@
 package org.apache.geode.internal.logging;
 
 import static org.apache.commons.lang3.SystemUtils.LINE_SEPARATOR;
+import static org.apache.geode.internal.logging.LogWriterLevel.ALL;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
@@ -335,7 +336,7 @@ public class LogFileParser {
       StringWriter sw = new StringWriter();
       PrintWriter pw = new PrintWriter(sw, true);
 
-      LocalLogWriter tempLogger = new LocalLogWriter(InternalLogWriter.ALL_LEVEL, pw);
+      LocalLogWriter tempLogger = new LocalLogWriter(ALL.intLevel(), pw);
       tempLogger.info("MISSING TIME STAMP");
       pw.flush();
       sb.insert(0, LINE_SEPARATOR + LINE_SEPARATOR);

--- a/geode-core/src/main/java/org/apache/geode/internal/logging/LoggingThreadGroup.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/logging/LoggingThreadGroup.java
@@ -14,7 +14,7 @@
  */
 package org.apache.geode.internal.logging;
 
-import static org.apache.geode.internal.logging.InternalLogWriter.ALL_LEVEL;
+import static org.apache.geode.internal.logging.LogWriterLevel.ALL;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -39,7 +39,7 @@ import org.apache.geode.internal.Assert;
 public class LoggingThreadGroup extends ThreadGroup {
 
   /** A "local" log writer that logs exceptions to standard error */
-  private static final StandardErrorPrinter stderr = new StandardErrorPrinter(ALL_LEVEL);
+  private static final StandardErrorPrinter stderr = new StandardErrorPrinter(ALL.intLevel());
 
   /** A set of all created LoggingThreadGroups */
   private static final Collection<LoggingThreadGroup> loggingThreadGroups = new ArrayList<>();

--- a/geode-core/src/main/java/org/apache/geode/internal/logging/log4j/LogWriterLogger.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/logging/log4j/LogWriterLogger.java
@@ -14,6 +14,15 @@
  */
 package org.apache.geode.internal.logging.log4j;
 
+import static org.apache.geode.internal.logging.LogWriterLevel.ALL;
+import static org.apache.geode.internal.logging.LogWriterLevel.ERROR;
+import static org.apache.geode.internal.logging.LogWriterLevel.FINE;
+import static org.apache.geode.internal.logging.LogWriterLevel.FINER;
+import static org.apache.geode.internal.logging.LogWriterLevel.INFO;
+import static org.apache.geode.internal.logging.LogWriterLevel.NONE;
+import static org.apache.geode.internal.logging.LogWriterLevel.SEVERE;
+import static org.apache.geode.internal.logging.LogWriterLevel.WARNING;
+
 import java.util.logging.Handler;
 
 import org.apache.logging.log4j.Level;
@@ -1689,21 +1698,21 @@ public class LogWriterLogger extends FastLogger implements InternalLogWriter, Ge
     final Level log4jLevel = logWrapper.getLevel();
 
     if (log4jLevel == Level.OFF) {
-      return InternalLogWriter.NONE_LEVEL;
+      return NONE.intLevel();
     } else if (log4jLevel == Level.FATAL) {
-      return InternalLogWriter.SEVERE_LEVEL;
+      return SEVERE.intLevel();
     } else if (log4jLevel == Level.ERROR) {
-      return InternalLogWriter.ERROR_LEVEL;
+      return ERROR.intLevel();
     } else if (log4jLevel == Level.WARN) {
-      return InternalLogWriter.WARNING_LEVEL;
+      return WARNING.intLevel();
     } else if (log4jLevel == Level.INFO) {
-      return InternalLogWriter.INFO_LEVEL;
+      return INFO.intLevel();
     } else if (log4jLevel == Level.DEBUG) {
-      return InternalLogWriter.FINE_LEVEL;
+      return FINE.intLevel();
     } else if (log4jLevel == Level.TRACE) {
-      return InternalLogWriter.FINER_LEVEL;
+      return FINER.intLevel();
     } else if (log4jLevel == Level.ALL) {
-      return InternalLogWriter.ALL_LEVEL;
+      return ALL.intLevel();
     }
 
     throw new IllegalStateException(

--- a/geode-core/src/test/java/org/apache/geode/cache/client/internal/OpExecutorImplJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/client/internal/OpExecutorImplJUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.client.internal;
 
+import static org.apache.geode.internal.logging.LogWriterLevel.FINE;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -76,7 +77,7 @@ public class OpExecutorImplJUnitTest {
 
   @Before
   public void setUp() {
-    this.logger = new LocalLogWriter(InternalLogWriter.FINEST_LEVEL, System.out);
+    this.logger = new LocalLogWriter(FINE.intLevel(), System.out);
     this.endpointManager = new DummyEndpointManager();
     this.queueManager = new DummyQueueManager();
     this.manager = new DummyManager();

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/ServerLocatorJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/ServerLocatorJUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.distributed.internal;
 
+import static org.apache.geode.internal.logging.LogWriterLevel.NONE;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -24,7 +25,6 @@ import org.junit.experimental.categories.Category;
 import org.apache.geode.LogWriter;
 import org.apache.geode.cache.client.internal.locator.LocatorStatusRequest;
 import org.apache.geode.cache.client.internal.locator.LocatorStatusResponse;
-import org.apache.geode.internal.logging.InternalLogWriter;
 import org.apache.geode.internal.logging.LocalLogWriter;
 import org.apache.geode.test.junit.categories.MembershipTest;
 
@@ -68,7 +68,7 @@ public class ServerLocatorJUnitTest {
 
     @Override
     LogWriter getLogWriter() {
-      return new LocalLogWriter(InternalLogWriter.NONE_LEVEL);
+      return new LocalLogWriter(NONE.intLevel());
     }
   }
 

--- a/geode-core/src/test/java/org/apache/geode/internal/logging/ManagerLogWriterTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/logging/ManagerLogWriterTest.java
@@ -14,7 +14,7 @@
  */
 package org.apache.geode.internal.logging;
 
-import static org.apache.geode.internal.logging.InternalLogWriter.CONFIG_LEVEL;
+import static org.apache.geode.internal.logging.LogWriterLevel.CONFIG;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.PrintStream;
@@ -33,9 +33,9 @@ public class ManagerLogWriterTest {
 
   @Test
   public void logWriterLevelIsPassedIntoConstructor() {
-    ManagerLogWriter logWriter =
-        new ManagerLogWriter(CONFIG_LEVEL, new PrintStream(NullOutputStream.getInstance()), true);
+    ManagerLogWriter logWriter = new ManagerLogWriter(CONFIG.intLevel(),
+        new PrintStream(NullOutputStream.getInstance()), true);
 
-    assertThat(logWriter.getLogWriterLevel()).isEqualTo(CONFIG_LEVEL);
+    assertThat(logWriter.getLogWriterLevel()).isEqualTo(CONFIG.intLevel());
   }
 }


### PR DESCRIPTION
Use LogWriterLevel enum instead of InternalLogWriter constants.
