### PR TITLE
GEODE-6197: Fix create and destroy jdbc-mapping

### DIFF
--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/CreateMappingCommand.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/CreateMappingCommand.java
@@ -97,7 +97,7 @@ public class CreateMappingCommand extends SingleGfshCommand {
     }
 
     // input
-    Set<DistributedMember> targetMembers = getMembers(null, null);
+    Set<DistributedMember> targetMembers = findMembersForRegion(regionName);
     RegionMapping mapping = new RegionMapping(regionName, pdxName, table, dataSourceName, id);
 
     try {

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyMappingCommand.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyMappingCommand.java
@@ -62,7 +62,7 @@ public class DestroyMappingCommand extends SingleGfshCommand {
     }
 
     // input
-    Set<DistributedMember> targetMembers = getMembers(null, null);
+    Set<DistributedMember> targetMembers = findMembersForRegion(regionName);
 
     // action
     List<CliFunctionResult> results =

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/CreateMappingCommandTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/CreateMappingCommandTest.java
@@ -43,7 +43,6 @@ import org.apache.geode.cache.configuration.RegionConfig;
 import org.apache.geode.connectors.jdbc.JdbcAsyncWriter;
 import org.apache.geode.connectors.jdbc.internal.configuration.RegionMapping;
 import org.apache.geode.distributed.ConfigurationPersistenceService;
-import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.management.cli.Result;
@@ -59,7 +58,6 @@ public class CreateMappingCommandTest {
   private String dataSourceName;
   private String tableName;
   private String pdxClass;
-  private DistributionManager distributionManager;
   private Set<InternalDistributedMember> members;
   private List<CliFunctionResult> results;
   private CliFunctionResult successFunctionResult;
@@ -76,11 +74,8 @@ public class CreateMappingCommandTest {
     tableName = "testTable";
     pdxClass = "myPdxClass";
     cache = mock(InternalCache.class);
-    distributionManager = mock(DistributionManager.class);
-    when(cache.getDistributionManager()).thenReturn(distributionManager);
     members = new HashSet<>();
     members.add(mock(InternalDistributedMember.class));
-    when(distributionManager.getNormalDistributionManagerIds()).thenReturn(members);
     createRegionMappingCommand = spy(CreateMappingCommand.class);
     createRegionMappingCommand.setCache(cache);
     results = new ArrayList<>();
@@ -89,6 +84,7 @@ public class CreateMappingCommandTest {
 
     doReturn(results).when(createRegionMappingCommand).executeAndGetFunctionResult(any(), any(),
         any());
+    doReturn(members).when(createRegionMappingCommand).findMembersForRegion(regionName);
 
     mapping = mock(RegionMapping.class);
     when(mapping.getRegionName()).thenReturn(regionName);

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyMappingCommandTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyMappingCommandTest.java
@@ -43,7 +43,6 @@ import org.apache.geode.cache.configuration.RegionAttributesType;
 import org.apache.geode.cache.configuration.RegionConfig;
 import org.apache.geode.connectors.jdbc.JdbcWriter;
 import org.apache.geode.connectors.jdbc.internal.configuration.RegionMapping;
-import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.management.cli.Result;
@@ -56,7 +55,6 @@ public class DestroyMappingCommandTest {
   private DestroyMappingCommand destroyRegionMappingCommand;
 
   private String regionName;
-  private DistributionManager distributionManager;
   private Set<InternalDistributedMember> members;
   private List<CliFunctionResult> results;
   private CliFunctionResult successFunctionResult;
@@ -68,11 +66,8 @@ public class DestroyMappingCommandTest {
   public void setup() {
     regionName = "regionName";
     cache = mock(InternalCache.class);
-    distributionManager = mock(DistributionManager.class);
-    when(cache.getDistributionManager()).thenReturn(distributionManager);
     members = new HashSet<>();
     members.add(mock(InternalDistributedMember.class));
-    when(distributionManager.getNormalDistributionManagerIds()).thenReturn(members);
     destroyRegionMappingCommand = spy(DestroyMappingCommand.class);
     destroyRegionMappingCommand.setCache(cache);
     results = new ArrayList<>();
@@ -81,6 +76,7 @@ public class DestroyMappingCommandTest {
 
     doReturn(results).when(destroyRegionMappingCommand).executeAndGetFunctionResult(any(), any(),
         any());
+    doReturn(members).when(destroyRegionMappingCommand).findMembersForRegion(regionName);
 
     cacheConfig = mock(CacheConfig.class);
 


### PR DESCRIPTION
Now `create jdbc-mapping` and `destroy jdbc-mapping` only target the members
that have the named region.

Authored-by: Jianxia Chen <jchen@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
