### PR TITLE
GEODE-6002: Adding configuration persistence for member specific options

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfigImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfigImpl.java
@@ -71,6 +71,7 @@ import java.lang.reflect.Method;
 import java.net.InetAddress;
 import java.net.URL;
 import java.net.UnknownHostException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -78,6 +79,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -2622,7 +2624,20 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
 
   @Override
   public String getGroups() {
-    return groups;
+    String internalMemberGroup = null;
+    if (StringUtils.isNotBlank(getName())) {
+      internalMemberGroup = "MEMBER_" + getName();
+    }
+
+    if (StringUtils.isBlank(internalMemberGroup)) {
+      return groups;
+    }
+
+    if (StringUtils.isBlank(groups)) {
+      return internalMemberGroup;
+    }
+
+    return groups + "," + internalMemberGroup;
   }
 
   @Override
@@ -2630,7 +2645,9 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
     if (value == null) {
       value = DEFAULT_GROUPS;
     }
-    groups = value;
+
+    groups = Arrays.stream(value.split(",")).filter(i -> !i.startsWith("MEMBER_"))
+        .collect(Collectors.joining(","));
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/remote/CommandExecutor.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/remote/CommandExecutor.java
@@ -45,8 +45,6 @@ import org.apache.geode.security.NotAuthorizedException;
  * For AuthorizationExceptions, it logs it and then rethrow it.
  */
 public class CommandExecutor {
-  public static final String RUN_ON_MEMBER_CHANGE_NOT_PERSISTED =
-      "Configuration change is not persisted because the command is executed on specific member.";
   public static final String SERVICE_NOT_RUNNING_CHANGE_NOT_PERSISTED =
       "Cluster configuration service is not running. Configuration change is not persisted.";
 
@@ -139,13 +137,17 @@ public class CommandExecutor {
       return resultModel;
     }
 
-    if (parseResult.getParamValue("member") != null) {
-      infoResultModel.addLine(RUN_ON_MEMBER_CHANGE_NOT_PERSISTED);
-      return resultModel;
+    // member and group are mutually exclusive options, checked in
+    // CliUtil.findMembers(Set<DistributedMember>, String[], String[])
+    String groupInput = null;
+    String members = parseResult.getParamValueAsString("member");
+    if (members != null) {
+      groupInput = Arrays.stream(members.split(",")).map(member -> "MEMBER_" + member).collect(
+          Collectors.joining(","));
     }
 
     List<String> groupsToUpdate;
-    String groupInput = parseResult.getParamValueAsString("group");
+    groupInput = parseResult.getParamValueAsString("group");
     TabularResultModel table = null;
 
     if (!StringUtils.isBlank(groupInput)) {

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateGatewayReceiverCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateGatewayReceiverCommandTest.java
@@ -133,16 +133,14 @@ public class CreateGatewayReceiverCommandTest {
   }
 
   @Test
-  public void gatewayReceiverIsCreatedButNotPersistedWithMemberOption() {
+  public void gatewayReceiverIsCreatedAndConfigIsPersistedWithMemberOption() {
     doReturn(mock(Set.class)).when(command).getMembers(any(), any());
     doReturn(ccService).when(command).getConfigurationPersistenceService();
     result1 = new CliFunctionResult("member", CliFunctionResult.StatusState.OK, "result1");
     functionResults.add(result1);
     gfsh.executeAndAssertThat(command, "create gateway-receiver --member=xyz").statusIsSuccess()
-        .containsOutput(
-            "Configuration change is not persisted because the command is executed on specific member");
-    verify(ccService, never()).addXmlEntity(any(), any());
-    verify(ccService, never()).updateCacheConfig(any(), any());
+        .tableHasRowWithValues("Member", "Status", "Message", "member", "OK", "result1");
+    verify(ccService, times(1)).updateCacheConfig(any(), any());
   }
 
   @Test

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/wancommand/DestroyGatewayReceiverCommandDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/wancommand/DestroyGatewayReceiverCommandDUnitTest.java
@@ -168,7 +168,7 @@ public class DestroyGatewayReceiverCommandDUnitTest {
         new CommandStringBuilder(DestroyGatewayReceiverCommand.DESTROY_GATEWAYRECEIVER)
             .addOption(CliStrings.MEMBER, server3.getName());
     gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess()
-        .containsOutput("change is not persisted")
+        .containsOutput("No changes were made to the configuration for group 'MEMBER_server-3'")
         .tableHasColumnWithExactValuesInAnyOrder("Member", "server-3");
     verifyConfigHasGatewayReceiver("cluster");
 
@@ -176,6 +176,37 @@ public class DestroyGatewayReceiverCommandDUnitTest {
     VMProvider.invokeInEveryMember(() -> verifyReceiverCreationWithAttributes(true, 10000, 11000,
         "localhost", 100000, 512000, null, GatewayReceiver.DEFAULT_HOSTNAME_FOR_SENDERS), server4,
         server5);
+  }
+
+  @Test
+  public void destroyStartedGatewayReceiver_destroysReceiverOnMember() {
+    Integer locator1Port = locatorSite1.getPort();
+    server3 = clusterStartupRule.startServerVM(3, locator1Port);
+    server4 = clusterStartupRule.startServerVM(4, locator1Port);
+    server5 = clusterStartupRule.startServerVM(5, locator1Port);
+
+    gfsh.executeAndAssertThat(
+        createGatewayReceiverCommand("false", CliStrings.MEMBER + ":server-3")).statusIsSuccess()
+        .tableHasColumnWithExactValuesInAnyOrder("Member", "server-3")
+        .tableHasColumnWithValuesContaining("Message",
+            "GatewayReceiver created on member \"server-3\"");
+    verifyConfigHasGatewayReceiver("MEMBER_server-3");
+
+    VMProvider
+        .invokeInEveryMember(
+            () -> verifyReceiverCreationWithAttributes(true, 10000, 11000, "localhost", 100000,
+                512000, null, GatewayReceiver.DEFAULT_HOSTNAME_FOR_SENDERS),
+            server3);
+
+    CommandStringBuilder csb =
+        new CommandStringBuilder(DestroyGatewayReceiverCommand.DESTROY_GATEWAYRECEIVER)
+            .addOption(CliStrings.MEMBER, server3.getName());
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess()
+        .containsOutput("Changes to configuration for group 'MEMBER_server-3' are persisted")
+        .tableHasColumnWithExactValuesInAnyOrder("Member", "server-3");
+    verifyConfigDoesNotHaveGatewayReceiver("MEMBER_server-3");
+
+    VMProvider.invokeInEveryMember(WANCommandUtils::verifyReceiverDoesNotExist, server3);
   }
 
   @Test
@@ -203,7 +234,7 @@ public class DestroyGatewayReceiverCommandDUnitTest {
         new CommandStringBuilder(DestroyGatewayReceiverCommand.DESTROY_GATEWAYRECEIVER)
             .addOption(CliStrings.MEMBER, server3.getName());
     gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess()
-        .containsOutput("change is not persisted")
+        .containsOutput("No changes were made to the configuration for group 'MEMBER_server-3'")
         .tableHasColumnWithExactValuesInAnyOrder("Member", "server-3");
     verifyConfigHasGatewayReceiver("cluster");
 
@@ -237,13 +268,14 @@ public class DestroyGatewayReceiverCommandDUnitTest {
         new CommandStringBuilder(DestroyGatewayReceiverCommand.DESTROY_GATEWAYRECEIVER)
             .addOption(CliStrings.MEMBER, server3.getName());
     gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess()
-        .containsOutput("change is not persisted")
+        .containsOutput("No changes were made to the configuration for group 'MEMBER_server-3'")
         .tableHasColumnWithExactValuesInAnyOrder("Member", "server-3");
     verifyConfigHasGatewayReceiver("cluster");
 
     csb = new CommandStringBuilder(DestroyGatewayReceiverCommand.DESTROY_GATEWAYRECEIVER);
     gfsh.executeAndAssertThat(csb.toString()).statusIsError()
-        .doesNotContainOutput("change is not persisted")
+        .doesNotContainOutput(
+            "No changes were made to the configuration for group 'MEMBER_server-3'")
         .tableHasColumnWithExactValuesInAnyOrder("Member", "server-3");
     verifyConfigHasGatewayReceiver("cluster");
 
@@ -271,7 +303,7 @@ public class DestroyGatewayReceiverCommandDUnitTest {
         new CommandStringBuilder(DestroyGatewayReceiverCommand.DESTROY_GATEWAYRECEIVER)
             .addOption(CliStrings.MEMBER, server3.getName());
     gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess()
-        .containsOutput("change is not persisted")
+        .containsOutput("No changes were made to the configuration for group 'MEMBER_server-3'")
         .tableHasColumnWithExactValuesInAnyOrder("Member", "server-3");
     verifyConfigHasGatewayReceiver("cluster");
 
@@ -309,7 +341,7 @@ public class DestroyGatewayReceiverCommandDUnitTest {
         new CommandStringBuilder(DestroyGatewayReceiverCommand.DESTROY_GATEWAYRECEIVER)
             .addOption(CliStrings.MEMBER, server3.getName());
     gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess()
-        .containsOutput("change is not persisted")
+        .containsOutput("No changes were made")
         .tableHasColumnWithExactValuesInAnyOrder("Member", "server-3");
     VMProvider.invokeInEveryMember(WANCommandUtils::verifyReceiverDoesNotExist, server3);
     VMProvider.invokeInEveryMember(() -> verifyReceiverCreationWithAttributes(false, 10000, 11000,


### PR DESCRIPTION
- Changed tests that had been expecting member specific configurations to not be persisted

Co-authored-by: Jens Deppe <jdeppe@pivotal.io>
Co-authored-by: Kenneth Howe <khowe@pivotal.io>
Co-authored-by: Aditya Anchuri <aanchuri@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
