### PR TITLE
GEODE-6102: fail destroy data-source if in use 

### DIFF
--- a/geode-connectors/src/distributedTest/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyDataSourceCommandDUnitTest.java
+++ b/geode-connectors/src/distributedTest/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyDataSourceCommandDUnitTest.java
@@ -17,8 +17,8 @@ package org.apache.geode.connectors.jdbc.internal.cli;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 import org.assertj.core.api.AssertionsForClassTypes;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -35,16 +35,16 @@ import org.apache.geode.test.junit.rules.GfshCommandRule;
 import org.apache.geode.test.junit.rules.VMProvider;
 
 public class DestroyDataSourceCommandDUnitTest {
-  private static MemberVM locator, server1, server2;
+  private MemberVM locator, server1, server2;
 
-  @ClassRule
-  public static ClusterStartupRule cluster = new ClusterStartupRule();
+  @Rule
+  public ClusterStartupRule cluster = new ClusterStartupRule();
 
-  @ClassRule
-  public static GfshCommandRule gfsh = new GfshCommandRule();
+  @Rule
+  public GfshCommandRule gfsh = new GfshCommandRule();
 
-  @BeforeClass
-  public static void before() throws Exception {
+  @Before
+  public void before() throws Exception {
     locator = cluster.startLocatorVM(0);
     server1 = cluster.startServerVM(1, locator.getPort());
     server2 = cluster.startServerVM(2, locator.getPort());
@@ -108,5 +108,18 @@ public class DestroyDataSourceCommandDUnitTest {
     server1.invoke(() -> {
       AssertionsForClassTypes.assertThat(JNDIInvoker.getNoOfAvailableDataSources()).isEqualTo(0);
     });
+  }
+
+  @Test
+  public void destroyDataSourceFailsIfInUseByJdbcMapping() {
+    gfsh.executeAndAssertThat("create region --name=myRegion --type=REPLICATE").statusIsSuccess();
+    gfsh.executeAndAssertThat(
+        "create jdbc-mapping --data-source=datasource1 --pdx-name=myPdxClass --region=myRegion")
+        .statusIsSuccess();
+
+    gfsh.executeAndAssertThat("destroy data-source --name=datasource1").statusIsError()
+        .containsOutput(
+            "Data source named \"datasource1\" is still being used by region \"myRegion\"."
+                + " Use destroy jdbc-mapping --name=myRegion and then try again.");
   }
 }

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyDataSourceCommand.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyDataSourceCommand.java
@@ -17,6 +17,7 @@ package org.apache.geode.connectors.jdbc.internal.cli;
 import java.util.List;
 import java.util.Set;
 
+import org.springframework.shell.core.annotation.CliAvailabilityIndicator;
 import org.springframework.shell.core.annotation.CliCommand;
 import org.springframework.shell.core.annotation.CliOption;
 
@@ -122,5 +123,10 @@ public class DestroyDataSourceCommand extends SingleGfshCommand {
   public boolean updateConfigForGroup(String group, CacheConfig config, Object element) {
     CacheElement.removeElement(config.getJndiBindings(), (String) element);
     return true;
+  }
+
+  @CliAvailabilityIndicator({DESTROY_DATA_SOURCE})
+  public boolean commandAvailable() {
+    return isOnlineCommandAvailable();
   }
 }

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyDataSourceCommandTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyDataSourceCommandTest.java
@@ -40,7 +40,10 @@ import org.mockito.ArgumentCaptor;
 
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.configuration.CacheConfig;
+import org.apache.geode.cache.configuration.CacheElement;
 import org.apache.geode.cache.configuration.JndiBindingsType;
+import org.apache.geode.cache.configuration.RegionConfig;
+import org.apache.geode.connectors.jdbc.internal.configuration.RegionMapping;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.internal.InternalConfigurationPersistenceService;
 import org.apache.geode.internal.cache.InternalCache;
@@ -134,7 +137,53 @@ public class DestroyDataSourceCommandTest {
             "Data source named \\\"name\\\" does not exist. A jndi-binding was found with that name.");
   }
 
+  @Test
+  public void whenClusterConfigRunningAndDataSourceInUseByRegionThenError() {
+    String DATA_SOURCE_NAME = "myDataSourceName";
+    List<JndiBindingsType.JndiBinding> bindings = new ArrayList<>();
+    JndiBindingsType.JndiBinding jndiBinding = new JndiBindingsType.JndiBinding();
+    jndiBinding.setJndiName(DATA_SOURCE_NAME);
+    jndiBinding.setType(CreateJndiBindingCommand.DATASOURCE_TYPE.SIMPLE.getType());
+    bindings.add(jndiBinding);
+    doReturn(bindings).when(cacheConfig).getJndiBindings();
+    setupRegionConfigToUseDataSource(DATA_SOURCE_NAME);
 
+    gfsh.executeAndAssertThat(command, COMMAND + " --name=" + DATA_SOURCE_NAME).statusIsError()
+        .containsOutput("Data source named \\\"" + DATA_SOURCE_NAME
+            + "\\\" is still being used by region \\\"regionUsingDataSource\\\"."
+            + " Use destroy jdbc-mapping --name=regionUsingDataSource and then try again.");
+  }
+
+  private void setupRegionConfigToUseDataSource(String dataSourceName) {
+    RegionConfig regionConfig = mock(RegionConfig.class);
+    when(regionConfig.getName()).thenReturn("regionUsingDataSource");
+    List<RegionConfig> regionConfigList = new ArrayList<>();
+    regionConfigList.add(regionConfig);
+    when(cacheConfig.getRegions()).thenReturn(regionConfigList);
+    RegionMapping regionMapping = mock(RegionMapping.class);
+    when(regionMapping.getDataSourceName()).thenReturn(dataSourceName);
+    List<CacheElement> cacheElementList = new ArrayList<>();
+    cacheElementList.add(regionMapping);
+    when(regionConfig.getCustomRegionElements()).thenReturn(cacheElementList);
+  }
+
+  @Test
+  public void whenNoMembersFoundAndClusterConfigRunningAndRegionUsingOtherDataSourceThenUpdateClusterConfig() {
+    List<JndiBindingsType.JndiBinding> bindings = new ArrayList<>();
+    JndiBindingsType.JndiBinding jndiBinding = new JndiBindingsType.JndiBinding();
+    jndiBinding.setJndiName("name");
+    jndiBinding.setType(CreateJndiBindingCommand.DATASOURCE_TYPE.SIMPLE.getType());
+    bindings.add(jndiBinding);
+    doReturn(bindings).when(cacheConfig).getJndiBindings();
+    setupRegionConfigToUseDataSource("otherDataSource");
+
+    gfsh.executeAndAssertThat(command, COMMAND + " --name=name").statusIsSuccess()
+        .containsOutput("No members found, data source removed from cluster configuration.")
+        .containsOutput("Changes to configuration for group 'cluster' are persisted.");
+
+    verify(ccService).updateCacheConfig(any(), any());
+    verify(command).updateConfigForGroup(eq("cluster"), eq(cacheConfig), isNotNull());
+  }
 
   @Test
   public void whenNoMembersFoundAndClusterConfigRunningThenUpdateClusterConfig() {


### PR DESCRIPTION
destroy data-source will now fail if it is used by a jdbc-mapping.
Also the command is now only available if gfsh is connected.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
