### PR TITLE
GEODE-5674: Stop using random values for test ports

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/AvailablePortHelperIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/AvailablePortHelperIntegrationTest.java
@@ -19,6 +19,7 @@ import static org.apache.geode.internal.AvailablePort.AVAILABLE_PORTS_LOWER_BOUN
 import static org.apache.geode.internal.AvailablePort.AVAILABLE_PORTS_UPPER_BOUND;
 import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPortRange;
 import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPortRangeKeepers;
+import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableUDPPort;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
@@ -222,6 +223,13 @@ public class AvailablePortHelperIntegrationTest {
       }
       previousPort = port;
     }
+  }
+
+  @Test
+  public void getRandomAvailableUDPPort_succeeds() throws IOException {
+    int udpPort = getRandomAvailableUDPPort();
+    assertThat(udpPort).isNotZero();
+    assertPortIsUsable(udpPort);
   }
 
   private void assertPortsAreUsable(int[] ports) throws IOException {

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/AvailablePortHelperIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/AvailablePortHelperIntegrationTest.java
@@ -17,6 +17,7 @@ package org.apache.geode.internal;
 import static org.apache.geode.distributed.internal.DistributionConfig.DEFAULT_MEMBERSHIP_PORT_RANGE;
 import static org.apache.geode.internal.AvailablePort.AVAILABLE_PORTS_LOWER_BOUND;
 import static org.apache.geode.internal.AvailablePort.AVAILABLE_PORTS_UPPER_BOUND;
+import static org.apache.geode.internal.AvailablePort.MULTICAST;
 import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPortRange;
 import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPortRangeKeepers;
 import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPorts;
@@ -231,7 +232,7 @@ public class AvailablePortHelperIntegrationTest {
   public void getRandomAvailableUDPPort_succeeds() throws IOException {
     int udpPort = getRandomAvailableUDPPort();
     assertThat(udpPort).isNotZero();
-    assertPortIsUsable(udpPort);
+    assertThat(AvailablePort.isPortAvailable(udpPort, MULTICAST)).isTrue();
   }
 
   @Test

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/AvailablePortHelperIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/AvailablePortHelperIntegrationTest.java
@@ -19,7 +19,9 @@ import static org.apache.geode.internal.AvailablePort.AVAILABLE_PORTS_LOWER_BOUN
 import static org.apache.geode.internal.AvailablePort.AVAILABLE_PORTS_UPPER_BOUND;
 import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPortRange;
 import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPortRangeKeepers;
+import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPorts;
 import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableUDPPort;
+import static org.apache.geode.internal.AvailablePortHelper.initializeUniquePortRange;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
@@ -230,6 +232,61 @@ public class AvailablePortHelperIntegrationTest {
     int udpPort = getRandomAvailableUDPPort();
     assertThat(udpPort).isNotZero();
     assertPortIsUsable(udpPort);
+  }
+
+  @Test
+  @Parameters({"true", "false"})
+  public void getRandomAvailableTCPPortRange_returnsUniqueRanges(
+      final boolean useMembershipPortRange) {
+    Set<Integer> ports = new HashSet<>();
+
+    for (int i = 0; i < 1000; ++i) {
+      int[] testPorts = getRandomAvailableTCPPortRange(5, useMembershipPortRange);
+      for (int testPort : testPorts) {
+        assertThat(ports).doesNotContain(testPort);
+        ports.add(testPort);
+      }
+    }
+  }
+
+  @Test
+  @Parameters({"true", "false"})
+  public void getRandomAvailableTCPPort_returnsUniqueValues(final boolean useMembershipPortRange) {
+    Set<Integer> ports = new HashSet<>();
+
+    for (int i = 0; i < 1000; ++i) {
+      int testPort = getRandomAvailableTCPPorts(1, useMembershipPortRange)[0];
+      assertThat(ports).doesNotContain(testPort);
+      ports.add(testPort);
+    }
+  }
+
+  @Test
+  @Parameters({"true", "false"})
+  public void initializeUniquePortRange_willReturnSamePortsForSameRange(
+      final boolean useMembershipPortRange) {
+    for (int i = 0; i < 1000; ++i) {
+      initializeUniquePortRange(i);
+      int[] testPorts = getRandomAvailableTCPPorts(3, useMembershipPortRange);
+      initializeUniquePortRange(i);
+      assertThat(getRandomAvailableTCPPorts(3, useMembershipPortRange)).isEqualTo(testPorts);
+    }
+  }
+
+  @Test
+  @Parameters({"true", "false"})
+  public void initializeUniquePortRange_willReturnUniquePortsForUniqueRanges(
+      final boolean useMembershipPortRange) {
+    Set<Integer> ports = new HashSet<>();
+
+    for (int i = 0; i < 1000; ++i) {
+      initializeUniquePortRange(i);
+      int[] testPorts = getRandomAvailableTCPPorts(5, useMembershipPortRange);
+      for (int testPort : testPorts) {
+        assertThat(ports).doesNotContain(testPort);
+        ports.add(testPort);
+      }
+    }
   }
 
   private void assertPortsAreUsable(int[] ports) throws IOException {

--- a/geode-core/src/main/java/org/apache/geode/internal/AvailablePort.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/AvailablePort.java
@@ -110,6 +110,7 @@ public class AvailablePort {
         InetAddress localHost = SocketCreator.getLocalHost();
         socket.setInterface(localHost);
         socket.setSoTimeout(Integer.getInteger("AvailablePort.timeout", 2000).intValue());
+        socket.setReuseAddress(true);
         byte[] buffer = new byte[4];
         buffer[0] = (byte) 'p';
         buffer[1] = (byte) 'i';

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/ChildVM.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/ChildVM.java
@@ -18,6 +18,7 @@ import java.rmi.Naming;
 
 import org.apache.logging.log4j.Logger;
 
+import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.internal.ExitCode;
 import org.apache.geode.internal.OSProcess;
 import org.apache.geode.internal.Version;
@@ -57,6 +58,7 @@ public class ChildVM {
       Naming.rebind(name, dunitVM);
       JUnit4DistributedTestCase.initializeBlackboard();
       holder.signalVMReady();
+      AvailablePortHelper.initializeUniquePortRange(vmNum + 2); // hacky, locator is -2
       // This loop is here so this VM will die even if the master is mean killed.
       while (!stopMainLoop) {
         holder.ping();

--- a/geode-junit/src/main/java/org/apache/geode/internal/AvailablePortHelper.java
+++ b/geode-junit/src/main/java/org/apache/geode/internal/AvailablePortHelper.java
@@ -143,6 +143,9 @@ public class AvailablePortHelper {
     int i = 0;
     while (i < count) {
       int port = getUniquePort(false, AvailablePort.SOCKET);
+      // This logic is from AvailablePort.getRandomAvailablePortWithMod which this method used to
+      // call. It seems like the check should be (port % FOO == site) for some FOO, but given how
+      // widely this is used, it's not at all clear that no one's depending on the current behavior.
       while (port % site != 0) {
         port = getUniquePort(false, AvailablePort.SOCKET);
       }


### PR DESCRIPTION
Rebased to current develop and no longer try to get keeper objects for UDP ports.  Also added better testing of the new behavior.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
