### PR TITLE
GEODE-6186: Reduced the number of EntryNotFoundExceptions thrown duri…

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/internal/cache/BucketRegionQueueJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/BucketRegionQueueJUnitTest.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.geode.cache.EntryNotFoundException;
+import org.apache.geode.cache.Operation;
+import org.apache.geode.cache.Region;
+import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.internal.cache.wan.AbstractGatewaySender;
+import org.apache.geode.internal.cache.wan.parallel.ParallelGatewaySenderHelper;
+import org.apache.geode.test.fake.Fakes;
+
+public class BucketRegionQueueJUnitTest {
+
+  private static final String GATEWAY_SENDER_ID = "ny";
+  private static final int BUCKET_ID = 85;
+  private static final long KEY = 198;
+
+  private GemFireCacheImpl cache;
+  private PartitionedRegion queueRegion;
+  private AbstractGatewaySender sender;
+  private PartitionedRegion rootRegion;
+  private BucketRegionQueue bucketRegionQueue;
+
+  @Before
+  public void setUpGemFire() {
+    createCache();
+    createQueueRegion();
+    createGatewaySender();
+    createRootRegion();
+    createBucketRegionQueue();
+  }
+
+  private void createCache() {
+    // Mock cache
+    this.cache = Fakes.cache();
+  }
+
+  private void createQueueRegion() {
+    // Mock queue region
+    this.queueRegion =
+        ParallelGatewaySenderHelper.createMockQueueRegion(this.cache,
+            ParallelGatewaySenderHelper.getRegionQueueName(GATEWAY_SENDER_ID));
+  }
+
+  private void createGatewaySender() {
+    // Mock gateway sender
+    this.sender = ParallelGatewaySenderHelper.createGatewaySender(this.cache);
+    when(this.queueRegion.getParallelGatewaySender()).thenReturn(this.sender);
+  }
+
+  private void createRootRegion() {
+    // Mock root region
+    this.rootRegion = mock(PartitionedRegion.class);
+    when(this.rootRegion.getFullPath())
+        .thenReturn(Region.SEPARATOR + PartitionedRegionHelper.PR_ROOT_REGION_NAME);
+  }
+
+  private void createBucketRegionQueue() {
+    BucketRegionQueue realBucketRegionQueue = ParallelGatewaySenderHelper
+        .createBucketRegionQueue(this.cache, this.rootRegion, this.queueRegion, BUCKET_ID);
+    this.bucketRegionQueue = spy(realBucketRegionQueue);
+  }
+
+  @Test
+  public void testBasicDestroyConflationEnabledAndValueInRegionAndIndex() {
+    // Create the event
+    EntryEventImpl event = EntryEventImpl.create(this.bucketRegionQueue, Operation.DESTROY,
+        KEY, "value", null, false, mock(DistributedMember.class));
+
+    // Don't allow hasSeenEvent to be invoked
+    doReturn(false).when(this.bucketRegionQueue).hasSeenEvent(event);
+
+    // Set conflation enabled and the appropriate return values for containsKey and removeIndex
+    when(this.queueRegion.isConflationEnabled()).thenReturn(true);
+    when(this.bucketRegionQueue.containsKey(KEY)).thenReturn(true);
+    doReturn(true).when(this.bucketRegionQueue).removeIndex(KEY);
+
+    // Invoke basicDestroy
+    this.bucketRegionQueue.basicDestroy(event, true, null);
+
+    // Verify mapDestroy is invoked
+    verify(this.bucketRegionQueue).mapDestroy(event, true, false, null);
+  }
+
+  @Test(expected = EntryNotFoundException.class)
+  public void testBasicDestroyConflationEnabledAndValueNotInRegion() {
+    // Create the event
+    EntryEventImpl event = EntryEventImpl.create(this.bucketRegionQueue, Operation.DESTROY,
+        KEY, "value", null, false, mock(DistributedMember.class));
+
+    // Don't allow hasSeenEvent to be invoked
+    doReturn(false).when(this.bucketRegionQueue).hasSeenEvent(event);
+
+    // Set conflation enabled and the appropriate return values for containsKey and removeIndex
+    when(this.queueRegion.isConflationEnabled()).thenReturn(true);
+    when(this.bucketRegionQueue.containsKey(KEY)).thenReturn(false);
+
+    // Invoke basicDestroy
+    this.bucketRegionQueue.basicDestroy(event, true, null);
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/wan/parallel/ParallelGatewaySenderHelper.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/wan/parallel/ParallelGatewaySenderHelper.java
@@ -14,21 +14,45 @@
  */
 package org.apache.geode.internal.cache.wan.parallel;
 
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.HashSet;
 import java.util.Set;
 
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
 import org.apache.geode.CancelCriterion;
+import org.apache.geode.cache.AttributesFactory;
+import org.apache.geode.cache.DataPolicy;
+import org.apache.geode.cache.EvictionAction;
+import org.apache.geode.cache.EvictionAttributes;
 import org.apache.geode.cache.Operation;
+import org.apache.geode.cache.PartitionAttributes;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionAttributes;
+import org.apache.geode.cache.Scope;
+import org.apache.geode.internal.cache.BucketAdvisor;
+import org.apache.geode.internal.cache.BucketRegionQueue;
 import org.apache.geode.internal.cache.EntryEventImpl;
 import org.apache.geode.internal.cache.EnumListenerEvent;
 import org.apache.geode.internal.cache.EventID;
+import org.apache.geode.internal.cache.EvictionAttributesImpl;
 import org.apache.geode.internal.cache.GemFireCacheImpl;
+import org.apache.geode.internal.cache.InternalRegionArguments;
 import org.apache.geode.internal.cache.KeyInfo;
 import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.PartitionedRegion;
+import org.apache.geode.internal.cache.PartitionedRegionDataStore;
+import org.apache.geode.internal.cache.PartitionedRegionHelper;
+import org.apache.geode.internal.cache.PartitionedRegionStats;
+import org.apache.geode.internal.cache.ProxyBucketRegion;
 import org.apache.geode.internal.cache.RegionQueue;
+import org.apache.geode.internal.cache.eviction.AbstractEvictionController;
+import org.apache.geode.internal.cache.eviction.EvictionController;
+import org.apache.geode.internal.cache.partitioned.RegionAdvisor;
 import org.apache.geode.internal.cache.wan.AbstractGatewaySender;
 import org.apache.geode.internal.cache.wan.GatewaySenderEventImpl;
 
@@ -64,6 +88,66 @@ public class ParallelGatewaySenderHelper {
         new GatewaySenderEventImpl(getEnumListenerEvent(operation), eei, null);
     gsei.setShadowKey(shadowKey);
     return gsei;
+  }
+
+  public static PartitionedRegion createMockQueueRegion(GemFireCacheImpl cache, String regionName) {
+    // Mock queue region
+    PartitionedRegion queueRegion = mock(PartitionedRegion.class);
+    when(queueRegion.getFullPath()).thenReturn(regionName);
+    when(queueRegion.getPrStats()).thenReturn(mock(PartitionedRegionStats.class));
+    when(queueRegion.getDataStore()).thenReturn(mock(PartitionedRegionDataStore.class));
+    when(queueRegion.getCache()).thenReturn(cache);
+    EvictionAttributesImpl ea = (EvictionAttributesImpl) EvictionAttributes
+        .createLRUMemoryAttributes(100, null, EvictionAction.OVERFLOW_TO_DISK);
+    EvictionController eviction = AbstractEvictionController.create(ea, false,
+        cache.getDistributedSystem(), "queueRegion");
+    when(queueRegion.getEvictionController()).thenReturn(eviction);
+    return queueRegion;
+  }
+
+  public static BucketRegionQueue createBucketRegionQueue(GemFireCacheImpl cache,
+      PartitionedRegion parentRegion, PartitionedRegion queueRegion, int bucketId) {
+    // Create InternalRegionArguments
+    InternalRegionArguments ira = new InternalRegionArguments();
+    ira.setPartitionedRegion(queueRegion);
+    ira.setPartitionedRegionBucketRedundancy(1);
+    BucketAdvisor ba = mock(BucketAdvisor.class);
+    ira.setBucketAdvisor(ba);
+    InternalRegionArguments pbrIra = new InternalRegionArguments();
+    RegionAdvisor ra = mock(RegionAdvisor.class);
+    when(ra.getPartitionedRegion()).thenReturn(queueRegion);
+    pbrIra.setPartitionedRegionAdvisor(ra);
+    PartitionAttributes pa = mock(PartitionAttributes.class);
+    when(queueRegion.getPartitionAttributes()).thenReturn(pa);
+
+    when(queueRegion.getBucketName(eq(bucketId))).thenAnswer(new Answer<String>() {
+      @Override
+      public String answer(final InvocationOnMock invocation) throws Throwable {
+        return PartitionedRegionHelper.getBucketName(queueRegion.getFullPath(), bucketId);
+      }
+    });
+
+    when(queueRegion.getDataPolicy()).thenReturn(DataPolicy.PARTITION);
+
+    when(pa.getColocatedWith()).thenReturn(null);
+
+    when(ba.getProxyBucketRegion()).thenReturn(mock(ProxyBucketRegion.class));
+
+    // Create RegionAttributes
+    AttributesFactory factory = new AttributesFactory();
+    factory.setScope(Scope.DISTRIBUTED_ACK);
+    factory.setDataPolicy(DataPolicy.REPLICATE);
+    factory.setEvictionAttributes(
+        EvictionAttributes.createLRUMemoryAttributes(100, null, EvictionAction.OVERFLOW_TO_DISK));
+    RegionAttributes attributes = factory.create();
+
+    // Create BucketRegionQueue
+    return new BucketRegionQueue(
+        queueRegion.getBucketName(bucketId), attributes, parentRegion, cache, ira);
+  }
+
+  public static String getRegionQueueName(String gatewaySenderId) {
+    return Region.SEPARATOR + gatewaySenderId + ParallelGatewaySenderQueue.QSTRING;
   }
 
   private static EnumListenerEvent getEnumListenerEvent(Operation operation) {


### PR DESCRIPTION
…ng wan conflation

The changes to ParallelGatewaySenderHelper and ParallelQueueRemovalMessageJUnitTest are just refactorings so that BucketRegionQueueJUnitTest can reuse some of the instantiations.

The changes to ParallelGatewaySenderQueue are to replace the hard-coded 50ms sleep time with a time based on the remaining time to wait before the batch time interval has ended.

The changes to BucketRegionQueue are to not call super.basicDestroy if the queue doesn't contain the key. EntryNotFoundException is thrown by basicDestroy because callers of this method behave differently based on whether it is thrown or not.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
