### PR TITLE
GEODE-6219: Add assertion to verify the OS commands really ran

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/NetstatDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/NetstatDUnitTest.java
@@ -102,7 +102,7 @@ public class NetstatDUnitTest {
     assertThat(lines[4].trim().split("[,\\s]+")).containsExactlyInAnyOrder("server-1");
   }
 
-  @Ignore("GEODE-2488")
+  @Ignore("GEODE-6228")
   @Test
   public void testOutputToConsoleWithLsofForOneMember() throws Exception {
     CommandResult result = gfsh.executeCommand("netstat --member=server-1 --with-lsof");
@@ -184,7 +184,7 @@ public class NetstatDUnitTest {
     assertThat(lines).filteredOn(e -> e.contains("## lsof output ##")).hasSize(1);
   }
 
-  @Ignore("GEODE-2488")
+  @Ignore("GEODE-6228")
   @Test
   public void testConnectToLocatorWithLargeCommandResponse() throws Exception {
     gfsh.connect(server0.getEmbeddedLocatorPort(), GfshCommandRule.PortType.locator);
@@ -192,7 +192,7 @@ public class NetstatDUnitTest {
         .doesNotContainOutput("Could not execute");
   }
 
-  @Ignore("GEODE-2488")
+  @Ignore("GEODE-6228")
   @Test
   public void testConnectToJmxManagerOneWithLargeCommandResponse() throws Exception {
     gfsh.connect(server0.getJmxPort(), GfshCommandRule.PortType.jmxManager);
@@ -201,7 +201,7 @@ public class NetstatDUnitTest {
 
   }
 
-  @Ignore("GEODE-2488")
+  @Ignore("GEODE-6228")
   @Test
   public void testConnectToJmxManagerTwoWithLargeCommandResponse() throws Exception {
     gfsh.connect(server1.getJmxPort(), GfshCommandRule.PortType.jmxManager);

--- a/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/NetstatDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/NetstatDUnitTest.java
@@ -102,7 +102,7 @@ public class NetstatDUnitTest {
     assertThat(lines[4].trim().split("[,\\s]+")).containsExactlyInAnyOrder("server-1");
   }
 
-  @Ignore
+  @Ignore("GEODE-2488")
   @Test
   public void testOutputToConsoleWithLsofForOneMember() throws Exception {
     CommandResult result = gfsh.executeCommand("netstat --member=server-1 --with-lsof");

--- a/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/NetstatDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/NetstatDUnitTest.java
@@ -102,6 +102,7 @@ public class NetstatDUnitTest {
     assertThat(lines[4].trim().split("[,\\s]+")).containsExactlyInAnyOrder("server-1");
   }
 
+  @Ignore
   @Test
   public void testOutputToConsoleWithLsofForOneMember() throws Exception {
     CommandResult result = gfsh.executeCommand("netstat --member=server-1 --with-lsof");

--- a/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/NetstatDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/NetstatDUnitTest.java
@@ -76,6 +76,9 @@ public class NetstatDUnitTest {
     CommandResult result = gfsh.executeCommand("netstat");
     assertThat(result.getStatus()).isEqualTo(Result.Status.OK);
 
+    // verify that the OS commands executed
+    assertThat(result.toString()).doesNotContain("Could not execute");
+
     String rawOutput = result.getMessageFromContent();
     String[] lines = rawOutput.split("\n");
 
@@ -89,6 +92,9 @@ public class NetstatDUnitTest {
     CommandResult result = gfsh.executeCommand("netstat --member=server-1");
     assertThat(result.getStatus()).isEqualTo(Result.Status.OK);
 
+    // verify that the OS commands executed
+    assertThat(result.toString()).doesNotContain("Could not execute");
+
     String rawOutput = result.getMessageFromContent();
     String[] lines = rawOutput.split("\n");
 
@@ -100,6 +106,9 @@ public class NetstatDUnitTest {
   public void testOutputToConsoleWithLsofForOneMember() throws Exception {
     CommandResult result = gfsh.executeCommand("netstat --member=server-1 --with-lsof");
     assertThat(result.getStatus()).isEqualTo(Result.Status.OK);
+
+    // verify that the OS commands executed
+    assertThat(result.toString()).doesNotContain("Could not execute");
 
     String rawOutput = result.getMessageFromContent();
     String[] lines = rawOutput.split("\n");
@@ -122,6 +131,9 @@ public class NetstatDUnitTest {
       lines.add(scanner.nextLine());
     }
 
+    // verify that the OS commands executed
+    assertThat(lines.toString()).doesNotContain("Could not execute");
+
     assertThat(lines.size()).isGreaterThan(5);
     assertThat(lines.get(4).trim().split("[,\\s]+")).containsExactlyInAnyOrder("locator-0",
         "server-1", "server-2");
@@ -141,6 +153,9 @@ public class NetstatDUnitTest {
       lines.add(scanner.nextLine());
     }
 
+    // verify that the OS commands executed
+    assertThat(lines.toString()).doesNotContain("Could not execute");
+
     assertThat(lines.size()).isGreaterThan(5);
     assertThat(lines.get(4).trim().split("[,\\s]+")).containsExactly("server-1");
   }
@@ -159,6 +174,9 @@ public class NetstatDUnitTest {
       lines.add(scanner.nextLine());
     }
 
+    // verify that the OS commands executed
+    assertThat(lines.toString()).doesNotContain("Could not execute");
+
     assertThat(lines.size()).isGreaterThan(5);
     assertThat(lines.get(4).trim().split("[,\\s]+")).containsExactlyInAnyOrder("locator-0",
         "server-1", "server-2");
@@ -169,20 +187,24 @@ public class NetstatDUnitTest {
   @Test
   public void testConnectToLocatorWithLargeCommandResponse() throws Exception {
     gfsh.connect(server0.getEmbeddedLocatorPort(), GfshCommandRule.PortType.locator);
-    gfsh.executeAndAssertThat(netStatLsofCommand).statusIsSuccess();
+    gfsh.executeAndAssertThat(netStatLsofCommand).statusIsSuccess()
+        .doesNotContainOutput("Could not execute");
   }
 
   @Ignore("GEODE-2488")
   @Test
   public void testConnectToJmxManagerOneWithLargeCommandResponse() throws Exception {
     gfsh.connect(server0.getJmxPort(), GfshCommandRule.PortType.jmxManager);
-    gfsh.executeAndAssertThat(netStatLsofCommand).statusIsSuccess();
+    gfsh.executeAndAssertThat(netStatLsofCommand).statusIsSuccess()
+        .doesNotContainOutput("Could not execute");
+
   }
 
   @Ignore("GEODE-2488")
   @Test
   public void testConnectToJmxManagerTwoWithLargeCommandResponse() throws Exception {
     gfsh.connect(server1.getJmxPort(), GfshCommandRule.PortType.jmxManager);
-    gfsh.executeAndAssertThat(netStatLsofCommand).statusIsSuccess();
+    gfsh.executeAndAssertThat(netStatLsofCommand).statusIsSuccess()
+        .doesNotContainOutput("Could not execute");
   }
 }


### PR DESCRIPTION
Failure of netstat command on the test instance was not being detected.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
