### PR TITLE
GEODE-6177: WAN Event processing continues after authentication failure

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/pdx/PdxRegistryMismatchException.java
+++ b/geode-core/src/main/java/org/apache/geode/pdx/PdxRegistryMismatchException.java
@@ -17,7 +17,7 @@ package org.apache.geode.pdx;
 import org.apache.geode.GemFireException;
 
 /**
- * Thrown when a an attempt is made to reuse a PDX Type. This can occur if the PDX registry files
+ * Thrown when an attempt is made to reuse a PDX Type. This can occur if the PDX registry files
  * are deleted from the sending side of a WAN Gateway.
  */
 public class PdxRegistryMismatchException extends GemFireException {

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/misc/NewWanAuthenticationDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/misc/NewWanAuthenticationDUnitTest.java
@@ -55,6 +55,7 @@ public class NewWanAuthenticationDUnitTest extends WANTestBase {
   private static final Logger logger = LogService.getLogger();
 
   private static boolean isDifferentServerInGetCredentialCall = false;
+  private static final int numPuts = 10;
 
   private static final String securityJsonResource =
       "org/apache/geode/security/templates/security.json";
@@ -65,7 +66,6 @@ public class NewWanAuthenticationDUnitTest extends WANTestBase {
   private String regionName;
   private final VM sender = vm2;
   private final VM receiver = vm3;
-  private final int numPuts = 10;
 
   @Before
   public void setup() {

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/misc/NewWanAuthenticationDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/misc/NewWanAuthenticationDUnitTest.java
@@ -27,6 +27,7 @@ import static org.apache.geode.test.dunit.Assert.assertTrue;
 import java.util.Properties;
 
 import org.apache.logging.log4j.Logger;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -34,6 +35,7 @@ import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.Region;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.DistributedSystem;
+import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.internal.Assert;
 import org.apache.geode.internal.cache.wan.WANTestBase;
 import org.apache.geode.internal.logging.LogService;
@@ -44,14 +46,34 @@ import org.apache.geode.security.TestSecurityManager;
 import org.apache.geode.security.generator.CredentialGenerator;
 import org.apache.geode.security.generator.DummyCredentialGenerator;
 import org.apache.geode.security.templates.UserPasswordAuthInit;
+import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.junit.categories.WanTest;
 
 @Category({WanTest.class})
 public class NewWanAuthenticationDUnitTest extends WANTestBase {
 
-  public static final Logger logger = LogService.getLogger();
+  private static final Logger logger = LogService.getLogger();
 
-  public static boolean isDifferentServerInGetCredentialCall = false;
+  private static boolean isDifferentServerInGetCredentialCall = false;
+
+  private static final String securityJsonResource =
+      "org/apache/geode/security/templates/security.json";
+  private static final String senderId = "ln";
+
+  private Integer lnPort;
+  private Integer nyPort;
+  private String regionName;
+  private final VM sender = vm2;
+  private final VM receiver = vm3;
+  private final int numPuts = 10;
+
+  @Before
+  public void setup() {
+    disconnectAllFromDS();
+    lnPort = vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
+    nyPort = vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(2, lnPort));
+    regionName = getTestMethodName() + "_RR";
+  }
 
   /**
    * Authentication test for new WAN with valid credentials. Although, nothing related to
@@ -60,112 +82,84 @@ public class NewWanAuthenticationDUnitTest extends WANTestBase {
    */
   @Test
   public void testWanAuthValidCredentials() {
-    Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-    logger.info("Created locator on local site");
+    final CredentialGenerator credentialGenerator = new DummyCredentialGenerator();
 
-    Integer nyPort = (Integer) vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(2, lnPort));
-    logger.info("Created locator on remote site");
+    final Properties extraProps = credentialGenerator.getSystemProperties();
 
-
-    CredentialGenerator gen = new DummyCredentialGenerator();
-    Properties extraProps = gen.getSystemProperties();
-
-    String clientauthenticator = gen.getAuthenticator();
-    String clientauthInit = gen.getAuthInit();
-
-    Properties credentials1 = gen.getValidCredentials(1);
+    final Properties senderCredentials = credentialGenerator.getValidCredentials(1);
     if (extraProps != null) {
-      credentials1.putAll(extraProps);
+      senderCredentials.putAll(extraProps);
     }
-    Properties javaProps1 = gen.getJavaProperties();
+    final Properties senderJavaProps = credentialGenerator.getJavaProperties();
 
-    // vm3's invalid credentials
-    Properties credentials2 = gen.getInvalidCredentials(1);
+    // receiver's invalid credentials
+    final Properties receiverCredentials = credentialGenerator.getInvalidCredentials(1);
     if (extraProps != null) {
-      credentials2.putAll(extraProps);
+      receiverCredentials.putAll(extraProps);
     }
-    Properties javaProps2 = gen.getJavaProperties();
+    final Properties receiverJavaProps = credentialGenerator.getJavaProperties();
 
-    Properties props1 =
-        buildProperties(clientauthenticator, clientauthInit, null, credentials1, null);
+    final String clientAuthenticator = credentialGenerator.getAuthenticator();
+    final String clientAuthInit = credentialGenerator.getAuthInit();
 
-    // have vm 3 start a cache with invalid credentails
-    Properties props2 =
-        buildProperties(clientauthenticator, clientauthInit, null, credentials2, null);
+    final Properties senderSecurityProps =
+        buildProperties(clientAuthenticator, clientAuthInit, null, senderCredentials, null);
+    // have receiver start a cache with invalid credentials
+    final Properties receiverSecurityProps =
+        buildProperties(clientAuthenticator, clientAuthInit, null, receiverCredentials, null);
 
-    vm2.invoke(() -> NewWanAuthenticationDUnitTest.createSecuredCache(props1, javaProps1, lnPort));
-    logger.info("Created secured cache in vm2");
+    // ------------------------------- Set Up With Valid Credentials -------------------------------
 
-    vm3.invoke(() -> NewWanAuthenticationDUnitTest.createSecuredCache(props2, javaProps2, nyPort));
-    logger.info("Created secured cache in vm3");
+    sender.invoke(() -> createSecuredCache(senderSecurityProps, senderJavaProps, lnPort));
+    receiver.invoke(() -> createSecuredCache(receiverSecurityProps, receiverJavaProps, nyPort));
 
-    vm2.invoke(() -> WANTestBase.createSender("ln", 2, false, 100, 10, false, false, null, true));
-    logger.info("Created sender in vm2");
+    sender.invoke(() -> createSender("ln", 2, false, 100, 10, false, false, null, true));
+    receiver.invoke(() -> createReceiverInSecuredCache());
 
-    vm3.invoke(() -> createReceiverInSecuredCache());
-    logger.info("Created receiver in vm3");
+    sender.invoke(
+        () -> createReplicatedRegion(regionName, "ln", isOffHeap()));
+    receiver.invoke(
+        () -> createReplicatedRegion(regionName, null, isOffHeap()));
 
-    vm2.invoke(
-        () -> WANTestBase.createReplicatedRegion(getTestMethodName() + "_RR", "ln", isOffHeap()));
-    logger.info("Created RR in vm2");
-    vm3.invoke(
-        () -> WANTestBase.createReplicatedRegion(getTestMethodName() + "_RR", null, isOffHeap()));
-    logger.info("Created RR in vm3");
+    // this tests verifies that even though the receiver has invalid credentials, the sender can
+    // still send data to
+    // the receiver because the sender has valid credentials
+    sender.invoke(() -> startSender("ln"));
+    sender.invoke(() -> waitForSenderRunningState("ln"));
 
-    // this tests verifies that even though vm3 has invalid credentials, vm2 can still send data to
-    // vm3 because
-    // vm2 has valid credentials
-    vm2.invoke(() -> WANTestBase.startSender("ln"));
-    vm2.invoke(() -> WANTestBase.waitForSenderRunningState("ln"));
-
-    vm2.invoke(() -> WANTestBase.doPuts(getTestMethodName() + "_RR", 1));
-    vm3.invoke(() -> {
-      Region r = cache.getRegion(Region.SEPARATOR + getTestMethodName() + "_RR");
+    sender.invoke(() -> doPuts(regionName, 1));
+    receiver.invoke(() -> {
+      Region r = cache.getRegion(Region.SEPARATOR + regionName);
       await().untilAsserted(() -> assertTrue(r.size() > 0));
     });
-    logger.info("Done successfully.");
   }
 
   @Test
   public void testWanIntegratedSecurityWithValidCredentials() {
-    Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-    logger.info("Created locator on local site");
+    final Properties senderSecurityProps = buildSecurityProperties("admin", "secret");
+    final Properties receiverSecurityProps = buildSecurityProperties("guest", "guest");
 
-    Integer nyPort = (Integer) vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(2, lnPort));
-    logger.info("Created locator on remote site");
+    // ------------------------------- Set Up With Valid Credentials -------------------------------
 
+    sender.invoke(() -> createSecuredCache(senderSecurityProps, null, lnPort));
+    receiver.invoke(() -> createSecuredCache(receiverSecurityProps, null, nyPort));
 
-    Properties props1 = buildSecurityProperties("admin", "secret");
-    Properties props2 = buildSecurityProperties("guest", "guest");
+    sender.invoke(() -> createSender("ln", 2, false, 100, 10, false, false, null, true));
+    receiver.invoke(() -> createReceiverInSecuredCache());
 
-    vm2.invoke(() -> NewWanAuthenticationDUnitTest.createSecuredCache(props1, null, lnPort));
-    logger.info("Created secured cache in vm2");
+    sender.invoke(
+        () -> createReplicatedRegion(regionName, "ln", isOffHeap()));
+    receiver.invoke(
+        () -> createReplicatedRegion(regionName, null, isOffHeap()));
 
-    vm3.invoke(() -> NewWanAuthenticationDUnitTest.createSecuredCache(props2, null, nyPort));
-    logger.info("Created secured cache in vm3");
+    sender.invoke(() -> startSender("ln"));
+    sender.invoke(() -> waitForSenderRunningState("ln"));
+    sender.invoke(() -> doPuts(regionName, 1));
 
-    vm2.invoke(() -> WANTestBase.createSender("ln", 2, false, 100, 10, false, false, null, true));
-    logger.info("Created sender in vm2");
-
-    vm3.invoke(() -> createReceiverInSecuredCache());
-    logger.info("Created receiver in vm3");
-
-    vm2.invoke(
-        () -> WANTestBase.createReplicatedRegion(getTestMethodName() + "_RR", "ln", isOffHeap()));
-    logger.info("Created RR in vm2");
-    vm3.invoke(
-        () -> WANTestBase.createReplicatedRegion(getTestMethodName() + "_RR", null, isOffHeap()));
-    logger.info("Created RR in vm3");
-
-    vm2.invoke(() -> WANTestBase.startSender("ln"));
-    vm2.invoke(() -> WANTestBase.waitForSenderRunningState("ln"));
-    vm2.invoke(() -> WANTestBase.doPuts(getTestMethodName() + "_RR", 1));
-    vm3.invoke(() -> {
-      Region r = cache.getRegion(Region.SEPARATOR + getTestMethodName() + "_RR");
+    receiver.invoke(() -> {
+      Region r = cache.getRegion(Region.SEPARATOR + regionName);
       await().untilAsserted(() -> assertTrue(r.size() > 0));
-
     });
-    logger.info("Done successfully.");
   }
 
   /**
@@ -175,66 +169,49 @@ public class NewWanAuthenticationDUnitTest extends WANTestBase {
    */
   @Test
   public void testWanAuthInvalidCredentials() {
-    Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-    logger.info("Created locator on local site");
+    final CredentialGenerator credentialGenerator = new DummyCredentialGenerator();
 
-    Integer nyPort = (Integer) vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(2, lnPort));
-    logger.info("Created locator on remote site");
+    final Properties extraProps = credentialGenerator.getSystemProperties();
 
-
-    CredentialGenerator gen = new DummyCredentialGenerator();
-    logger.info("Picked up credential: " + gen);
-
-    Properties extraProps = gen.getSystemProperties();
-
-    String clientauthenticator = gen.getAuthenticator();
-    String clientauthInit = gen.getAuthInit();
-
-    Properties credentials1 = gen.getInvalidCredentials(1);
+    final Properties senderCredentials = credentialGenerator.getInvalidCredentials(1);
     if (extraProps != null) {
-      credentials1.putAll(extraProps);
+      senderCredentials.putAll(extraProps);
     }
-    Properties javaProps1 = gen.getJavaProperties();
-    Properties credentials2 = gen.getInvalidCredentials(2);
+    final Properties senderJavaProperties = credentialGenerator.getJavaProperties();
+
+    final Properties receiverCredentials = credentialGenerator.getInvalidCredentials(2);
     if (extraProps != null) {
-      credentials2.putAll(extraProps);
+      receiverCredentials.putAll(extraProps);
     }
-    Properties javaProps2 = gen.getJavaProperties();
+    final Properties receiverJavaProps = credentialGenerator.getJavaProperties();
 
-    Properties props1 =
-        buildProperties(clientauthenticator, clientauthInit, null, credentials1, null);
-    Properties props2 =
-        buildProperties(clientauthenticator, clientauthInit, null, credentials2, null);
+    final String clientAuthenticator = credentialGenerator.getAuthenticator();
+    final String clientAuthInit = credentialGenerator.getAuthInit();
 
-    logger.info("Done building auth properties");
+    final Properties senderSecurityProps =
+        buildProperties(clientAuthenticator, clientAuthInit, null, senderCredentials, null);
+    final Properties receiverSecurityPropsWithIncorrectSenderCreds =
+        buildProperties(clientAuthenticator, clientAuthInit, null, receiverCredentials, null);
 
-    vm2.invoke(() -> NewWanAuthenticationDUnitTest.createSecuredCache(props1, javaProps1, lnPort));
-    logger.info("Created secured cache in vm2");
+    // ------------------------------ Set Up With Invalid Credentials ------------------------------
 
-    vm3.invoke(() -> NewWanAuthenticationDUnitTest.createSecuredCache(props2, javaProps2, nyPort));
-    logger.info("Created secured cache in vm3");
+    sender.invoke(() -> {
+      createSecuredCache(senderSecurityProps, senderJavaProperties, lnPort);
+      createReplicatedRegion(regionName, senderId, isOffHeap());
+      createSender(senderId, 2, false, 100, 10, false, false, null, true);
+    });
 
-    vm2.invoke(() -> WANTestBase.createSender("ln", 2, false, 100, 10, false, false, null, true));
-    logger.info("Created sender in vm2");
+    receiver.invoke(() -> {
+      createSecuredReceiver(nyPort, regionName, receiverSecurityPropsWithIncorrectSenderCreds,
+          receiverJavaProps);
+    });
 
-    vm3.invoke(() -> createReceiverInSecuredCache());
-    logger.info("Created receiver in vm3");
+    sender.invoke(() -> {
+      startSender(senderId);
+      doPutsAndVerifyQueue(regionName, numPuts, false, numPuts);
+    });
 
-    vm2.invoke(
-        () -> WANTestBase.createReplicatedRegion(getTestMethodName() + "_RR", "ln", isOffHeap()));
-    logger.info("Created RR in vm2");
-    vm3.invoke(
-        () -> WANTestBase.createReplicatedRegion(getTestMethodName() + "_RR", null, isOffHeap()));
-    logger.info("Created RR in vm3");
-
-    // Start sender
-    vm2.invoke(() -> WANTestBase.startSender("ln"));
-
-    // Verify the sender is started
-    vm2.invoke(() -> verifySenderRunningState("ln"));
-
-    // Verify the sender is not connected
-    vm2.invoke(() -> verifySenderConnectedState("ln", false));
+    receiver.invoke(() -> validateRegionSize(regionName, 0));
   }
 
   /**
@@ -243,79 +220,220 @@ public class NewWanAuthenticationDUnitTest extends WANTestBase {
    * defect 44650.
    */
   @Test
-  public void testWanSecurityManagerWithInvalidCredentials() {
-    Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-    logger.info("Created locator on local site");
+  public void testWanSecurityManagerWithInvalidThenValidCredentials() {
+    final Properties senderSecurityProps = buildSecurityProperties("admin", "wrongPswd");
 
-    Integer nyPort = (Integer) vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(2, lnPort));
-    logger.info("Created locator on remote site");
+    final String securityJsonResource =
+        "org/apache/geode/internal/cache/wan/misc/NewWanAuthenticationDUnitTest.testWanSecurityManagerWithInvalidCredentials.security.json";
+    final Properties receiverSecurityPropsWithCorrectSenderCreds =
+        buildSecurityProperties(securityJsonResource);
+    final Properties receiverSecurityPropsWithIncorrectSenderCreds = buildSecurityProperties();
 
-    Properties props1 = buildSecurityProperties("admin", "wrongPswd");
-    Properties props2 = buildSecurityProperties("guest", "wrongPswd");
+    // ------------------------------ Set Up With Invalid Credentials ------------------------------
 
-    logger.info("Done building auth properties");
+    sender.invoke(() -> {
+      createSecuredCache(senderSecurityProps, null, lnPort);
+      createReplicatedRegion(regionName, senderId, isOffHeap());
+      createSender(senderId, 2, false, 100, 10, false, false, null, true);
+    });
 
-    vm2.invoke(() -> NewWanAuthenticationDUnitTest.createSecuredCache(props1, null, lnPort));
-    logger.info("Created secured cache in vm2");
+    receiver.invoke(() -> {
+      createSecuredReceiver(nyPort, regionName, receiverSecurityPropsWithIncorrectSenderCreds,
+          null);
+    });
 
-    vm3.invoke(() -> NewWanAuthenticationDUnitTest.createSecuredCache(props2, null, nyPort));
-    logger.info("Created secured cache in vm3");
+    sender.invoke(() -> {
+      startSender(senderId);
+      doPutsAndVerifyQueue(regionName, numPuts, false, numPuts);
+    });
 
-    String senderId = "ln";
-    vm2.invoke(
-        () -> WANTestBase.createSender(senderId, 2, false, 100, 10, false, false, null, true));
-    logger.info("Created sender in vm2");
+    receiver.invoke(() -> validateRegionSize(regionName, 0));
 
-    vm3.invoke(() -> createReceiverInSecuredCache());
-    logger.info("Created receiver in vm3");
+    // ------------------------------- Set Up With Valid Credentials -------------------------------
 
-    String regionName = getTestMethodName() + "_RR";
-    vm2.invoke(() -> WANTestBase.createReplicatedRegion(regionName, senderId, isOffHeap()));
-    logger.info("Created RR in vm2");
-    vm3.invoke(() -> WANTestBase.createReplicatedRegion(regionName, null, isOffHeap()));
-    logger.info("Created RR in vm3");
+    receiver.invoke(() -> {
+      closeCache();
+      createSecuredReceiver(nyPort, regionName, receiverSecurityPropsWithCorrectSenderCreds, null);
+    });
 
-    // Start sender
-    vm2.invoke(() -> WANTestBase.startSender(senderId));
+    sender.invoke(() -> {
+      doPutsAndVerifyQueue(regionName, numPuts, true, 0);
+    });
 
-    // Verify the sender is started
-    vm2.invoke(() -> verifySenderRunningState(senderId));
+    receiver.invoke(() -> validateRegionSize(regionName, numPuts));
+  }
 
-    // Verify the sender is not connected
-    vm2.invoke(() -> verifySenderConnectedState(senderId, false));
+  @Test
+  public void testWanSecurityManagerWithValidThenInvalidThenValidCredentials() {
+    final String securityJsonResource =
+        "org/apache/geode/internal/cache/wan/misc/NewWanAuthenticationDUnitTest.testWanSecurityManagerWithInvalidCredentials.security.json";
+    final String gatewayConnectionRetryIntervalConfigParameter =
+        DistributionConfig.GEMFIRE_PREFIX + "gateway-connection-retry-interval";
 
-    // Do some puts in the sender
-    int numPuts = 10;
-    vm2.invoke(() -> WANTestBase.doPuts(regionName, numPuts));
+    final Properties senderSecurityProps = buildSecurityProperties("admin", "wrongPswd");
 
-    // Verify the sender is still started
-    vm2.invoke(() -> verifySenderRunningState(senderId));
+    final Properties receiverSecurityPropsWithCorrectSenderCreds =
+        buildSecurityProperties(securityJsonResource);
+    final Properties receiverSecurityPropsWithIncorrectSenderCreds = buildSecurityProperties();
 
-    // Verify the sender is still not connected
-    vm2.invoke(() -> verifySenderConnectedState(senderId, false));
+    // ------------------------------- Set Up With Valid Credentials -------------------------------
 
-    // Verify the sender queue size
-    vm2.invoke(() -> testQueueSize(senderId, numPuts));
+    sender.invoke(() -> {
+      createSecuredCache(senderSecurityProps, null, lnPort);
+      createReplicatedRegion(regionName, senderId, isOffHeap());
+      try {
+        /*
+         * Setting the gateway-connection-retry-interval to 0 ensures that the Dispatcher and
+         * AckReader eagerly retry connections, so we may detect any issues with the retry logic
+         * early.
+         */
+        System.setProperty(gatewayConnectionRetryIntervalConfigParameter, "0");
+        createSender(senderId, 2, false, 100, 10, false, false, null, true);
+      } finally {
+        System.clearProperty(gatewayConnectionRetryIntervalConfigParameter);
+      }
+    });
 
-    // Stop the receiver
-    vm3.invoke(() -> closeCache());
+    receiver.invoke(() -> {
+      createSecuredReceiver(nyPort, regionName, receiverSecurityPropsWithCorrectSenderCreds, null);
+    });
 
-    // Restart the receiver with a SecurityManager that accepts the existing sender's username and
-    // password. The
-    // NewWanAuthenticationDUnitTest.testWanSecurityManagerWithInvalidCredentials.security.json.
-    // file contains the admin user definition that the SecurityManager will accept.
-    String securityJsonRersource = "org/apache/geode/internal/cache/wan/misc/"
-        + getClass().getSimpleName() + "." + getTestMethodName() + ".security.json";
-    Properties propsRestart = buildSecurityProperties("guest", "guest", securityJsonRersource);
-    vm3.invoke(() -> createSecuredCache(propsRestart, null, nyPort));
-    vm3.invoke(() -> createReplicatedRegion(regionName, null, isOffHeap()));
-    vm3.invoke(() -> createReceiverInSecuredCache());
+    sender.invoke(() -> {
+      startSender(senderId);
+      doPutsAndVerifyQueue(regionName, numPuts, true, 0);
+    });
 
-    // Wait for the queue to drain
-    vm2.invoke(() -> checkQueueSize(senderId, 0));
+    receiver.invoke(() -> validateRegionSize(regionName, numPuts));
 
-    // Verify region size on receiver
-    vm3.invoke(() -> validateRegionSize(regionName, numPuts));
+    // ------------------------------ Set Up With Invalid Credentials ------------------------------
+
+    receiver.invoke(() -> {
+      // Simulate restarting the receiver, this time without valid credentials for the sender.
+      closeCache();
+      createSecuredReceiver(nyPort, regionName, receiverSecurityPropsWithIncorrectSenderCreds,
+          null);
+    });
+
+    sender.invoke(() -> {
+      doPutsAndVerifyQueue(regionName, numPuts, false, numPuts);
+    });
+
+    receiver.invoke(() -> validateRegionSize(regionName, 0));
+
+    // ------------------------------- Set Up With Valid Credentials -------------------------------
+
+    receiver.invoke(() -> {
+      closeCache();
+      // Simulate restarting the receiver, and restore valid credentials for the sender.
+      createSecuredReceiver(nyPort, regionName, receiverSecurityPropsWithCorrectSenderCreds, null);
+    });
+
+    sender.invoke(() -> {
+      // Data should be able to flow properly after valid credentials have been restored.
+      doPutsAndVerifyQueue(regionName, numPuts, true, 0);
+    });
+
+    receiver.invoke(() -> validateRegionSize(regionName, numPuts));
+  }
+
+  @Test
+  public void testWanAuthValidCredentialsWithServer() {
+    final DummyCredentialGenerator credentialGenerator = new DummyCredentialGenerator();
+    credentialGenerator.init();
+
+    final Properties extraProps = credentialGenerator.getSystemProperties();
+
+    final Properties senderCredentials = credentialGenerator.getValidCredentials(1);
+    if (extraProps != null) {
+      senderCredentials.putAll(extraProps);
+    }
+    final Properties senderJavaProps = credentialGenerator.getJavaProperties();
+
+    final Properties receiverCredentials = credentialGenerator.getInvalidCredentials(2);
+    if (extraProps != null) {
+      receiverCredentials.putAll(extraProps);
+    }
+    final Properties receiverJavaProps = credentialGenerator.getJavaProperties();
+
+    final String clientAuthenticator = credentialGenerator.getAuthenticator();
+    final String clientAuthInit = UserPasswdAI.class.getName() + ".createAI";
+
+    final Properties senderSecurityProps =
+        buildProperties(clientAuthenticator, clientAuthInit, null, senderCredentials, null);
+    final Properties receiverSecurityProps =
+        buildProperties(clientAuthenticator, clientAuthInit, null, receiverCredentials, null);
+
+    // ------------------------------- Set Up With Valid Credentials -------------------------------
+
+    sender.invoke(() -> createSecuredCache(senderSecurityProps, senderJavaProps, lnPort));
+
+    receiver.invoke(() -> createSecuredCache(receiverSecurityProps, receiverJavaProps, nyPort));
+
+    sender.invoke(() -> createSender("ln", 2, false, 100, 10, false, false, null, true));
+
+    receiver.invoke(() -> createReceiverInSecuredCache());
+
+    sender.invoke(() -> {
+      startSender("ln");
+      waitForSenderRunningState("ln");
+      verifyDifferentServerInGetCredentialCall();
+    });
+
+    receiver.invoke(() -> verifyDifferentServerInGetCredentialCall());
+  }
+
+  @Test
+  public void testWanSecurityManagerAuthValidCredentialsWithServer() {
+    Properties senderSecurityProps = buildSecurityProperties("admin", "secret");
+    Properties receiverSecurityProps = buildSecurityProperties("guest", "guest");
+
+    // ------------------------------- Set Up With Valid Credentials -------------------------------
+
+    sender.invoke(() -> createSecuredCache(senderSecurityProps, null, lnPort));
+
+    receiver.invoke(() -> createSecuredCache(receiverSecurityProps, null, nyPort));
+
+    sender.invoke(() -> createSender("ln", 2, false, 100, 10, false, false, null, true));
+
+    receiver.invoke(() -> createReceiverInSecuredCache());
+
+    sender.invoke(() -> {
+      startSender("ln");
+      waitForSenderRunningState("ln");
+      verifyDifferentServerInGetCredentialCall();
+    });
+
+    // this would fail for now because for integrated security, we are not sending the receiver's
+    // credentials back
+    // to the sender. Because in the old security implementation, even though the receiver's
+    // credentials are sent back to the sender
+    // the sender is not checking it.
+    // sender.invoke(() -> verifyDifferentServerInGetCredentialCall());
+  }
+
+  private void doPutsAndVerifyQueue(final String regionName, final int numPuts,
+      final boolean shouldBeConnected,
+      final int expectedQueueSize) {
+    doPuts(regionName, numPuts);
+    verifyRunningWithConnectedState(senderId, shouldBeConnected);
+    checkQueueSize(senderId, expectedQueueSize);
+  }
+
+  private void createSecuredReceiver(Integer nyPort, String regionName,
+      Properties receiverSecurityPropsWithCorrectSenderCreds,
+      Object javaProps) {
+    createSecuredCache(receiverSecurityPropsWithCorrectSenderCreds, javaProps, nyPort);
+    createReplicatedRegion(regionName, null, isOffHeap());
+    createReceiverInSecuredCache();
+  }
+
+  private void verifyRunningWithConnectedState(
+      final String senderId,
+      final boolean shouldBeConnected) {
+    await().untilAsserted(() -> {
+      verifySenderRunningState(senderId);
+      verifySenderConnectedState(senderId, shouldBeConnected);
+    });
   }
 
   private static Properties buildProperties(String clientauthenticator, String clientAuthInit,
@@ -339,23 +457,29 @@ public class NewWanAuthenticationDUnitTest extends WANTestBase {
     return authProps;
   }
 
-  private static Properties buildSecurityProperties(String username, String password) {
-    return buildSecurityProperties(username, password,
-        "org/apache/geode/security/templates/security.json");
-  }
-
-  private static Properties buildSecurityProperties(String username, String password,
-      String securityJsonResource) {
-    Properties props = new Properties();
-    props.put(SECURITY_MANAGER, TestSecurityManager.class.getName());
-    props.put("security-json", securityJsonResource);
-    props.put(SECURITY_CLIENT_AUTH_INIT, UserPasswdAI.class.getName());
+  private static Properties buildSecurityProperties(final String username, final String password) {
+    final Properties props = buildSecurityProperties();
     props.put("security-username", username);
     props.put("security-password", password);
     return props;
   }
 
-  public static void createSecuredCache(Properties authProps, Object javaProps, Integer locPort) {
+  private static Properties buildSecurityProperties(
+      final String securityJsonResource) {
+    final Properties props = buildSecurityProperties();
+    props.put("security-json", securityJsonResource);
+    return props;
+  }
+
+  private static Properties buildSecurityProperties() {
+    final Properties props = new Properties();
+    props.put(SECURITY_MANAGER, TestSecurityManager.class.getName());
+    props.put(SECURITY_CLIENT_AUTH_INIT, UserPasswdAI.class.getName());
+    props.put("security-json", securityJsonResource);
+    return props;
+  }
+
+  private static void createSecuredCache(Properties authProps, Object javaProps, Integer locPort) {
     authProps.setProperty(MCAST_PORT, "0");
     authProps.setProperty(LOCATORS, "localhost[" + locPort + "]");
 
@@ -397,104 +521,9 @@ public class NewWanAuthenticationDUnitTest extends WANTestBase {
     }
   }
 
-  public static void verifyDifferentServerInGetCredentialCall() {
+  private static void verifyDifferentServerInGetCredentialCall() {
     Assert.assertTrue(isDifferentServerInGetCredentialCall,
         "verifyDifferentServerInGetCredentialCall: Server should be different");
     isDifferentServerInGetCredentialCall = false;
-  }
-
-  @Test
-  public void testWanAuthValidCredentialsWithServer() {
-    disconnectAllFromDS();
-    {
-      Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-      logger.info("Created locator on local site");
-
-      Integer nyPort = (Integer) vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(2, lnPort));
-      logger.info("Created locator on remote site");
-
-      DummyCredentialGenerator gen = new DummyCredentialGenerator();
-      gen.init();
-      Properties extraProps = gen.getSystemProperties();
-
-      String clientauthenticator = gen.getAuthenticator();
-      String clientauthInit = UserPasswdAI.class.getName() + ".createAI";
-
-      Properties credentials1 = gen.getValidCredentials(1);
-      if (extraProps != null) {
-        credentials1.putAll(extraProps);
-      }
-      Properties javaProps1 = gen.getJavaProperties();
-
-      Properties credentials2 = gen.getInvalidCredentials(2);
-      if (extraProps != null) {
-        credentials2.putAll(extraProps);
-      }
-      Properties javaProps2 = gen.getJavaProperties();
-
-      Properties props1 =
-          buildProperties(clientauthenticator, clientauthInit, null, credentials1, null);
-      Properties props2 =
-          buildProperties(clientauthenticator, clientauthInit, null, credentials2, null);
-
-      vm2.invoke(
-          () -> NewWanAuthenticationDUnitTest.createSecuredCache(props1, javaProps1, lnPort));
-      logger.info("Created secured cache in vm2");
-
-      vm3.invoke(
-          () -> NewWanAuthenticationDUnitTest.createSecuredCache(props2, javaProps2, nyPort));
-      logger.info("Created secured cache in vm3");
-
-      vm2.invoke(() -> WANTestBase.createSender("ln", 2, false, 100, 10, false, false, null, true));
-      logger.info("Created sender in vm2");
-
-      vm3.invoke(() -> createReceiverInSecuredCache());
-      logger.info("Created receiver in vm3");
-
-      vm2.invoke(() -> WANTestBase.startSender("ln"));
-      vm2.invoke(() -> WANTestBase.waitForSenderRunningState("ln"));
-
-      vm2.invoke(() -> verifyDifferentServerInGetCredentialCall());
-      vm3.invoke(() -> verifyDifferentServerInGetCredentialCall());
-    }
-  }
-
-  @Test
-  public void testWanSecurityManagerAuthValidCredentialsWithServer() {
-    disconnectAllFromDS();
-    {
-      Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-      logger.info("Created locator on local site");
-
-      Integer nyPort = (Integer) vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(2, lnPort));
-      logger.info("Created locator on remote site");
-
-      Properties props1 = buildSecurityProperties("admin", "secret");
-      Properties props2 = buildSecurityProperties("guest", "guest");
-
-      vm2.invoke(() -> NewWanAuthenticationDUnitTest.createSecuredCache(props1, null, lnPort));
-      logger.info("Created secured cache in vm2");
-
-      vm3.invoke(() -> NewWanAuthenticationDUnitTest.createSecuredCache(props2, null, nyPort));
-      logger.info("Created secured cache in vm3");
-
-      vm2.invoke(() -> WANTestBase.createSender("ln", 2, false, 100, 10, false, false, null, true));
-      logger.info("Created sender in vm2");
-
-      vm3.invoke(() -> createReceiverInSecuredCache());
-      logger.info("Created receiver in vm3");
-
-      vm2.invoke(() -> WANTestBase.startSender("ln"));
-      vm2.invoke(() -> WANTestBase.waitForSenderRunningState("ln"));
-
-      vm2.invoke(() -> verifyDifferentServerInGetCredentialCall());
-
-      // this would fail for now because for integrated security, we are not sending the receiver's
-      // credentials back
-      // to the sender. Because in the old security implementation, even though the receiver's
-      // credentials are sent back to the sender
-      // the sender is not checking it.
-      // vm3.invoke(() -> verifyDifferentServerInGetCredentialCall());
-    }
   }
 }


### PR DESCRIPTION
Due to different handling in the GatewaySenderEventRemoteDispatcher
dispatcher and ack reader threads, it was possible for event processing
to stop when a GemFireSecurityException was encountered by the ack
reader connection retry logic.

This commit attempts to share common recoverable cases between the ack
reader and dispatcher, while maintaining the cases which are specific to
each.  We also added a test which ensures that if a connection is denied
due to invalid credentials upon a restart of the receiver, that the
sender can recover if it again provides valid credentials.  In the process,
we removed a significant amount of duplicated and noisy code in the
NewWanAuthenticationDUnitTests.

Co-authored-by: Bill Burcham <bburcham@pivotal.io>
Co-authored-by: Ryan McMahon <rmcmahon@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- N/A If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
