### PR TITLE
GEODE-5786: Create txEntryState based on createIfAbsent condition.

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ClientServerRepeatableReadTransactionDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ClientServerRepeatableReadTransactionDistributedTest.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache;
+
+import static org.apache.geode.test.dunit.VM.getHostName;
+import static org.apache.geode.test.dunit.VM.getVM;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.Serializable;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.apache.geode.cache.CommitConflictException;
+import org.apache.geode.cache.PartitionAttributes;
+import org.apache.geode.cache.PartitionAttributesFactory;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.cache.TransactionId;
+import org.apache.geode.cache.client.ClientRegionFactory;
+import org.apache.geode.cache.client.ClientRegionShortcut;
+import org.apache.geode.cache.client.PoolFactory;
+import org.apache.geode.cache.client.PoolManager;
+import org.apache.geode.cache.client.internal.PoolImpl;
+import org.apache.geode.cache.server.CacheServer;
+import org.apache.geode.internal.cache.tier.sockets.CacheServerTestUtil;
+import org.apache.geode.test.dunit.VM;
+import org.apache.geode.test.dunit.rules.CacheRule;
+import org.apache.geode.test.dunit.rules.ClientCacheRule;
+import org.apache.geode.test.dunit.rules.DistributedRule;
+import org.apache.geode.test.junit.rules.serializable.SerializableTestName;
+
+public class ClientServerRepeatableReadTransactionDistributedTest implements Serializable {
+  private String hostName;
+  private String uniqueName;
+  private String regionName;
+  private VM server1;
+  private int port1;
+
+  @Rule
+  public DistributedRule distributedRule = new DistributedRule();
+
+  @Rule
+  public CacheRule cacheRule = new CacheRule();
+
+  @Rule
+  public ClientCacheRule clientCacheRule = new ClientCacheRule();
+
+  @Rule
+  public SerializableTestName testName = new SerializableTestName();
+
+  @Before
+  public void setUp() {
+    server1 = getVM(0);
+
+    hostName = getHostName();
+    uniqueName = getClass().getSimpleName() + "_" + testName.getMethodName();
+    regionName = uniqueName + "_region";
+  }
+
+  @Test
+  public void valuesRepeatableReadDoesNotIncludeTombstones() {
+    port1 = server1.invoke(() -> createServerRegion(1));
+
+    createClientRegion(port1);
+    Region region = clientCacheRule.getClientCache().getRegion(regionName);
+    region.put("key1", "value1");
+    region.destroy("key1"); // creates a tombstone
+
+    TXManagerImpl txMgr =
+        (TXManagerImpl) clientCacheRule.getClientCache().getCacheTransactionManager();
+
+    Region region1 = clientCacheRule.getClientCache().getRegion(regionName);
+    txMgr.begin(); // tx1
+    region1.values().toArray(); // this is a repeatable read
+    TransactionId txId = txMgr.suspend();
+
+    txMgr.begin(); // tx2
+    region1.put("key1", "newValue");
+    txMgr.commit();
+
+    txMgr.resume(txId);
+    region1.put("key1", "value1");
+    txMgr.commit();
+    assertThat(region.get("key1")).isEqualTo("value1");
+  }
+
+  @Test
+  public void keySetRepeatableReadDoesNotIncludeTombstones() {
+    port1 = server1.invoke(() -> createServerRegion(1));
+
+    createClientRegion(port1);
+    Region region = clientCacheRule.getClientCache().getRegion(regionName);
+    region.put("key1", "value1");
+    region.destroy("key1"); // creates a tombstone
+
+    TXManagerImpl txMgr =
+        (TXManagerImpl) clientCacheRule.getClientCache().getCacheTransactionManager();
+
+    Region region1 = clientCacheRule.getClientCache().getRegion(regionName);
+    txMgr.begin(); // tx1
+    region1.keySet().toArray(); // this is a repeatable read
+    TransactionId txId = txMgr.suspend();
+
+    txMgr.begin(); // tx2
+    region1.put("key1", "newValue");
+    txMgr.commit();
+
+    txMgr.resume(txId);
+    region1.put("key1", "value1");
+    txMgr.commit();
+    assertThat(region.get("key1")).isEqualTo("value1");
+  }
+
+  @Test
+  public void valuesRepeatableReadIncludesInvalidates() {
+    port1 = server1.invoke(() -> createServerRegion(1));
+
+    createClientRegion(port1);
+    Region region = clientCacheRule.getClientCache().getRegion(regionName);
+    region.put("key1", "value1");
+    region.invalidate("key1");
+
+    TXManagerImpl txMgr =
+        (TXManagerImpl) clientCacheRule.getClientCache().getCacheTransactionManager();
+
+    Region region1 = clientCacheRule.getClientCache().getRegion(regionName);
+    txMgr.begin(); // tx1
+    region1.values().toArray(); // this is a repeatable read
+    TransactionId txId = txMgr.suspend();
+
+    txMgr.begin(); // tx2
+    region1.put("key1", "newValue");
+    txMgr.commit();
+
+    txMgr.resume(txId);
+    region1.put("key1", "value1");
+    assertThatThrownBy(() -> txMgr.commit()).isExactlyInstanceOf(CommitConflictException.class);
+    assertThat(region.get("key1")).isEqualTo("newValue");
+  }
+
+  @Test
+  public void keySetRepeatableReadIncludesInvalidates() {
+    port1 = server1.invoke(() -> createServerRegion(1));
+
+    createClientRegion(port1);
+    Region region = clientCacheRule.getClientCache().getRegion(regionName);
+    region.put("key1", "value1");
+    region.invalidate("key1");
+
+    TXManagerImpl txMgr =
+        (TXManagerImpl) clientCacheRule.getClientCache().getCacheTransactionManager();
+
+    Region region1 = clientCacheRule.getClientCache().getRegion(regionName);
+    txMgr.begin(); // tx1
+    region1.keySet().toArray(); // this is a repeatable read
+    TransactionId txId = txMgr.suspend();
+
+    txMgr.begin(); // tx2
+    region1.put("key1", "newValue");
+    txMgr.commit();
+
+    txMgr.resume(txId);
+    region1.put("key1", "value1");
+    assertThatThrownBy(() -> txMgr.commit()).isExactlyInstanceOf(CommitConflictException.class);
+    assertThat(region.get("key1")).isEqualTo("newValue");
+  }
+
+  private int createServerRegion(int totalNumBuckets) throws Exception {
+    PartitionAttributesFactory factory = new PartitionAttributesFactory();
+    factory.setTotalNumBuckets(totalNumBuckets);
+    PartitionAttributes partitionAttributes = factory.create();
+    cacheRule.getOrCreateCache().createRegionFactory(RegionShortcut.PARTITION)
+        .setPartitionAttributes(partitionAttributes).create(regionName);
+
+    CacheServer server = cacheRule.getCache().addCacheServer();
+    server.setPort(0);
+    server.start();
+    return server.getPort();
+  }
+
+  private void createClientRegion(int port) {
+    clientCacheRule.createClientCache();
+
+    CacheServerTestUtil.disableShufflingOfEndpoints();
+    PoolImpl pool;
+    try {
+      pool = getPool(port);
+    } finally {
+      CacheServerTestUtil.enableShufflingOfEndpoints();
+    }
+
+    ClientRegionFactory crf =
+        clientCacheRule.getClientCache().createClientRegionFactory(ClientRegionShortcut.LOCAL);
+    crf.setPoolName(pool.getName());
+    crf.create(regionName);
+  }
+
+  private PoolImpl getPool(int port) {
+    PoolFactory factory = PoolManager.createFactory();
+    factory.addServer(hostName, port);
+    factory.setReadTimeout(12000).setSocketBufferSize(1000);
+    return (PoolImpl) factory.create(uniqueName);
+  }
+
+}

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/RepeatableReadTransactionDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/RepeatableReadTransactionDistributedTest.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.execute;
+
+import static org.apache.geode.test.dunit.VM.getVM;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.Serializable;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.apache.geode.cache.CommitConflictException;
+import org.apache.geode.cache.PartitionAttributes;
+import org.apache.geode.cache.PartitionAttributesFactory;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.cache.TransactionId;
+import org.apache.geode.cache.server.CacheServer;
+import org.apache.geode.internal.cache.TXManagerImpl;
+import org.apache.geode.test.dunit.VM;
+import org.apache.geode.test.dunit.rules.CacheRule;
+import org.apache.geode.test.dunit.rules.DistributedRule;
+import org.apache.geode.test.junit.rules.serializable.SerializableTestName;
+
+public class RepeatableReadTransactionDistributedTest implements Serializable {
+  private String uniqueName;
+  private String regionName;
+  private VM server1;
+  private VM server2;
+  private String key = "key";
+  private String originalValue = "originalValue";
+  private String value1 = "value1";
+  private String value2 = "value2";
+
+  @Rule
+  public DistributedRule distributedRule = new DistributedRule();
+
+  @Rule
+  public CacheRule cacheRule = new CacheRule();
+  @Rule
+  public SerializableTestName testName = new SerializableTestName();
+
+  @Before
+  public void setUp() {
+    server1 = getVM(0);
+    server2 = getVM(1);
+
+    uniqueName = getClass().getSimpleName() + "_" + testName.getMethodName();
+    regionName = uniqueName + "_region";
+  }
+
+  @Test
+  public void valuesRepeatableReadDoesNotIncludeTombstones() {
+    server1.invoke(() -> createServerRegion(1, false));
+    server2.invoke(() -> createServerRegion(1, true));
+    server2.invoke(() -> doDestroyOps());
+    server2.invoke(() -> doValuesTransactionWithTombstone());
+  }
+
+  @Test
+  public void keySetRepeatableReadDoesNotIncludeTombstones() {
+    server1.invoke(() -> createServerRegion(1, false));
+    server2.invoke(() -> createServerRegion(1, true));
+    server2.invoke(() -> doDestroyOps());
+    server2.invoke(() -> doKeySetTransactionWithTombstone());
+  }
+
+  @Test
+  public void valuesRepeatableReadIncludesInvalidates() {
+    server1.invoke(() -> createServerRegion(1, false));
+    server2.invoke(() -> createServerRegion(1, true));
+    server2.invoke(() -> doInvalidateOps());
+    server2.invoke(() -> doValuesTransactionWithInvalidate());
+  }
+
+  @Test
+  public void keySetRepeatableReadIncludesInvalidates() {
+    server1.invoke(() -> createServerRegion(1, false));
+    server2.invoke(() -> createServerRegion(1, true));
+    server2.invoke(() -> doInvalidateOps());
+    server2.invoke(() -> doKeySetTransactionWithInvalidate());
+  }
+
+  private int createServerRegion(int totalNumBuckets, boolean isAccessor) throws Exception {
+    PartitionAttributesFactory factory = new PartitionAttributesFactory();
+    factory.setTotalNumBuckets(totalNumBuckets);
+    if (isAccessor) {
+      factory.setLocalMaxMemory(0);
+    }
+    PartitionAttributes partitionAttributes = factory.create();
+    cacheRule.getOrCreateCache().createRegionFactory(RegionShortcut.PARTITION)
+        .setPartitionAttributes(partitionAttributes).create(regionName);
+
+    CacheServer server = cacheRule.getCache().addCacheServer();
+    server.setPort(0);
+    server.start();
+    return server.getPort();
+  }
+
+  private void doDestroyOps() {
+    Region region = cacheRule.getCache().getRegion(regionName);
+    region.put(key, originalValue);
+    region.destroy(key); // creates a tombstone
+  }
+
+  private void doInvalidateOps() {
+    Region region = cacheRule.getCache().getRegion(regionName);
+    region.put(key, originalValue);
+    region.invalidate(key);
+  }
+
+  private void doValuesTransactionWithTombstone() {
+    TXManagerImpl txMgr =
+        (TXManagerImpl) cacheRule.getCache().getCacheTransactionManager();
+
+    Region region = cacheRule.getCache().getRegion(regionName);
+    txMgr.begin(); // tx1
+    region.put("key2", "someValue");
+    region.values().toArray();
+    TransactionId txId = txMgr.suspend();
+
+    txMgr.begin(); // tx2
+    region.put(key, value2);
+    txMgr.commit();
+
+    txMgr.resume(txId);
+    region.put(key, value1);
+    txMgr.commit();
+
+    assertThat(region.get(key)).isEqualTo(value1);
+  }
+
+  private void doKeySetTransactionWithTombstone() {
+    TXManagerImpl txMgr =
+        (TXManagerImpl) cacheRule.getCache().getCacheTransactionManager();
+
+    Region region = cacheRule.getCache().getRegion(regionName);
+    txMgr.begin(); // tx1
+    region.put("key2", "someValue");
+    region.keySet().toArray();
+    TransactionId txId = txMgr.suspend();
+
+    txMgr.begin(); // tx2
+    region.put(key, value2);
+    txMgr.commit();
+
+    txMgr.resume(txId);
+    region.put(key, value1);
+    txMgr.commit();
+
+    assertThat(region.get(key)).isEqualTo(value1);
+  }
+
+  private void doValuesTransactionWithInvalidate() {
+    TXManagerImpl txMgr =
+        (TXManagerImpl) cacheRule.getCache().getCacheTransactionManager();
+
+    Region region = cacheRule.getCache().getRegion(regionName);
+    txMgr.begin(); // tx1
+    region.put("key2", "someValue");
+    region.values().toArray();
+    TransactionId txId = txMgr.suspend();
+
+    txMgr.begin(); // tx2
+    region.put(key, value2);
+    txMgr.commit();
+
+    txMgr.resume(txId);
+    region.put(key, value1);
+    assertThatThrownBy(() -> txMgr.commit()).isExactlyInstanceOf(CommitConflictException.class);
+    assertThat(region.get(key)).isEqualTo(value2);
+  }
+
+  private void doKeySetTransactionWithInvalidate() {
+    TXManagerImpl txMgr =
+        (TXManagerImpl) cacheRule.getCache().getCacheTransactionManager();
+
+    Region region = cacheRule.getCache().getRegion(regionName);
+    txMgr.begin(); // tx1
+    region.put("key2", "someValue");
+    region.keySet().toArray();
+    TransactionId txId = txMgr.suspend();
+
+    txMgr.begin(); // tx2
+    region.put(key, value2);
+    txMgr.commit();
+
+    txMgr.resume(txId);
+    region.put(key, value1);
+    assertThatThrownBy(() -> txMgr.commit()).isExactlyInstanceOf(CommitConflictException.class);
+    assertThat(region.get(key)).isEqualTo(value2);
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/EntriesSet.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/EntriesSet.java
@@ -178,7 +178,11 @@ public class EntriesSet extends AbstractSet {
                 } else if (ignoreCopyOnReadForQuery) {
                   result = ((NonTXEntry) re).getValue(true);
                 } else {
-                  result = re.getValue();
+                  if ((re instanceof TXEntry)) {
+                    result = ((TXEntry) re).getValue(allowTombstones);
+                  } else {
+                    result = re.getValue();
+                  }
                 }
                 if (result != null && !Token.isInvalidOrRemoved(result)) { // fix for bug 34583
                   return result;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalDataView.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalDataView.java
@@ -42,7 +42,7 @@ public interface InternalDataView {
   @Retained
   Object getDeserializedValue(KeyInfo keyInfo, LocalRegion localRegion, boolean updateStats,
       boolean disableCopyOnRead, boolean preferCD, EntryEventImpl clientEvent,
-      boolean returnTombstones, boolean retainResult);
+      boolean returnTombstones, boolean retainResult, boolean createIfAbsent);
 
   /**
    * @param expectedOldValue TODO

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
@@ -1399,7 +1399,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
     try {
       KeyInfo keyInfo = getKeyInfo(key, aCallbackArgument);
       Object value = getDataView().getDeserializedValue(keyInfo, this, true, disableCopyOnRead,
-          preferCD, clientEvent, returnTombstones, retainResult);
+          preferCD, clientEvent, returnTombstones, retainResult, true);
       final boolean isCreate = value == null;
       isMiss = value == null || Token.isInvalid(value)
           || (!returnTombstones && value == Token.TOMBSTONE);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegionDataView.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegionDataView.java
@@ -39,7 +39,7 @@ public class LocalRegionDataView implements InternalDataView {
    */
   public Object getDeserializedValue(KeyInfo keyInfo, LocalRegion localRegion, boolean updateStats,
       boolean disableCopyOnRead, boolean preferCD, EntryEventImpl clientEvent,
-      boolean returnTombstones, boolean retainResult) {
+      boolean returnTombstones, boolean retainResult, boolean createIfAbsent) {
     return localRegion.getDeserializedValue(null, keyInfo, updateStats, disableCopyOnRead, preferCD,
         clientEvent, returnTombstones, retainResult);
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PausedTXStateProxyImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PausedTXStateProxyImpl.java
@@ -110,7 +110,7 @@ public class PausedTXStateProxyImpl implements TXStateProxy {
   @Override
   public Object getDeserializedValue(KeyInfo keyInfo, LocalRegion localRegion, boolean updateStats,
       boolean disableCopyOnRead, boolean preferCD, EntryEventImpl clientEvent,
-      boolean returnTombstones, boolean retainResult) {
+      boolean returnTombstones, boolean retainResult, boolean createIfAbsent) {
     return null;
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXEntry.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXEntry.java
@@ -89,12 +89,17 @@ public class TXEntry implements Region.Entry {
 
   @Unretained
   public Object getValue() {
+    return getValue(true);
+  }
+
+  @Unretained
+  public Object getValue(boolean createIfAbsent) {
     checkTX();
     // Object value = this.localRegion.getDeserialized(this.key, false, this.myTX,
     // this.rememberReads);
     @Unretained
     Object value = this.myTX.getDeserializedValue(keyInfo, this.localRegion, false, false, false,
-        null, false, false);
+        null, false, false, createIfAbsent);
     if (value == null) {
       throw new EntryDestroyedException(this.keyInfo.getKey().toString());
     } else if (Token.isInvalid(value)) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXStateInterface.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXStateInterface.java
@@ -110,13 +110,6 @@ public interface TXStateInterface extends Synchronization, InternalDataView {
    */
   Entry getEntry(final KeyInfo keyInfo, final LocalRegion region, boolean allowTombstones);
 
-  /**
-   * @param updateStats TODO
-   */
-  Object getDeserializedValue(KeyInfo keyInfo, LocalRegion localRegion, boolean updateStats,
-      boolean disableCopyOnRead, boolean preferCD, EntryEventImpl clientEvent,
-      boolean returnTombstones, boolean retainResult);
-
   TXEvent getEvent();
 
   TXRegionState txWriteRegion(final InternalRegion internalRegion, final KeyInfo entryKey);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXStateProxyImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXStateProxyImpl.java
@@ -290,9 +290,9 @@ public class TXStateProxyImpl implements TXStateProxy {
   @Override
   public Object getDeserializedValue(KeyInfo keyInfo, LocalRegion localRegion, boolean updateStats,
       boolean disableCopyOnRead, boolean preferCD, EntryEventImpl clientEvent,
-      boolean returnTombstones, boolean retainResult) {
+      boolean returnTombstones, boolean retainResult, boolean createIfAbsent) {
     Object val = getRealDeal(keyInfo, localRegion).getDeserializedValue(keyInfo, localRegion,
-        updateStats, disableCopyOnRead, preferCD, null, false, retainResult);
+        updateStats, disableCopyOnRead, preferCD, null, false, retainResult, createIfAbsent);
     if (val != null) {
       // fixes bug 51057: TXStateStub on client always returns null, so do not increment
       // the operation count it will be incremented in findObject()

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXStateStub.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXStateStub.java
@@ -189,7 +189,7 @@ public abstract class TXStateStub implements TXStateInterface {
   @Override
   public Object getDeserializedValue(KeyInfo keyInfo, LocalRegion localRegion, boolean updateStats,
       boolean disableCopyOnRead, boolean preferCD, EntryEventImpl clientEvent,
-      boolean returnTombstones, boolean retainResult) {
+      boolean returnTombstones, boolean retainResult, boolean createIfAbsent) {
     // We never have a local value if we are a stub...
     return null;
   }


### PR DESCRIPTION
 * Do not create txEntryState for entries with tombstones during set operations - keySet, values, etc.
 * Only create txEntryState for tombstones during get operation.

 Co-authored-by: lgallinat

