### PR TITLE
GEODE-6202: Remove VALIDATE_SERIALIZABLE_OBJECTS from dunit

### DIFF
--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/DUnitLauncher.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/DUnitLauncher.java
@@ -21,7 +21,6 @@ import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.apache.geode.distributed.ConfigurationProperties.USE_CLUSTER_CONFIGURATION;
-import static org.apache.geode.distributed.ConfigurationProperties.VALIDATE_SERIALIZABLE_OBJECTS;
 import static org.apache.geode.distributed.internal.DistributionConfig.GEMFIRE_PREFIX;
 
 import java.io.BufferedReader;
@@ -234,7 +233,6 @@ public class DUnitLauncher {
     p.setProperty(MCAST_PORT, "0");
     p.setProperty(ENABLE_CLUSTER_CONFIGURATION, "false");
     p.setProperty(USE_CLUSTER_CONFIGURATION, "false");
-    p.setProperty(VALIDATE_SERIALIZABLE_OBJECTS, "true");
     p.setProperty(LOG_LEVEL, logLevel);
     return p;
   }

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/ProcessManager.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/ProcessManager.java
@@ -38,7 +38,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.JavaVersion;
 import org.apache.commons.lang3.SystemUtils;
 
-import org.apache.geode.distributed.ConfigurationProperties;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.InternalLocator;
 import org.apache.geode.test.dunit.VM;
@@ -278,8 +277,6 @@ public class ProcessManager {
     cmds.add("-D" + DistributionConfig.GEMFIRE_PREFIX + "DEFAULT_MAX_OPLOG_SIZE=10");
     cmds.add("-D" + DistributionConfig.GEMFIRE_PREFIX + "disallowMcastDefaults=true");
     cmds.add("-D" + DistributionConfig.RESTRICT_MEMBERSHIP_PORT_RANGE + "=true");
-    cmds.add("-D" + DistributionConfig.GEMFIRE_PREFIX
-        + ConfigurationProperties.VALIDATE_SERIALIZABLE_OBJECTS + "=true");
     cmds.add("-ea");
     cmds.add("-XX:MetaspaceSize=512m");
     cmds.add("-XX:SoftRefLRUPolicyMSPerMB=1");

--- a/geode-web/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/QueryCommandOverHttpDUnitTest.java
+++ b/geode-web/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/QueryCommandOverHttpDUnitTest.java
@@ -19,7 +19,7 @@ import org.apache.geode.test.junit.rules.GfshCommandRule;
 
 public class QueryCommandOverHttpDUnitTest extends QueryCommandDUnitTestBase {
   @Override
-  public void connectToLocator() throws Exception {
+  protected void connectToLocator() throws Exception {
     gfsh.connectAndVerify(locator.getHttpPort(), GfshCommandRule.PortType.http);
   }
 }


### PR DESCRIPTION
Consensus on the dev-list back in March was to remove VALIDATE_SERIALIZABLE_OBJECTS from default configuration of dunit, so I've gone ahead and removed it in this PR.

After removing VALIDATE_SERIALIZABLE_OBJECTS, the only dunit tests that failed were the two subclasses of QueryCommandDUnitTestBase. Since that test actually includes a test to explicitly verify SERIALIZABLE_OBJECT_FILTER, I changed the test itself to enable VALIDATE_SERIALIZABLE_OBJECTS. That's the 2nd commit in this PR.

Many tests still set SERIALIZABLE_OBJECT_FILTER which is harmless (they still pass), and I'd like to remove those as a follow-up to this PR (since it'll be a very large diff). As I remove it from each test, I'd like to take a closer look to see if any of those tests would be appropriate ones to add in a new test specific to enabling VALIDATE_SERIALIZABLE_OBJECTS like I've done in QueryCommandDUnitTestBase.