### PR TITLE
Fix ZipSlip bug found by LGTM.com

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/configuration/utils/ZipUtils.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/configuration/utils/ZipUtils.java
@@ -73,13 +73,16 @@ public class ZipUtils {
     try {
       while (zipEntries.hasMoreElements()) {
         ZipEntry zipEntry = zipEntries.nextElement();
-        String fileName = outputDirectoryPath + File.separator + zipEntry.getName();
+        File entryDestination = new File(outputDirectoryPath + File.separator + zipEntry.getName());
+
+        if (!entryDestination.toPath().normalize().startsWith(Paths.get(outputDirectoryPath))) {
+          throw new IOException("Zip entry contained path traversal");
+        }
 
         if (zipEntry.isDirectory()) {
-          FileUtils.forceMkdir(new File(fileName));
+          FileUtils.forceMkdir(entryDestination);
           continue;
         }
-        File entryDestination = new File(fileName);
         File parent = entryDestination.getParentFile();
         if (parent != null) {
           FileUtils.forceMkdir(parent);


### PR DESCRIPTION
The unsanitized path of a zip archive entry, which may
contain '..', was used directly to resolve the destination
path for the files being unzipped.

Extracting files from a malicious archive without validating
that the destination file path is within the destination
directory can cause files outside the destination directory
to be overwritten.

I've checked where this method is used, and it seems to mostly be isolated to unit tests and some CLI commands / management stuff, so felt it is likely safe to publicly open a PR to fix this, especially given that the problem is already listed [as an alert on LGTM](https://lgtm.com/projects/g/apache/geode/alerts/?mode=tree&ruleFocus=1506728586782).

cc @bschuchardt (who has fixed a number of LGTM alerts before)

*(Full disclosure: I'm part of the team behind LGTM.com)*

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message? - No

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes? - No. Existing unit tests will check that unzip() still works. I could add a unit test to ensure that an `IOException` is thrown when a zip file contains path traversal.

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
